### PR TITLE
Getting an error as Error: NotFound: Topic does not exist, status code: 404 from aws_sns_topic_subscription table. Closes #335

### DIFF
--- a/aws-test/tests/aws_sns_topic_subscription/test-get-subscription-attributes-expected.json
+++ b/aws-test/tests/aws_sns_topic_subscription/test-get-subscription-attributes-expected.json
@@ -1,11 +1,11 @@
 [
   {
     "confirmation_was_authenticated": true,
-    "delivery_policy": "<null>",
-    "effective_delivery_policy": "<null>",
-    "filter_policy": "<null>",
+    "delivery_policy": null,
+    "effective_delivery_policy": null,
+    "filter_policy": null,
     "pending_confirmation": false,
     "raw_message_delivery": false,
-    "redrive_policy": "<null>"
+    "redrive_policy": null
   }
 ]

--- a/aws/table_aws_sns_topic_subscription.go
+++ b/aws/table_aws_sns_topic_subscription.go
@@ -32,7 +32,7 @@ func tableAwsSnsTopicSubscription(_ context.Context) *plugin.Table {
 				Name:        "subscription_arn",
 				Description: "Amazon Resource Name of the subscription.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Attributes.SubscriptionArn").Transform(subscriptionArnNotconformStatus),
+				Transform:   transform.FromField("Attributes.SubscriptionArn").NullIfEqual("PendingConfirmation"),
 			},
 			{
 				Name:        "topic_arn",
@@ -206,17 +206,6 @@ func getSubscriptionAttributes(ctx context.Context, d *plugin.QueryData, h *plug
 }
 
 //// TRANSFORM FUNCTIONS
-
-func subscriptionArnNotconformStatus(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("pendingConfirmationArn")
-	arn := types.SafeString(d.Value)
-
-	if arn == "PendingConfirmation" {
-		return "null", nil
-	}
-
-	return arn, nil
-}
 
 func subscriptionArnToAkas(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	arn := types.SafeString(d.Value)


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
vishalkumar@Vishals-MacBook-Air aws-test % TURBOT_PROFILE=shaktiman TF_VAR_aws_profile=shaktiman ./tint.js tests/aws_sns_topic_subscription
No env file present for the current environment:  staging
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_sns_topic_subscription []

PRETEST: tests/aws_sns_topic_subscription

TEST: tests/aws_sns_topic_subscription
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_sqs_queue.aws_sns_subscription: Creating...
aws_sns_topic.aws_sns_subscription: Creating...
aws_sns_topic.aws_sns_subscription: Creation complete after 4s [id=arn:aws:sns:us-east-1:123456789012:turbottest53265]
aws_sqs_queue.aws_sns_subscription: Creation complete after 4s [id=https://sqs.us-east-1.amazonaws.com/123456789012/turbottest53265]
aws_sns_topic_subscription.named_test_resource: Creating...
aws_sns_topic_subscription.named_test_resource: Creation complete after 5s [id=arn:aws:sns:us-east-1:123456789012:turbottest53265:8c3017e6-f431-4c43-ad29-6ac454b68f68]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = 123456789012
aws_partition = aws
aws_region = us-east-1
endpoint = arn:aws:sqs:us-east-1:123456789012:turbottest53265
resource_aka = arn:aws:sns:us-east-1:123456789012:turbottest53265:8c3017e6-f431-4c43-ad29-6ac454b68f68
resource_name = turbottest53265
topic_arn = arn:aws:sns:us-east-1:123456789012:turbottest53265

Running SQL query: test-get-query.sql
[
  {
    "endpoint": "arn:aws:sqs:us-east-1:123456789012:turbottest53265",
    "protocol": "sqs",
    "topic_arn": "arn:aws:sns:us-east-1:123456789012:turbottest53265"
  }
]
✔ PASSED

Running SQL query: test-get-subscription-attributes-query.sql
[
  {
    "confirmation_was_authenticated": true,
    "delivery_policy": null,
    "effective_delivery_policy": null,
    "filter_policy": null,
    "pending_confirmation": false,
    "raw_message_delivery": false,
    "redrive_policy": null
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "endpoint": "arn:aws:sqs:us-east-1:123456789012:turbottest53265",
    "owner": "123456789012",
    "protocol": "sqs",
    "subscription_arn": "arn:aws:sns:us-east-1:123456789012:turbottest53265:8c3017e6-f431-4c43-ad29-6ac454b68f68",
    "topic_arn": "arn:aws:sns:us-east-1:123456789012:turbottest53265"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "123456789012",
    "akas": [
      "arn:aws:sns:us-east-1:123456789012:turbottest53265:8c3017e6-f431-4c43-ad29-6ac454b68f68"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "title": "8c3017e6-f431-4c43-ad29-6ac454b68f68"
  }
]
✔ PASSED

POSTTEST: tests/aws_sns_topic_subscription

TEARDOWN: tests/aws_sns_topic_subscription

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
