### PR TITLE
[FIX] Query example for aws_iam_server_certificate not working as expected. Closes #308

### DIFF
--- a/docs/tables/aws_iam_server_certificate.md
+++ b/docs/tables/aws_iam_server_certificate.md
@@ -27,5 +27,5 @@ select
 from
   aws_iam_server_certificate
 where
-  expiration > (current_date - interval '1' second);
+  expiration < now()::timestamp;
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select now()::timestamp
+---------------------+
| now                 |
+---------------------+
| 2021-04-12 06:31:25 |
+---------------------+
> select
  name,
  arn,
  expiration
from
  aws_iam_server_certificate
where
  expiration < now()::timestamp;
+------------------------------------+---------------------------------------------------------------------------------+---------------------+
| name                               | arn                                                                             | expiration          |
+------------------------------------+---------------------------------------------------------------------------------+---------------------+
| turbot-test-20200125-create-update | arn:aws:iam::123456789012:server-certificate/turbot-test-20200125-create-update | 2021-04-10 18:35:03 |
+------------------------------------+---------------------------------------------------------------------------------+---------------------+
```

```
> select now()::timestamp
+---------------------+
| now                 |
+---------------------+
| 2021-04-12 06:35:13 |
+---------------------+
> 
> 
> 
> select name, expiration from aws_iam_server_certificate
+------------------------------------+---------------------+
| name                               | expiration          |
+------------------------------------+---------------------+
| turbot-test-20200126-create-update | 2021-04-12 18:34:33 |
+------------------------------------+---------------------+
> 
> 
> select
  name,
  arn,
  expiration
from
  aws_iam_server_certificate
where
  expiration < now()::timestamp;
+------+-----+------------+
| name | arn | expiration |
+------+-----+------------+
+------+-----+------------+
```
</details>