### PR TITLE
Add support to query CertificateTransparencyLoggingPreference status in aws_acm_certificate. Closes #258

### DIFF
--- a/aws/table_aws_acm_certificate.go
+++ b/aws/table_aws_acm_certificate.go
@@ -33,7 +33,6 @@ func tableAwsAcmCertificate(_ context.Context) *plugin.Table {
 				Name:        "certificate_arn",
 				Description: "Amazon Resource Name (ARN) of the certificate. This is of the form: arn:aws:acm:region:123456789012:certificate/12345678-1234-1234-1234-123456789012",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Certificate.CertificateArn"),
 			},
 			{
 				Name:        "certificate",
@@ -51,119 +50,127 @@ func tableAwsAcmCertificate(_ context.Context) *plugin.Table {
 				Name:        "domain_name",
 				Description: "Fully qualified domain name (FQDN), such as www.example.com or example.com, for the certificate",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Certificate.DomainName"),
 				Hydrate:     getAwsAcmCertificateAttributes,
+			},
+			{
+				Name:        "certificate_transparency_logging_preference",
+				Description: "Indicates whether to opt in to or out of certificate transparency logging. Certificates that are not logged typically generate a browser error. Transparency makes it possible for you to detect SSL/TLS certificates that have been mistakenly or maliciously issued for your domain.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsAcmCertificateAttributes,
+				Transform:   transform.FromField("Options.CertificateTransparencyLoggingPreference"),
 			},
 			{
 				Name:        "created_at",
 				Description: "The time at which the certificate was requested. This value exists only when the certificate type is AMAZON_ISSUED",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromField("Certificate.CreatedAt"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "subject",
 				Description: "The name of the entity that is associated with the public key contained in the certificate",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Certificate.Subject"),
+				Hydrate:     getAwsAcmCertificateAttributes,
+			},
+			{
+				Name:        "imported_at",
+				Description: "The name of the certificate authority that issued and signed the certificate",
+				Type:        proto.ColumnType_TIMESTAMP,
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "issuer",
 				Description: "The name of the certificate authority that issued and signed the certificate",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Certificate.Issuer"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "signature_algorithm",
 				Description: "The algorithm that was used to sign the certificate",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Certificate.SignatureAlgorithm"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "failure_reason",
 				Description: "The reason the certificate request failed. This value exists only when the certificate status is FAILED",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Certificate.FailureReason"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "issued_at",
 				Description: "A list of ARNs for the AWS resources that are using the certificate. A certificate can be used by multiple AWS resources",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromField("Certificate.IssuedAt"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "status",
 				Description: "The status of the certificate",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Certificate.Status"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "key_algorithm",
 				Description: "The algorithm that was used to generate the public-private key pair",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Certificate.KeyAlgorithm"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "not_after",
 				Description: "The time after which the certificate is not valid",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromField("Certificate.NotAfter"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "not_before",
 				Description: "The time before which the certificate is not valid",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromField("Certificate.NotBefore"),
+				Hydrate:     getAwsAcmCertificateAttributes,
+			},
+			{
+				Name:        "renewal_eligibility",
+				Description: "Specifies whether the certificate is eligible for renewal.",
+				Type:        proto.ColumnType_STRING,
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "revocation_reason",
 				Description: "The reason the certificate was revoked. This value exists only when the certificate status is REVOKED",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Certificate.RevocationReason"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "revoked_at",
 				Description: "The time at which the certificate was revoked. This value exists only when the certificate status is REVOKED",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromField("Certificate.RevokedAt"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "serial",
 				Description: "The serial number of the certificate",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Certificate.Serial"),
+				Hydrate:     getAwsAcmCertificateAttributes,
+			},
+			{
+				Name:        "type",
+				Description: "The source of the certificate. For certificates provided by ACM, this value is AMAZON_ISSUED.",
+				Type:        proto.ColumnType_STRING,
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "domain_validation_options",
 				Description: "Contains information about the initial validation of each domain name that occurs as a result of the RequestCertificate request. This field exists only when the certificate type is AMAZON_ISSUED",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Certificate.DomainValidationOptions"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "in_use_by",
 				Description: "A list of ARNs for the AWS resources that are using the certificate",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Certificate.InUseBy"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "subject_alternative_names",
 				Description: "One or more domain names (subject alternative names) included in the certificate. This list contains the domain names that are bound to the public key that is contained in the certificate. The subject alternative names include the canonical domain name (CN) of the certificate and additional domain names that can be used to connect to the website",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Certificate.SubjectAlternativeNames"),
 				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
@@ -173,11 +180,13 @@ func tableAwsAcmCertificate(_ context.Context) *plugin.Table {
 				Hydrate:     listTagsForAcmCertificate,
 				Transform:   transform.FromField("Tags"),
 			},
+
+			// Steampipe standard columns
 			{
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Certificate.CertificateArn").Transform(certificateArnToTitle),
+				Transform:   transform.FromField("CertificateArn").Transform(certificateArnToTitle),
 			},
 			{
 				Name:        "tags",
@@ -190,7 +199,7 @@ func tableAwsAcmCertificate(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Certificate.CertificateArn").Transform(arnToAkas),
+				Transform:   transform.FromField("CertificateArn").Transform(arnToAkas),
 			},
 		}),
 	}
@@ -214,10 +223,8 @@ func listAwsAcmCertificates(ctx context.Context, d *plugin.QueryData, _ *plugin.
 		&acm.ListCertificatesInput{},
 		func(page *acm.ListCertificatesOutput, lastPage bool) bool {
 			for _, certificate := range page.CertificateSummaryList {
-				d.StreamListItem(ctx, &acm.DescribeCertificateOutput{
-					Certificate: &acm.CertificateDetail{
-						CertificateArn: certificate.CertificateArn,
-					},
+				d.StreamListItem(ctx, &acm.CertificateDetail{
+					CertificateArn: certificate.CertificateArn,
 				})
 			}
 			return !lastPage
@@ -240,7 +247,7 @@ func getAwsAcmCertificateAttributes(ctx context.Context, d *plugin.QueryData, h 
 
 	var arn string
 	if h.Item != nil {
-		arn = *h.Item.(*acm.DescribeCertificateOutput).Certificate.CertificateArn
+		arn = *h.Item.(*acm.CertificateDetail).CertificateArn
 	} else {
 		arn = d.KeyColumnQuals["certificate_arn"].GetStringValue()
 	}
@@ -254,13 +261,13 @@ func getAwsAcmCertificateAttributes(ctx context.Context, d *plugin.QueryData, h 
 		log.Println("[DEBUG] getAwsAcmCertificateAttributes__", "ERROR", err)
 		return nil, err
 	}
-	return detail, nil
+	return detail.Certificate, nil
 }
 
 func getAwsAcmCertificateProperties(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	plugin.Logger(ctx).Trace("getAwsAcmCertificateProperties")
-	item := h.Item.(*acm.DescribeCertificateOutput)
+	item := h.Item.(*acm.CertificateDetail)
 
 	// Create session
 	svc, err := ACMService(ctx, d, region)
@@ -269,7 +276,7 @@ func getAwsAcmCertificateProperties(ctx context.Context, d *plugin.QueryData, h 
 	}
 
 	detail, err := svc.GetCertificate(&acm.GetCertificateInput{
-		CertificateArn: item.Certificate.CertificateArn,
+		CertificateArn: item.CertificateArn,
 	})
 
 	if err != nil {
@@ -281,7 +288,7 @@ func getAwsAcmCertificateProperties(ctx context.Context, d *plugin.QueryData, h 
 func listTagsForAcmCertificate(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := plugin.GetMatrixItem(ctx)[matrixKeyRegion].(string)
 	plugin.Logger(ctx).Trace("listTagsForAcmCertificate")
-	item := h.Item.(*acm.DescribeCertificateOutput)
+	item := h.Item.(*acm.CertificateDetail)
 
 	// Create session
 	svc, err := ACMService(ctx, d, region)
@@ -291,11 +298,10 @@ func listTagsForAcmCertificate(ctx context.Context, d *plugin.QueryData, h *plug
 
 	// Build param
 	param := &acm.ListTagsForCertificateInput{
-		CertificateArn: item.Certificate.CertificateArn,
+		CertificateArn: item.CertificateArn,
 	}
 
 	certificateTags, err := svc.ListTagsForCertificate(param)
-
 	if err != nil {
 		return nil, err
 	}
@@ -318,6 +324,7 @@ func certificateTurbotTags(_ context.Context, d *transform.TransformData) (inter
 
 func certificateArnToTitle(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	item := types.SafeString(d.Value)
+
 	// Get the resource title
 	title := item[strings.LastIndex(item, "/")+1:]
 

--- a/docs/tables/aws_acm_certificate.md
+++ b/docs/tables/aws_acm_certificate.md
@@ -4,7 +4,7 @@ AWS Certificate Manager (ACM) handles the complexity of creating, storing, and r
 
 ## Examples
 
-### Basic ACM certificate info
+### Basic info
 
 ```sql
 select
@@ -33,7 +33,21 @@ where
 ```
 
 
-### List of ACM certificates without application tag key
+### List certificates for which transparency logging is disabled
+
+```sql
+select
+  certificate_arn,
+  domain_name,
+  status
+from
+  aws_acm_certificate
+where
+  certificate_transparency_logging_preference <> 'ENABLED';
+```
+
+
+### List certificates without application tag key
 
 ```sql
 select


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/aws_acm_certificate []

PRETEST: tests/aws_acm_certificate

TEST: tests/aws_acm_certificate
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_partition.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
tls_private_key.example: Creating...
tls_private_key.example: Creation complete after 0s [id=4fe1c12dc73a6c275ca0db63cada3e17a2710c09]
tls_self_signed_cert.example: Creating...
tls_self_signed_cert.example: Creation complete after 0s [id=243652078250898666809132085765261986387]
aws_acm_certificate.named_test_resource: Creating...
aws_acm_certificate.named_test_resource: Creation complete after 4s [id=arn:aws:acm:us-east-1:123456789012:certificate/9e4e5d55-846b-4ee3-afa4-1f4f1b259925]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = 123456789012
aws_region = us-east-1
certificate_body = -----BEGIN CERTIFICATE-----\nMIIDJjCCAg6gAwIBAgIRALdNrvAgtJdQnYkh37eXilMwDQYJKoZIhvcNAQELBQAw\nMzEcMBoGA1UEChMTVHVyYm90IEhRIFB2dC4gTHRkLjETMBEGA1UEAxMKdHVyYm90\nLmNvbTAeFw0yMTA0MDcwOTIzMDRaFw0yMTA0MDcyMTIzMDRaMDMxHDAaBgNVBAoT\nE1R1cmJvdCBIUSBQdnQuIEx0ZC4xEzARBgNVBAMTCnR1cmJvdC5jb20wggEiMA0G\nCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIKU8RnzuHOpy2PFfL7hcnmqYAmwYU\nW12jX4V/ERD4YSDvUgRS0C++IcjS+9yztCMoGWBzbWEn2+GUBdu4Bw3Ofm+vqWp3\neD6AcHIHnXMkfBVe9CWeE74skF8B1g/FGMHaFL8gxcKJcUoK8M5L0n6WQBYOqCCi\npk5T+B6HPkqZXPjMhcza0460i16WqQIXJV4lJHj45yBSBb5/o0rcWfiSgka/usUy\nH3vxm1e+pUg0dTL0dqyR3Uey/T6nNNs2PeFHD2iMXMr7MwMzf4Ufx2sdlvxMS3KD\nmM+SL7XzSmCuW4Vls5DcCO3diPXuB+SKVtugWXOIQs76erITmy6W3+ajAgMBAAGj\nNTAzMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMB\nAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQB7sy1grCKtj4veorpVWCXutOLw2Qg/\nYSZXGgjT8CdIhznnY7mCPNBjRGPieuPgDqbOyoWskMV4cajWifsUeemvFGTP6Xw/\nDwCnTX0Rd+Op4oY76/HY444cfOwQnKboI8G/md3CZatIUbDO2PvgYq7cy8yKINkW\nriXq2uSAPP5eLIhyp0joV0iSvv3WYQOr5WZArFp7T8eR+gtHHmz7C0x6Gl9V+IMS\nbDRrog7MZhQh5WYO0GYoFHTKBkvKb5pUZmYadel6VCiwpems3hAXDzDqh3yGBkt6\nOXDr3t8x1kh7xsvXtXGJQIgQxqQCkUCviY2HWE3XkeOR4JLEsnr7I1ac\n-----END CERTIFICATE-----\n
resource_aka = arn:aws:acm:us-east-1:986325076436:certificate/9e4e5d55-846b-4ee3-afa4-1f4f1b259925
resource_name = turbottest86049

Running SQL query: test-get-certificate-chain-query.sql
[
  {
    "certificate": "-----BEGIN CERTIFICATE-----\nMIIDJjCCAg6gAwIBAgIRALdNrvAgtJdQnYkh37eXilMwDQYJKoZIhvcNAQELBQAw\nMzEcMBoGA1UEChMTVHVyYm90IEhRIFB2dC4gTHRkLjETMBEGA1UEAxMKdHVyYm90\nLmNvbTAeFw0yMTA0MDcwOTIzMDRaFw0yMTA0MDcyMTIzMDRaMDMxHDAaBgNVBAoT\nE1R1cmJvdCBIUSBQdnQuIEx0ZC4xEzARBgNVBAMTCnR1cmJvdC5jb20wggEiMA0G\nCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIKU8RnzuHOpy2PFfL7hcnmqYAmwYU\nW12jX4V/ERD4YSDvUgRS0C++IcjS+9yztCMoGWBzbWEn2+GUBdu4Bw3Ofm+vqWp3\neD6AcHIHnXMkfBVe9CWeE74skF8B1g/FGMHaFL8gxcKJcUoK8M5L0n6WQBYOqCCi\npk5T+B6HPkqZXPjMhcza0460i16WqQIXJV4lJHj45yBSBb5/o0rcWfiSgka/usUy\nH3vxm1e+pUg0dTL0dqyR3Uey/T6nNNs2PeFHD2iMXMr7MwMzf4Ufx2sdlvxMS3KD\nmM+SL7XzSmCuW4Vls5DcCO3diPXuB+SKVtugWXOIQs76erITmy6W3+ajAgMBAAGj\nNTAzMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMB\nAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQB7sy1grCKtj4veorpVWCXutOLw2Qg/\nYSZXGgjT8CdIhznnY7mCPNBjRGPieuPgDqbOyoWskMV4cajWifsUeemvFGTP6Xw/\nDwCnTX0Rd+Op4oY76/HY444cfOwQnKboI8G/md3CZatIUbDO2PvgYq7cy8yKINkW\nriXq2uSAPP5eLIhyp0joV0iSvv3WYQOr5WZArFp7T8eR+gtHHmz7C0x6Gl9V+IMS\nbDRrog7MZhQh5WYO0GYoFHTKBkvKb5pUZmYadel6VCiwpems3hAXDzDqh3yGBkt6\nOXDr3t8x1kh7xsvXtXGJQIgQxqQCkUCviY2HWE3XkeOR4JLEsnr7I1ac\n-----END CERTIFICATE-----\n",
    "certificate_chain": "-----BEGIN CERTIFICATE-----\nMIIDJjCCAg6gAwIBAgIRALdNrvAgtJdQnYkh37eXilMwDQYJKoZIhvcNAQELBQAw\nMzEcMBoGA1UEChMTVHVyYm90IEhRIFB2dC4gTHRkLjETMBEGA1UEAxMKdHVyYm90\nLmNvbTAeFw0yMTA0MDcwOTIzMDRaFw0yMTA0MDcyMTIzMDRaMDMxHDAaBgNVBAoT\nE1R1cmJvdCBIUSBQdnQuIEx0ZC4xEzARBgNVBAMTCnR1cmJvdC5jb20wggEiMA0G\nCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDIKU8RnzuHOpy2PFfL7hcnmqYAmwYU\nW12jX4V/ERD4YSDvUgRS0C++IcjS+9yztCMoGWBzbWEn2+GUBdu4Bw3Ofm+vqWp3\neD6AcHIHnXMkfBVe9CWeE74skF8B1g/FGMHaFL8gxcKJcUoK8M5L0n6WQBYOqCCi\npk5T+B6HPkqZXPjMhcza0460i16WqQIXJV4lJHj45yBSBb5/o0rcWfiSgka/usUy\nH3vxm1e+pUg0dTL0dqyR3Uey/T6nNNs2PeFHD2iMXMr7MwMzf4Ufx2sdlvxMS3KD\nmM+SL7XzSmCuW4Vls5DcCO3diPXuB+SKVtugWXOIQs76erITmy6W3+ajAgMBAAGj\nNTAzMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMB\nAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQB7sy1grCKtj4veorpVWCXutOLw2Qg/\nYSZXGgjT8CdIhznnY7mCPNBjRGPieuPgDqbOyoWskMV4cajWifsUeemvFGTP6Xw/\nDwCnTX0Rd+Op4oY76/HY444cfOwQnKboI8G/md3CZatIUbDO2PvgYq7cy8yKINkW\nriXq2uSAPP5eLIhyp0joV0iSvv3WYQOr5WZArFp7T8eR+gtHHmz7C0x6Gl9V+IMS\nbDRrog7MZhQh5WYO0GYoFHTKBkvKb5pUZmYadel6VCiwpems3hAXDzDqh3yGBkt6\nOXDr3t8x1kh7xsvXtXGJQIgQxqQCkUCviY2HWE3XkeOR4JLEsnr7I1ac\n-----END CERTIFICATE-----\n"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "certificate_arn": "arn:aws:acm:us-east-1:123456789012:certificate/9e4e5d55-846b-4ee3-afa4-1f4f1b259925",
    "domain_name": "turbot.com",
    "in_use_by": [],
    "issuer": "Turbot HQ Pvt. Ltd."
  }
]
✔ PASSED

Running SQL query: test-get-tags-query.sql
[
  {
    "tags": {
      "name": "turbottest86049"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:acm:us-east-1:123456789012:certificate/9e4e5d55-846b-4ee3-afa4-1f4f1b259925"
    ],
    "certificate_arn": "arn:aws:acm:us-east-1:123456789012:certificate/9e4e5d55-846b-4ee3-afa4-1f4f1b259925",
    "domain_name": "turbot.com",
    "title": "9e4e5d55-846b-4ee3-afa4-1f4f1b259925"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "123456789012",
    "akas": [
      "arn:aws:acm:us-east-1:123456789012:certificate/9e4e5d55-846b-4ee3-afa4-1f4f1b259925"
    ],
    "region": "us-east-1",
    "title": "9e4e5d55-846b-4ee3-afa4-1f4f1b259925"
  }
]
✔ PASSED

POSTTEST: tests/aws_acm_certificate

TEARDOWN: tests/aws_acm_certificate

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
### List certificates for which transparency logging is disabled

```sql
select
  certificate_arn,
  domain_name,
  status
from
  aws_acm_certificate
where
  certificate_transparency_logging_preference <> 'ENABLED';
```
```
+-------------------------------------------------------------------------------------+-------------+--------+
| certificate_arn                                                                     | domain_name | status |
+-------------------------------------------------------------------------------------+-------------+--------+
| arn:aws:acm:us-east-1:123456789012:certificate/9d2c60ba-96cb-4097-aec4-fe36ff5a23a1 | rups.com    | ISSUED |
+-------------------------------------------------------------------------------------+-------------+--------+
```
</details>
