### PR TITLE
Add 'arn' column to aws_vpc_eip table. Closes #393

### DIFF
--- a/aws-test/tests/aws_vpc_eip/test-get-expected.json
+++ b/aws-test/tests/aws_vpc_eip/test-get-expected.json
@@ -1,6 +1,7 @@
 [
   {
     "allocation_id": "{{ output.resource_id.value }}",
+    "arn": "{{ output.resource_aka.value }}",
     "domain": "vpc",
     "public_ip": "{{ output.public_ip.value }}",
     "public_ipv4_pool": "amazon",

--- a/aws-test/tests/aws_vpc_eip/test-get-query.sql
+++ b/aws-test/tests/aws_vpc_eip/test-get-query.sql
@@ -1,3 +1,3 @@
-select allocation_id, public_ip, public_ipv4_pool, domain, tags_src
+select allocation_id, arn, public_ip, public_ipv4_pool, domain, tags_src
 from aws.aws_vpc_eip
 where allocation_id = '{{ output.resource_id.value }}'

--- a/aws/table_aws_vpc_eip.go
+++ b/aws/table_aws_vpc_eip.go
@@ -30,6 +30,13 @@ func tableAwsVpcEip(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "arn",
+				Description: "The Amazon Resource Name (ARN) specifying the vpc eip.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getVpcEipTurbotArn,
+				Transform:   transform.FromValue(),
+			},
+			{
 				Name:        "public_ip",
 				Description: "Contains the Elastic IP address.",
 				Type:        proto.ColumnType_IPADDR,
@@ -113,8 +120,8 @@ func tableAwsVpcEip(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getVpcEipTurbotAkas,
-				Transform:   transform.FromValue(),
+				Hydrate:     getVpcEipTurbotArn,
+				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
 			},
 		}),
 	}
@@ -184,8 +191,8 @@ func getVpcEip(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 	return nil, nil
 }
 
-func getVpcEipTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getVpcEipTurbotAkas")
+func getVpcEipTurbotArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getVpcEipTurbotArn")
 	eip := h.Item.(*ec2.Address)
 	commonData, err := getCommonColumns(ctx, d, h)
 	if err != nil {
@@ -193,10 +200,10 @@ func getVpcEipTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	}
 	commonColumnData := commonData.(*awsCommonColumnData)
 
-	// Get resource aka
-	akas := []string{"arn:" + commonColumnData.Partition + ":ec2:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":eip/" + *eip.AllocationId}
+	// Get resource arn
+	arn := "arn:" + commonColumnData.Partition + ":ec2:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":eip/" + *eip.AllocationId
 
-	return akas, nil
+	return arn, nil
 }
 
 //// TRANSFORM FUNCTIONS

--- a/aws/table_aws_vpc_eip.go
+++ b/aws/table_aws_vpc_eip.go
@@ -33,7 +33,7 @@ func tableAwsVpcEip(_ context.Context) *plugin.Table {
 				Name:        "arn",
 				Description: "The Amazon Resource Name (ARN) specifying the vpc eip.",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getVpcEipTurbotArn,
+				Hydrate:     getVpcEipARN,
 				Transform:   transform.FromValue(),
 			},
 			{
@@ -120,7 +120,7 @@ func tableAwsVpcEip(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getVpcEipTurbotArn,
+				Hydrate:     getVpcEipARN,
 				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
 			},
 		}),
@@ -191,8 +191,8 @@ func getVpcEip(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 	return nil, nil
 }
 
-func getVpcEipTurbotArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getVpcEipTurbotArn")
+func getVpcEipARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getVpcEipARN")
 	eip := h.Item.(*ec2.Address)
 	commonData, err := getCommonColumns(ctx, d, h)
 	if err != nil {

--- a/aws/table_aws_vpc_eip.go
+++ b/aws/table_aws_vpc_eip.go
@@ -31,7 +31,7 @@ func tableAwsVpcEip(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "arn",
-				Description: "The Amazon Resource Name (ARN) specifying the vpc eip.",
+				Description: "The Amazon Resource Name (ARN) specifying the VPC EIP.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getVpcEipARN,
 				Transform:   transform.FromValue(),


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_vpc_eip []

PRETEST: tests/aws_vpc_eip

TEST: tests/aws_vpc_eip
Running terraform
aws_eip.named_test_resource: Creating...
aws_eip.named_test_resource: Creation complete after 2s [id=eipalloc-00e3bae6a3908370b]
data.template_file.resource_aka: Reading...
data.template_file.resource_aka: Read complete after 0s [id=22fbdd015a523114439f60aebdf4643025b1f683ad324f448b5f5a5acdd9a8ea]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

public_ip = "35.171.125.28"
resource_aka = "arn:aws:ec2:us-east-1:013122550996:eip/eipalloc-00e3bae6a3908370b"
resource_id = "eipalloc-00e3bae6a3908370b"
resource_name = "turbottest6172"

Running SQL query: test-get-query.sql
[
  {
    "allocation_id": "eipalloc-00e3bae6a3908370b",
    "arn": "arn:aws:ec2:us-east-1:013122550996:eip/eipalloc-00e3bae6a3908370b",
    "domain": "vpc",
    "public_ip": "35.171.125.28",
    "public_ipv4_pool": "amazon",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest6172"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:013122550996:eip/eipalloc-00e3bae6a3908370b"
    ],
    "allocation_id": "eipalloc-00e3bae6a3908370b",
    "tags": {
      "Name": "turbottest6172"
    },
    "title": "eipalloc-00e3bae6a3908370b"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "allocation_id": "eipalloc-00e3bae6a3908370b",
    "public_ip": "35.171.125.28"
  }
]
✔ PASSED

POSTTEST: tests/aws_vpc_eip

TEARDOWN: tests/aws_vpc_eip

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_vpc_eip
+----------------------------+-------------------------------------------------------------------+---------------+------------------+--------+----------------+------------+-------------------+------------
| allocation_id              | arn                                                               | public_ip     | public_ipv4_pool | domain | association_id | carrier_ip | customer_owned_ip | customer_ow
+----------------------------+-------------------------------------------------------------------+---------------+------------------+--------+----------------+------------+-------------------+------------
| eipalloc-0485c055f10b027c6 | arn:aws:ec2:us-east-1:013122550996:eip/eipalloc-0485c055f10b027c6 | 54.145.13.180 | amazon           | vpc    | <null>         | <null>     | <null>            | <null>     
+----------------------------+-------------------------------------------------------------------+---------------+------------------+--------+----------------+------------+-------------------+------------
```
</details>
