### PR TITLE
Add shadow trails in table aws_cloudtrail_trail closes #438

### DIFF
--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -323,6 +323,11 @@ func getCloudtrailTrailStatus(ctx context.Context, d *plugin.QueryData, h *plugi
 	// List resource tags
 	item, err := svc.GetTrailStatus(params)
 	if err != nil {
+		if a, ok := err.(awserr.Error); ok {
+			if a.Code() == "TrailNotFoundException" {
+				return nil, nil
+			}
+		}
 		return nil, err
 	}
 	return item, nil
@@ -352,6 +357,11 @@ func getCloudtrailTrailEventSelector(ctx context.Context, d *plugin.QueryData, h
 	// List resource tags
 	item, err := svc.GetEventSelectors(params)
 	if err != nil {
+		if a, ok := err.(awserr.Error); ok {
+			if a.Code() == "TrailNotFoundException" {
+				return nil, nil
+			}
+		}
 		return nil, err
 	}
 	return item, nil
@@ -381,6 +391,11 @@ func getCloudtrailTrailInsightSelector(ctx context.Context, d *plugin.QueryData,
 	// List resource tags
 	item, err := svc.GetInsightSelectors(params)
 	if err != nil {
+		if a, ok := err.(awserr.Error); ok {
+			if a.Code() == "TrailNotFoundException" {
+				return nil, nil
+			}
+		}
 		return nil, err
 	}
 	return item, nil

--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -9,7 +9,6 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/cloudtrail"
 )
 
@@ -310,6 +309,12 @@ func getCloudtrailTrailStatus(ctx context.Context, d *plugin.QueryData, h *plugi
 	}
 	trail := h.Item.(*cloudtrail.Trail)
 
+	// Avoid api call if home_region is not equal to current region
+	homeRegion := *h.Item.(*cloudtrail.Trail).HomeRegion
+	if region != homeRegion {
+		return nil, nil
+	}
+
 	// Create session
 	svc, err := CloudTrailService(ctx, d, region)
 	if err != nil {
@@ -323,11 +328,6 @@ func getCloudtrailTrailStatus(ctx context.Context, d *plugin.QueryData, h *plugi
 	// List resource tags
 	item, err := svc.GetTrailStatus(params)
 	if err != nil {
-		if a, ok := err.(awserr.Error); ok {
-			if a.Code() == "TrailNotFoundException" {
-				return nil, nil
-			}
-		}
 		return nil, err
 	}
 	return item, nil
@@ -344,6 +344,12 @@ func getCloudtrailTrailEventSelector(ctx context.Context, d *plugin.QueryData, h
 	}
 	trail := h.Item.(*cloudtrail.Trail)
 
+	// Avoid api call if home_region is not equal to current region
+	homeRegion := *h.Item.(*cloudtrail.Trail).HomeRegion
+	if region != homeRegion {
+		return nil, nil
+	}
+
 	// Create session
 	svc, err := CloudTrailService(ctx, d, region)
 	if err != nil {
@@ -357,11 +363,6 @@ func getCloudtrailTrailEventSelector(ctx context.Context, d *plugin.QueryData, h
 	// List resource tags
 	item, err := svc.GetEventSelectors(params)
 	if err != nil {
-		if a, ok := err.(awserr.Error); ok {
-			if a.Code() == "TrailNotFoundException" {
-				return nil, nil
-			}
-		}
 		return nil, err
 	}
 	return item, nil
@@ -378,6 +379,12 @@ func getCloudtrailTrailInsightSelector(ctx context.Context, d *plugin.QueryData,
 	}
 	trail := h.Item.(*cloudtrail.Trail)
 
+	// Avoid api call if home_region is not equal to current region
+	homeRegion := *h.Item.(*cloudtrail.Trail).HomeRegion
+	if region != homeRegion {
+		return nil, nil
+	}
+
 	// Create session
 	svc, err := CloudTrailService(ctx, d, region)
 	if err != nil {
@@ -391,11 +398,6 @@ func getCloudtrailTrailInsightSelector(ctx context.Context, d *plugin.QueryData,
 	// List resource tags
 	item, err := svc.GetInsightSelectors(params)
 	if err != nil {
-		if a, ok := err.(awserr.Error); ok {
-			if a.Code() == "TrailNotFoundException" {
-				return nil, nil
-			}
-		}
 		return nil, err
 	}
 	return item, nil
@@ -412,6 +414,12 @@ func getCloudtrailTrailTags(ctx context.Context, d *plugin.QueryData, h *plugin.
 	}
 	trail := h.Item.(*cloudtrail.Trail)
 
+	// Avoid api call if home_region is not equal to current region
+	homeRegion := *h.Item.(*cloudtrail.Trail).HomeRegion
+	if region != homeRegion {
+		return []*cloudtrail.Tag{}, nil
+	}
+
 	// Create session
 	svc, err := CloudTrailService(ctx, d, region)
 	if err != nil {
@@ -424,11 +432,6 @@ func getCloudtrailTrailTags(ctx context.Context, d *plugin.QueryData, h *plugin.
 
 	resp, err := svc.ListTags(params)
 	if err != nil {
-		if a, ok := err.(awserr.Error); ok {
-			if a.Code() == "CloudTrailARNInvalidException" || a.Code() == "InvalidTrailNameException" || a.Code() == "TrailNotFoundException" {
-				return []*cloudtrail.Tag{}, nil
-			}
-		}
 		return nil, err
 	}
 

--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -310,7 +310,7 @@ func getCloudtrailTrailStatus(ctx context.Context, d *plugin.QueryData, h *plugi
 	trail := h.Item.(*cloudtrail.Trail)
 
 	// Avoid api call if home_region is not equal to current region
-	homeRegion := *h.Item.(*cloudtrail.Trail).HomeRegion
+	homeRegion := *trail.HomeRegion
 	if region != homeRegion {
 		return nil, nil
 	}
@@ -345,7 +345,7 @@ func getCloudtrailTrailEventSelector(ctx context.Context, d *plugin.QueryData, h
 	trail := h.Item.(*cloudtrail.Trail)
 
 	// Avoid api call if home_region is not equal to current region
-	homeRegion := *h.Item.(*cloudtrail.Trail).HomeRegion
+	homeRegion := *trail.HomeRegion
 	if region != homeRegion {
 		return nil, nil
 	}
@@ -380,7 +380,7 @@ func getCloudtrailTrailInsightSelector(ctx context.Context, d *plugin.QueryData,
 	trail := h.Item.(*cloudtrail.Trail)
 
 	// Avoid api call if home_region is not equal to current region
-	homeRegion := *h.Item.(*cloudtrail.Trail).HomeRegion
+	homeRegion := *trail.HomeRegion
 	if region != homeRegion {
 		return nil, nil
 	}
@@ -415,7 +415,7 @@ func getCloudtrailTrailTags(ctx context.Context, d *plugin.QueryData, h *plugin.
 	trail := h.Item.(*cloudtrail.Trail)
 
 	// Avoid api call if home_region is not equal to current region
-	homeRegion := *h.Item.(*cloudtrail.Trail).HomeRegion
+	homeRegion := *trail.HomeRegion
 	if region != homeRegion {
 		return []*cloudtrail.Tag{}, nil
 	}

--- a/docs/tables/aws_cloudtrail_trail.md
+++ b/docs/tables/aws_cloudtrail_trail.md
@@ -80,12 +80,17 @@ where
   not log_file_validation_enabled;
 ```
 
-### List distinct trails 
+### List shadow trails
+
 ```sql
-select DISTINCT
+select
   name,
   arn,
+  region,
   home_region
 from
-  aws_cloudtrail_trail;
+  aws_cloudtrail_trail
+where
+  is_multi_region_trail
+  and home_region <> region;
 ```

--- a/docs/tables/aws_cloudtrail_trail.md
+++ b/docs/tables/aws_cloudtrail_trail.md
@@ -80,7 +80,7 @@ where
   not log_file_validation_enabled;
 ```
 
-### List trails with DISTINCT 
+### List distinct trails 
 ```sql
 select DISTINCT
   name,

--- a/docs/tables/aws_cloudtrail_trail.md
+++ b/docs/tables/aws_cloudtrail_trail.md
@@ -79,3 +79,13 @@ from
 where
   not log_file_validation_enabled;
 ```
+
+### List trails with DISTINCT 
+```sql
+select DISTINCT
+  name,
+  arn,
+  home_region
+from
+  aws_cloudtrail_trail;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```

SETUP: tests/aws_cloudtrail_trail []

PRETEST: tests/aws_cloudtrail_trail

TEST: tests/aws_cloudtrail_trail
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_s3_bucket.named_test_resource: Creating...
aws_s3_bucket.named_test_resource: Still creating... [10s elapsed]
aws_s3_bucket.named_test_resource: Creation complete after 17s [id=turbottest66556]
aws_cloudtrail.named_test_resource: Creating...
aws_cloudtrail.named_test_resource: Creation complete after 8s [id=turbottest66556]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

account_id = 986325076436
aws_partition = aws
region_name = us-east-1
resource_aka = arn:aws:cloudtrail:us-east-1:986325076436:trail/turbottest66556
resource_name = turbottest66556

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:cloudtrail:us-east-1:986325076436:trail/turbottest66556",
    "has_custom_event_selectors": true,
    "has_insight_selectors": false,
    "home_region": "us-east-1",
    "include_global_service_events": false,
    "is_multi_region_trail": false,
    "is_organization_trail": false,
    "log_file_validation_enabled": false,
    "name": "turbottest66556",
    "s3_bucket_name": "turbottest66556",
    "s3_key_prefix": "prefix"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "event_selectors": [
      {
        "DataResources": [
          {
            "Type": "AWS::Lambda::Function",
            "Values": [
              "arn:aws:lambda"
            ]
          }
        ],
        "ExcludeManagementEventSources": [],
        "IncludeManagementEvents": true,
        "ReadWriteType": "All"
      }
    ],
    "is_logging": true,
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest66556"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "arn": "arn:aws:cloudtrail:us-east-1:986325076436:trail/turbottest66556",
    "name": "turbottest66556"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:cloudtrail:us-east-1:986325076436:trail/turbottest66556"
    ],
    "tags": {
      "name": "turbottest66556"
    },
    "title": "turbottest66556"
  }
]
✔ PASSED

POSTTEST: tests/aws_cloudtrail_trail

TEARDOWN: tests/aws_cloudtrail_trail

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
select name, arn, tags_src, tags from aws_cloudtrail_trail;

```

```
+-------------------------------------+-------------------------------------------------------------------------------------+----------+------+
| name                                | arn                                                                                 | tags_src | tags |
+-------------------------------------+-------------------------------------------------------------------------------------+----------+------+
| turbot-986325076436-us-east-2-trail | arn:aws:cloudtrail:us-east-2:986325076436:trail/turbot-986325076436-us-east-2-trail | []       | {}   |
| turbot-986325076436-us-east-1-trail | arn:aws:cloudtrail:us-east-1:986325076436:trail/turbot-986325076436-us-east-1-trail | []       | {}   |
+-------------------------------------+-------------------------------------------------------------------------------------+----------+------+
```
</details>
