### PR TITLE
Fix browse tables link

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ from
 
 ## Documentation
 
-- **[Table definitions & examples →](aws/tables)**
+- **[Table definitions & examples →](/plugins/aws/tables)**
 
 ## Get started
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,7 +41,7 @@ from
 
 ## Documentation
 
-- **[Table definitions & examples →](/plugins/aws/tables)**
+- **[Table definitions & examples →](/plugins/turbot/aws/tables)**
 
 ## Get started
 


### PR DESCRIPTION
changed link in index.md to be qualified from the root of the website 

`aws/tables` to `/plugins/turbot/aws/tables`
