### PR TITLE
Simple query results in error: `listS3Buckets failed with panic AWS_REGION must be set`. Fixes #17

### DIFF
--- a/aws/common_columns.go
+++ b/aws/common_columns.go
@@ -109,7 +109,7 @@ func getCommonColumns(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 			// extract partition from arn
 			Partition: strings.Split(*callerIdentity.Arn, ":")[1],
 			AccountId: *callerIdentity.Account,
-			Region:    GetDefaultRegion(),
+			Region:    GetDefaultAwsRegion(),
 		}
 
 		// save to extension cache

--- a/aws/service.go
+++ b/aws/service.go
@@ -253,7 +253,7 @@ func IAMService(ctx context.Context, connectionManager *connection.Manager) (*ia
 		return cachedData.(*iam.IAM), nil
 	}
 	// so it was not in cache - create service
-	sess, err := getSession(ctx, connectionManager, GetDefaultRegion())
+	sess, err := getSession(ctx, connectionManager, GetDefaultAwsRegion())
 	if err != nil {
 		return nil, err
 	}
@@ -434,7 +434,7 @@ func StsService(ctx context.Context, connectionManager *connection.Manager) (*st
 		return cachedData.(*sts.STS), nil
 	}
 	// so it was not in cache - create service
-	sess, err := getSession(ctx, connectionManager, GetDefaultRegion())
+	sess, err := getSession(ctx, connectionManager, GetDefaultAwsRegion())
 	if err != nil {
 		return nil, err
 	}
@@ -473,7 +473,23 @@ func GetDefaultRegion() string {
 	// region := os.Getenv("AWS_REGION")
 	region := *session.Config.Region
 	if region == "" {
-		panic("AWS_REGION must be set to use the aws extension")
+		panic("\n\nYou must specify a region. You can configure your region by running \"aws configure\" or setting AWS_REGION environment variable.")
+	}
+	return region
+}
+
+// GetDefaultAwsRegion returns the default region for AWS partiton
+// if not set by Env variable or in aws profile
+func GetDefaultAwsRegion() string {
+	os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	session, err := session.NewSession(aws.NewConfig())
+	if err != nil {
+		panic(err)
+	}
+
+	region := *session.Config.Region
+	if region == "" {
+		region = "us-east-1"
 	}
 	return region
 }

--- a/aws/table_aws_s3_bucket.go
+++ b/aws/table_aws_s3_bucket.go
@@ -227,7 +227,7 @@ func bucketFromKey(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 
 func listS3Buckets(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listS3Buckets")
-	defaultRegion := GetDefaultRegion()
+	defaultRegion := GetDefaultAwsRegion()
 
 	// Create Session
 	svc, err := S3Service(ctx, d.ConnectionManager, defaultRegion)
@@ -256,7 +256,7 @@ func listS3Buckets(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 func getS3Bucket(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listS3Buckets")
 	bucket := h.Item.(*s3.Bucket)
-	defaultRegion := GetDefaultRegion()
+	defaultRegion := GetDefaultAwsRegion()
 
 	// Create Session
 	svc, err := S3Service(ctx, d.ConnectionManager, defaultRegion)
@@ -283,7 +283,7 @@ func getS3Bucket(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 func getBucketLocation(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getBucketLocation")
 	bucket := h.Item.(*s3.Bucket)
-	defaultRegion := GetDefaultRegion()
+	defaultRegion := GetDefaultAwsRegion()
 
 	// Create Session
 	svc, err := S3Service(ctx, d.ConnectionManager, defaultRegion)


### PR DESCRIPTION
```
➜  steampipe-plugin-gcp git:(main) unset SP_LOG 
➜  steampipe-plugin-gcp git:(main) aws configure list
      Name                    Value             Type    Location
      ----                    -----             ----    --------
   profile                <not set>             None    None
access_key     ******************** shared-credentials-file    
secret_key     ******************** shared-credentials-file    
    region                <not set>             None    None
➜  steampipe-plugin-gcp git:(main) steampipe query   
Welcome to Steampipe v0.1.0
Type ".inspect" for more information.
> select * from aws.aws_s3_bucket;
+------------------------------------+---------------------+-------------------------+--------------------+-----------------------+-------------------+---------------------+--------------------+-------------------------+----------------
|                name                |    creation_date    | bucket_policy_is_public | versioning_enabled | versioning_mfa_delete | block_public_acls | block_public_policy | ignore_public_acls | restrict_public_buckets |                
+------------------------------------+---------------------+-------------------------+--------------------+-----------------------+-------------------+---------------------+--------------------+-------------------------+----------------
| turbot-abcd-eu-central-1   | 2020-01-07 07:14:37 | false                   | true               | false                 | false             | false               | false              | false                   | {"Rules":[{"App
+------------------------------------+---------------------+-------------------------+--------------------+-----------------------+-------------------+---------------------+--------------------+-------------------------+----------------
> select * from aws.aws_ec2_instance;
Error: pq: rpc error: code = Internal desc = list call listEc2Instance failed with panic 

You must specify a region. You can configure your region by running "aws configure" or setting AWS_REGION environment variable.
> 
```