### PR TITLE
[WIP] Add aws_ecs_container_instance table

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -74,6 +74,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_ec2_transit_gateway_vpc_attachment": tableAwsEc2TransitGatewayVpcAttachment(ctx),
 			"aws_ecr_repository":                     tableAwsEcrRepository(ctx),
 			"aws_ecs_cluster":                        tableAwsEcsCluster(ctx),
+			"aws_ecs_container_instance":             tableAwsEcsContainerInstance(ctx),
 			"aws_ecs_task_definition":                tableAwsEcsTaskDefinition(ctx),
 			"aws_efs_access_point":                   tableAwsEfsAccessPoint(ctx),
 			"aws_efs_file_system":                    tableAwsElasticFileSystem(ctx),

--- a/aws/table_aws_ecs_container_instance.go
+++ b/aws/table_aws_ecs_container_instance.go
@@ -1,0 +1,315 @@
+package aws
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ecs"
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+)
+
+func tableAwsEcsContainerInstance(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_ecs_container",
+		Description: "AWS ECS Container",
+		Get: &plugin.GetConfig{
+			KeyColumns:        plugin.SingleColumn("container_instance_arn"),
+			Hydrate:    getEcsContainerInstance,
+
+		},
+		List: &plugin.ListConfig{
+			ParentHydrate:  listEcsClusters,
+			Hydrate: listEcsContainerInstances,
+		},
+		GetMatrixItem: BuildRegionList,
+		Columns: awsS3Columns([]*plugin.Column{
+			{
+				Name:        "container_instance_arn",
+				Description: "The namespace Amazon Resource Name (ARN) of the cluster.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ContainerInstanceArn"),
+			},
+			{
+				Name:        "instance_id",
+				Description: "The EC2 instance ID of the container instance.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Ec2InstanceId"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "agent_connected",
+				Description: "True if the agent is connected to Amazon ECS.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromField("AgentConnected"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "agent_update_status",
+				Description: "The status of the most recent agent update.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("AgentUpdateStatus"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "attachments",
+				Description: "The resources attached to a container instance, such as elastic network interfaces.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Attachments"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "attributes",
+				Description: "The attributes set for the container instance.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Attributes"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "capacity_provider_name",
+				Description: "The capacity provider associated with the container instance.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("CapacityProviderName"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "pending_tasks_count",
+				Description: "The number of tasks on the container instance that are in the PENDING status.",
+				Type:        proto.ColumnType_INT,
+				// TODO: this is a 64bit int, make sure ColumnType_INT will work
+				Transform:   transform.FromField("PendingTasksCount"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "registered_at",
+				Description: "The Unix timestamp for when the container instance was registered.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("RegisteredAt"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "registered_resources",
+				Description: "CPU and memory that can be allocated on this container instance to tasks.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("RegisteredResources"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "remaining_resources",
+				Description: "CPU and memory that is available for new tasks.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("RemainingResources"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "running_tasks_count",
+				Description: "CPU and memory that is available for new tasks.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("RunningTasksCount"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "status",
+				Description: "The status of the container instance.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Status"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "status_reason",
+				Description: "The reason that the container instance reached its current status.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("StatusReason"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "version",
+				Description: "The reason that the container instance reached its current status.",
+				// TODO: This is a 64 bit int, make sure we're using the right column type
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("Version"),
+				Hydrate: getEcsContainerInstance,
+			},
+			{
+				Name:        "version_info",
+				Description: "Version information for the Amazon ECS container agent and Docker daemon running on the container instance.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("VersionInfo"),
+				Hydrate: getEcsContainerInstance,
+			},
+			//{
+			//	Name:        "tags",
+			//	Description: resourceInterfaceDescription("tags"),
+			//	Type:        proto.ColumnType_JSON,
+			//	Hydrate:     getAwsEcsClusterTags,
+			//	Transform:   transform.From(getAwsEcsTurbotTags),
+			//},
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ContainerInstanceArn"),
+			},
+			{
+				Name:        "akas",
+				Description: resourceInterfaceDescription("akas"),
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("ContainerInstanceArn").Transform(arnToAkas),
+			},
+		}),
+	}
+}
+
+func containerInstanceArnFromKey(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	quals := d.KeyColumnQuals
+	clusterArn := quals["container_instance_arn"].GetStringValue()
+	item := &ecs.Cluster{
+		ClusterArn: &clusterArn,
+	}
+	return item, nil
+}
+
+//// LIST FUNCTION
+
+func listEcsContainerInstances(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("listEcsContainerInstances")
+
+	var region string
+	matrixRegion := plugin.GetMatrixItem(ctx)[matrixKeyRegion]
+	if matrixRegion != nil {
+		region = matrixRegion.(string)
+	}
+
+	// Create Session
+	svc, err := EcsService(ctx, d, region)
+	if err != nil {
+		return nil, err
+	}
+
+	var clusterArn string
+	if h.Item != nil {
+		clusterArn = *h.Item.(*ecs.Cluster).ClusterArn
+	} else {
+		clusterArn = d.KeyColumnQuals["cluster_arn"].GetStringValue()
+	}
+
+	// execute list call
+	err = svc.ListContainerInstancesPages(
+		&ecs.ListContainerInstancesInput{
+			Cluster: aws.String(clusterArn),
+		},
+		func(page *ecs.ListContainerInstancesOutput, isLast bool) bool {
+			for _, arn := range page.ContainerInstanceArns {
+				d.StreamListItem(ctx, &ecs.ContainerInstance{ContainerInstanceArn: arn})
+			}
+			return !isLast
+		},
+	)
+	return nil, err
+}
+
+//// HYDRATE FUNCTIONS
+
+// do not have a get call for s3 bucket.
+// using list api call to create get function
+func getEcsContainerInstance(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("describeEcsContainerInstance")
+	var region string
+	matrixRegion := plugin.GetMatrixItem(ctx)[matrixKeyRegion]
+	if matrixRegion != nil {
+		region = matrixRegion.(string)
+	}
+
+	var containerInstanceArn string
+	if h.Item != nil {
+		containerInstanceArn = *h.Item.(*ecs.ContainerInstance).ContainerInstanceArn
+	} else {
+		containerInstanceArn = d.KeyColumnQuals["container_instances_arn"].GetStringValue()
+	}
+
+	clusterArn := clusterArnFromContainerInstanceArn(containerInstanceArn)
+
+	// Create Session
+	svc, err := EcsService(ctx, d, region)
+	if err != nil {
+		return nil, err
+	}
+
+	// execute list call
+	input := &ecs.DescribeContainerInstancesInput{
+		Cluster: aws.String(clusterArn),
+		ContainerInstances: []*string{aws.String(containerInstanceArn)},
+		Include: []*string{aws.String("TAGS")},
+	}
+	result, err := svc.DescribeContainerInstances(input)
+	if err != nil {
+		return nil, err
+	}
+
+	if result.ContainerInstances != nil && len(result.ContainerInstances) > 0 {
+		return result.ContainerInstances[0], nil
+	}
+
+	return nil, nil
+}
+
+// clusterArnFromContainerInstanceArn returns the ClusterArn associated with a given container instance.
+func clusterArnFromContainerInstanceArn(arn string) string {
+	// Example ARN: arn:aws:ecs:us-east-1:111111111111:container-instance/test
+	parts := strings.Split(arn, ":")
+	resource := strings.Split(parts[5], "/")
+	resource[0] = "cluster"
+
+	parts[5] = strings.Join(resource[0:2], "/")
+	return strings.Join(parts, ":")
+}
+
+//func getContainerInstanceTagging(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+//	plugin.Logger(ctx).Trace("getBucketTagging")
+//	bucket := h.Item.(*s3.Bucket)
+//	location := h.HydrateResults["getBucketLocation"].(*s3.GetBucketLocationOutput)
+//
+//	// Create Session
+//	svc, err := S3Service(ctx, d, *location.LocationConstraint)
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	params := &s3.GetBucketTaggingInput{
+//		Bucket: bucket.Name,
+//	}
+//
+//	bucketTags, _ := svc.GetBucketTagging(params)
+//	if err != nil {
+//		return nil, err
+//	}
+//
+//	return bucketTags, nil
+//}
+//
+
+func getContainerInstanceARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getAwsEcsContainerInstanceArn")
+	return h.Item.(*ecs.ContainerInstance).ContainerInstanceArn, nil
+}
+
+//// TRANSFORM FUNCTIONS
+
+func containerInstanceTagsToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("s3TagsToTurbotTags")
+	tags := d.Value.([]*s3.Tag)
+
+	// Mapping the resource tags inside turbotTags
+	var turbotTagsMap map[string]string
+	if tags != nil {
+		turbotTagsMap = map[string]string{}
+		for _, i := range tags {
+			turbotTagsMap[*i.Key] = *i.Value
+		}
+	}
+
+	return turbotTagsMap, nil
+}


