### PR TITLE
Add 'arn' column to aws_config_configuration_recorder table closes #370

### DIFF
--- a/aws-test/tests/aws_config_configuration_recorder/test-get-expected.json
+++ b/aws-test/tests/aws_config_configuration_recorder/test-get-expected.json
@@ -3,8 +3,9 @@
     "akas": [
       "arn:{{ output.aws_partition.value }}:config:{{ output.region_name.value }}:{{ output.account_id.value }}:config-recorder/{{resourceName}}"
     ],
+    "arn": "arn:{{ output.aws_partition.value }}:config:{{ output.region_name.value }}:{{ output.account_id.value }}:config-recorder/{{resourceName}}",
     "name": "{{resourceName}}",
-    "role_arn": "arn:{{ output.aws_partition.value }}:iam::{{ output.account_id.value }}:role/awsconfig-example",
+    "role_arn": "arn:{{ output.aws_partition.value }}:iam::{{ output.account_id.value }}:role/{{resourceName}}",
     "status": {
       "LastErrorCode": null,
       "LastErrorMessage": null,

--- a/aws-test/tests/aws_config_configuration_recorder/test-get-expected.json
+++ b/aws-test/tests/aws_config_configuration_recorder/test-get-expected.json
@@ -1,11 +1,11 @@
 [
   {
     "akas": [
-      "arn:{{ output.aws_partition.value }}:config:{{ output.region_name.value }}:{{ output.account_id.value }}:config-recorder/{{resourceName}}"
+      "arn:{{ output.aws_partition.value }}:config:{{ output.region_name.value }}:{{ output.account_id.value }}:config-recorder/{{ resourceName }}"
     ],
-    "arn": "arn:{{ output.aws_partition.value }}:config:{{ output.region_name.value }}:{{ output.account_id.value }}:config-recorder/{{resourceName}}",
+    "arn": "arn:{{ output.aws_partition.value }}:config:{{ output.region_name.value }}:{{ output.account_id.value }}:config-recorder/{{ resourceName }}",
     "name": "{{resourceName}}",
-    "role_arn": "arn:{{ output.aws_partition.value }}:iam::{{ output.account_id.value }}:role/{{resourceName}}",
+    "role_arn": "arn:{{ output.aws_partition.value }}:iam::{{ output.account_id.value }}:role/{{ resourceName }}",
     "status": {
       "LastErrorCode": null,
       "LastErrorMessage": null,

--- a/aws-test/tests/aws_config_configuration_recorder/test-get-query.sql
+++ b/aws-test/tests/aws_config_configuration_recorder/test-get-query.sql
@@ -1,3 +1,3 @@
-select name, role_arn, status, status_recording, title, akas
+select name, arn, role_arn, status, status_recording, title, akas
 from aws.aws_config_configuration_recorder
 where name = '{{ resourceName }}';

--- a/aws-test/tests/aws_config_configuration_recorder/test-hydrate-expected.json
+++ b/aws-test/tests/aws_config_configuration_recorder/test-hydrate-expected.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "{{resourceName}}",
-    "role_arn": "arn:{{ output.aws_partition.value }}:iam::{{ output.account_id.value }}:role/awsconfig-example",
+    "role_arn": "arn:{{ output.aws_partition.value }}:iam::{{ output.account_id.value }}:role/{{resourceName}}",
     "status": {
       "LastErrorCode": null,
       "LastErrorMessage": null,

--- a/aws-test/tests/aws_config_configuration_recorder/test-hydrate-expected.json
+++ b/aws-test/tests/aws_config_configuration_recorder/test-hydrate-expected.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "{{resourceName}}",
-    "role_arn": "arn:{{ output.aws_partition.value }}:iam::{{ output.account_id.value }}:role/{{resourceName}}",
+    "role_arn": "arn:{{ output.aws_partition.value }}:iam::{{ output.account_id.value }}:role/{{ resourceName }}",
     "status": {
       "LastErrorCode": null,
       "LastErrorMessage": null,

--- a/aws-test/tests/aws_config_configuration_recorder/test-list-call-expected.json
+++ b/aws-test/tests/aws_config_configuration_recorder/test-list-call-expected.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "{{resourceName}}",
-    "role_arn": "arn:{{ output.aws_partition.value }}:iam::{{ output.account_id.value }}:role/awsconfig-example",
+    "role_arn": "arn:{{ output.aws_partition.value }}:iam::{{ output.account_id.value }}:role/{{resourceName}}",
     "status": {
       "LastErrorCode": null,
       "LastErrorMessage": null,

--- a/aws-test/tests/aws_config_configuration_recorder/test-list-call-expected.json
+++ b/aws-test/tests/aws_config_configuration_recorder/test-list-call-expected.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "{{resourceName}}",
-    "role_arn": "arn:{{ output.aws_partition.value }}:iam::{{ output.account_id.value }}:role/{{resourceName}}",
+    "role_arn": "arn:{{ output.aws_partition.value }}:iam::{{ output.account_id.value }}:role/{{ resourceName }}",
     "status": {
       "LastErrorCode": null,
       "LastErrorMessage": null,

--- a/aws-test/tests/aws_config_configuration_recorder/test-turbot-expected.json
+++ b/aws-test/tests/aws_config_configuration_recorder/test-turbot-expected.json
@@ -2,7 +2,7 @@
   {
     "account_id": "{{ output.account_id.value }}",
     "akas": [
-      "arn:{{ output.aws_partition.value }}:config:{{ output.region_name.value }}:{{ output.account_id.value }}:config-recorder/{{resourceName}}"
+      "arn:{{ output.aws_partition.value }}:config:{{ output.region_name.value }}:{{ output.account_id.value }}:config-recorder/{{ resourceName }}"
     ],
     "name": "{{resourceName}}",
     "region": "{{ output.region_name.value }}",

--- a/aws-test/tests/aws_config_configuration_recorder/variables.tf
+++ b/aws-test/tests/aws_config_configuration_recorder/variables.tf
@@ -7,13 +7,13 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "integration-tests"
+  default     = "default"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
 variable "aws_region" {
   type        = string
-  default     = "us-east-1"
+  default     = "us-west-2"
   description = "AWS region used for the test. Does not work with default region in config, so must be defined here."
 }
 

--- a/aws-test/tests/aws_config_configuration_recorder/variables.tf
+++ b/aws-test/tests/aws_config_configuration_recorder/variables.tf
@@ -7,13 +7,13 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
 variable "aws_region" {
   type        = string
-  default     = "us-west-2"
+  default     = "us-east-1"
   description = "AWS region used for the test. Does not work with default region in config, so must be defined here."
 }
 

--- a/aws/table_aws_config_configuration_recorder.go
+++ b/aws/table_aws_config_configuration_recorder.go
@@ -31,6 +31,13 @@ func tableAwsConfigConfigurationRecorder(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Name"),
 			},
 			{
+				Name:        "arn",
+				Description: "Amazon resource name of Configuration Recorder",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsConfigurationRecorderARN,
+				Transform:   transform.FromValue(),
+			},
+			{
 				Name:        "recording_group",
 				Description: "Specifies the types of AWS resources for which AWS Config records configuration changes.",
 				Type:        proto.ColumnType_JSON,
@@ -61,8 +68,8 @@ func tableAwsConfigConfigurationRecorder(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getAwsConfigurationRecorderAkas,
-				Transform:   transform.FromValue(),
+				Hydrate:     getAwsConfigurationRecorderARN,
+				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
 			},
 			{
 				Name:        "title",
@@ -170,9 +177,7 @@ func getConfigConfigurationRecorderStatus(ctx context.Context, d *plugin.QueryDa
 	return status.ConfigurationRecordersStatus[0], nil
 }
 
-//// TRANSFORM FUNCTIONS
-
-func getAwsConfigurationRecorderAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+func getAwsConfigurationRecorderARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getAwsConfigurationRecorderAkas")
 	configurationRecorder := h.Item.(*configservice.ConfigurationRecorder)
 	c, err := getCommonColumns(ctx, d, h)
@@ -180,7 +185,7 @@ func getAwsConfigurationRecorderAkas(ctx context.Context, d *plugin.QueryData, h
 		return nil, err
 	}
 	commonColumnData := c.(*awsCommonColumnData)
-	aka := "arn:" + commonColumnData.Partition + ":config:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":config-recorder" + "/" + *configurationRecorder.Name
+	arn := "arn:" + commonColumnData.Partition + ":config:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":config-recorder" + "/" + *configurationRecorder.Name
 
-	return []string{aka}, nil
+	return arn, nil
 }

--- a/aws/table_aws_config_configuration_recorder.go
+++ b/aws/table_aws_config_configuration_recorder.go
@@ -32,7 +32,7 @@ func tableAwsConfigConfigurationRecorder(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "arn",
-				Description: "Amazon resource name of Configuration Recorder",
+				Description: "The Amazon Resource Name (ARN) of the configuration recorder.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getAwsConfigurationRecorderARN,
 				Transform:   transform.FromValue(),
@@ -176,6 +176,8 @@ func getConfigConfigurationRecorderStatus(ctx context.Context, d *plugin.QueryDa
 
 	return status.ConfigurationRecordersStatus[0], nil
 }
+
+//// TRANSFORM FUNCTIONS
 
 func getAwsConfigurationRecorderARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getAwsConfigurationRecorderAkas")


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_config_configuration_recorder []
PRETEST: tests/aws_config_configuration_recorder
TEST: tests/aws_config_configuration_recorder
Running terraform
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_region.alternate: Refreshing state...
data.null_data_source.resource: Refreshing state...
data.template_file.resource_aka: Refreshing state...
aws_iam_role.r: Creating...
aws_iam_role.r: Creation complete after 5s [id=turbottest91142]
aws_config_configuration_recorder.named_test_resource: Creating...
aws_config_configuration_recorder.named_test_resource: Creation complete after 2s [id=turbottest91142]
Warning: Deprecated Resource
The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals
Apply complete! Resources: 2 added, 0 changed, 0 destroyed.
Outputs:
account_id = 986325076436
aws_partition = aws
region_name = us-west-2
resource_aka = arn:aws:config:us-west-2:986325076436:config-recorder/turbottest91142
resource_name = turbottest91142
Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:config:us-west-2:986325076436:config-recorder/turbottest91142"
    ],
    "arn": "arn:aws:config:us-west-2:986325076436:config-recorder/turbottest91142",
    "name": "turbottest91142",
    "role_arn": "arn:aws:iam::986325076436:role/turbottest91142",
    "status": {
      "LastErrorCode": null,
      "LastErrorMessage": null,
      "LastStartTime": null,
      "LastStatus": null,
      "LastStatusChangeTime": null,
      "LastStopTime": null,
      "Name": "turbottest91142",
      "Recording": false
    },
    "status_recording": false,
    "title": "turbottest91142"
  }
]
✔ PASSED
Running SQL query: test-hydrate-query.sql
[
  {
    "name": "turbottest91142",
    "role_arn": "arn:aws:iam::986325076436:role/turbottest91142",
    "status": {
      "LastErrorCode": null,
      "LastErrorMessage": null,
      "LastStartTime": null,
      "LastStatus": null,
      "LastStatusChangeTime": null,
      "LastStopTime": null,
      "Name": "turbottest91142",
      "Recording": false
    },
    "status_recording": false
  }
]
✔ PASSED
Running SQL query: test-list-call-query.sql
[
  {
    "name": "turbottest91142",
    "role_arn": "arn:aws:iam::986325076436:role/turbottest91142",
    "status": {
      "LastErrorCode": null,
      "LastErrorMessage": null,
      "LastStartTime": null,
      "LastStatus": null,
      "LastStatusChangeTime": null,
      "LastStopTime": null,
      "Name": "turbottest91142",
      "Recording": false
    },
    "title": "turbottest91142"
  }
]
✔ PASSED
Running SQL query: test-not-found-query.sql
null
✔ PASSED
Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "986325076436",
    "akas": [
      "arn:aws:config:us-west-2:986325076436:config-recorder/turbottest91142"
    ],
    "name": "turbottest91142",
    "region": "us-west-2",
    "title": "turbottest91142"
  }
]
✔ PASSED
POSTTEST: tests/aws_config_configuration_recorder
TEARDOWN: tests/aws_config_configuration_recorder
SUMMARY:
1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,arn,recording_group,role_arn from aws_config_configuration_recorder
+---------+---------------------------------------------------------------+----------------------------------------------------------------------------+-----------------------------------------------------+
| name    | arn                                                           | recording_group                                                            | role_arn                                            |
+---------+---------------------------------------------------------------+----------------------------------------------------------------------------+-----------------------------------------------------+
| default | arn:aws:config:us-east-1:986325076436:config-recorder/default | {"AllSupported":true,"IncludeGlobalResourceTypes":true,"ResourceTypes":[]} | arn:aws:iam::986325076436:role/turbot/turbot_config |
+---------+---------------------------------------------------------------+----------------------------------------------------------------------------+-----------------------------------------------------+
```
</details>
