### PR TITLE
Add 'arn' column to aws_ec2_instance table. Closes #366

### DIFF
--- a/aws-test/tests/aws_ec2_instance/test-get-expected.json
+++ b/aws-test/tests/aws_ec2_instance/test-get-expected.json
@@ -1,18 +1,20 @@
 [
-  {
-    "cpu_options_core_count": 1,
-    "cpu_options_threads_per_core": 1,
-    "ebs_optimized": false,
-    "hypervisor": "xen",
-    "image_id": "{{ output.image_id.value }}",
-    "instance_id": "{{ output.resource_id.value }}",
-    "instance_type": "t2.micro",
-    "monitoring_state": "disabled",
-    "tags_src": [
-      {
-        "Key": "Name",
-        "Value": "{{resourceName}}"
-      }
-    ]
-  }
+	{
+		"akas": ["{{ output.resource_aka.value }}"],
+		"arn": "{{ output.resource_aka.value }}",
+		"cpu_options_core_count": 1,
+		"cpu_options_threads_per_core": 1,
+		"ebs_optimized": false,
+		"hypervisor": "xen",
+		"image_id": "{{ output.image_id.value }}",
+		"instance_id": "{{ output.resource_id.value }}",
+		"instance_type": "t2.micro",
+		"monitoring_state": "disabled",
+		"tags_src": [
+			{
+				"Key": "Name",
+				"Value": "{{resourceName}}"
+			}
+		]
+	}
 ]

--- a/aws-test/tests/aws_ec2_instance/test-get-query.sql
+++ b/aws-test/tests/aws_ec2_instance/test-get-query.sql
@@ -1,3 +1,3 @@
-select instance_id, instance_type, monitoring_state, cpu_options_core_count, cpu_options_threads_per_core, ebs_optimized, hypervisor, image_id, tags_src
+select instance_id, arn, instance_type, monitoring_state, cpu_options_core_count, cpu_options_threads_per_core, ebs_optimized, hypervisor, image_id, tags_src, akas
 from aws.aws_ec2_instance
 where instance_id = '{{ output.resource_id.value }}'

--- a/aws-test/tests/aws_ec2_instance/test-hydrate-expected.json
+++ b/aws-test/tests/aws_ec2_instance/test-hydrate-expected.json
@@ -1,48 +1,46 @@
 [
-  {
-    "akas": [
-      "{{ output.resource_aka.value }}"
-    ],
-    "disable_api_termination": false,
-    "instance_id": "{{ output.resource_id.value }}",
-    "instance_initiated_shutdown_behavior": "stop",
-    "instance_status": {
-      "AvailabilityZone": "{{ output.availability_zone.value }}",
-      "Events": null,
-      "InstanceId": "{{ output.resource_id.value }}",
-      "InstanceState": {
-        "Code": 16,
-        "Name": "running"
-      },
-      "InstanceStatus": {
-        "Details": [
-          {
-            "ImpairedSince": null,
-            "Name": "reachability",
-            "Status": "initializing"
-          }
-        ],
-        "Status": "initializing"
-      },
-      "OutpostArn": null,
-      "SystemStatus": {
-        "Details": [
-          {
-            "ImpairedSince": null,
-            "Name": "reachability",
-            "Status": "initializing"
-          }
-        ],
-        "Status": "initializing"
-      }
-    },
-    "kernel_id": "<null>",
-    "ram_disk_id": "<null>",
-    "sriov_net_support": "simple",
-    "tags": {
-      "Name": "{{ resourceName }}"
-    },
-    "title": "{{ resourceName }}",
-    "user_data": "dHVyYm90"
-  }
+	{
+		"akas": ["{{ output.resource_aka.value }}"],
+		"disable_api_termination": false,
+		"instance_id": "{{ output.resource_id.value }}",
+		"instance_initiated_shutdown_behavior": "stop",
+		"instance_status": {
+			"AvailabilityZone": "{{ output.availability_zone.value }}",
+			"Events": null,
+			"InstanceId": "{{ output.resource_id.value }}",
+			"InstanceState": {
+				"Code": 16,
+				"Name": "running"
+			},
+			"InstanceStatus": {
+				"Details": [
+					{
+						"ImpairedSince": null,
+						"Name": "reachability",
+						"Status": "initializing"
+					}
+				],
+				"Status": "initializing"
+			},
+			"OutpostArn": null,
+			"SystemStatus": {
+				"Details": [
+					{
+						"ImpairedSince": null,
+						"Name": "reachability",
+						"Status": "initializing"
+					}
+				],
+				"Status": "initializing"
+			}
+		},
+		"kernel_id": null,
+		"ram_disk_id": null,
+		"sriov_net_support": "simple",
+		"tags": {
+			"Name": "{{ resourceName }}"
+		},
+		"title": "{{ resourceName }}",
+		"user_data": "dHVyYm90"
+	}
 ]

