### PR TITLE
Fix incorrect instance profile ARN data in aws_iam_role table fixes #285

### DIFF
--- a/aws-test/tests/aws_iam_role/test-get-expected.json
+++ b/aws-test/tests/aws_iam_role/test-get-expected.json
@@ -21,33 +21,27 @@
     "assume_role_policy_std": {
       "Statement": [
         {
-          "Action": [
-            "sts:assumerole"
-          ],
+          "Action": ["sts:assumerole"],
           "Effect": "Allow",
           "Principal": {
-            "Service": [
-              "ec2.amazonaws.com"
-            ]
+            "Service": ["ec2.amazonaws.com"]
           },
           "Sid": "test"
         }
       ],
       "Version": "2012-10-17"
     },
-    "attached_policy_arns": [
-      "{{ output.attached_policy_arn.value }}"
-    ],
+    "attached_policy_arns": ["{{ output.attached_policy_arn.value }}"],
     "description": "Test Role",
-    "inline_policies": "<null>",
+    "inline_policies": null,
     "max_session_duration": 3600,
     "name": "{{resourceName}}",
     "partition": "{{ output.aws_partition.value }}",
     "path": "/",
-    "permissions_boundary_arn": "<null>",
-    "permissions_boundary_type": "<null>",
-    "role_last_used_date": "<null>",
-    "role_last_used_region": "<null>",
+    "permissions_boundary_arn": null,
+    "permissions_boundary_type": null,
+    "role_last_used_date": null,
+    "role_last_used_region": null,
     "tags": {
       "name": "{{resourceName}}"
     },

--- a/aws-test/tests/aws_iam_role/test-hydrate-expected.json
+++ b/aws-test/tests/aws_iam_role/test-hydrate-expected.json
@@ -1,12 +1,10 @@
 [
   {
     "arn": "{{ output.resource_aka.value }}",
-    "attached_policy_arns": [
-      "{{ output.attached_policy_arn.value }}"
-    ],
-    "inline_policies": "<null>",
+    "attached_policy_arns": ["{{ output.attached_policy_arn.value }}"],
+    "inline_policies": null,
     "name": "{{resourceName}}",
-    "permissions_boundary_arn": "<null>",
+    "permissions_boundary_arn": null,
     "tags_src": [
       {
         "Key": "name",

--- a/aws/table_aws_iam_role.go
+++ b/aws/table_aws_iam_role.go
@@ -245,18 +245,11 @@ func getAwsIamInstanceProfileData(ctx context.Context, d *plugin.QueryData, h *p
 		return nil, err
 	}
 
-	/*
-		instanceProfileData, err := svc.ListInstanceProfilesForRole(params)
-		if err != nil {
-			return nil, err
-		}
-	*/
+	var associatedInstanceProfileArns []string
 
 	params := &iam.ListInstanceProfilesForRoleInput{
 		RoleName: role.RoleName,
 	}
-
-	var associatedInstanceProfileArns []string
 
 	err = svc.ListInstanceProfilesForRolePages(
 		params,
@@ -267,14 +260,6 @@ func getAwsIamInstanceProfileData(ctx context.Context, d *plugin.QueryData, h *p
 			return !lastPage
 		},
 	)
-
-	/*
-		if instanceProfileData.InstanceProfiles != nil {
-			for _, instanceProfile := range instanceProfileData.InstanceProfiles {
-				associatedInstanceProfileArns = append(associatedInstanceProfileArns, *instanceProfile.Arn)
-			}
-		}
-	*/
 
 	return associatedInstanceProfileArns, err
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Codys-MacBook-Pro:aws-test cbruno$ node tint.js aws_iam_role
No env file present for the current environment:  staging
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_iam_role []

PRETEST: tests/aws_iam_role

TEST: tests/aws_iam_role
Running terraform
aws_iam_policy.named_test_resource: Creating...
aws_iam_role.named_test_resource: Creating...
aws_iam_policy.named_test_resource: Creation complete after 0s [id=arn:aws:iam::828685001623:policy/turbottest30593]
aws_iam_role.named_test_resource: Creation complete after 0s [id=turbottest30593]
aws_iam_role_policy_attachment.test-attach: Creating...
aws_iam_role_policy_attachment.test-attach: Creation complete after 1s [id=turbottest30593-20210405200914496300000001]

Warning: Deprecated Resource

  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "828685001623"
attached_policy_arn = "arn:aws:iam::828685001623:policy/turbottest30593"
aws_partition = "aws"
resource_aka = "arn:aws:iam::828685001623:role/turbottest30593"
resource_name = "turbottest30593"

Running SQL query: query.sql
[
  {
    "arn": "arn:aws:iam::828685001623:role/turbottest30593",
    "name": "turbottest30593"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "account_id": "828685001623",
    "akas": [
      "arn:aws:iam::828685001623:role/turbottest30593"
    ],
    "arn": "arn:aws:iam::828685001623:role/turbottest30593",
    "assume_role_policy": {
      "Statement": [
        {
          "Action": "sts:AssumeRole",
          "Effect": "Allow",
          "Principal": {
            "Service": "ec2.amazonaws.com"
          },
          "Sid": "test"
        }
      ],
      "Version": "2012-10-17"
    },
    "assume_role_policy_std": {
      "Statement": [
        {
          "Action": [
            "sts:assumerole"
          ],
          "Effect": "Allow",
          "Principal": {
            "Service": [
              "ec2.amazonaws.com"
            ]
          },
          "Sid": "test"
        }
      ],
      "Version": "2012-10-17"
    },
    "attached_policy_arns": [
      "arn:aws:iam::828685001623:policy/turbottest30593"
    ],
    "description": "Test Role",
    "inline_policies": null,
    "max_session_duration": 3600,
    "name": "turbottest30593",
    "partition": "aws",
    "path": "/",
    "permissions_boundary_arn": null,
    "permissions_boundary_type": null,
    "role_last_used_date": null,
    "role_last_used_region": null,
    "tags": {
      "name": "turbottest30593"
    },
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest30593"
      }
    ],
    "title": "turbottest30593"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "arn": "arn:aws:iam::828685001623:role/turbottest30593",
    "attached_policy_arns": [
      "arn:aws:iam::828685001623:policy/turbottest30593"
    ],
    "inline_policies": null,
    "name": "turbottest30593",
    "permissions_boundary_arn": null,
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest30593"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:iam::828685001623:role/turbottest30593",
    "name": "turbottest30593"
  }
]
✔ PASSED

POSTTEST: tests/aws_iam_role

TEARDOWN: tests/aws_iam_role

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
