### PR TITLE
Add 'arn' column to aws_ebs_snapshot table. Closes #391

### DIFF
--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
-	pb "github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
 
@@ -29,7 +28,7 @@ func tableAwsEBSSnapshot(_ context.Context) *plugin.Table {
 			{
 				Name:        "snapshot_id",
 				Description: "The ID of the snapshot. Each snapshot receives a unique identifier when it is created.",
-				Type:        pb.ColumnType_STRING,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "arn",
@@ -41,73 +40,73 @@ func tableAwsEBSSnapshot(_ context.Context) *plugin.Table {
 			{
 				Name:        "state",
 				Description: "The snapshot state.",
-				Type:        pb.ColumnType_STRING,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "volume_size",
 				Description: "The size of the volume, in GiB.",
-				Type:        pb.ColumnType_INT,
+				Type:        proto.ColumnType_INT,
 			},
 			{
 				Name:        "volume_id",
 				Description: "The ID of the volume that was used to create the snapshot. Snapshots created by the CopySnapshot action have an arbitrary volume ID that should not be used for any purpose.",
-				Type:        pb.ColumnType_STRING,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "encrypted",
 				Description: "Indicates whether the snapshot is encrypted.",
-				Type:        pb.ColumnType_BOOL,
+				Type:        proto.ColumnType_BOOL,
 			},
 			{
 				Name:        "start_time",
 				Description: "The time stamp when the snapshot was initiated.",
-				Type:        pb.ColumnType_TIMESTAMP,
+				Type:        proto.ColumnType_TIMESTAMP,
 			},
 			{
 				Name:        "description",
 				Description: "The description for the snapshot.",
-				Type:        pb.ColumnType_STRING,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "kms_key_id",
 				Description: "The Amazon Resource Name (ARN) of the AWS Key Management Service (AWS KMS) customer master key (CMK) that was used to protect the volume encryption key for the parent volume.",
-				Type:        pb.ColumnType_STRING,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "data_encryption_key_id",
 				Description: "The data encryption key identifier for the snapshot. This value is a unique identifier that corresponds to the data encryption key that was used to encrypt the original volume or snapshot copy. Because data encryption keys are inherited by volumes created from snapshots, and vice versa, if snapshots share the same data encryption key identifier, then they belong to the same volume/snapshot lineage.",
-				Type:        pb.ColumnType_STRING,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "progress",
 				Description: "The progress of the snapshot, as a percentage.",
-				Type:        pb.ColumnType_STRING,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "state_message",
 				Description: "Encrypted Amazon EBS snapshots are copied asynchronously. If a snapshot copy operation fails this field displays error state details to help you diagnose why the error occurred.",
-				Type:        pb.ColumnType_STRING,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "owner_alias",
 				Description: "The AWS owner alias, from an Amazon-maintained list (amazon). This is not the user-configured AWS account alias set using the IAM console.",
-				Type:        pb.ColumnType_STRING,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "owner_id",
 				Description: "The AWS account ID of the EBS snapshot owner.",
-				Type:        pb.ColumnType_STRING,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "create_volume_permissions",
 				Description: "The users and groups that have the permissions for creating volumes from the snapshot.",
-				Type:        pb.ColumnType_JSON,
+				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsEBSSnapshotCreateVolumePermissions,
 			},
 			{
 				Name:        "tags_src",
 				Description: "A list of tags assigned to the snapshot.",
-				Type:        pb.ColumnType_JSON,
+				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("Tags"),
 			},
 
@@ -115,19 +114,19 @@ func tableAwsEBSSnapshot(_ context.Context) *plugin.Table {
 			{
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
-				Type:        pb.ColumnType_STRING,
+				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("SnapshotId"),
 			},
 			{
 				Name:        "tags",
 				Description: resourceInterfaceDescription("tags"),
-				Type:        pb.ColumnType_JSON,
+				Type:        proto.ColumnType_JSON,
 				Transform:   transform.From(ec2SnapshotTurbotTags),
 			},
 			{
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
-				Type:        pb.ColumnType_JSON,
+				Type:        proto.ColumnType_JSON,
 				Hydrate:     getEBSSnapshotARN,
 				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
 			},

--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -35,7 +35,7 @@ func tableAwsEBSSnapshot(_ context.Context) *plugin.Table {
 				Name:        "arn",
 				Description: "The Amazon Resource Name (ARN) specifying the snapshot.",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getAwsEBSSnapshotArn,
+				Hydrate:     getEBSSnapshotARN,
 				Transform:   transform.FromValue(),
 			},
 			{
@@ -128,7 +128,7 @@ func tableAwsEBSSnapshot(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        pb.ColumnType_JSON,
-				Hydrate:     getAwsEBSSnapshotArn,
+				Hydrate:     getEBSSnapshotARN,
 				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
 			},
 		}),
@@ -237,8 +237,8 @@ func getAwsEBSSnapshotCreateVolumePermissions(ctx context.Context, d *plugin.Que
 	return resp, nil
 }
 
-func getAwsEBSSnapshotArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getAwsEBSSnapshotArn")
+func getEBSSnapshotARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getEBSSnapshotARN")
 	snapshotData := h.Item.(*ec2.Snapshot)
 	c, err := getCommonColumns(ctx, d, h)
 	if err != nil {

--- a/docs/tables/aws_ebs_snapshot.md
+++ b/docs/tables/aws_ebs_snapshot.md
@@ -9,6 +9,7 @@ An EBS snapshot is a point-in-time copy of Amazon EBS volume, which is copied to
 ```sql
 select
   snapshot_id,
+  arn,
   encrypted
 from
   aws_ebs_snapshot
@@ -16,12 +17,12 @@ where
   not encrypted;
 ```
 
-
 ### List of EBS snapshots which are publicly accessible
 
 ```sql
 select
   snapshot_id,
+  arn,
   volume_id,
   perm ->> 'UserId' as userid,
   perm ->> 'Group' as group
@@ -31,7 +32,6 @@ from
 where
   perm ->> 'Group' = 'all';
 ```
-
 
 ### Find the Account IDs with which the snapshots are shared
 
@@ -44,7 +44,6 @@ from
   aws_ebs_snapshot
   cross join jsonb_array_elements(create_volume_permissions) as perm;
 ```
-
 
 ### Find the snapshot count per volume
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_ebs_snapshot []

PRETEST: tests/aws_ebs_snapshot

TEST: tests/aws_ebs_snapshot
Running terraform
aws_ebs_volume.test_volume: Creating...
aws_ebs_volume.test_volume: Still creating... [10s elapsed]
aws_ebs_volume.test_volume: Creation complete after 15s [id=vol-0e3ac6780e5445870]
aws_ebs_snapshot.named_test_resource: Creating...
aws_ebs_snapshot.named_test_resource: Creation complete after 4s [id=snap-0b466018061d8ae5e]
aws_snapshot_create_volume_permission.example_perm: Creating...
aws_snapshot_create_volume_permission.example_perm: Still creating... [10s elapsed]
aws_snapshot_create_volume_permission.example_perm: Creation complete after 14s [id=snap-0b466018061d8ae5e-388460667113]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "013122550996"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:ec2:us-east-1::snapshot/snap-0b466018061d8ae5e"
resource_name = "turbottest62408"
snapshot_id = "snap-0b466018061d8ae5e"
volume_id = "vol-0e3ac6780e5445870"

Running SQL query: test-get-query.sql
[
  {
    "description": "Test snapshot",
    "encrypted": false,
    "owner_id": "013122550996",
    "snapshot_id": "snap-0b466018061d8ae5e",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest62408"
      }
    ],
    "volume_id": "vol-0e3ac6780e5445870",
    "volume_size": 1
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:013122550996:snapshot/snap-0b466018061d8ae5e"
    ],
    "create_volume_permissions": [
      {
        "Group": null,
        "UserId": "388460667113"
      }
    ],
    "snapshot_id": "snap-0b466018061d8ae5e",
    "tags": {
      "Name": "turbottest62408"
    },
    "title": "snap-0b466018061d8ae5e"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "snapshot_id": "snap-0b466018061d8ae5e",
    "volume_id": "vol-0e3ac6780e5445870"
  }
]
✔ PASSED

POSTTEST: tests/aws_ebs_snapshot

TEARDOWN: tests/aws_ebs_snapshot

SUMMARY:

1/1 passed.


```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  snapshot_id,
  arn,
  encrypted
from
  aws_ebs_snapshot
where
  not encrypted;
+------------------------+--------------------------------------------------------------------+-----------+
| snapshot_id            | arn                                                                | encrypted |
+------------------------+--------------------------------------------------------------------+-----------+
| snap-0871f5e46b157d81b | arn:aws:ec2:us-east-1:013122550996:snapshot/snap-0871f5e46b157d81b | false     |
+------------------------+--------------------------------------------------------------------+-----------+
> select
  snapshot_id,
  arn,
  volume_id,
  perm ->> 'UserId' as userid,
  perm ->> 'Group' as group
from
  aws_ebs_snapshot
  cross join jsonb_array_elements(create_volume_permissions) as perm
where
  perm ->> 'Group' = 'all';
+-------------+-----+-----------+--------+-------+
| snapshot_id | arn | volume_id | userid | group |
+-------------+-----+-----------+--------+-------+
+-------------+-----+-----------+--------+-------+

```
</details>
