### PR TITLE
Update hardcoded 'aws' to dynamic reference to partition in akas and arns.  Closes #320

### DIFF
--- a/aws-test/tests/aws_s3_bucket/test-hydrate-expected.json
+++ b/aws-test/tests/aws_s3_bucket/test-hydrate-expected.json
@@ -32,12 +32,12 @@
             "Prefix": "log/",
             "Tags": [
               {
-                "Key": "autoclean",
-                "Value": "true"
-              },
-              {
                 "Key": "rule",
                 "Value": "log"
+              },
+              {
+                "Key": "autoclean",
+                "Value": "true"
               }
             ]
           },
@@ -82,7 +82,7 @@
         "Transitions": null
       }
     ],
-    "logging": "<null>",
+    "logging": null,
     "name": "{{ resourceName }}",
     "policy": {
       "Id": "MYBUCKETPOLICY",
@@ -130,7 +130,7 @@
       ],
       "Version": "2012-10-17"
     },
-    "replication": "<null>",
+    "replication": null,
     "server_side_encryption_configuration": {
       "Rules": [
         {

--- a/aws-test/tests/aws_s3_bucket/test-list-expected.json
+++ b/aws-test/tests/aws_s3_bucket/test-list-expected.json
@@ -20,12 +20,12 @@
             "Prefix": "log/",
             "Tags": [
               {
-                "Key": "autoclean",
-                "Value": "true"
-              },
-              {
                 "Key": "rule",
                 "Value": "log"
+              },
+              {
+                "Key": "autoclean",
+                "Value": "true"
               }
             ]
           },
@@ -70,7 +70,7 @@
         "Transitions": null
       }
     ],
-    "logging": "<null>",
+    "logging": null,
     "name": "{{resourceName}}",
     "partition": "{{ output.aws_partition.value }}",
     "restrict_public_buckets": false,

