### PR TITLE
Update region table to include default EBS encryption setting. closes #225

### DIFF
--- a/aws-test/tests/aws_region/test-get-expected.json
+++ b/aws-test/tests/aws_region/test-get-expected.json
@@ -4,6 +4,8 @@
     "akas": [
       "arn:{{ output.aws_partition.value }}::ap-south-1:{{ output.account_id.value }}"
     ],
+    "default_ebs_encryption_enabled": false,
+    "default_ebs_encryption_key": "alias/aws/ebs",
     "name": "ap-south-1",
     "opt_in_status": "opt-in-not-required",
     "partition": "{{ output.aws_partition.value }}",

--- a/aws-test/tests/aws_region/test-get-query.sql
+++ b/aws-test/tests/aws_region/test-get-query.sql
@@ -1,4 +1,3 @@
-
 select *
 from aws.aws_region
-where name='ap-south-1'
+where name='ap-south-1';

--- a/aws-test/tests/aws_region/test-list-expected.json
+++ b/aws-test/tests/aws_region/test-list-expected.json
@@ -4,6 +4,8 @@
     "akas": [
       "arn:{{ output.aws_partition.value }}::ap-south-1:{{ output.account_id.value }}"
     ],
+    "default_ebs_encryption_enabled": false,
+    "default_ebs_encryption_key": "alias/aws/ebs",
     "name": "ap-south-1",
     "opt_in_status": "opt-in-not-required",
     "partition": "{{ output.aws_partition.value }}",

--- a/aws-test/tests/aws_region/test-list-query.sql
+++ b/aws-test/tests/aws_region/test-list-query.sql
@@ -1,4 +1,3 @@
-
 select *
 from aws.aws_region
-where akas::text = '["arn:{{ output.aws_partition.value }}::ap-south-1:{{ output.account_id.value }}"]'
+where akas::text = '["arn:{{ output.aws_partition.value }}::ap-south-1:{{ output.account_id.value }}"]';

--- a/aws-test/tests/aws_region/test-notfound-query.sql
+++ b/aws-test/tests/aws_region/test-notfound-query.sql
@@ -1,4 +1,3 @@
-
 select *
 from aws.aws_region
-where name = 'ap-south-123'
+where name = 'ap-south-123';

--- a/aws/table_aws_region.go
+++ b/aws/table_aws_region.go
@@ -150,7 +150,7 @@ func getDefaultEBSVolumeEncryption(ctx context.Context, d *plugin.QueryData, h *
 	data := h.Item.(*ec2.Region)
 
 	// Returning false for disabled regions to avoid permission denied error AuthFailure
-	if(*data.OptInStatus == "not-opted-in"){
+	if *data.OptInStatus == "not-opted-in" {
 		return false, nil
 	}
 	// Create session
@@ -171,7 +171,7 @@ func getDefaultEBSVolumeEncryptionKey(ctx context.Context, d *plugin.QueryData, 
 	data := h.Item.(*ec2.Region)
 
 	// Returning default ebs key alias for disabled regions to avoid permission denied error AuthFailure
-	if(*data.OptInStatus == "not-opted-in"){
+	if *data.OptInStatus == "not-opted-in" {
 		return "alias/aws/ebs", nil
 	}
 	// Create session


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300
SETUP: tests/aws_region []
PRETEST: tests/aws_region
TEST: tests/aws_region
Running terraform
data.null_data_source.resource: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.alternate: Refreshing state...
Warning: Deprecated Resource
The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals
Apply complete! Resources: 0 added, 0 changed, 0 destroyed.
Outputs:
account_id = 123456789012
aws_partition = aws
Running SQL query: test-get-query.sql
[
  {
    "account_id": "123456789012",
    "akas": [
      "arn:aws::ap-south-1:123456789012"
    ],
    "default_ebs_encryption_enabled": false,
    "default_ebs_encryption_key": "alias/aws/ebs",
    "name": "ap-south-1",
    "opt_in_status": "opt-in-not-required",
    "partition": "aws",
    "region": "ap-south-1",
    "title": "ap-south-1"
  }
]
✔ PASSED
Running SQL query: test-list-query.sql
[
  {
    "account_id": "123456789012",
    "akas": [
      "arn:aws::ap-south-1:123456789012"
    ],
    "default_ebs_encryption_enabled": false,
    "default_ebs_encryption_key": "alias/aws/ebs",
    "name": "ap-south-1",
    "opt_in_status": "opt-in-not-required",
    "partition": "aws",
    "region": "ap-south-1",
    "title": "ap-south-1"
  }
]
✔ PASSED
Running SQL query: test-notfound-query.sql
null
✔ PASSED
POSTTEST: tests/aws_region
TEARDOWN: tests/aws_region
SUMMARY:
1/1 passed.
```
</details>

