### PR TITLE
Add column to store Auto Scaling Enabled/Disabled property in aws_dynamodb_table. Closes #314

### DIFF
--- a/aws/service.go
+++ b/aws/service.go
@@ -52,6 +52,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/ssm"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/aws-sdk-go/service/wellarchitected"
+	"github.com/aws/aws-sdk-go/service/applicationautoscaling"
 
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 )
@@ -114,6 +115,27 @@ func APIGatewayV2Service(ctx context.Context, d *plugin.QueryData, region string
 		return nil, err
 	}
 	svc := apigatewayv2.New(sess)
+	d.ConnectionManager.Cache.Set(serviceCacheKey, svc)
+
+	return svc, nil
+}
+
+// ApplicationAutoscalingService returns the service connection for AWS ACM service
+func ApplicationAutoscalingService(ctx context.Context, d *plugin.QueryData, region string) (*applicationautoscaling.ApplicationAutoScaling, error) {
+	if region == "" {
+		return nil, fmt.Errorf("region must be passed ApplicationAutoscalingService")
+	}
+	// have we already created and cached the service?
+	serviceCacheKey := fmt.Sprintf("applicationautoscaling-%s", region)
+	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
+		return cachedData.(*applicationautoscaling.ApplicationAutoScaling), nil
+	}
+	// so it was not in cache - create service
+	sess, err := getSession(ctx, d, region)
+	if err != nil {
+		return nil, err
+	}
+	svc := applicationautoscaling.New(sess)
 	d.ConnectionManager.Cache.Set(serviceCacheKey, svc)
 
 	return svc, nil


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
select
  name,
  scalable_target ->> 'ScalableDimension' scalable_dimension
from
  aws_dynamodb_table,
  jsonb_array_elements(scalable_targets) scalable_target
where
  scalable_target ->> 'ScalableDimension' = 'dynamodb:table:ReadCapacityUnits'
  or scalable_target ->> 'ScalableDimension' = 'dynamodb:table:WriteCapacityUnits';
```
```
+------------+-----------------------------------+
| name       | scalable_dimension                |
+------------+-----------------------------------+
| testtable1 | dynamodb:table:ReadCapacityUnits  |
| testtable1 | dynamodb:table:WriteCapacityUnits |
+------------+-----------------------------------+
```
</details>
