### PR TITLE
Add a column to store "Enable automatic backups" for EFS file system in 'aws_efs_file_system' table. Closes #303

### DIFF
--- a/aws-test/tests/aws_efs_file_system/test-list-expected.json
+++ b/aws-test/tests/aws_efs_file_system/test-list-expected.json
@@ -1,8 +1,7 @@
 [
   {
-    "akas": [
-      "{{ output.resource_aka.value }}"
-    ],
+    "akas": ["{{ output.resource_aka.value }}"],
+    "automatic_backup": "disabled",
     "encrypted": true,
     "file_system_id": "{{ output.resource_id.value }}",
     "performance_mode": "maxIO",

--- a/aws-test/tests/aws_efs_file_system/test-list-expected.json
+++ b/aws-test/tests/aws_efs_file_system/test-list-expected.json
@@ -1,7 +1,7 @@
 [
   {
     "akas": ["{{ output.resource_aka.value }}"],
-    "automatic_backup": "disabled",
+    "automatic_backups": "disabled",
     "encrypted": true,
     "file_system_id": "{{ output.resource_id.value }}",
     "performance_mode": "maxIO",

--- a/aws-test/tests/aws_efs_file_system/test-list-query.sql
+++ b/aws-test/tests/aws_efs_file_system/test-list-query.sql
@@ -1,3 +1,3 @@
-select akas, file_system_id, encrypted, performance_mode, title, tags
+select akas, automatic_backup, file_system_id, encrypted, performance_mode, title, tags
 from aws.aws_efs_file_system
 where akas::text = '["{{ output.resource_aka.value }}"]';

--- a/aws-test/tests/aws_efs_file_system/test-list-query.sql
+++ b/aws-test/tests/aws_efs_file_system/test-list-query.sql
@@ -1,3 +1,3 @@
-select akas, automatic_backup, file_system_id, encrypted, performance_mode, title, tags
+select akas, automatic_backups, file_system_id, encrypted, performance_mode, title, tags
 from aws.aws_efs_file_system
 where akas::text = '["{{ output.resource_aka.value }}"]';

--- a/aws/table_aws_efs_file_system.go
+++ b/aws/table_aws_efs_file_system.go
@@ -62,7 +62,7 @@ func tableAwsElasticFileSystem(_ context.Context) *plugin.Table {
 				Name:        "automatic_backup",
 				Description: "Automatic backups use a default backup plan with the AWS Backup recommended settings for automatic backups.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Tags").Transform(getAutomaticBackupValue),
+				Transform:   transform.FromField("Tags").Transform(automaticBackupValue),
 			},
 			{
 				Name:        "life_cycle_state",
@@ -282,11 +282,8 @@ func getElasticFileSystemTurbotTitle(_ context.Context, d *transform.TransformDa
 	return fileSystemTitle.FileSystemId, nil
 }
 
-func getAutomaticBackupValue(_ context.Context, d *transform.TransformData) (interface{}, error) {
+func automaticBackupValue(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	automaticBackup := d.HydrateItem.(*efs.FileSystemDescription)
-	if automaticBackup.Tags == nil {
-		return "disabled", nil
-	}
 
 	if automaticBackup.Tags != nil {
 		for _, i := range automaticBackup.Tags {

--- a/aws/table_aws_efs_file_system.go
+++ b/aws/table_aws_efs_file_system.go
@@ -59,6 +59,12 @@ func tableAwsElasticFileSystem(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
 			{
+				Name:        "automatic_backup",
+				Description: "Automatic backups use a default backup plan with the AWS Backup recommended settings for automatic backups.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Tags").Transform(getAutomaticBackupValue),
+			},
+			{
 				Name:        "life_cycle_state",
 				Description: "The lifecycle phase of the file system.",
 				Type:        proto.ColumnType_STRING,
@@ -274,4 +280,20 @@ func getElasticFileSystemTurbotTitle(_ context.Context, d *transform.TransformDa
 	}
 
 	return fileSystemTitle.FileSystemId, nil
+}
+
+func getAutomaticBackupValue(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	automaticBackup := d.HydrateItem.(*efs.FileSystemDescription)
+	if automaticBackup.Tags == nil {
+		return "disabled", nil
+	}
+
+	if automaticBackup.Tags != nil {
+		for _, i := range automaticBackup.Tags {
+			if *i.Key == "aws:elasticfilesystem:default-backup" {
+				return *i.Value, nil
+			}
+		}
+	}
+	return "disabled", nil
 }

--- a/aws/table_aws_efs_file_system.go
+++ b/aws/table_aws_efs_file_system.go
@@ -59,10 +59,10 @@ func tableAwsElasticFileSystem(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
 			{
-				Name:        "automatic_backup",
+				Name:        "automatic_backups",
 				Description: "Automatic backups use a default backup plan with the AWS Backup recommended settings for automatic backups.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Tags").Transform(automaticBackupValue),
+				Transform:   transform.FromField("Tags").Transform(automaticBackupsValue),
 			},
 			{
 				Name:        "life_cycle_state",
@@ -282,7 +282,7 @@ func getElasticFileSystemTurbotTitle(_ context.Context, d *transform.TransformDa
 	return fileSystemTitle.FileSystemId, nil
 }
 
-func automaticBackupValue(_ context.Context, d *transform.TransformData) (interface{}, error) {
+func automaticBackupsValue(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	automaticBackup := d.HydrateItem.(*efs.FileSystemDescription)
 
 	if automaticBackup.Tags != nil {

--- a/docs/tables/aws_efs_file_system.md
+++ b/docs/tables/aws_efs_file_system.md
@@ -98,7 +98,7 @@ where
 ```
 
 
-### List file systems that have enable automatic backup
+### List file systems with automatic backup feature enabled
 
 ```sql
 select

--- a/docs/tables/aws_efs_file_system.md
+++ b/docs/tables/aws_efs_file_system.md
@@ -96,3 +96,18 @@ where
       and ssl :: bool = false
   );
 ```
+
+
+### List file systems that have enable automatic backup
+
+```sql
+select
+  name,
+  automatic_backup,
+  file_system_arn,
+  file_system_id
+from
+  aws_efs_file_system
+where
+  automatic_backup = 'enabled';
+```

--- a/docs/tables/aws_efs_file_system.md
+++ b/docs/tables/aws_efs_file_system.md
@@ -11,6 +11,7 @@ select
   name,
   file_system_id,
   owner_id,
+  automatic_backup,
   creation_token,
   creation_time,
   life_cycle_state,

--- a/docs/tables/aws_efs_file_system.md
+++ b/docs/tables/aws_efs_file_system.md
@@ -11,7 +11,7 @@ select
   name,
   file_system_id,
   owner_id,
-  automatic_backup,
+  automatic_backups,
   creation_token,
   creation_time,
   life_cycle_state,
@@ -98,16 +98,16 @@ where
 ```
 
 
-### List file systems with automatic backup feature enabled
+### List file systems with automatic backups enabled
 
 ```sql
 select
   name,
-  automatic_backup,
+  automatic_backups,
   file_system_arn,
   file_system_id
 from
   aws_efs_file_system
 where
-  automatic_backup = 'enabled';
+  automatic_backups = 'enabled';
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_efs_file_system []

PRETEST: tests/aws_efs_file_system

TEST: tests/aws_efs_file_system
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_efs_file_system.named_test_resource: Creating...
aws_efs_file_system.named_test_resource: Creation complete after 8s [id=fs-078753b3]
data.template_file.resource_aka: Refreshing state...
aws_efs_file_system_policy.efs_file_system_policy: Creating...
aws_efs_file_system_policy.efs_file_system_policy: Creation complete after 3s [id=fs-078753b3]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-078753b3
resource_id = fs-078753b3
resource_name = turbottest22148

Running SQL query: test-get-query.sql
[
  {
    "encrypted": true,
    "file_system_id": "fs-078753b3",
    "performance_mode": "maxIO",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest22148"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-078753b3"
    ],
    "file_system_id": "fs-078753b3",
    "policy": {
      "Id": "test_policy",
      "Statement": [
        {
          "Action": [
            "elasticfilesystem:ClientMount",
            "elasticfilesystem:ClientWrite"
          ],
          "Condition": {
            "Bool": {
              "aws:SecureTransport": "true"
            }
          },
          "Effect": "Allow",
          "Principal": {
            "AWS": "*"
          },
          "Resource": "arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-078753b3",
          "Sid": "__default_policy_ID"
        }
      ],
      "Version": "2012-10-17"
    },
    "tags": {
      "name": "turbottest22148"
    },
    "title": "fs-078753b3"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:elasticfilesystem:us-east-1:123456789012:file-system/fs-078753b3"
    ],
    "automatic_backup": "disabled",
    "encrypted": true,
    "file_system_id": "fs-078753b3",
    "performance_mode": "maxIO",
    "tags": {
      "name": "turbottest22148"
    },
    "title": "fs-078753b3"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

POSTTEST: tests/aws_efs_file_system

TEARDOWN: tests/aws_efs_file_system

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
- Basic info

select
  name,
  file_system_id,
  owner_id,
  automatic_backup,
  creation_token,
  creation_time,
  life_cycle_state,
  number_of_mount_targets,
  performance_mode,
  throughput_mode
from
  aws_efs_file_system;

+----------------------------+----------------+--------------+------------------+---------------------------------------------------+---------------------+------------------+-------------------------+------------------+-----------------+
| name                       | file_system_id | owner_id     | automatic_backup | creation_token                                    | creation_time       | life_cycle_state | number_of_mount_targets | performance_mode | throughput_mode |
+----------------------------+----------------+--------------+------------------+---------------------------------------------------+---------------------+------------------+-------------------------+------------------+-----------------+
| test-file-syastem          | fs-3423f680    | 123456789012 | enabled          | quickCreated-8e2630ac-fd8f-4bdf-8ce0-11e5dc26f92e | 2021-04-27 07:30:45 | available        | 6                       | generalPurpose   | bursting        |
| test-steampipe-file-system | fs-c0914574    | 123456789012 | disabled         | quickCreated-e6fc2536-2111-47ef-ad49-e3b085316e85 | 2021-04-27 10:46:06 | available        | 6                       | generalPurpose   | bursting        |
+----------------------------+----------------+--------------+------------------+---------------------------------------------------+---------------------+------------------+-------------------------+------------------+-----------------+

- List file systems that have enable automatic backup

+-------------------+------------------+--------------------------------------------------------------------------+----------------+
| name              | automatic_backup | file_system_arn                                                          | file_system_id |
+-------------------+------------------+--------------------------------------------------------------------------+----------------+
| test-file-syastem | enabled          | arn:aws:elasticfilesystem:us-east-1:986325076436:file-system/fs-3423f680 | fs-3423f680    |
+-------------------+------------------+--------------------------------------------------------------------------+----------------+
```
</details>