--- a/aws/table_aws_iam_policy.go
+++ b/aws/table_aws_iam_policy.go
@@ -218,8 +218,10 @@ func isPolicyAwsManaged(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 
 	commonColumnData := c.(*awsCommonColumnData)
 
-	// TODO arn:{{ partition }}:iam::aws:policy
-	if strings.HasPrefix(*policy.Arn, "arn:"+commonColumnData.Partition+":iam::"+commonColumnData.Partition+":policy") {
+	// policy arn for aws managed policy
+	// arn:aws-us-gov:iam::aws:policy/aws-service-role/AccessAnalyzerServiceRolePolicy in us gov cloud
+	// arn:aws:iam::aws:policy/aws-service-role/AccessAnalyzerServiceRolePolicy in commercial cloud
+	if strings.HasPrefix(*policy.Arn, "arn:"+commonColumnData.Partition+":iam::aws:policy") {
 		return true, nil
 	}
 

--- a/aws/table_aws_s3_bucket.go
+++ b/aws/table_aws_s3_bucket.go
@@ -206,7 +206,7 @@ func tableAwsS3Bucket(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getBucketARN,
-				Transform:   transform.FromValue().Transform(arnToAkas),
+				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
 			},
 			{
 				Name:        "region",

--- a/aws/table_aws_s3_bucket.go
+++ b/aws/table_aws_s3_bucket.go
@@ -205,7 +205,8 @@ func tableAwsS3Bucket(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.From(s3NameToAkas),
+				Hydrate:     getBucketARN,
+				Transform:   transform.FromValue().Transform(arnToAkas),
 			},
 			{
 				Name:        "region",
@@ -590,12 +591,6 @@ func getBucketARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 }
 
 //// TRANSFORM FUNCTIONS
-
-func s3NameToAkas(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("s3NameToAkas")
-	bucket := d.HydrateItem.(*s3.Bucket)
-	return []string{"arn:aws:s3:::" + *bucket.Name}, nil
-}
 
 func s3TagsToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("s3TagsToTurbotTags")


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_s3_bucket []

PRETEST: tests/aws_s3_bucket

TEST: tests/aws_s3_bucket
Running terraform
aws_kms_key.mykey: Creating...
aws_kms_key.mykey: Creation complete after 6s [id=6059c096-85a3-43ad-b473-9eb41f88bd39]
aws_s3_bucket.named_test_resource: Creating...
aws_s3_bucket.named_test_resource: Still creating... [10s elapsed]
aws_s3_bucket.named_test_resource: Still creating... [20s elapsed]
aws_s3_bucket.named_test_resource: Creation complete after 27s [id=turbottest44403]
aws_s3_bucket_policy.b: Creating...
aws_s3_bucket_policy.b: Creation complete after 2s [id=turbottest44403]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "013122550996"
aws_partition = "aws"
canonical_user_id = "26e5574fa16859426a6540699e6e3fe6ac1e8758991572c1ffe9a36671cb4570"
kms_key_id = "arn:aws:kms:us-east-2:013122550996:key/6059c096-85a3-43ad-b473-9eb41f88bd39"
resource_aka = "arn:aws:s3:::turbottest44403"
resource_name = "turbottest44403"

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:s3:::turbottest44403"
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "acl": {
      "Grants": [
        {
          "Grantee": {
            "DisplayName": null,
            "EmailAddress": null,
            "ID": "26e5574fa16859426a6540699e6e3fe6ac1e8758991572c1ffe9a36671cb4570",
            "Type": "CanonicalUser",
            "URI": null
          },
          "Permission": "FULL_CONTROL"
        }
      ],
      "Owner": {
        "DisplayName": null,
        "ID": "26e5574fa16859426a6540699e6e3fe6ac1e8758991572c1ffe9a36671cb4570"
      }
    },
    "bucket_policy_is_public": false,
    "lifecycle_rules": [
      {
        "AbortIncompleteMultipartUpload": null,
        "Expiration": {
          "Date": null,
          "Days": 90,
          "ExpiredObjectDeleteMarker": null
        },
        "Filter": {
          "And": {
            "Prefix": "log/",
            "Tags": [
              {
                "Key": "rule",
                "Value": "log"
              },
              {
                "Key": "autoclean",
                "Value": "true"
              }
            ]
          },
          "Prefix": null,
          "Tag": null
        },
        "ID": "log",
        "NoncurrentVersionExpiration": null,
        "NoncurrentVersionTransitions": null,
        "Prefix": null,
        "Status": "Enabled",
        "Transitions": [
          {
            "Date": null,
            "Days": 30,
            "StorageClass": "STANDARD_IA"
          },
          {
            "Date": null,
            "Days": 60,
            "StorageClass": "GLACIER"
          }
        ]
      },
      {
        "AbortIncompleteMultipartUpload": null,
        "Expiration": {
          "Date": "2022-01-12T00:00:00Z",
          "Days": null,
          "ExpiredObjectDeleteMarker": null
        },
        "Filter": {
          "And": null,
          "Prefix": "tmp/",
          "Tag": null
        },
        "ID": "tmp",
        "NoncurrentVersionExpiration": null,
        "NoncurrentVersionTransitions": null,
        "Prefix": null,
        "Status": "Enabled",
        "Transitions": null
      }
    ],
    "logging": null,
    "name": "turbottest44403",
    "policy": {
      "Id": "MYBUCKETPOLICY",
      "Statement": [
        {
          "Action": "s3:*",
          "Condition": {
            "IpAddress": {
              "aws:SourceIp": "8.8.8.8/32"
            }
          },
          "Effect": "Deny",
          "Principal": "*",
          "Resource": "arn:aws:s3:::turbottest44403/*",
          "Sid": "IPAllow"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Id": "MYBUCKETPOLICY",
      "Statement": [
        {
          "Action": [
            "s3:*"
          ],
          "Condition": {
            "IpAddress": {
              "aws:sourceip": [
                "8.8.8.8/32"
              ]
            }
          },
          "Effect": "Deny",
          "Principal": {
            "AWS": [
              "*"
            ]
          },
          "Resource": [
            "arn:aws:s3:::turbottest44403/*"
          ],
          "Sid": "IPAllow"
        }
      ],
      "Version": "2012-10-17"
    },
    "replication": null,
    "server_side_encryption_configuration": {
      "Rules": [
        {
          "ApplyServerSideEncryptionByDefault": {
            "KMSMasterKeyID": "arn:aws:kms:us-east-2:013122550996:key/6059c096-85a3-43ad-b473-9eb41f88bd39",
            "SSEAlgorithm": "aws:kms"
          },
          "BucketKeyEnabled": false
        }
      ]
    },
    "versioning_enabled": true,
    "versioning_mfa_delete": false
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:s3:::turbottest44403"
    ],
    "block_public_acls": false,
    "block_public_policy": false,
    "bucket_policy_is_public": false,
    "ignore_public_acls": false,
    "lifecycle_rules": [
      {
        "AbortIncompleteMultipartUpload": null,
        "Expiration": {
          "Date": null,
          "Days": 90,
          "ExpiredObjectDeleteMarker": null
        },
        "Filter": {
          "And": {
            "Prefix": "log/",
            "Tags": [
              {
                "Key": "rule",
                "Value": "log"
              },
              {
                "Key": "autoclean",
                "Value": "true"
              }
            ]
          },
          "Prefix": null,
          "Tag": null
        },
        "ID": "log",
        "NoncurrentVersionExpiration": null,
        "NoncurrentVersionTransitions": null,
        "Prefix": null,
        "Status": "Enabled",
        "Transitions": [
          {
            "Date": null,
            "Days": 30,
            "StorageClass": "STANDARD_IA"
          },
          {
            "Date": null,
            "Days": 60,
            "StorageClass": "GLACIER"
          }
        ]
      },
      {
        "AbortIncompleteMultipartUpload": null,
        "Expiration": {
          "Date": "2022-01-12T00:00:00Z",
          "Days": null,
          "ExpiredObjectDeleteMarker": null
        },
        "Filter": {
          "And": null,
          "Prefix": "tmp/",
          "Tag": null
        },
        "ID": "tmp",
        "NoncurrentVersionExpiration": null,
        "NoncurrentVersionTransitions": null,
        "Prefix": null,
        "Status": "Enabled",
        "Transitions": null
      }
    ],
    "logging": null,
    "name": "turbottest44403",
    "partition": "aws",
    "restrict_public_buckets": false,
    "server_side_encryption_configuration": {
      "Rules": [
        {
          "ApplyServerSideEncryptionByDefault": {
            "KMSMasterKeyID": "arn:aws:kms:us-east-2:013122550996:key/6059c096-85a3-43ad-b473-9eb41f88bd39",
            "SSEAlgorithm": "aws:kms"
          },
          "BucketKeyEnabled": false
        }
      ]
    },
    "tags": {
      "name": "turbottest44403"
    },
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest44403"
      }
    ],
    "title": "turbottest44403",
    "versioning_enabled": true,
    "versioning_mfa_delete": false
  }
]
✔ PASSED

