### PR TITLE
Add 'arn' column to aws_ebs_volume table. Closes #365

### DIFF
--- a/aws-test/tests/aws_ebs_volume/test-get-expected.json
+++ b/aws-test/tests/aws_ebs_volume/test-get-expected.json
@@ -1,14 +1,15 @@
 [
-  {
-    "attachments": "<null>",
-    "encrypted": false,
-    "multi_attach_enabled": false,
-    "tags_src": [
-      {
-        "Key": "Name",
-        "Value": "{{ resourceName }}"
-      }
-    ],
-    "volume_id": "{{ output.resource_id.value }}"
-  }
+	{
+		"arn": "{{ output.resource_aka.value }}",
+		"attachments": null,
+		"encrypted": false,
+		"multi_attach_enabled": false,
+		"tags_src": [
+			{
+				"Key": "Name",
+				"Value": "{{ resourceName }}"
+			}
+		],
+		"volume_id": "{{ output.resource_id.value }}"
+	}
 ]

--- a/aws-test/tests/aws_ebs_volume/test-get-query.sql
+++ b/aws-test/tests/aws_ebs_volume/test-get-query.sql
@@ -1,3 +1,3 @@
-select volume_id, encrypted, tags_src, attachments, multi_attach_enabled
+select volume_id, arn, encrypted, tags_src, attachments, multi_attach_enabled
 from aws.aws_ebs_volume
 where volume_id = '{{ output.resource_id.value }}'

--- a/aws-test/tests/aws_ebs_volume/test-hydrate-expected.json
+++ b/aws-test/tests/aws_ebs_volume/test-hydrate-expected.json
@@ -1,7 +1,7 @@
 [
-  {
-    "auto_enable_io": false,
-    "product_codes": "<null>",
-    "volume_id": "{{ output.resource_id.value }}"
-  }
+	{
+		"auto_enable_io": false,
+		"product_codes": null,
+		"volume_id": "{{ output.resource_id.value }}"
+	}
 ]

--- a/aws-test/tests/aws_ebs_volume/test-list-expected.json
+++ b/aws-test/tests/aws_ebs_volume/test-list-expected.json
@@ -1,18 +1,16 @@
 [
-  {
-    "akas": [
-      "{{ output.resource_aka.value }}"
-    ],
-    "tags": {
-      "Name": "{{ resourceName }}"
-    },
-    "tags_src": [
-      {
-        "Key": "Name",
-        "Value": "{{ resourceName }}"
-      }
-    ],
-    "title":"{{ resourceName }}",
-    "volume_id":"{{ output.resource_id.value }}"
-  }
+	{
+		"akas": ["{{ output.resource_aka.value }}"],
+		"tags": {
+			"Name": "{{ resourceName }}"
+		},
+		"tags_src": [
+			{
+				"Key": "Name",
+				"Value": "{{ resourceName }}"
+			}
+		],
+		"title": "{{ resourceName }}",
+		"volume_id": "{{ output.resource_id.value }}"
+	}
 ]


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/aws_ebs_volume []

PRETEST: tests/aws_ebs_volume

TEST: tests/aws_ebs_volume
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_ebs_volume.named_test_resource: Creating...
aws_ebs_volume.named_test_resource: Still creating... [10s elapsed]
aws_ebs_volume.named_test_resource: Creation complete after 14s [id=vol-06ad0e5a6ea25412b]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = 123456789012
aws_partition = aws
resource_aka = arn:aws:ec2:us-east-1:123456789012:volume/vol-06ad0e5a6ea25412b
resource_id = vol-06ad0e5a6ea25412b
resource_name = turbottest46729

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-06ad0e5a6ea25412b",
    "attachments": null,
    "encrypted": false,
    "multi_attach_enabled": false,
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest46729"
      }
    ],
    "volume_id": "vol-06ad0e5a6ea25412b"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "auto_enable_io": false,
    "product_codes": null,
    "volume_id": "vol-06ad0e5a6ea25412b"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:123456789012:volume/vol-06ad0e5a6ea25412b"
    ],
    "tags": {
      "Name": "turbottest46729"
    },
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest46729"
      }
    ],
    "title": "turbottest46729",
    "volume_id": "vol-06ad0e5a6ea25412b"
  }
]
✔ PASSED

POSTTEST: tests/aws_ebs_volume

TEARDOWN: tests/aws_ebs_volume

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>
