### PR TITLE
Add a column or a property to any existing column in aws_ec2_instance table to store LaunchTime for an instance. Closes #221

### DIFF
--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -117,6 +117,11 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "launch_time",
+				Description: "The time the instance was launched.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
 				Name:        "outpost_arn",
 				Description: "The Amazon Resource Name (ARN) of the Outpost, if applicable.",
 				Type:        proto.ColumnType_STRING,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_instance []

PRETEST: tests/aws_ec2_instance

TEST: tests/aws_ec2_instance
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_ami.ubuntu: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.main: Creating...
aws_vpc.main: Still creating... [10s elapsed]
aws_vpc.main: Creation complete after 12s [id=vpc-03509ffafee3fda69]
aws_subnet.named_test_resource: Creating...
aws_subnet.named_test_resource: Creation complete after 4s [id=subnet-047460a545b715915]
aws_instance.named_test_resource: Creating...
aws_instance.named_test_resource: Still creating... [10s elapsed]
aws_instance.named_test_resource: Still creating... [20s elapsed]
aws_instance.named_test_resource: Still creating... [30s elapsed]
aws_instance.named_test_resource: Still creating... [40s elapsed]
aws_instance.named_test_resource: Creation complete after 43s [id=i-0fe647690981fb3b2]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = 013122550996
availability_zone = us-east-1b
aws_partition = aws
image_id = ami-00a2faa3cbd561d33
region_name = us-east-1
resource_aka = arn:aws:ec2:us-east-1:013122550996:instance/i-0fe647690981fb3b2
resource_id = i-0fe647690981fb3b2
resource_name = turbottest30762
subnet_id = subnet-047460a545b715915
vpc_id = vpc-03509ffafee3fda69

Running SQL query: query.sql
[
  {
    "image_id": "ami-00a2faa3cbd561d33",
    "instance_id": "i-0fe647690981fb3b2"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "cpu_options_core_count": 1,
    "cpu_options_threads_per_core": 1,
    "ebs_optimized": false,
    "hypervisor": "xen",
    "image_id": "ami-00a2faa3cbd561d33",
    "instance_id": "i-0fe647690981fb3b2",
    "instance_type": "t2.micro",
    "monitoring_state": "disabled",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest30762"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:013122550996:instance/i-0fe647690981fb3b2"
    ],
    "disable_api_termination": false,
    "instance_id": "i-0fe647690981fb3b2",
    "instance_initiated_shutdown_behavior": "stop",
    "instance_status": {
      "AvailabilityZone": "us-east-1b",
      "Events": null,
      "InstanceId": "i-0fe647690981fb3b2",
      "InstanceState": {
        "Code": 16,
        "Name": "running"
      },
      "InstanceStatus": {
        "Details": [
          {
            "ImpairedSince": null,
            "Name": "reachability",
            "Status": "initializing"
          }
        ],
        "Status": "initializing"
      },
      "OutpostArn": null,
      "SystemStatus": {
        "Details": [
          {
            "ImpairedSince": null,
            "Name": "reachability",
            "Status": "initializing"
          }
        ],
        "Status": "initializing"
      }
    },
    "kernel_id": "<null>",
    "ram_disk_id": "<null>",
    "sriov_net_support": "simple",
    "tags": {
      "Name": "turbottest30762"
    },
    "title": "turbottest30762",
    "user_data": "dHVyYm90"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "image_id": "ami-00a2faa3cbd561d33",
    "instance_id": "i-0fe647690981fb3b2"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_instance

TEARDOWN: tests/aws_ec2_instance

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
 ```
  ➜  steampipe-plugin-aws git:(issue-221) ✗ steampipe query
Welcome to Steampipe v0.3.2
For more information, type .help
> select instance_id, instance_type, launch_time, image_id from aws_new.aws_ec2_instance
```
+---------------------+---------------+---------------------+-----------------------+
| instance_id         | instance_type | launch_time         | image_id              |
+---------------------+---------------+---------------------+-----------------------+
| i-0fe647690981fb3b2 | t2.micro      | 2021-03-22 08:00:53 | ami-00a2faa3cbd561d33 |
+---------------------+---------------+---------------------+-----------------------+
```
```
```
</details>
