### PR TITLE
Add arn column to aws_vpc table. Closes #375

### DIFF
--- a/aws-test/tests/aws_vpc/test-get-expected.json
+++ b/aws-test/tests/aws_vpc/test-get-expected.json
@@ -1,5 +1,6 @@
 [
   {
+    "arn": "{{ output.resource_aka.value }}",
     "cidr_block": "10.0.0.0/16",
     "is_default": false,
     "owner_id": "{{ output.account_id.value}}",

--- a/aws-test/tests/aws_vpc/test-get-query.sql
+++ b/aws-test/tests/aws_vpc/test-get-query.sql
@@ -1,3 +1,3 @@
-select vpc_id, cidr_block, is_default, owner_id, tags_src
+select vpc_id, arn, cidr_block, is_default, owner_id, tags_src
 from aws.aws_vpc
 where vpc_id = '{{ output.resource_id.value }}';


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/aws_vpc []

PRETEST: tests/aws_vpc

TEST: tests/aws_vpc
Running terraform
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.alternate: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.named_test_resource: Creating...
aws_vpc.named_test_resource: Still creating... [10s elapsed]
aws_vpc.named_test_resource: Creation complete after 12s [id=vpc-0d3580037a6e18fa9]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = 123456789012
resource_aka = arn:aws:ec2:us-east-1:123456789012:vpc/vpc-0d3580037a6e18fa9
resource_id = vpc-0d3580037a6e18fa9
resource_name = turbottest3293

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-0d3580037a6e18fa9",
    "cidr_block": "10.0.0.0/16",
    "is_default": false,
    "owner_id": "123456789012",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest3293"
      }
    ],
    "vpc_id": "vpc-0d3580037a6e18fa9"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:123456789012:vpc/vpc-0d3580037a6e18fa9"
    ],
    "tags": {
      "Name": "turbottest3293"
    },
    "title": "turbottest3293",
    "vpc_id": "vpc-0d3580037a6e18fa9"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "cidr_block": "10.0.0.0/16",
    "vpc_id": "vpc-0d3580037a6e18fa9"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

POSTTEST: tests/aws_vpc

TEARDOWN: tests/aws_vpc

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>
