### PR TITLE
Add Stale workflow for Issues/PRs closes #373

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -35,5 +35,5 @@
   description: New version
   color: 0EE607
 - name: stale
-  description: The lable will be attach to tha Issue/PR if there is not activity found on it from last 30 days
+  description: No recent activity has been detected on this issue/PR and it will be closed
   color: eb7134

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -35,5 +35,5 @@
   description: New version
   color: 0EE607
 - name: stale
-  description: The lable will be attach to tha Issue/PR if there is not activity found from last 30 days on the particular Issue/PR
+  description: The lable will be attach to tha Issue/PR if there is not activity found on it from last 30 days
   color: eb7134

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -34,3 +34,6 @@
 - name: release
   description: New version
   color: 0EE607
+- name: stale
+  description: The lable will be attach to tha Issue/PR if there is not activity found from last 30 days on the particular Issue/PR
+  color: eb7134

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,36 @@
+name: "Close stale issues and PRs"
+on:
+  schedule:
+    - cron: "30 23 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set environment variable for stale action
+        id: set-stale-action-env
+        run: |
+          echo "STALE_ISSUE_MESSAGE=This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 30 days." >> $GITHUB_ENV
+          echo "STALE_PR_MESSAGE=This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 30 days." >> $GITHUB_ENV
+          echo "CLOSE_ISSUE_MESSAGE=This issue was closed because it has been stalled for 60 days with no activity." >> $GITHUB_ENV
+          echo "CLOSE_PR_MESSAGE=This PR was closed because it has been stalled for 60 days with no activity." >> $GITHUB_ENV
+          echo "DAYS_BEFORE_STALE=30" >> $GITHUB_ENV
+          # DAYS_BEFORE_CLOSE is set to 30 because the we want to close the issue/pr after 60 days(DAYS_BEFORE_STALE value is 30) so we need to set this value accordingly
+          echo "DAYS_BEFORE_CLOSE=30" >> $GITHUB_ENV
+          echo "STALE_ISSUE_LABEL=stale" >> $GITHUB_ENV
+          echo "STALE_PR_LABEL=stale" $GITHUB_ENV
+
+      - name: Stale issues or PRs
+        id: stale-issues-or-prs
+        uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: ${{ env.STALE_ISSUE_MESSAGE }}
+          stale-pr-message: ${{ env.STALE_PR_MESSAGE }}
+          close-issue-message: ${{ env.CLOSE_ISSUE_MESSAGE }}
+          close-pr-message: ${{ env.CLOSE_PR_MESSAGE }}
+          days-before-stale: ${{ env.DAYS_BEFORE_STALE }}
+          days-before-close: ${{ env.DAYS_BEFORE_CLOSE }}
+          stale-issue-label: ${{ env.STALE_ISSUE_LABEL }}
+          stale-pr-label: ${{ env.STALE_PR_LABEL }}
+

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: "Close stale issues and PRs"
+name: "Close Stale Issues and PRs"
 on:
   schedule:
     - cron: "30 23 * * *"
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - name: Set environment variable for stale action
+      - name: Set environment variables
         id: set-stale-action-env
         run: |
           echo "STALE_ISSUE_MESSAGE=This issue is stale because it has been open 30 days with no activity. Remove stale label or comment or this will be closed in 30 days." >> $GITHUB_ENV
@@ -20,7 +20,7 @@ jobs:
           echo "STALE_ISSUE_LABEL=stale" >> $GITHUB_ENV
           echo "STALE_PR_LABEL=stale" $GITHUB_ENV
 
-      - name: Stale issues or PRs
+      - name: Stale issues and PRs
         id: stale-issues-or-prs
         uses: actions/stale@v3
         with:
@@ -33,4 +33,3 @@ jobs:
           days-before-close: ${{ env.DAYS_BEFORE_CLOSE }}
           stale-issue-label: ${{ env.STALE_ISSUE_LABEL }}
           stale-pr-label: ${{ env.STALE_PR_LABEL }}
-

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,4 @@
-name: "Close Stale Issues and PRs"
+name: "Stale Issues and PRs"
 on:
   schedule:
     - cron: "30 23 * * *"


### PR DESCRIPTION
- Add a workflow which will stale the issues/PRs if no activity found for a given time period
- Issues/PRs should be stale after 30 days
- Issues/PRs should be close after 30 days
- The workflow should post a comment in the Issue/PR while doing stale/close