### PR TITLE
Add a column in aws_redshift_cluster table to store audit logging information. Closes #333

### DIFF
--- a/aws/table_aws_redshift_cluster.go
+++ b/aws/table_aws_redshift_cluster.go
@@ -388,7 +388,7 @@ func getRedshiftLoggingDetails(ctx context.Context, d *plugin.QueryData, h *plug
 		region = matrixRegion.(string)
 	}
 
-	name := *h.Item.(*redshift.Cluster).ClusterIdentifier
+	name := h.Item.(*redshift.Cluster).ClusterIdentifier
 
 	// Create service
 	svc, err := RedshiftService(ctx, d, region)
@@ -397,7 +397,7 @@ func getRedshiftLoggingDetails(ctx context.Context, d *plugin.QueryData, h *plug
 	}
 
 	params := &redshift.DescribeLoggingStatusInput{
-		ClusterIdentifier: aws.String(name),
+		ClusterIdentifier: name,
 	}
 
 	op, err := svc.DescribeLoggingStatus(params)

--- a/aws/table_aws_redshift_cluster.go
+++ b/aws/table_aws_redshift_cluster.go
@@ -265,7 +265,7 @@ func tableAwsRedshiftCluster(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
-				Name:        "logging_details",
+				Name:        "logging_status",
 				Description: "Describes the status of logging for a cluster.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getRedshiftLoggingDetails,

--- a/aws/table_aws_redshift_cluster.go
+++ b/aws/table_aws_redshift_cluster.go
@@ -255,12 +255,6 @@ func tableAwsRedshiftCluster(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "tags_src",
-				Description: "The list of tags for the cluster.",
-				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Tags"),
-			},
-			{
 				Name:        "vpc_id",
 				Description: "The identifier of the VPC the cluster is in, if the cluster is in a VPC.",
 				Type:        proto.ColumnType_STRING,
@@ -269,6 +263,19 @@ func tableAwsRedshiftCluster(_ context.Context) *plugin.Table {
 				Name:        "vpc_security_groups",
 				Description: "A list of Amazon Virtual Private Cloud (Amazon VPC) security groups that are associated with the cluster. This parameter is returned only if the cluster is in a VPC.",
 				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "logging_details",
+				Description: "Describes the status of logging for a cluster.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getRedshiftLoggingDetails,
+				Transform:   transform.FromValue(),
+			},
+			{
+				Name:        "tags_src",
+				Description: "The list of tags for the cluster.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Tags"),
 			},
 			// Standard columns
 			{
@@ -371,6 +378,39 @@ func getRedshiftCluster(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 		return op.Clusters[0], nil
 	}
 	return nil, nil
+}
+
+func getRedshiftLoggingDetails(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	// TODO Put me in helper function
+	var region string
+	matrixRegion := plugin.GetMatrixItem(ctx)[matrixKeyRegion]
+	if matrixRegion != nil {
+		region = matrixRegion.(string)
+	}
+
+	var name string
+	if h.Item != nil {
+		name = *h.Item.(*redshift.Cluster).ClusterIdentifier
+	} else {
+		name = d.KeyColumnQuals["cluster_identifier"].GetStringValue()
+	}
+
+	// Create service
+	svc, err := RedshiftService(ctx, d, region)
+	if err != nil {
+		return nil, err
+	}
+
+	params := &redshift.DescribeLoggingStatusInput{
+		ClusterIdentifier: aws.String(name),
+	}
+
+	op, err := svc.DescribeLoggingStatus(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
 }
 
 func getRedshiftClusterAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/aws/table_aws_redshift_cluster.go
+++ b/aws/table_aws_redshift_cluster.go
@@ -388,12 +388,7 @@ func getRedshiftLoggingDetails(ctx context.Context, d *plugin.QueryData, h *plug
 		region = matrixRegion.(string)
 	}
 
-	var name string
-	if h.Item != nil {
-		name = *h.Item.(*redshift.Cluster).ClusterIdentifier
-	} else {
-		name = d.KeyColumnQuals["cluster_identifier"].GetStringValue()
-	}
+	name := *h.Item.(*redshift.Cluster).ClusterIdentifier
 
 	// Create service
 	svc, err := RedshiftService(ctx, d, region)

--- a/docs/tables/aws_redshift_cluster.md
+++ b/docs/tables/aws_redshift_cluster.md
@@ -58,12 +58,14 @@ where
   not encrypted;
 ```
 
-### List clusters audit logging status
+### List logging status for a specific cluster
 
 ```sql
 select
   cluster_identifier,
   logging_details -> 'LoggingEnabled' as LoggingEnabled
 from
-  aws_redshift_cluster;
+  aws_redshift_cluster
+where
+  cluster_identifier = 'redshift-cluster-1';
 ```

--- a/docs/tables/aws_redshift_cluster.md
+++ b/docs/tables/aws_redshift_cluster.md
@@ -16,7 +16,6 @@ from
   aws_redshift_cluster;
 ```
 
-
 ### List clusters that are publicly accessible
 
 ```sql
@@ -30,7 +29,6 @@ from
 where
   publicly_accessible;
 ```
-
 
 ### List clusters that are not in a VPC
 
@@ -46,7 +44,6 @@ where
   vpc_id is null;
 ```
 
-
 ### List clusters whose storage is not encrypted
 
 ```sql
@@ -59,4 +56,14 @@ from
   aws_redshift_cluster
 where
   not encrypted;
+```
+
+### List clusters audit logging status
+
+```sql
+select
+  cluster_identifier,
+  logging_details -> 'LoggingEnabled' as LoggingEnabled
+from
+  aws_redshift_cluster;
 ```

--- a/docs/tables/aws_redshift_cluster.md
+++ b/docs/tables/aws_redshift_cluster.md
@@ -58,7 +58,7 @@ where
   not encrypted;
 ```
 
-### List logging status for a specific cluster
+### Get logging status for each cluster
 
 ```sql
 select
@@ -66,6 +66,4 @@ select
   logging_status -> 'LoggingEnabled' as LoggingEnabled
 from
   aws_redshift_cluster
-where
-  cluster_identifier = 'redshift-cluster-1';
 ```

--- a/docs/tables/aws_redshift_cluster.md
+++ b/docs/tables/aws_redshift_cluster.md
@@ -63,7 +63,7 @@ where
 ```sql
 select
   cluster_identifier,
-  logging_details -> 'LoggingEnabled' as LoggingEnabled
+  logging_status -> 'LoggingEnabled' as LoggingEnabled
 from
   aws_redshift_cluster
 where


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_redshift_cluster []

PRETEST: tests/aws_redshift_cluster

TEST: tests/aws_redshift_cluster
Running terraform
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Still creating... [10s elapsed]
aws_vpc.my_vpc: Creation complete after 19s [id=vpc-03469fa3c39de898d]
aws_internet_gateway.igw: Creating...
aws_internet_gateway.igw: Creation complete after 6s [id=igw-0c8027f1e6942a06d]
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet2: Creation complete after 4s [id=subnet-05121773bfed20728]
aws_subnet.my_subnet1: Creation complete after 5s [id=subnet-04320b80dd353904b]
aws_redshift_subnet_group.my_subnet_group: Creating...
aws_redshift_subnet_group.my_subnet_group: Creation complete after 3s [id=turbottest32649]
aws_redshift_cluster.named_test_resource: Creating...
aws_redshift_cluster.named_test_resource: Still creating... [10s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [20s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [30s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [40s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [50s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m0s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m10s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m20s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m30s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m40s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m50s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m0s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m10s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m20s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m30s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m40s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m50s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [3m0s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [3m10s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [3m20s elapsed]
aws_redshift_cluster.named_test_resource: Creation complete after 3m21s [id=turbottest32649]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: Interpolation-only expressions are deprecated

  on variables.tf line 78, in resource "aws_redshift_subnet_group" "my_subnet_group":
  78:   subnet_ids = ["${aws_subnet.my_subnet1.id}", "${aws_subnet.my_subnet2.id}"]

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.

(and one more similar warning elsewhere)


Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Outputs:

account_id = "013122550996"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:redshift:us-east-1:013122550996:cluster:turbottest32649"
resource_name = "turbottest32649"

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:redshift:us-east-1:013122550996:cluster:turbottest32649"
    ],
    "allow_version_upgrade": true,
    "cluster_identifier": "turbottest32649"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:redshift:us-east-1:013122550996:cluster:turbottest32649"
    ],
    "allow_version_upgrade": true,
    "cluster_identifier": "turbottest32649"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:redshift:us-east-1:013122550996:cluster:turbottest32649"
    ],
    "cluster_identifier": "turbottest32649"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:redshift:us-east-1:013122550996:cluster:turbottest32649"
    ],
    "cluster_identifier": "turbottest32649",
    "tags": {
      "name": "turbottest32649"
    },
    "title": "turbottest32649"
  }
]
✔ PASSED

POSTTEST: tests/aws_redshift_cluster

TEARDOWN: tests/aws_redshift_cluster

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
 select
  cluster_identifier,
  logging_status -> 'LoggingEnabled' as LoggingEnabled
from
  aws_redshift_cluster where cluster_identifier = 'redshift-cluster-1'
+--------------------+----------------+
| cluster_identifier | loggingenabled |
+--------------------+----------------+
| redshift-cluster-1 | false          |
+--------------------+----------------+
```
</details>
