### PR TITLE
Add 'arn' column to aws_guardduty_detector table. Closes #395

### DIFF
--- a/aws-test/tests/aws_guardduty_detector/test-list-expected.json
+++ b/aws-test/tests/aws_guardduty_detector/test-list-expected.json
@@ -1,5 +1,6 @@
 [
   {
+    "arn": "{{ output.resource_aka.value }}",
     "detector_id": "{{ output.resource_id.value }}",
     "finding_publishing_frequency": "SIX_HOURS",
     "status": "ENABLED"

--- a/aws-test/tests/aws_guardduty_detector/test-list-query.sql
+++ b/aws-test/tests/aws_guardduty_detector/test-list-query.sql
@@ -1,3 +1,3 @@
-select detector_id, status, finding_publishing_frequency
+select detector_id, arn, status, finding_publishing_frequency
 from aws.aws_guardduty_detector
 where akas::text = '["{{ output.resource_aka.value }}"]';

--- a/aws/table_aws_guardduty_detector.go
+++ b/aws/table_aws_guardduty_detector.go
@@ -37,6 +37,13 @@ func tableAwsGuardDutyDetector(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("DetectorID"),
 			},
 			{
+				Name:        "arn",
+				Description: "The Amazon Resource Name (ARN) specifying the detector.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsGuardDutyDetectorAkas,
+				Transform:   transform.FromValue(),
+			},
+			{
 				Name:        "status",
 				Description: "The detector status.",
 				Type:        proto.ColumnType_STRING,
@@ -91,7 +98,7 @@ func tableAwsGuardDutyDetector(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsGuardDutyDetectorAkas,
-				Transform:   transform.FromValue(),
+				Transform:   transform.FromValue().Transform(arnToAkas),
 			},
 		}),
 	}
@@ -177,7 +184,7 @@ func getAwsGuardDutyDetectorAkas(ctx context.Context, d *plugin.QueryData, h *pl
 		return nil, err
 	}
 	commonColumnData := c.(*awsCommonColumnData)
-	aka := []string{"arn:" + commonColumnData.Partition + ":guardduty:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":detector/" + data.DetectorID}
+	aka := "arn:" + commonColumnData.Partition + ":guardduty:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":detector/" + data.DetectorID
 
 	return aka, nil
 }

--- a/aws/table_aws_guardduty_detector.go
+++ b/aws/table_aws_guardduty_detector.go
@@ -40,7 +40,7 @@ func tableAwsGuardDutyDetector(_ context.Context) *plugin.Table {
 				Name:        "arn",
 				Description: "The Amazon Resource Name (ARN) specifying the detector.",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getAwsGuardDutyDetectorAkas,
+				Hydrate:     getGuardDutyDetectorARN,
 				Transform:   transform.FromValue(),
 			},
 			{
@@ -97,8 +97,8 @@ func tableAwsGuardDutyDetector(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getAwsGuardDutyDetectorAkas,
-				Transform:   transform.FromValue().Transform(arnToAkas),
+				Hydrate:     getGuardDutyDetectorARN,
+				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
 			},
 		}),
 	}
@@ -175,8 +175,8 @@ func getGuardDutyDetector(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	return detectorInfo{*op, id}, nil
 }
 
-func getAwsGuardDutyDetectorAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getAwsGuardDutyDetectorAkas")
+func getGuardDutyDetectorARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getGuardDutyDetectorARN")
 	data := h.Item.(detectorInfo)
 
 	c, err := getCommonColumns(ctx, d, h)
@@ -184,7 +184,7 @@ func getAwsGuardDutyDetectorAkas(ctx context.Context, d *plugin.QueryData, h *pl
 		return nil, err
 	}
 	commonColumnData := c.(*awsCommonColumnData)
-	aka := "arn:" + commonColumnData.Partition + ":guardduty:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":detector/" + data.DetectorID
+	arn := "arn:" + commonColumnData.Partition + ":guardduty:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":detector/" + data.DetectorID
 
-	return aka, nil
+	return arn, nil
 }

--- a/docs/tables/aws_guardduty_detector.md
+++ b/docs/tables/aws_guardduty_detector.md
@@ -9,6 +9,7 @@ Amazon GuardDuty is a threat detection service that continuously monitors for ma
 ```sql
 select
   detector_id,
+  arn,
   created_at,
   status,
   service_role


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_guardduty_detector []

PRETEST: tests/aws_guardduty_detector

TEST: tests/aws_guardduty_detector
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_guardduty_detector.named_test_resource: Creating...
aws_guardduty_detector.named_test_resource: Creation complete after 3s [id=6c983ebd982a448492568221c6879275]
data.template_file.resource_aka: Refreshing state...

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = 986325076436
aws_partition = aws
region_name = us-east-1
resource_aka = arn:aws:guardduty:us-east-1:986325076436:detector/6c983ebd982a448492568221c6879275
resource_id = 6c983ebd982a448492568221c6879275
resource_name = turbottest36931

Running SQL query: test-get-query.sql
[
  {
    "detector_id": "6c983ebd982a448492568221c6879275",
    "finding_publishing_frequency": "SIX_HOURS",
    "status": "ENABLED",
    "tags": {
      "name": "turbottest36931"
    }
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:guardduty:us-east-1:986325076436:detector/6c983ebd982a448492568221c6879275"
    ],
    "detector_id": "6c983ebd982a448492568221c6879275",
    "status": "ENABLED",
    "tags": {
      "name": "turbottest36931"
    },
    "title": "6c983ebd982a448492568221c6879275"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:guardduty:us-east-1:986325076436:detector/6c983ebd982a448492568221c6879275",
    "detector_id": "6c983ebd982a448492568221c6879275",
    "finding_publishing_frequency": "SIX_HOURS",
    "status": "ENABLED"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

POSTTEST: tests/aws_guardduty_detector

TEARDOWN: tests/aws_guardduty_detector

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
- Basic info

select
  detector_id,
  arn,
  created_at,
  status,
  service_role
from
  aws_guardduty_detector;

+----------------------------------+-------------------------------------------------------------------------------------+---------------------+---------+----------------------------------------------------------------------------------------------------------+
| detector_id                      | arn                                                                                 | created_at          | status  | service_role                                                                                             |
+----------------------------------+-------------------------------------------------------------------------------------+---------------------+---------+----------------------------------------------------------------------------------------------------------+
| 14b904863ae3b3c24d48d2ee21ac160a | arn:aws:guardduty:ap-south-1:986325076436:detector/14b904863ae3b3c24d48d2ee21ac160a | 2020-05-12 13:21:51 | ENABLED | arn:aws:iam::986325076436:role/aws-service-role/guardduty.amazonaws.com/AWSServiceRoleForAmazonGuardDuty |
+----------------------------------+-------------------------------------------------------------------------------------+---------------------+---------+----------------------------------------------------------------------------------------------------------+
```
</details>
