### PR TITLE
Update aws_vpc_flow_log with status field. Closes #228

### DIFF
--- a/aws/table_aws_vpc_flow_log.go
+++ b/aws/table_aws_vpc_flow_log.go
@@ -53,6 +53,11 @@ func tableAwsVpcFlowlog(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "flow_log_status",
+				Description: "The status of the flow log (ACTIVE).",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "log_group_name",
 				Description: "The name of the flow log group.",
 				Type:        proto.ColumnType_STRING,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_vpc_flow_log []

PRETEST: tests/aws_vpc_flow_log

TEST: tests/aws_vpc_flow_log
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_cloudwatch_log_group.example: Creating...
aws_iam_role.example: Creating...
aws_vpc.main: Creating...
aws_cloudwatch_log_group.example: Creation complete after 3s [id=turbottest39373]
aws_iam_role.example: Creation complete after 4s [id=turbottest39373]
aws_iam_role_policy.example: Creating...
aws_iam_role_policy.example: Creation complete after 2s [id=turbottest39373:turbottest39373]
aws_vpc.main: Still creating... [10s elapsed]
aws_vpc.main: Creation complete after 11s [id=vpc-0b53542b528bb158d]
aws_flow_log.named_test_resource: Creating...
aws_flow_log.named_test_resource: Creation complete after 3s [id=fl-07dddbd48165b00e5]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = 013122550996
log_group_arn = arn:aws:logs:us-east-1:013122550996:log-group:turbottest39373
resource_aka = arn:aws:ec2:us-east-1:013122550996:vpc-flow-log/fl-07dddbd48165b00e5
resource_id = fl-07dddbd48165b00e5
resource_name = turbottest39373
role_arn = arn:aws:iam::013122550996:role/turbottest39373

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:013122550996:vpc-flow-log/fl-07dddbd48165b00e5"
    ],
    "deliver_logs_permission_arn": "arn:aws:iam::013122550996:role/turbottest39373",
    "flow_log_id": "fl-07dddbd48165b00e5",
    "log_destination": "arn:aws:logs:us-east-1:013122550996:log-group:turbottest39373",
    "log_destination_type": "cloud-watch-logs",
    "log_format": "${version} ${account-id} ${interface-id} ${srcaddr} ${dstaddr} ${srcport} ${dstport} ${protocol} ${packets} ${bytes} ${start} ${end} ${action} ${log-status}",
    "log_group_name": "turbottest39373",
    "tags": {
      "Name": "turbottest39373"
    },
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest39373"
      }
    ],
    "title": "turbottest39373",
    "traffic_type": "ALL"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:013122550996:vpc-flow-log/fl-07dddbd48165b00e5"
    ],
    "flow_log_id": "fl-07dddbd48165b00e5",
    "tags": {
      "Name": "turbottest39373"
    },
    "title": "turbottest39373"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:013122550996:vpc-flow-log/fl-07dddbd48165b00e5"
    ],
    "flow_log_id": "fl-07dddbd48165b00e5",
    "tags": {
      "Name": "turbottest39373"
    },
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest39373"
      }
    ],
    "title": "turbottest39373",
    "traffic_type": "ALL"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

POSTTEST: tests/aws_vpc_flow_log

TEARDOWN: tests/aws_vpc_flow_log

SUMMARY:

1/1 passed.


```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
➜  steampipe-plugin-aws git:(issue-228) ✗ steampipe query
Welcome to Steampipe v0.3.2
For more information, type .help
> select flow_log_id, creation_time, flow_log_status from aws_new.aws_vpc_flow_log where  flow_log_id = 'fl-0f6ef79a99cab7725'
+----------------------+---------------------+-----------------+
| flow_log_id          | creation_time       | flow_log_status |
+----------------------+---------------------+-----------------+
| fl-0f6ef79a99cab7725 | 2021-03-22 11:10:07 | ACTIVE          |
+----------------------+---------------------+-----------------+

```
</details>