POSTTEST: tests/aws_s3_bucket

TEARDOWN: tests/aws_s3_bucket

SUMMARY:

1/1 passed.


SETUP: tests/aws_iam_policy []

PRETEST: tests/aws_iam_policy

TEST: tests/aws_iam_policy
Running terraform
aws_iam_policy.named_test_resource: Creating...
aws_iam_policy.named_test_resource: Creation complete after 3s [id=arn:aws:iam::013122550996:policy/turbottest15795]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "013122550996"
aws_partition = "aws"
resource_aka = "arn:aws:iam::013122550996:policy/turbottest15795"
resource_id = "arn:aws:iam::013122550996:policy/turbottest15795"
resource_name = "turbottest15795"

Running SQL query: query.sql
[
  {
    "arn": "arn:aws:iam::013122550996:policy/turbottest15795",
    "name": "turbottest15795",
    "policy": {
      "Statement": [
        {
          "Action": [
            "ec2:Describe*"
          ],
          "Effect": "Allow",
          "Resource": "*"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Statement": [
        {
          "Action": [
            "ec2:describe*"
          ],
          "Effect": "Allow",
          "Resource": [
            "*"
          ]
        }
      ],
      "Version": "2012-10-17"
    }
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:iam::013122550996:policy/turbottest15795",
    "attachment_count": 0,
    "default_version_id": "v1",
    "is_attachable": true,
    "name": "turbottest15795",
    "path": "/",
    "permissions_boundary_usage_count": 0,
    "title": "turbottest15795"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:iam::013122550996:policy/turbottest15795"
    ],
    "name": "turbottest15795",
    "policy": {
      "Statement": [
        {
          "Action": [
            "ec2:Describe*"
          ],
          "Effect": "Allow",
          "Resource": "*"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Statement": [
        {
          "Action": [
            "ec2:describe*"
          ],
          "Effect": "Allow",
          "Resource": [
            "*"
          ]
        }
      ],
      "Version": "2012-10-17"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:iam::013122550996:policy/turbottest15795",
    "name": "turbottest15795"
  }
]
✔ PASSED

POSTTEST: tests/aws_iam_policy

TEARDOWN: tests/aws_iam_policy

SUMMARY:

1/1 passed.


```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
