### PR TITLE
Add column arn for the table aws_vpc_network_acl. Closes #451

### DIFF
--- a/aws-test/tests/aws_vpc_network_acl/test-get-expected.json
+++ b/aws-test/tests/aws_vpc_network_acl/test-get-expected.json
@@ -1,5 +1,6 @@
 [
   {
+    "arn": "{{ output.resource_aka.value }}",
     "entries": [
       {
         "CidrBlock": "10.3.0.0/18",

--- a/aws-test/tests/aws_vpc_network_acl/test-get-query.sql
+++ b/aws-test/tests/aws_vpc_network_acl/test-get-query.sql
@@ -1,3 +1,3 @@
-select network_acl_id, vpc_id, owner_id, is_default, entries, tags_src
+select network_acl_id, arn, vpc_id, owner_id, is_default, entries, tags_src
 from aws.aws_vpc_network_acl
 where network_acl_id = '{{ output.resource_id.value }}'

--- a/aws/table_aws_vpc_network_acl.go
+++ b/aws/table_aws_vpc_network_acl.go
@@ -30,6 +30,13 @@ func tableAwsVpcNetworkACL(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "arn",
+				Description: "The Amazon Resource Name (ARN) specifying the network ACL.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getVpcNetworkACLARN,
+				Transform:   transform.FromValue(),
+			},
+			{
 				Name:        "is_default",
 				Description: "Indicates whether this is the default network ACL for the VPC.",
 				Type:        proto.ColumnType_BOOL,
@@ -76,8 +83,8 @@ func tableAwsVpcNetworkACL(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getVpcNetworkACLTurbotAkas,
-				Transform:   transform.FromValue(),
+				Hydrate:     getVpcNetworkACLARN,
+				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
 			},
 		}),
 	}
@@ -152,8 +159,8 @@ func getVpcNetworkACL(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 	return nil, nil
 }
 
-func getVpcNetworkACLTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getVpcNetworkACLTurbotAkas")
+func getVpcNetworkACLARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getVpcNetworkACLARN")
 	networkACL := h.Item.(*ec2.NetworkAcl)
 	commonData, err := getCommonColumns(ctx, d, h)
 	if err != nil {
@@ -162,9 +169,9 @@ func getVpcNetworkACLTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plu
 	commonColumnData := commonData.(*awsCommonColumnData)
 
 	// Get data for turbot defined properties
-	akas := []string{"arn:" + commonColumnData.Partition + ":ec2:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":network-acl/" + *networkACL.NetworkAclId}
+	arn := "arn:" + commonColumnData.Partition + ":ec2:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":network-acl/" + *networkACL.NetworkAclId
 
-	return akas, nil
+	return arn, nil
 }
 
 //// TRANSFORM FUNCTIONS

--- a/docs/tables/aws_vpc_network_acl.md
+++ b/docs/tables/aws_vpc_network_acl.md
@@ -9,6 +9,7 @@ A network access control list (ACL) is an optional layer of security for your VP
 ```sql
 select
   network_acl_id,
+  arn,
   vpc_id
 from
   aws_vpc_network_acl;


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
vishalkumar@Vishals-MacBook-Air aws-test % TURBOT_PROFILE=shaktiman TF_VAR_aws_profile=shaktiman ./tint.js tests/aws_vpc_network_acl
No env file present for the current environment:  staging
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_vpc_network_acl []

PRETEST: tests/aws_vpc_network_acl

TEST: tests/aws_vpc_network_acl
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.main: Creating...
aws_vpc.main: Still creating... [10s elapsed]
aws_vpc.main: Creation complete after 20s [id=vpc-08c99d389ef9adc82]
aws_network_acl.named_test_resource: Creating...
aws_network_acl.named_test_resource: Creation complete after 8s [id=acl-06bb49039a769505b]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

account_id = 986325076436
resource_aka = arn:aws:ec2:us-east-1:986325076436:network-acl/acl-06bb49039a769505b
resource_id = acl-06bb49039a769505b
resource_name = turbottest76308
vpc_id = vpc-08c99d389ef9adc82

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:ec2:us-east-1:986325076436:network-acl/acl-06bb49039a769505b",
    "entries": [
      {
        "CidrBlock": "10.3.0.0/18",
        "Egress": true,
        "IcmpTypeCode": null,
        "Ipv6CidrBlock": null,
        "PortRange": {
          "From": 443,
          "To": 443
        },
        "Protocol": "6",
        "RuleAction": "allow",
        "RuleNumber": 200
      },
      {
        "CidrBlock": "0.0.0.0/0",
        "Egress": true,
        "IcmpTypeCode": null,
        "Ipv6CidrBlock": null,
        "PortRange": null,
        "Protocol": "-1",
        "RuleAction": "deny",
        "RuleNumber": 32767
      },
      {
        "CidrBlock": "10.3.0.0/18",
        "Egress": false,
        "IcmpTypeCode": null,
        "Ipv6CidrBlock": null,
        "PortRange": {
          "From": 80,
          "To": 80
        },
        "Protocol": "6",
        "RuleAction": "allow",
        "RuleNumber": 100
      },
      {
        "CidrBlock": "0.0.0.0/0",
        "Egress": false,
        "IcmpTypeCode": null,
        "Ipv6CidrBlock": null,
        "PortRange": null,
        "Protocol": "-1",
        "RuleAction": "deny",
        "RuleNumber": 32767
      }
    ],
    "is_default": false,
    "network_acl_id": "acl-06bb49039a769505b",
    "owner_id": "986325076436",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest76308"
      }
    ],
    "vpc_id": "vpc-08c99d389ef9adc82"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:986325076436:network-acl/acl-06bb49039a769505b"
    ],
    "network_acl_id": "acl-06bb49039a769505b",
    "tags": {
      "Name": "turbottest76308"
    },
    "title": "turbottest76308"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:986325076436:network-acl/acl-06bb49039a769505b"
    ],
    "network_acl_id": "acl-06bb49039a769505b",
    "owner_id": "986325076436",
    "tags": {
      "Name": "turbottest76308"
    },
    "title": "turbottest76308"
  }
]
✔ PASSED

POSTTEST: tests/aws_vpc_network_acl

TEARDOWN: tests/aws_vpc_network_acl

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
- List the attached VPC IDs for each network ACL

select
  network_acl_id,
  arn,
  vpc_id
from
  aws_vpc_network_acl;

+-----------------------+----------------------------------------------------------------------+-----------------------+
| network_acl_id        | arn                                                                  | vpc_id                |
+-----------------------+----------------------------------------------------------------------+-----------------------+
| acl-014e28281358c25a8 | arn:aws:ec2:us-east-1:986325076436:network-acl/acl-014e28281358c25a8 | vpc-0d8ff19ff4f78357c |
| acl-0763deb33af3eeb72 | arn:aws:ec2:us-east-1:986325076436:network-acl/acl-0763deb33af3eeb72 | vpc-029ff5058a3b30699 |
+-----------------------+----------------------------------------------------------------------+-----------------------+
```
</details>
