### PR TITLE
Add MFA details to the  `aws_iam_user` table. Closes #27

### DIFF
--- a/aws-test/tests/aws_iam_user/test-hydrate-expected.json
+++ b/aws-test/tests/aws_iam_user/test-hydrate-expected.json
@@ -3,6 +3,7 @@
     "arn": "{{ output.resource_aka.value }}",
     "attached_policy_arns": null,
     "inline_policies": null,
+    "mfa_enabled": false,
     "name": "{{resourceName}}",
     "permissions_boundary_arn": "",
     "permissions_boundary_type": "",

--- a/aws-test/tests/aws_iam_user/test-hydrate-query.sql
+++ b/aws-test/tests/aws_iam_user/test-hydrate-query.sql
@@ -1,3 +1,3 @@
-select name, arn, inline_policies, attached_policy_arns, permissions_boundary_arn, permissions_boundary_type, tags_src
+select name, arn, inline_policies, attached_policy_arns, permissions_boundary_arn, permissions_boundary_type, mfa_enabled, tags_src
 from aws.aws_iam_user
 where name = '{{ resourceName }}'

--- a/docs/tables/aws_iam_user.md
+++ b/docs/tables/aws_iam_user.md
@@ -17,7 +17,6 @@ from
   aws_iam_user;
 ```
 
-
 ### Groups details to which the IAM user belongs
 
 ```sql
@@ -30,7 +29,6 @@ from
   aws_iam_user
   cross join jsonb_array_elements(groups) as iam_group;
 ```
-
 
 ### List all the users having Administrator access
 
@@ -45,6 +43,18 @@ where
   split_part(attachments, '/', 2) = 'AdministratorAccess';
 ```
 
+### List all the users for whom MFA is not enabled
+
+```sql
+select
+  name,
+  user_id,
+  mfa_enabled
+from
+  aws.aws_iam_user
+where
+  not mfa_enabled;
+```
 
 ### List the policies attached to each IAM user
 


### PR DESCRIPTION
```
> select
  name,
  user_id,
  mfa_enabled
from
  aws.aws_iam_user
where
  not mfa_enabled;
+----------------+-----------------------+-------------+
| NAME           | USER_ID               | MFA_ENABLED |
+----------------+-----------------------+-------------+
| abcd           | AIDAQGDRKHTKJHQNPAAAA | false       |
| efgh           | AIDAQGDRKHTKH5AV7AAAA | false       |
| ijkl           | AIDAQGDRKHTKLVK23AAAA | false       |
+----------------+-----------------------+-------------+
```