### PR TITLE
Improve / fix example: Availability zone count for each VPC lambda function. Closes #396

### DIFF
--- a/docs/tables/aws_lambda_function.md
+++ b/docs/tables/aws_lambda_function.md
@@ -58,7 +58,7 @@ select
 from
   aws_lambda_function as fn
   cross join jsonb_array_elements_text(vpc_subnet_ids) as vpc_subnet
-  join aws_new.aws_vpc_subnet as sub on sub.subnet_id = vpc_subnet
+  join aws_vpc_subnet as sub on sub.subnet_id = vpc_subnet
 group by
   fn.name,
   fn.region

--- a/docs/tables/aws_lambda_function.md
+++ b/docs/tables/aws_lambda_function.md
@@ -53,14 +53,17 @@ where
 ```sql
 select
   fn.name,
+  fn.region,
   count (availability_zone) as zone_count
 from
   aws_lambda_function as fn
   cross join jsonb_array_elements_text(vpc_subnet_ids) as vpc_subnet
-  join aws_vpc_subnet as sub on sub.subnet_id = vpc_subnet
+  join aws_new.aws_vpc_subnet as sub on sub.subnet_id = vpc_subnet
 group by
   fn.name,
-  sub.availability_zone;
+  fn.region
+order by
+  zone_count;
 ```
 
 
@@ -72,7 +75,7 @@ select
   a.action,
   a.access_level,
   a.description
-from 
+from
   aws_lambda_function as f,
   aws_iam_role as r,
   jsonb_array_elements_text(r.attached_policy_arns) as pol_arn,
@@ -83,7 +86,7 @@ from
   join aws_iam_action a ON a.action LIKE action_regex
 where
   f.role = r.arn
-  and pol_arn = p.arn 
+  and pol_arn = p.arn
   and stmt ->> 'Effect' = 'Allow'
   and f.name = 'hellopython';
 ```


### PR DESCRIPTION
…

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
NA
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Table: aws_lambda_function

### Availability zone count for each VPC lambda function
> select
  fn.name,
  fn.region,
  count (availability_zone) as zone_count
from
  aws_lambda_function as fn
  cross join jsonb_array_elements_text(vpc_subnet_ids) as vpc_subnet
  join aws_vpc_subnet as sub on sub.subnet_id = vpc_subnet
group by
  fn.name,
  fn.region
order by
  zone_count;
  
+---------+-----------+------------+
| name    | region    | zone_count |
+---------+-----------+------------+
| testing | us-east-2 | 1          |
| test5   | us-east-2 | 3          |
+---------+-----------+------------+
```
</details>
