### PR TITLE
Decoding of secrets rendered in the encoded user_data for EC2. Closes #261

### DIFF
--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -270,18 +270,18 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Tags"),
 			},
 
-			/// Standard columns
-			{
-				Name:        "tags",
-				Description: resourceInterfaceDescription("tags"),
-				Type:        proto.ColumnType_JSON,
-				Transform:   transform.From(getEc2InstanceTurbotTags),
-			},
+			// Steampipe standard columns
 			{
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.From(getEc2InstanceTurbotTitle),
+			},
+			{
+				Name:        "tags",
+				Description: resourceInterfaceDescription("tags"),
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.From(getEc2InstanceTurbotTags),
 			},
 			{
 				Name:        "akas",

--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -214,7 +214,7 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Description: "The user data of the instance.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getInstanceUserData,
-				Transform:   transform.FromField("UserData.Value").Transform(getBase64DecodedData),
+				Transform:   transform.FromField("UserData.Value").Transform(base64DecodedData),
 			},
 			{
 				Name:        "virtualization_type",

--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -214,7 +214,7 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Description: "The user data of the instance.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getInstanceUserData,
-				Transform:   transform.FromField("UserData.Value"),
+				Transform:   transform.FromField("UserData.Value").Transform(getBase64DecodedData),
 			},
 			{
 				Name:        "virtualization_type",

--- a/aws/table_aws_ec2_launch_configuration.go
+++ b/aws/table_aws_ec2_launch_configuration.go
@@ -147,6 +147,8 @@ func tableAwsEc2LaunchConfiguration(_ context.Context) *plugin.Table {
 				Description: "A list that contains the security groups to assign to the instances in the Auto Scaling group.",
 				Type:        proto.ColumnType_JSON,
 			},
+
+			/// Steampipe standard columns
 			{
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),

--- a/aws/table_aws_ec2_launch_configuration.go
+++ b/aws/table_aws_ec2_launch_configuration.go
@@ -94,7 +94,7 @@ func tableAwsEc2LaunchConfiguration(_ context.Context) *plugin.Table {
 				Name:        "user_data",
 				Description: "The Base64-encoded user data to make available to the launched EC2 instances.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("UserData").Transform(getBase64DecodedData),
+				Transform:   transform.FromField("UserData").Transform(base64DecodedData),
 			},
 			{
 				Name:        "placement_tenancy",

--- a/aws/table_aws_ec2_launch_configuration.go
+++ b/aws/table_aws_ec2_launch_configuration.go
@@ -94,6 +94,7 @@ func tableAwsEc2LaunchConfiguration(_ context.Context) *plugin.Table {
 				Name:        "user_data",
 				Description: "The Base64-encoded user data to make available to the launched EC2 instances.",
 				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("UserData").Transform(getBase64DecodedData),
 			},
 			{
 				Name:        "placement_tenancy",

--- a/aws/table_aws_ec2_launch_configuration.go
+++ b/aws/table_aws_ec2_launch_configuration.go
@@ -148,7 +148,7 @@ func tableAwsEc2LaunchConfiguration(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 
-			/// Steampipe standard columns
+			// Steampipe standard columns
 			{
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -148,7 +148,7 @@ func lastPathElement(_ context.Context, d *transform.TransformData) (interface{}
 	return getLastPathElement(types.SafeString(d.Value)), nil
 }
 
-func getBase64DecodedData(_ context.Context, d *transform.TransformData) (interface{}, error) {
+func base64DecodedData(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	data, err := base64.StdEncoding.DecodeString(types.SafeString(d.Value))
 	if err != nil {
 		return nil, nil

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"encoding/base64"
 	"fmt"
 	"math"
 	"net/url"
@@ -145,4 +146,12 @@ func getLastPathElement(path string) string {
 
 func lastPathElement(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	return getLastPathElement(types.SafeString(d.Value)), nil
+}
+
+func getBase64DecodedData(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	data, err := base64.StdEncoding.DecodeString(types.SafeString(d.Value))
+	if err != nil {
+		return nil, nil
+	}
+	return data, nil
 }

--- a/docs/tables/aws_ec2_instance.md
+++ b/docs/tables/aws_ec2_instance.md
@@ -109,7 +109,7 @@ where
   not vol.encrypted;
 ```
 
-### List instances having secrets in user data
+### List instances with secrets in user data
 
 ```sql
 select

--- a/docs/tables/aws_ec2_instance.md
+++ b/docs/tables/aws_ec2_instance.md
@@ -118,7 +118,6 @@ select
 from
   aws_ec2_instance
 where
-  user_data like any (
-    array ['%pass%', '%secret%','%token%','%key%','(?=.*[a-z]
-  )(? =.* [A-Z])(? =.* \ d)(? =.* [@$!%*?&]) [A-Za-z\d@$!%*?&] ']);
+  user_data like any (array ['%pass%', '%secret%','%token%','%key%'])
+  or user_data ~ '(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]';
 ```

--- a/docs/tables/aws_ec2_instance.md
+++ b/docs/tables/aws_ec2_instance.md
@@ -18,7 +18,6 @@ group by
   instance_type;
 ```
 
-
 ### List instances whose detailed monitoring is not enabled
 
 ```sql
@@ -30,7 +29,6 @@ from
 where
   monitoring_state = 'disabled';
 ```
-
 
 ### Count the number of instances by instance type
 
@@ -44,7 +42,6 @@ group by
   instance_type;
 ```
 
-
 ### List of instances without application tag key
 
 ```sql
@@ -56,7 +53,6 @@ from
 where
   not tags :: JSONB ? 'application';
 ```
-
 
 ### List of EC2 instances provisioned with undesired(for example t2.large and m3.medium is desired) instance type(s).
 
@@ -72,7 +68,6 @@ group by
   instance_type;
 ```
 
-
 ### List EC2 instances having termination protection safety feature enabled
 
 ```sql
@@ -84,7 +79,6 @@ from
 where
   not disable_api_termination;
 ```
-
 
 ### Find instances which have default security group attached
 
@@ -100,7 +94,6 @@ where
   sg ->> 'GroupName' = 'default';
 ```
 
-
 ### List the unencrypted volumes attached to the instances
 
 ```sql
@@ -114,4 +107,18 @@ from
   join aws_ebs_volume as vol on vol.volume_id = vols -> 'Ebs' ->> 'VolumeId'
 where
   not vol.encrypted;
+```
+
+### List instances having secrets in user data
+
+```sql
+select
+  instance_id,
+  user_data
+from
+  aws_ec2_instance
+where
+  user_data like any (
+    array ['%pass%', '%secret%','%token%','%key%','(?=.*[a-z]
+  )(? =.* [A-Z])(? =.* \ d)(? =.* [@$!%*?&]) [A-Za-z\d@$!%*?&] ']);
 ```

--- a/docs/tables/aws_ec2_launch_configuration.md
+++ b/docs/tables/aws_ec2_launch_configuration.md
@@ -4,7 +4,7 @@ A launch configuration is a template that an EC2 Auto Scaling group uses to laun
 
 ## Examples
 
-### Basic AMI info
+### Basic launch configuration info
 
 ```sql
 select
@@ -20,7 +20,7 @@ from
   aws_ec2_launch_configuration;
 ```
 
-### IAM role attached to each Launch Configurations
+### Get IAM role attached to each launch configuration
 
 ```sql
 select
@@ -30,7 +30,7 @@ from
   aws_ec2_launch_configuration;
 ```
 
-### List Launch Configurations with public IPs
+### List launch configurations with public IPs
 
 ```sql
 select
@@ -42,7 +42,7 @@ where
   associate_public_ip_address;
 ```
 
-### Security groups attached to each Launch Configuration
+### Security groups attached to each launch configuration
 
 ```sql
 select
@@ -52,7 +52,7 @@ from
   aws_ec2_launch_configuration;
 ```
 
-### List Launch Configurations having secrets in user data
+### List launch configurations with secrets in user data
 
 ```sql
 select

--- a/docs/tables/aws_ec2_launch_configuration.md
+++ b/docs/tables/aws_ec2_launch_configuration.md
@@ -61,7 +61,6 @@ select
 from
   aws_ec2_launch_configuration
 where
-  user_data like any (
-    array ['%pass%', '%secret%','%token%','%key%','(?=.*[a-z]
-  )(? =.* [A-Z])(? =.* \ d)(? =.* [@$!%*?&]) [A-Za-z\d@$!%*?&] ']);
+  user_data like any (array ['%pass%', '%secret%','%token%','%key%'])
+  or user_data ~ '(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]';
 ```

--- a/docs/tables/aws_ec2_launch_configuration.md
+++ b/docs/tables/aws_ec2_launch_configuration.md
@@ -20,7 +20,6 @@ from
   aws_ec2_launch_configuration;
 ```
 
-
 ### IAM role attached to each Launch Configurations
 
 ```sql
@@ -30,7 +29,6 @@ select
 from
   aws_ec2_launch_configuration;
 ```
-
 
 ### List Launch Configurations with public IPs
 
@@ -44,7 +42,6 @@ where
   associate_public_ip_address;
 ```
 
-
 ### Security groups attached to each Launch Configuration
 
 ```sql
@@ -53,4 +50,18 @@ select
   jsonb_array_elements_text(security_groups) as security_groups
 from
   aws_ec2_launch_configuration;
+```
+
+### List Launch Configurations having secrets in user data
+
+```sql
+select
+  name,
+  user_data
+from
+  aws_ec2_launch_configuration
+where
+  user_data like any (
+    array ['%pass%', '%secret%','%token%','%key%','(?=.*[a-z]
+  )(? =.* [A-Z])(? =.* \ d)(? =.* [@$!%*?&]) [A-Za-z\d@$!%*?&] ']);
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_ec2_launch_configuration []

PRETEST: tests/aws_ec2_launch_configuration

TEST: tests/aws_ec2_launch_configuration
Running terraform
aws_ebs_volume.my_volume: Creating...
aws_ebs_volume.my_volume: Still creating... [10s elapsed]
aws_ebs_volume.my_volume: Creation complete after 14s [id=vol-0a2167ddb36ce908e]
aws_ebs_snapshot.my_snapshot: Creating...
aws_ebs_snapshot.my_snapshot: Creation complete after 3s [id=snap-09a75f883a51923ed]
aws_ami.named_test_resource: Creating...
aws_ami.named_test_resource: Still creating... [10s elapsed]
aws_ami.named_test_resource: Creation complete after 11s [id=ami-0ecf7b5ba1697e802]
aws_launch_configuration.named_test_resource: Creating...
aws_launch_configuration.named_test_resource: Creation complete after 3s [id=turbottest74833]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

account_id = "013122550996"
aws_partition = "aws"
image_id = "ami-0ecf7b5ba1697e802"
resource_aka = "arn:aws:autoscaling:us-east-1:013122550996:launchConfiguration:869773ad-5aa4-4d20-bd2c-47927146b6e9:launchConfigurationName/turbottest74833"
resource_id = "turbottest74833"
resource_name = "turbottest74833"

Running SQL query: test-get-query.sql
[
  {
    "ebs_optimized": false,
    "image_id": "ami-0ecf7b5ba1697e802",
    "instance_monitoring_enabled": true,
    "instance_type": "t2.nano",
    "launch_configuration_arn": "arn:aws:autoscaling:us-east-1:013122550996:launchConfiguration:869773ad-5aa4-4d20-bd2c-47927146b6e9:launchConfigurationName/turbottest74833",
    "name": "turbottest74833"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:autoscaling:us-east-1:013122550996:launchConfiguration:869773ad-5aa4-4d20-bd2c-47927146b6e9:launchConfigurationName/turbottest74833"
    ],
    "name": "turbottest74833",
    "title": "turbottest74833"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "launch_configuration_arn": "arn:aws:autoscaling:us-east-1:013122550996:launchConfiguration:869773ad-5aa4-4d20-bd2c-47927146b6e9:launchConfigurationName/turbottest74833",
    "name": "turbottest74833"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_launch_configuration

TEARDOWN: tests/aws_ec2_launch_configuration

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,user_data from aws_ec2_launch_configuration where user_data like any (array['%pass%', '%secret%','%token%','%key%']) or user_data ~ '(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]'
+----------+---------------------------------------------------------------+
| name     | user_data                                                     |
+----------+---------------------------------------------------------------+
| testCopy | #!/bin/bash                                                   |
|          | yum update -y                                                 |
|          | amazon-linux-extras install -y lamp-mariadb10.2-php7.2 php7.2 |
|          | yum install -y httpd mariadb-server                           |
|          | systemctl start httpd                                         |
|          | systemctl enable httpd                                        |
|          | usermod -a -G apache ec2-user                                 |
|          | chown -R ec2-user:apache /var/www                             |
|          | chmod 2775 /var/www                                           |
|          | find /var/www -type d -exec chmod 2775 {} \;                  |
|          | find /var/www -type f -exec chmod 0664 {} \;                  |
|          | echo "<?php phpinfo(); ?>" > /var/www/html/phpinfo.php        |
|          | $key Test@123                                                 |
+----------+---------------------------------------------------------------+
> select instance_id,user_data from aws_ec2_instance where user_data like any (array['%pass%', '%secret%','%token%','%key%']) or user_data ~ '(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]'
+---------------------+---------------------------------------------------------------+
| instance_id         | user_data                                                     |
+---------------------+---------------------------------------------------------------+
| i-0017619f4ea5acf9c | #!/bin/bash                                                   |
|                     | yum update -y                                                 |
|                     | amazon-linux-extras install -y lamp-mariadb10.2-php7.2 php7.2 |
|                     | yum install -y httpd mariadb-server                           |
|                     | systemctl start httpd                                         |
|                     | systemctl enable httpd                                        |
|                     | usermod -a -G apache ec2-user                                 |
|                     | chown -R ec2-user:apache /var/www                             |
|                     | chmod 2775 /var/www                                           |
|                     | find /var/www -type d -exec chmod 2775 {} \;                  |
|                     | find /var/www -type f -exec chmod 0664 {} \;                  |
|                     | echo "<?php phpinfo(); ?>" > /var/www/html/phpinfo.php        |
|                     | echo "password - Test@123"                                    |
+---------------------+---------------------------------------------------------------+

```
</details>
