### PR TITLE
Adds metadata columns to ec2_iam_instance table

### DIFF
--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -124,7 +124,7 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 			{
 				Name:        "metadata_options",
 				Description: "The metadata options for the instance.",
-				Type:        proto.ColumnType_STRING,
+				Type:        proto.ColumnType_JSON,
 			},
 			{
 				Name:        "outpost_arn",

--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -287,7 +287,7 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Transform:   transform.FromValue(),
 			},
 			{
-				Name:        "metadata_options_state",
+				Name:        "metadata_options_http_endpoint",
 				Description: "Indicates whether the instance metadata service is enabled (disabled | enabled).",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("MetadataOptions.HttpEndpoint"),

--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -122,6 +122,11 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
 			{
+				Name:        "metadata_options",
+				Description: "The metadata options for the instance.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "outpost_arn",
 				Description: "The Amazon Resource Name (ARN) of the Outpost, if applicable.",
 				Type:        proto.ColumnType_STRING,
@@ -284,18 +289,6 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsEc2InstanceTurbotData,
 				Transform:   transform.FromValue(),
-			},
-			{
-				Name:        "metadata_options_http_endpoint",
-				Description: "Indicates whether the instance metadata service is enabled (disabled | enabled).",
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("MetadataOptions.HttpEndpoint"),
-			},
-			{
-				Name:        "metadata_options_http_tokens",
-				Description: "Indicates whether IMDSv2 auth tokens are requrired to retrieve instance metadata (optional | required).",
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("MetadataOptions.HttpTokens"),
 			},
 		}),
 	}

--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -121,6 +121,7 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Description: "The time the instance was launched.",
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
+
 			{
 				Name:        "outpost_arn",
 				Description: "The Amazon Resource Name (ARN) of the Outpost, if applicable.",
@@ -284,6 +285,18 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsEc2InstanceTurbotData,
 				Transform:   transform.FromValue(),
+			},
+			{
+				Name:        "metadata_options_state",
+				Description: "Indicates whether the instance metadata service is enabled (disabled | enabled).",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("MetadataOptions.HttpEndpoint"),
+			},
+			{
+				Name:        "metadata_options_http_tokens",
+				Description: "Indicates whether IMDSv2 auth tokens are requrired to retrieve instance metadata (optional | required).",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("MetadataOptions.HttpTokens"),
 			},
 		}),
 	}

--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -121,7 +121,6 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Description: "The time the instance was launched.",
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
-
 			{
 				Name:        "outpost_arn",
 				Description: "The Amazon Resource Name (ARN) of the Outpost, if applicable.",


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```sql
select
  i.instance_id,
  i.metadata_options_http_endpoint as imds_enabled,
  i.metadata_options_http_tokens as imdsv2,
  r.title as role_name
from
  aws_ec2_instance as i,
  aws_iam_role as r
where
  r.instance_profile_arns::jsonb ? i.iam_instance_profile_arn;

+---------------------+--------------+----------+----------------------------------+
| instance_id         | imds_enabled | imdsv2   | role_name                        |
+---------------------+--------------+----------+----------------------------------+
| i-0dc60dd191cb86539 | enabled      | optional | turbot_default_ec2_instance_role |
| i-022a51a815773780d | enabled      | optional | turbot_default_ec2_instance_role |
| i-0e97f373db22dfa3f | enabled      | optional | turbot_default_ec2_instance_role |
| i-00cfa26db9b8a58b6 | enabled      | optional | turbot_default_ec2_instance_role |
+---------------------+--------------+----------+----------------------------------+
```

</details>
