### PR TITLE
Fix same method name in `aws_redshift_event_subscription` and `aws_redshift_parameter_group` table. Closes #295

### DIFF
--- a/aws/table_aws_redshift_event_subscription.go
+++ b/aws/table_aws_redshift_event_subscription.go
@@ -93,7 +93,7 @@ func tableAwsRedshiftEventSubscription(_ context.Context) *plugin.Table {
 				Name:        "tags",
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Tags").Transform(tagSubListToTurbotTags),
+				Transform:   transform.FromField("Tags").Transform(redshiftEventSubListToTurbotTags),
 			},
 			{
 				Name:        "akas",
@@ -197,8 +197,8 @@ func getAwsRedshiftEventSubscriptionAkas(ctx context.Context, d *plugin.QueryDat
 
 //// TRANSFORM FUNCTION
 
-func tagSubListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("tagSubListToTurbotTags")
+func redshiftEventSubListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("redshiftEventSubListToTurbotTags")
 
 	tagList := d.HydrateItem.(*redshift.EventSubscription)
 

--- a/aws/table_aws_redshift_event_subscription.go
+++ b/aws/table_aws_redshift_event_subscription.go
@@ -93,7 +93,7 @@ func tableAwsRedshiftEventSubscription(_ context.Context) *plugin.Table {
 				Name:        "tags",
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Tags").Transform(tagListToTurbotTags),
+				Transform:   transform.FromField("Tags").Transform(tagSubListToTurbotTags),
 			},
 			{
 				Name:        "akas",
@@ -197,8 +197,8 @@ func getAwsRedshiftEventSubscriptionAkas(ctx context.Context, d *plugin.QueryDat
 
 //// TRANSFORM FUNCTION
 
-func tagListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("tagListToTurbotTags")
+func tagSubListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("tagSubListToTurbotTags")
 
 	tagList := d.HydrateItem.(*redshift.EventSubscription)
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