### PR DESCRIPTION
This is a work in progress, just wanted to open a PR for now to track it or get feedback earlier than later if needed.

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_ecs_container_instance;
-[ RECORD 1  ]---------------------------------------------------------------------------
container_instance_arn | arn:aws:ecs:us-east-1:922105094392:container-instance/test2/e0c999bd9eb64fc6a7719d9ca480ae26
instance_id            | i-024755e0ea05037fb
agent_connected        | true
agent_update_status    | <null>
attachments            | []
attributes             | [{"Name":"ecs.capability.secrets.asm.environment-variables","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.branch-cni-plugin-version","TargetId":null,"TargetType":null,"Value":"a21d3a41-"},{"Name":"ecs.ami-id","TargetId":null,"TargetType":null,"Value":"ami-0be13a99cd970f6a9"},{"Name":"ecs.capability.secrets.asm.bootstrap.log-driver","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.task-eia.optimized-cpu","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.logging-driver.none","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.ecr-endpoint","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.docker-plugin.local","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.task-cpu-mem-limit","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.secrets.ssm.bootstrap.log-driver","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.efsAuth","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.full-sync","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.30","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.31","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.32","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.logging-driver.fluentd","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.firelens.options.config.file","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.availability-zone","TargetId":null,"TargetType":null,"Value":"us-east-1b"},{"Name":"ecs.capability.aws-appmesh","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.logging-driver.awslogs","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.24","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.25","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.task-eni-trunking","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.26","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.27","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.28","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.privileged-container","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.29","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.cpu-architecture","TargetId":null,"TargetType":null,"Value":"x86_64"},{"Name":"ecs.capability.firelens.fluentbit","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.ecr-auth","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.20","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.os-type","TargetId":null,"TargetType":null,"Value":"linux"},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.21","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.22","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.23","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.private-registry-authentication.secretsmanager","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.task-eia","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.logging-driver.syslog","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.logging-driver.awsfirelens","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.firelens.options.config.s3","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.logging-driver.json-file","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.execution-role-awslogs","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.vpc-id","TargetId":null,"TargetType":null,"Value":"vpc-04a91864355539a41"},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.17","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.18","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.docker-remote-api.1.19","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.docker-plugin.amazon-ecs-volume-plugin","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.task-eni","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.firelens.fluentd","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.efs","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.execution-role-ecr-pull","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.task-eni.ipv6","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.container-health-check","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.execute-command","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.subnet-id","TargetId":null,"TargetType":null,"Value":"subnet-0e56cd55282fa9158"},{"Name":"ecs.instance-type","TargetId":null,"TargetType":null,"Value":"t2.medium"},{"Name":"com.amazonaws.ecs.capability.task-iam-role-network-host","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.container-ordering","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.cni-plugin-version","TargetId":null,"TargetType":null,"Value":"55b2ae77-2020.09.0"},{"Name":"ecs.capability.env-files.s3","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.secrets.ssm.environment-variables","TargetId":null,"TargetType":null,"Value":null},{"Name":"ecs.capability.pid-ipc-namespace-sharing","TargetId":null,"TargetType":null,"Value":null},{"Name":"com.amazonaws.ecs.capability.task-iam-role","TargetId":null,"TargetType":null,"Value":null}]
capacity_provider_name | <null>
pending_tasks_count    | 0
registered_at          | 2021-04-23 04:16:36
registered_resources   | [{"DoubleValue":0,"IntegerValue":2048,"LongValue":0,"Name":"CPU","StringSetValue":null,"Type":"INTEGER"},{"DoubleValue":0,"IntegerValue":3942,"LongValue":0,"Name":"MEMORY","StringSetValue":null,"Type":"INTEGER"},{"DoubleValue":0,"IntegerValue":0,"LongValue":0,"Name":"PORTS","StringSetValue":["22","2376","2375","51678","51679"],"Type":"STRINGSET"},{"DoubleValue":0,"IntegerValue":0,"LongValue":0,"Name":"PORTS_UDP","StringSetValue":[],"Type":"STRINGSET"}]
remaining_resources    | [{"DoubleValue":0,"IntegerValue":2048,"LongValue":0,"Name":"CPU","StringSetValue":null,"Type":"INTEGER"},{"DoubleValue":0,"IntegerValue":3942,"LongValue":0,"Name":"MEMORY","StringSetValue":null,"Type":"INTEGER"},{"DoubleValue":0,"IntegerValue":0,"LongValue":0,"Name":"PORTS","StringSetValue":["22","2376","2375","51678","51679"],"Type":"STRINGSET"},{"DoubleValue":0,"IntegerValue":0,"LongValue":0,"Name":"PORTS_UDP","StringSetValue":[],"Type":"STRINGSET"}]
running_tasks_count    | 0
status                 | ACTIVE
status_reason          | <null>
version                | 15
version_info           | {"AgentHash":"5c821610","AgentVersion":"1.51.0","DockerVersion":"DockerVersion: 19.03.13-ce"}
title                  | arn:aws:ecs:us-east-1:922105094392:container-instance/test2/e0c999bd9eb64fc6a7719d9ca480ae26
akas                   | ["arn:aws:ecs:us-east-1:922105094392:container-instance/test2/e0c999bd9eb64fc6a7719d9ca480ae26"]
partition              | aws
account_id             | 922105094392
```
</details>
