### PR TITLE
Add table aws_sagemaker_training_job. Closes #348

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -139,6 +139,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_s3_account_settings":                tableAwsS3AccountSettings(ctx),
 			"aws_s3_bucket":                          tableAwsS3Bucket(ctx),
 			"aws_sagemaker_notebook_instance":        tableAwsSageMakerNotebookInstance(ctx),
+			"aws_sagemaker_training_job":             tableAwsSageMakerTrainingJob(ctx),
 			"aws_secretsmanager_secret":              tableAwsSecretsManagerSecret(ctx),
 			"aws_securityhub_hub":                    tableAwsSecurityHub(ctx),
 			"aws_securityhub_product":                tableAwsSecurityhubProduct(ctx),

--- a/aws/table aws_sagemaker_training_job.go
+++ b/aws/table aws_sagemaker_training_job.go
@@ -289,7 +289,6 @@ func tableAwsSageMakerTrainingJob(_ context.Context) *plugin.Table {
 //// LIST FUNCTION
 
 func listAwsSageMakerTrainingJobs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	// TODO Put me in helper function
 	var region string
 	matrixRegion := plugin.GetMatrixItem(ctx)[matrixKeyRegion]
 	if matrixRegion != nil {
@@ -319,7 +318,6 @@ func listAwsSageMakerTrainingJobs(ctx context.Context, d *plugin.QueryData, _ *p
 //// HYDRATE FUNCTIONS
 
 func getAwsSageMakerTrainingJob(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	// TODO Put me in helper function
 	var region string
 	matrixRegion := plugin.GetMatrixItem(ctx)[matrixKeyRegion]
 	if matrixRegion != nil {

--- a/aws/table aws_sagemaker_training_job.go
+++ b/aws/table aws_sagemaker_training_job.go
@@ -1,0 +1,432 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+)
+
+func tableAwsSageMakerTrainingJob(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_sagemaker_training_job",
+		Description: "AWS Sagemaker Training Job",
+		Get: &plugin.GetConfig{
+			KeyColumns:        plugin.SingleColumn("name"),
+			ShouldIgnoreError: isNotFoundError([]string{"ValidationException", "NotFoundException", "RecordNotFound"}),
+			Hydrate:           getAwsSageMakerTrainingJob,
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listAwsSageMakerTrainingJobs,
+		},
+		GetMatrixItem: BuildRegionList,
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "name",
+				Description: "The name of the training job.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("TrainingJobName"),
+			},
+			{
+				Name:        "arn",
+				Description: "The Amazon Resource Name (ARN) of the training job.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("TrainingJobArn"),
+			},
+			{
+				Name:        "training_job_status",
+				Description: "The status of the training job.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "auto_ml_job_arn",
+				Description: "The Amazon Resource Name (ARN) of an AutoML job.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "billable_time_in_seconds",
+				Description: "The billable time in seconds. Billable time refers to the absolute wall-clock time.",
+				Type:        proto.ColumnType_INT,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "checkpoint_config",
+				Description: "The billable time in seconds. Billable time refers to the absolute wall-clock time.",
+				Type:        proto.ColumnType_INT,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "creation_time",
+				Description: "A timestamp that shows when the training job was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "enable_managed_spot_training",
+				Description: "A Boolean indicating whether managed spot training is enabled or not.",
+				Type:        proto.ColumnType_BOOL,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "enable_network_isolation",
+				Description: "Specifies enable network isolation for training jobs.",
+				Type:        proto.ColumnType_BOOL,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "enableInter_container_traffic_encryption",
+				Description: "To encrypt all communications between ML compute instances in distributed training, choose True.",
+				Type:        proto.ColumnType_BOOL,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "failure_reason",
+				Description: "If the training job failed, the reason it failed.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "labeling_job_arn",
+				Description: "The Amazon Resource Name (ARN) of the Amazon SageMaker Ground Truth labeling job that created the transform or training job.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "last_modified_time",
+				Description: "Timestamp when the training job was last modified.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "profiling_status",
+				Description: "Profiling status of a training job.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "role_arn",
+				Description: "The AWS Identity and Access Management (IAM) role configured for the training job.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "secondary_status",
+				Description: "Provides detailed information about the state of the training job.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "training_end_time",
+				Description: "A timestamp that shows when the training job ended.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "training_start_time",
+				Description: "Indicates the time when the training job starts on training instances.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "training_time_in_seconds",
+				Description: "The training time in seconds.",
+				Type:        proto.ColumnType_INT,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "tuning_job_arn",
+				Description: "The Amazon Resource Name (ARN) of the associated hyperparameter tuning job if the training job was launched by a hyperparameter tuning job.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "algorithm_specification",
+				Description: "Information about the algorithm used for training, and algorithm metadata.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "debug_hook_config",
+				Description: "Configuration information for the Debugger hook parameters, metric and tensor collections, and storage paths.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "debug_rule_configurations",
+				Description: "Configuration information for Debugger rules for debugging output tensors.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "debug_rule_evaluation_statuses",
+				Description: "Evaluation status of Debugger rules for debugging on a training job.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "environment",
+				Description: "The environment variables to set in the Docker container.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "experiment_config",
+				Description: "Associates a SageMaker job as a trial component with an experiment and trial.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "final_metric_data_list",
+				Description: "A collection of MetricData objects that specify the names, values, and dates and times that the training algorithm emitted to Amazon CloudWatch.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "hyper_parameters",
+				Description: "Algorithm-specific parameters.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "input_data_config",
+				Description: "An array of Channel objects that describes each data input channel.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "model_artifacts",
+				Description: "Information about the Amazon S3 location that is configured for storing model artifacts.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "output_data_config",
+				Description: "The S3 path where model artifacts that you configured when creating the job are stored.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "profiler_config",
+				Description: "Configuration information for Debugger system monitoring,framework profiling and storage paths.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "profiler_rule_configurations",
+				Description: "Configuration information for Debugger rules for profiling system and framework metrics.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "profiler_rule_evaluation_statuses",
+				Description: "Evaluation status of Debugger rules for profiling on a training job.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "resource_config",
+				Description: "Resources, including ML compute instances and ML storage volumes, that are configured for model training.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "secondary_status_transitions",
+				Description: "A history of all of the secondary statuses that the training job has transitioned through.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "stopping_condition",
+				Description: "Specifies a limit to how long a model training job can run.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "tensor_board_output_config",
+				Description: "Configuration of storage locations for the Debugger TensorBoard output data.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "vpc_config",
+				Description: "A VpcConfig object that specifies the VPC that this training job has access to.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "tags_src",
+				Description: "A list of tags assigned to the training job.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJobTags,
+				Transform:   transform.FromField("Tags"),
+			},
+
+			// Standard columns for all tables
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("TrainingJobName"),
+			},
+			{
+				Name:        "tags",
+				Description: resourceInterfaceDescription("tags"),
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJobTags,
+				Transform:   transform.FromField("Tags").Transform(sageMakerTrainingJobtagListToTurbotTags),
+			},
+			{
+				Name:        "akas",
+				Description: resourceInterfaceDescription("akas"),
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("TrainingJobArn").Transform(arnToAkas),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listAwsSageMakerTrainingJobs(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	// TODO Put me in helper function
+	var region string
+	matrixRegion := plugin.GetMatrixItem(ctx)[matrixKeyRegion]
+	if matrixRegion != nil {
+		region = matrixRegion.(string)
+	}
+	plugin.Logger(ctx).Trace("listAwsSageMakerTrainingJobs", "AWS_REGION", region)
+
+	// Create Session
+	svc, err := SageMakerService(ctx, d, region)
+	if err != nil {
+		return nil, err
+	}
+
+	// List call
+	err = svc.ListTrainingJobsPages(
+		&sagemaker.ListTrainingJobsInput{},
+		func(page *sagemaker.ListTrainingJobsOutput, isLast bool) bool {
+			for _, job := range page.TrainingJobSummaries {
+				d.StreamListItem(ctx, job)
+			}
+			return !isLast
+		},
+	)
+	return nil, err
+}
+
+//// HYDRATE FUNCTIONS
+
+func getAwsSageMakerTrainingJob(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	// TODO Put me in helper function
+	var region string
+	matrixRegion := plugin.GetMatrixItem(ctx)[matrixKeyRegion]
+	if matrixRegion != nil {
+		region = matrixRegion.(string)
+	}
+
+	var name string
+	if h.Item != nil {
+		name = trainingJobName(h.Item)
+	} else {
+		name = d.KeyColumnQuals["name"].GetStringValue()
+	}
+
+	// Create service
+	svc, err := SageMakerService(ctx, d, region)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the params
+	params := &sagemaker.DescribeTrainingJobInput{
+		TrainingJobName: aws.String(name),
+	}
+
+	// Get call
+	data, err := svc.DescribeTrainingJob(params)
+	if err != nil {
+		return nil, err
+	}
+	return data, nil
+}
+
+func getAwsSageMakerTrainingJobTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("getAwsSageMakerTrainingJobTags")
+
+	// TODO put me in helper function
+	var region string
+	matrixRegion := plugin.GetMatrixItem(ctx)[matrixKeyRegion]
+	if matrixRegion != nil {
+		region = matrixRegion.(string)
+	}
+
+	var arn string
+	if h.Item != nil {
+		arn = trainingJobArn(h.Item)
+	} else {
+		arn = d.KeyColumnQuals["arn"].GetStringValue()
+	}
+
+	// Create Session
+	svc, err := SageMakerService(ctx, d, region)
+	if err != nil {
+		return nil, err
+	}
+
+	// Build the params
+	params := &sagemaker.ListTagsInput{
+		ResourceArn: aws.String(arn),
+	}
+
+	// Get call
+	op, err := svc.ListTags(params)
+	if err != nil {
+		return nil, err
+	}
+
+	return op, nil
+}
+
+//// TRANSFORM FUNCTION
+
+func sageMakerTrainingJobtagListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("sageMakerTrainingJobtagListToTurbotTags")
+	tagList := d.HydrateItem.(*sagemaker.ListTagsOutput)
+
+	if tagList.Tags == nil {
+		return nil, nil
+	}
+	// Mapping the resource tags inside turbotTags
+	var turbotTagsMap map[string]string
+	if tagList != nil {
+		turbotTagsMap = map[string]string{}
+		for _, i := range tagList.Tags {
+			turbotTagsMap[*i.Key] = *i.Value
+		}
+	}
+
+	return turbotTagsMap, nil
+}
+
+func trainingJobName(item interface{}) string {
+	switch item.(type) {
+	case *sagemaker.TrainingJobSummary:
+		return *item.(*sagemaker.TrainingJobSummary).TrainingJobName
+	case *sagemaker.DescribeTrainingJobOutput:
+		return *item.(*sagemaker.DescribeTrainingJobOutput).TrainingJobName
+	}
+	return ""
+}
+
+func trainingJobArn(item interface{}) string {
+	switch item.(type) {
+	case *sagemaker.TrainingJobSummary:
+		return *item.(*sagemaker.TrainingJobSummary).TrainingJobArn
+	case *sagemaker.DescribeTrainingJobOutput:
+		return *item.(*sagemaker.DescribeTrainingJobOutput).TrainingJobArn
+	}
+	return ""
+}

--- a/aws/table_aws_sagemaker_training_job.go
+++ b/aws/table_aws_sagemaker_training_job.go
@@ -262,7 +262,7 @@ func tableAwsSageMakerTrainingJob(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Tags"),
 			},
 
-			// Standard columns for all tables
+			// Steampipe standard columns
 			{
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
@@ -326,7 +326,7 @@ func getAwsSageMakerTrainingJob(ctx context.Context, d *plugin.QueryData, h *plu
 
 	var name string
 	if h.Item != nil {
-		name = trainingJobName(h.Item)
+		name = *h.Item.(*sagemaker.TrainingJobSummary).TrainingJobName
 	} else {
 		name = d.KeyColumnQuals["name"].GetStringValue()
 	}
@@ -361,13 +361,7 @@ func getAwsSageMakerTrainingJobTags(ctx context.Context, d *plugin.QueryData, h 
 		region = matrixRegion.(string)
 	}
 
-	var arn string
-	if h.Item != nil {
-		arn = trainingJobArn(h.Item)
-	} else {
-		arn = d.KeyColumnQuals["arn"].GetStringValue()
-	}
-
+	arn := trainingJobArn(h.Item)
 	// Create Session
 	svc, err := SageMakerService(ctx, d, region)
 	if err != nil {
@@ -388,7 +382,7 @@ func getAwsSageMakerTrainingJobTags(ctx context.Context, d *plugin.QueryData, h 
 	return op, nil
 }
 
-//// TRANSFORM FUNCTION
+//// TRANSFORM FUNCTIONS
 
 func sageMakerTrainingJobTagListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("sageMakerTrainingJobTagListToTurbotTags")
@@ -407,16 +401,6 @@ func sageMakerTrainingJobTagListToTurbotTags(ctx context.Context, d *transform.T
 	}
 
 	return turbotTagsMap, nil
-}
-
-func trainingJobName(item interface{}) string {
-	switch item.(type) {
-	case *sagemaker.TrainingJobSummary:
-		return *item.(*sagemaker.TrainingJobSummary).TrainingJobName
-	case *sagemaker.DescribeTrainingJobOutput:
-		return *item.(*sagemaker.DescribeTrainingJobOutput).TrainingJobName
-	}
-	return ""
 }
 
 func trainingJobArn(item interface{}) string {

--- a/aws/table_aws_sagemaker_training_job.go
+++ b/aws/table_aws_sagemaker_training_job.go
@@ -13,7 +13,7 @@ import (
 func tableAwsSageMakerTrainingJob(_ context.Context) *plugin.Table {
 	return &plugin.Table{
 		Name:        "aws_sagemaker_training_job",
-		Description: "AWS Sagemaker Training Job",
+		Description: "AWS SageMaker Training Job",
 		Get: &plugin.GetConfig{
 			KeyColumns:        plugin.SingleColumn("name"),
 			ShouldIgnoreError: isNotFoundError([]string{"ValidationException", "NotFoundException", "RecordNotFound"}),
@@ -54,12 +54,6 @@ func tableAwsSageMakerTrainingJob(_ context.Context) *plugin.Table {
 				Hydrate:     getAwsSageMakerTrainingJob,
 			},
 			{
-				Name:        "checkpoint_config",
-				Description: "The billable time in seconds. Billable time refers to the absolute wall-clock time.",
-				Type:        proto.ColumnType_INT,
-				Hydrate:     getAwsSageMakerTrainingJob,
-			},
-			{
 				Name:        "creation_time",
 				Description: "A timestamp that shows when the training job was created.",
 				Type:        proto.ColumnType_TIMESTAMP,
@@ -77,7 +71,7 @@ func tableAwsSageMakerTrainingJob(_ context.Context) *plugin.Table {
 				Hydrate:     getAwsSageMakerTrainingJob,
 			},
 			{
-				Name:        "enableInter_container_traffic_encryption",
+				Name:        "enable_inter_container_traffic_encryption",
 				Description: "To encrypt all communications between ML compute instances in distributed training, choose True.",
 				Type:        proto.ColumnType_BOOL,
 				Hydrate:     getAwsSageMakerTrainingJob,
@@ -143,6 +137,12 @@ func tableAwsSageMakerTrainingJob(_ context.Context) *plugin.Table {
 			{
 				Name:        "algorithm_specification",
 				Description: "Information about the algorithm used for training, and algorithm metadata.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsSageMakerTrainingJob,
+			},
+			{
+				Name:        "checkpoint_config",
+				Description: "Contains information about the output location for managed spot training checkpoint data.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsSageMakerTrainingJob,
 			},
@@ -274,7 +274,7 @@ func tableAwsSageMakerTrainingJob(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsSageMakerTrainingJobTags,
-				Transform:   transform.FromField("Tags").Transform(sageMakerTrainingJobtagListToTurbotTags),
+				Transform:   transform.FromField("Tags").Transform(sageMakerTrainingJobTagListToTurbotTags),
 			},
 			{
 				Name:        "akas",
@@ -390,8 +390,8 @@ func getAwsSageMakerTrainingJobTags(ctx context.Context, d *plugin.QueryData, h 
 
 //// TRANSFORM FUNCTION
 
-func sageMakerTrainingJobtagListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("sageMakerTrainingJobtagListToTurbotTags")
+func sageMakerTrainingJobTagListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("sageMakerTrainingJobTagListToTurbotTags")
 	tagList := d.HydrateItem.(*sagemaker.ListTagsOutput)
 
 	if tagList.Tags == nil {

--- a/docs/tables/aws_sagemaker_training_job.md
+++ b/docs/tables/aws_sagemaker_training_job.md
@@ -1,6 +1,6 @@
 # Table: aws_sagemaker_training_job
 
-A Training job helps to train a model in Amazon SageMaker.
+A training job helps to train a model in Amazon SageMaker.
 
 ## Examples
 
@@ -17,7 +17,7 @@ from
   aws_sagemaker_training_job;
 ```
 
-### Get details of ML compute instances and ML storage volumes associated with training job
+### Get details of associated ML compute instances and storage volumes for each training job
 
 ```sql
 select
@@ -31,7 +31,7 @@ from
   aws_sagemaker_training_job;
 ```
 
-### List of failed training jobs
+### List failed training jobs
 
 ```sql
 select

--- a/docs/tables/aws_sagemaker_training_job.md
+++ b/docs/tables/aws_sagemaker_training_job.md
@@ -44,15 +44,3 @@ from
 where
   training_job_status = 'Failed';
 ```
-
-### List training jobs by status
-
-```sql
-select
-  secondary_status,
-  count(*)
-from
-  aws_sagemaker_training_job
-group by
-  secondary_status;
-```

--- a/docs/tables/aws_sagemaker_training_job.md
+++ b/docs/tables/aws_sagemaker_training_job.md
@@ -30,3 +30,29 @@ select
 from
   aws_sagemaker_training_job;
 ```
+
+### List of failed training jobs
+
+```sql
+select
+  name,
+  arn,
+  training_job_status,
+  failure_reason
+from
+  aws_sagemaker_training_job
+where
+  training_job_status = 'Failed';
+```
+
+### List training jobs by status
+
+```sql
+select
+  secondary_status,
+  count(*)
+from
+  aws_sagemaker_training_job
+group by
+  secondary_status;
+```

--- a/docs/tables/aws_sagemaker_training_job.md
+++ b/docs/tables/aws_sagemaker_training_job.md
@@ -1,0 +1,32 @@
+# Table: aws_sagemaker_training_job
+
+A Training job helps to train a model in Amazon SageMaker.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  arn,
+  training_job_status,
+  creation_time,
+  last_modified_time
+from
+  aws_sagemaker_training_job;
+```
+
+### Get details of ML compute instances and ML storage volumes associated with training job
+
+```sql
+select
+  name,
+  arn,
+  resource_config ->> 'InstanceType' as instance_type,
+  resource_config ->> 'InstanceCount' as instance_count,
+  resource_config ->> 'VolumeKmsKeyId' as volume_kms_id,
+  resource_config ->> 'VolumeSizeInGB' as volume_size
+from
+  aws_sagemaker_training_job;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Terraform not supported. Resource creation is failed through cli  and also this resource doesn't have any delete api call
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select
  name,
  arn,
  training_job_status,
  creation_time,
  last_modified_time
from
  aws_sagemaker_training_job;

+-----------------------------+-----------------------------------------------------------------------------------+---------------------+---------------------+---------------------+
| name                        | arn                                                                               | training_job_status | creation_time       | last_modified_time  |
+-----------------------------+-----------------------------------------------------------------------------------+---------------------+---------------------+---------------------+
| jobtesting                  | arn:aws:sagemaker:us-east-1:986325076436:training-job/jobtesting                  | Stopped             | 2021-05-10 12:48:24 | 2021-05-10 12:50:40 |
| turbottest56375             | arn:aws:sagemaker:us-east-1:986325076436:training-job/turbottest56375             | Failed              | 2021-05-10 13:04:10 | 2021-05-10 13:05:30 |
| pca-2021-04-08-09-31-38-028 | arn:aws:sagemaker:us-east-1:986325076436:training-job/pca-2021-04-08-09-31-38-028 | Completed           | 2021-04-08 09:31:38 | 2021-04-08 09:36:02 |
+-----------------------------+-----------------------------------------------------------------------------------+---------------------+---------------------+---------------------+


select
  name,
  arn,
  resource_config ->> 'InstanceType' as instance_type,
  resource_config ->> 'InstanceCount' as instance_count,
  resource_config ->> 'VolumeKmsKeyId' as volume_kms_id,
  resource_config ->> 'VolumeSizeInGB' as volume_size
from
  aws_sagemaker_training_job;

+-----------------------------+-----------------------------------------------------------------------------------+---------------+----------------+---------------+-------------+
| name                        | arn                                                                               | instance_type | instance_count | volume_kms_id | volume_size |
+-----------------------------+-----------------------------------------------------------------------------------+---------------+----------------+---------------+-------------+
| pca-2021-04-08-09-31-38-028 | arn:aws:sagemaker:us-east-1:986325076436:training-job/pca-2021-04-08-09-31-38-028 | ml.c4.xlarge  | 1              | <null>        | 30          |
| turbottest56375             | arn:aws:sagemaker:us-east-1:986325076436:training-job/turbottest56375             | ml.c4.xlarge  | 1              | <null>        | 30          |
| jobtesting                  | arn:aws:sagemaker:us-east-1:986325076436:training-job/jobtesting                  | ml.c4.xlarge  | 1              | <null>        | 30          |
+-----------------------------+-----------------------------------------------------------------------------------+---------------+----------------+---------------+-------------+

select
  name,
  arn,
  training_job_status,
  failure_reason
from
  aws_sagemaker_training_job
where
  training_job_status = 'Failed';

+-----------------+-----------------------------------------------------------------------+---------------------+------------------------------------------------------------------------------
| name            | arn                                                                   | training_job_status | failure_reason                                                               
+-----------------+-----------------------------------------------------------------------+---------------------+------------------------------------------------------------------------------
| turbottest56375 | arn:aws:sagemaker:us-east-1:986325076436:training-job/turbottest56375 | Failed              | ClientError: SageMaker was unable to assume the role 'arn:aws:iam::9863250764
+-----------------+-----------------------------------------------------------------------+---------------------+------------------------------------------------------------------------------

select
  secondary_status,
  count(*)
from
  aws_sagemaker_training_job
group by
  secondary_status;

+------------------+-------+
| secondary_status | count |
+------------------+-------+
| Completed        | 1     |
| Failed           | 1     |
| Stopped          | 1     |
+------------------+-------+
```
</details>
