### PR TITLE
aws_region table region column always shows as global?. closes #121

### DIFF
--- a/aws/table_aws_region.go
+++ b/aws/table_aws_region.go
@@ -25,7 +25,7 @@ func tableAwsRegion(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listAwsRegions,
 		},
-		Columns: awsColumns([]*plugin.Column{
+		Columns: []*plugin.Column{
 			{
 				Name:        "name",
 				Description: "The name of the region",
@@ -50,7 +50,26 @@ func tableAwsRegion(_ context.Context) *plugin.Table {
 				Hydrate:     getAwsRegionAkas,
 				Transform:   transform.FromValue(),
 			},
-		}),
+			{
+				Name:        "partition",
+				Description: "The AWS partition in which the resource is located (aws, aws-cn, or aws-us-gov).",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getCommonColumns,
+			},
+			{
+				Name:        "region",
+				Description: "The AWS Region in which the resource is located.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("RegionName"),
+			},
+			{
+				Name:        "account_id",
+				Description: "The AWS Account ID in which the resource is located.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getCommonColumns,
+				Transform:   transform.FromCamel(),
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Output
```
+----------------+---------------------+----------------+------------------------------------------+-----------+----------------+--------------+
| name           | opt_in_status       | title          | akas                                     | partition | region         | account_id   |
+----------------+---------------------+----------------+------------------------------------------+-----------+----------------+--------------+
| us-west-2      | opt-in-not-required | us-west-2      | ["arn:aws::us-west-2:388460667113"]      | aws       | us-west-2      | 388460667113 |
| us-east-1      | opt-in-not-required | us-east-1      | ["arn:aws::us-east-1:388460667113"]      | aws       | us-east-1      | 388460667113 |
| ap-northeast-1 | opt-in-not-required | ap-northeast-1 | ["arn:aws::ap-northeast-1:388460667113"] | aws       | ap-northeast-1 | 388460667113 |
| eu-west-1      | opt-in-not-required | eu-west-1      | ["arn:aws::eu-west-1:388460667113"]      | aws       | eu-west-1      | 388460667113 |
| us-west-1      | opt-in-not-required | us-west-1      | ["arn:aws::us-west-1:388460667113"]      | aws       | us-west-1      | 388460667113 |
| eu-west-2      | opt-in-not-required | eu-west-2      | ["arn:aws::eu-west-2:388460667113"]      | aws       | eu-west-2      | 388460667113 |
| eu-west-3      | opt-in-not-required | eu-west-3      | ["arn:aws::eu-west-3:388460667113"]      | aws       | eu-west-3      | 388460667113 |
| af-south-1     | not-opted-in        | af-south-1     | ["arn:aws::af-south-1:388460667113"]     | aws       | af-south-1     | 388460667113 |
| ap-southeast-2 | opt-in-not-required | ap-southeast-2 | ["arn:aws::ap-southeast-2:388460667113"] | aws       | ap-southeast-2 | 388460667113 |
| ap-east-1      | not-opted-in        | ap-east-1      | ["arn:aws::ap-east-1:388460667113"]      | aws       | ap-east-1      | 388460667113 |
| eu-central-1   | opt-in-not-required | eu-central-1   | ["arn:aws::eu-central-1:388460667113"]   | aws       | eu-central-1   | 388460667113 |
| eu-south-1     | not-opted-in        | eu-south-1     | ["arn:aws::eu-south-1:388460667113"]     | aws       | eu-south-1     | 388460667113 |
| me-south-1     | not-opted-in        | me-south-1     | ["arn:aws::me-south-1:388460667113"]     | aws       | me-south-1     | 388460667113 |
| ap-south-1     | opt-in-not-required | ap-south-1     | ["arn:aws::ap-south-1:388460667113"]     | aws       | ap-south-1     | 388460667113 |
| ap-northeast-3 | opt-in-not-required | ap-northeast-3 | ["arn:aws::ap-northeast-3:388460667113"] | aws       | ap-northeast-3 | 388460667113 |
| ap-southeast-1 | opt-in-not-required | ap-southeast-1 | ["arn:aws::ap-southeast-1:388460667113"] | aws       | ap-southeast-1 | 388460667113 |
| ca-central-1   | opt-in-not-required | ca-central-1   | ["arn:aws::ca-central-1:388460667113"]   | aws       | ca-central-1   | 388460667113 |
| sa-east-1      | opt-in-not-required | sa-east-1      | ["arn:aws::sa-east-1:388460667113"]      | aws       | sa-east-1      | 388460667113 |
| eu-north-1     | opt-in-not-required | eu-north-1     | ["arn:aws::eu-north-1:388460667113"]     | aws       | eu-north-1     | 388460667113 |
| ap-northeast-2 | opt-in-not-required | ap-northeast-2 | ["arn:aws::ap-northeast-2:388460667113"] | aws       | ap-northeast-2 | 388460667113 |
| us-east-2      | opt-in-not-required | us-east-2      | ["arn:aws::us-east-2:388460667113"]      | aws       | us-east-2      | 388460667113 |
+----------------+---------------------+----------------+------------------------------------------+-----------+----------------+--------------+
```