### PR TITLE
return null for key_rotation_enabled when origin=EXTERNAL

### DIFF
--- a/aws-test/bin
+++ b/aws-test/bin
@@ -1,0 +1,1 @@
+/usr/local/Cellar/terraform/0.15.3/bin

--- a/aws-test/bin
+++ b/aws-test/bin
@@ -1,1 +1,0 @@
-/usr/local/Cellar/terraform/0.15.3/bin

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -294,6 +294,9 @@ func getAwsKmsKeyRotationStatus(ctx context.Context, d *plugin.QueryData, h *plu
 			if a.Code() == "AccessDeniedException" {
 				return kms.GetKeyRotationStatusOutput{}, nil
 			}
+			if a.Code() == "UnsupportedOperationException" {
+				return kms.GetKeyRotationStatusOutput{}, nil
+			}
 		}
 		return nil, err
 	}

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/kms"
 
+	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
@@ -291,10 +292,7 @@ func getAwsKmsKeyRotationStatus(ctx context.Context, d *plugin.QueryData, h *plu
 	keyData, err := svc.GetKeyRotationStatus(params)
 	if err != nil {
 		if a, ok := err.(awserr.Error); ok {
-			if a.Code() == "AccessDeniedException" {
-				return kms.GetKeyRotationStatusOutput{}, nil
-			}
-			if a.Code() == "UnsupportedOperationException" {
+			if helpers.StringSliceContains([]string{"AccessDeniedException", "UnsupportedOperationException"}, a.Code()) {
 				return kms.GetKeyRotationStatusOutput{}, nil
 			}
 		}


### PR DESCRIPTION

# Example query results

steampipe query "select key_rotation_enabled from aws_kms_key where origin = 'EXTERNAL'"
+----------------------+
| key_rotation_enabled |
+----------------------+
| <null>               |
| <null>               |
| <null>               |
+----------------------+


steampipe query "select origin, key_rotation_enabled from aws_kms_key"     
+----------+----------------------+
| origin   | key_rotation_enabled |
+----------+----------------------+
| AWS_KMS  | false                |
| AWS_KMS  | true                 |
| AWS_KMS  | true                 |
| AWS_KMS  | false                |
| AWS_KMS  | true                 |
| AWS_KMS  | true                 |
| EXTERNAL | <null>               |
| AWS_KMS  | false                |
| EXTERNAL | <null>               |
| EXTERNAL | <null>               |
| AWS_KMS  | false                |
| AWS_KMS  | true                 |
| AWS_KMS  | <null>               |
| AWS_KMS  | false                |
+----------+----------------------+




Current Results with out fix
steampipe query "select key_rotation_enabled from aws_kms_key where origin != 'EXTERNAL'"

Error: UnsupportedOperationException: arn:aws:kms:us-east-1:1295521:key/4ac8-91c1-3928cc14 origin is EXTERNAL which is not valid for this operation.




