### PR TITLE
Add arn column to aws_vpc_security_group table. Closes #376

### DIFF
--- a/aws-test/tests/aws_vpc_security_group/test-get-expected.json
+++ b/aws-test/tests/aws_vpc_security_group/test-get-expected.json
@@ -1,5 +1,6 @@
 [
   {
+    "arn": "{{ output.resource_aka.value }}",
     "description": "Test Security Group.",
     "group_id": "{{ output.resource_id.value }}",
     "group_name": "{{resourceName}}",

--- a/aws-test/tests/aws_vpc_security_group/test-get-query.sql
+++ b/aws-test/tests/aws_vpc_security_group/test-get-query.sql
@@ -1,3 +1,3 @@
-select group_name, group_id, description, vpc_id, owner_id, tags_src
+select group_name, arn, group_id, description, vpc_id, owner_id, tags_src
 from aws.aws_vpc_security_group
 where group_id = '{{ output.resource_id.value }}'

--- a/aws/table_aws_vpc_security_group.go
+++ b/aws/table_aws_vpc_security_group.go
@@ -35,6 +35,13 @@ func tableAwsVpcSecurityGroup(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "arn",
+				Description: "The Amazon Resource Name (ARN) specifying the security group.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getVpcSecurityGroupARN,
+				Transform:   transform.FromValue(),
+			},
+			{
 				Name:        "description",
 				Description: "A description of the security group.",
 				Type:        proto.ColumnType_STRING,
@@ -83,8 +90,8 @@ func tableAwsVpcSecurityGroup(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getVpcSecurityGroupTurbotAkas,
-				Transform:   transform.FromValue(),
+				Hydrate:     getVpcSecurityGroupARN,
+				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
 			},
 		}),
 	}
@@ -159,8 +166,8 @@ func getVpcSecurityGroup(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	return nil, nil
 }
 
-func getVpcSecurityGroupTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getVpcSecurityGroupTurbotAkas")
+func getVpcSecurityGroupARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getVpcSecurityGroupARN")
 	securityGroup := h.Item.(*ec2.SecurityGroup)
 	commonData, err := getCommonColumns(ctx, d, h)
 	if err != nil {
@@ -168,10 +175,9 @@ func getVpcSecurityGroupTurbotAkas(ctx context.Context, d *plugin.QueryData, h *
 	}
 	commonColumnData := commonData.(*awsCommonColumnData)
 
-	// Get data for turbot defined properties
-	akas := []string{"arn:" + commonColumnData.Partition + ":ec2:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":security-group/" + *securityGroup.GroupId}
+	arn := "arn:" + commonColumnData.Partition + ":ec2:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":security-group/" + *securityGroup.GroupId
 
-	return akas, nil
+	return arn, nil
 }
 
 //// TRANSFORM FUNCTIONS


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/aws_vpc_security_group []

PRETEST: tests/aws_vpc_security_group

TEST: tests/aws_vpc_security_group
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.main: Creating...
aws_vpc.main: Still creating... [10s elapsed]
aws_vpc.main: Creation complete after 14s [id=vpc-0c7b1c8e0e46254d7]
aws_security_group.named_test_resource: Creating...
aws_security_group.named_test_resource: Creation complete after 7s [id=sg-01ba4e77f58775044]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

account_id = 123456789012
resource_aka = arn:aws:ec2:us-east-1:123456789012:security-group/sg-01ba4e77f58775044
resource_id = sg-01ba4e77f58775044
resource_name = turbottest37985
vpc_id = vpc-0c7b1c8e0e46254d7

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:ec2:us-east-1:123456789012:security-group/sg-01ba4e77f58775044",
    "description": "Test Security Group.",
    "group_id": "sg-01ba4e77f58775044",
    "group_name": "turbottest37985",
    "owner_id": "123456789012",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest37985"
      }
    ],
    "vpc_id": "vpc-0c7b1c8e0e46254d7"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:123456789012:security-group/sg-01ba4e77f58775044"
    ],
    "group_name": "turbottest37985",
    "tags": {
      "name": "turbottest37985"
    },
    "title": "turbottest37985"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "group_id": "sg-01ba4e77f58775044",
    "group_name": "turbottest37985"
  }
]
✔ PASSED

POSTTEST: tests/aws_vpc_security_group

TEARDOWN: tests/aws_vpc_security_group

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>