--- a/aws-test/tests/aws_ec2_instance/test-list-expected.json
+++ b/aws-test/tests/aws_ec2_instance/test-list-expected.json
@@ -1,6 +1,6 @@
 [
-  {
-    "image_id": "{{ output.image_id.value }}",
-    "instance_id": "{{ output.resource_id.value }}"
-  }
+	{
+		"image_id": "{{ output.image_id.value }}",
+		"instance_id": "{{ output.resource_id.value }}"
+	}
 ]

--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -37,7 +37,7 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Name:        "arn",
 				Description: "The Amazon Resource Name (ARN) specifying the instance.",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getEc2InstanceArn,
+				Hydrate:     getEc2InstanceARN,
 				Transform:   transform.FromValue(),
 			},
 			{
@@ -294,7 +294,7 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getEc2InstanceArn,
+				Hydrate:     getEc2InstanceARN,
 				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
 			},
 		}),
@@ -372,8 +372,8 @@ func getEc2Instance(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	return nil, nil
 }
 
-func getEc2InstanceArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getEc2InstanceArn")
+func getEc2InstanceARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getEc2InstanceARN")
 	instance := h.Item.(*ec2.Instance)
 
 	commonData, err := getCommonColumns(ctx, d, h)


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/aws_ec2_instance []

PRETEST: tests/aws_ec2_instance

TEST: tests/aws_ec2_instance
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_ami.ubuntu: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.main: Creating...
aws_vpc.main: Still creating... [10s elapsed]
aws_vpc.main: Creation complete after 12s [id=vpc-0e7575cf94254b710]
aws_subnet.named_test_resource: Creating...
aws_subnet.named_test_resource: Creation complete after 4s [id=subnet-08de9a7aa3834a059]
aws_instance.named_test_resource: Creating...
aws_instance.named_test_resource: Still creating... [10s elapsed]
aws_instance.named_test_resource: Still creating... [20s elapsed]
aws_instance.named_test_resource: Still creating... [30s elapsed]
aws_instance.named_test_resource: Still creating... [40s elapsed]
aws_instance.named_test_resource: Creation complete after 44s [id=i-0bd531d05d5c1d637]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = 123456789012
availability_zone = us-east-1f
aws_partition = aws
image_id = ami-0440ef3ccfc350027
region_name = us-east-1
resource_aka = arn:aws:ec2:us-east-1:123456789012:instance/i-0bd531d05d5c1d637
resource_id = i-0bd531d05d5c1d637
resource_name = turbottest61688
subnet_id = subnet-08de9a7aa3834a059
vpc_id = vpc-0e7575cf94254b710

Running SQL query: query.sql
[
  {
    "image_id": "ami-0440ef3ccfc350027",
    "instance_id": "i-0bd531d05d5c1d637"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:123456789012:instance/i-0bd531d05d5c1d637"
    ],
    "arn": "arn:aws:ec2:us-east-1:123456789012:instance/i-0bd531d05d5c1d637",
    "cpu_options_core_count": 1,
    "cpu_options_threads_per_core": 1,
    "ebs_optimized": false,
    "hypervisor": "xen",
    "image_id": "ami-0440ef3ccfc350027",
    "instance_id": "i-0bd531d05d5c1d637",
    "instance_type": "t2.micro",
    "monitoring_state": "disabled",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest61688"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:123456789012:instance/i-0bd531d05d5c1d637"
    ],
    "disable_api_termination": false,
    "instance_id": "i-0bd531d05d5c1d637",
    "instance_initiated_shutdown_behavior": "stop",
    "instance_status": {
      "AvailabilityZone": "us-east-1f",
      "Events": null,
      "InstanceId": "i-0bd531d05d5c1d637",
      "InstanceState": {
        "Code": 16,
        "Name": "running"
      },
      "InstanceStatus": {
        "Details": [
          {
            "ImpairedSince": null,
            "Name": "reachability",
            "Status": "initializing"
          }
        ],
        "Status": "initializing"
      },
      "OutpostArn": null,
      "SystemStatus": {
        "Details": [
          {
            "ImpairedSince": null,
            "Name": "reachability",
            "Status": "initializing"
          }
        ],
        "Status": "initializing"
      }
    },
    "kernel_id": null,
    "ram_disk_id": null,
    "kernel_id": "<null>",
    "ram_disk_id": "<null>",
    "sriov_net_support": "simple",
    "tags": {
      "Name": "turbottest61688"
    },
    "title": "turbottest61688",
    "user_data": "dHVyYm90"
  }
]

✘ FAILED

Running SQL query: test-list-query.sql
[
  {
    "image_id": "ami-0440ef3ccfc350027",
    "instance_id": "i-0bd531d05d5c1d637"
  }
]
✔ PASSED

TEARDOWN: tests/aws_ec2_instance

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>
