### PR TITLE
Add a column to store CacheCluster.SnapshotRetentionLimit property in table aws_elasticache_cluster. Closes #448

### DIFF
--- a/aws/table_aws_elasticache_cluster.go
+++ b/aws/table_aws_elasticache_cluster.go
@@ -114,6 +114,12 @@ func tableAwsElastiCacheCluster(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_BOOL,
 			},
 			{
+				Name:        "snapshot_retention_limit",
+				Description: "The number of days for which ElastiCache retains automatic cluster snapshots before deleting them.",
+				Type:        proto.ColumnType_INT,
+				Hydrate:     getElastiCacheCluster,
+			},
+			{
 				Name:        "cache_parameter_group",
 				Description: "Status of the cache parameter group.",
 				Type:        proto.ColumnType_JSON,

--- a/aws/table_aws_elasticache_cluster.go
+++ b/aws/table_aws_elasticache_cluster.go
@@ -117,7 +117,6 @@ func tableAwsElastiCacheCluster(_ context.Context) *plugin.Table {
 				Name:        "snapshot_retention_limit",
 				Description: "The number of days for which ElastiCache retains automatic cluster snapshots before deleting them.",
 				Type:        proto.ColumnType_INT,
-				Hydrate:     getElastiCacheCluster,
 			},
 			{
 				Name:        "cache_parameter_group",

--- a/aws/table_aws_elasticache_cluster.go
+++ b/aws/table_aws_elasticache_cluster.go
@@ -109,14 +109,24 @@ func tableAwsElastiCacheCluster(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "transit_encryption_enabled",
-				Description: "A flag that enables in-transit encryption when set to true.",
-				Type:        proto.ColumnType_BOOL,
+				Name:        "replication_group_id",
+				Description: "The replication group to which this cluster belongs.",
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "snapshot_retention_limit",
 				Description: "The number of days for which ElastiCache retains automatic cluster snapshots before deleting them.",
 				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "snapshot_window",
+				Description: "The daily time range (in UTC) during which ElastiCache begins taking a daily snapshot of your cluster.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "transit_encryption_enabled",
+				Description: "A flag that enables in-transit encryption when set to true.",
+				Type:        proto.ColumnType_BOOL,
 			},
 			{
 				Name:        "cache_parameter_group",

--- a/docs/tables/aws_elasticache_cluster.md
+++ b/docs/tables/aws_elasticache_cluster.md
@@ -17,7 +17,6 @@ where
   not at_rest_encryption_enabled;
 ```
 
-
 ### List clusters whose availability zone count is less than 2
 
 ```sql
@@ -29,7 +28,6 @@ from
 where
   preferred_availability_zone <> 'Multiple';
 ```
-
 
 ### List clusters that do not enforce encryption in transit
 
@@ -43,7 +41,6 @@ from
 where
   not transit_encryption_enabled;
 ```
-
 
 ### List clusters provisioned with undesired (for example, cache.m5.large and cache.m4.4xlarge are desired) node types
 
@@ -59,7 +56,6 @@ group by
   cache_node_type;
 ```
 
-
 ### List clusters with inactive notification configuration topics
 
 ```sql
@@ -74,7 +70,6 @@ where
   notification_configuration ->> 'TopicStatus' = 'inactive';
 ```
 
-
 ### Get security group details for each cluster
 
 ```sql
@@ -87,17 +82,16 @@ from
   jsonb_array_elements(security_groups) as sg;
 ```
 
-
-### Check Minimum snapshot retention period for Redis cluster is 15 days
+### List clusters with automatic backup disabled
 
 ```sql
 select
   cache_cluster_id,
   cache_node_type,
-  at_rest_encryption_enabled,
+  cache_cluster_status,
   snapshot_retention_limit
 from
   aws_elasticache_cluster
 where
-  snapshot_retention_limit > 15;
+  snapshot_retention_limit is null;
 ```

--- a/docs/tables/aws_elasticache_cluster.md
+++ b/docs/tables/aws_elasticache_cluster.md
@@ -86,3 +86,18 @@ from
   aws_elasticache_cluster,
   jsonb_array_elements(security_groups) as sg;
 ```
+
+
+### Check Minimum snapshot retention period for Redis cluster is 15 days
+
+```sql
+select
+  cache_cluster_id,
+  cache_node_type,
+  at_rest_encryption_enabled,
+  snapshot_retention_limit
+from
+  aws_elasticache_cluster
+where
+  snapshot_retention_limit > 15;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_elasticache_cluster []

PRETEST: tests/aws_elasticache_cluster

TEST: tests/aws_elasticache_cluster
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.template_file.resource_aka will be read during apply
  # (config refers to values not yet known)
 <= data "template_file" "resource_aka"  {
      + id       = (known after apply)
      + rendered = (known after apply)
      + template = "arn:${partition}:elasticache:${region}:${account_id}:cluster:turbottest40310"
      + vars     = {
          + "account_id" = "986325076436"
          + "partition"  = "aws"
          + "region"     = "us-east-1"
        }
    }

  # aws_elasticache_cluster.named_test_resource will be created
  + resource "aws_elasticache_cluster" "named_test_resource" {
      + apply_immediately      = (known after apply)
      + arn                    = (known after apply)
      + availability_zone      = (known after apply)
      + az_mode                = (known after apply)
      + cache_nodes            = (known after apply)
      + cluster_address        = (known after apply)
      + cluster_id             = "turbottest40310"
      + configuration_endpoint = (known after apply)
      + engine                 = "memcached"
      + engine_version         = (known after apply)
      + engine_version_actual  = (known after apply)
      + id                     = (known after apply)
      + maintenance_window     = (known after apply)
      + node_type              = "cache.t2.micro"
      + num_cache_nodes        = 2
      + parameter_group_name   = "default.memcached1.6"
      + port                   = 11211
      + replication_group_id   = (known after apply)
      + security_group_ids     = (known after apply)
      + security_group_names   = (known after apply)
      + snapshot_window        = (known after apply)
      + subnet_group_name      = "turbottest40310"
      + tags                   = {
          + "name" = "turbottest40310"
        }
      + tags_all               = (known after apply)
    }

  # aws_elasticache_subnet_group.my_subnet_group will be created
  + resource "aws_elasticache_subnet_group" "my_subnet_group" {
      + arn         = (known after apply)
      + description = "Managed by Terraform"
      + id          = (known after apply)
      + name        = "turbottest40310"
      + subnet_ids  = (known after apply)
      + tags_all    = (known after apply)
    }

  # aws_subnet.my_subnet will be created
  + resource "aws_subnet" "my_subnet" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "us-east-1a"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "10.0.0.0/24"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags_all                        = (known after apply)
      + vpc_id                          = (known after apply)
    }

  # aws_vpc.my_vpc will be created
  + resource "aws_vpc" "my_vpc" {
      + arn                              = (known after apply)
      + assign_generated_ipv6_cidr_block = false
      + cidr_block                       = "10.0.0.0/16"
      + default_network_acl_id           = (known after apply)
      + default_route_table_id           = (known after apply)
      + default_security_group_id        = (known after apply)
      + dhcp_options_id                  = (known after apply)
      + enable_classiclink               = (known after apply)
      + enable_classiclink_dns_support   = (known after apply)
      + enable_dns_hostnames             = (known after apply)
      + enable_dns_support               = true
      + id                               = (known after apply)
      + instance_tenancy                 = "default"
      + ipv6_association_id              = (known after apply)
      + ipv6_cidr_block                  = (known after apply)
      + main_route_table_id              = (known after apply)
      + owner_id                         = (known after apply)
      + tags_all                         = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id       = "986325076436"
  + cache_cluster_id = "turbottest40310"
  + resource_aka     = (known after apply)
  + resource_id      = "turbottest40310"
  + resource_name    = "turbottest40310"
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Still creating... [10s elapsed]
aws_vpc.my_vpc: Creation complete after 16s [id=vpc-0ea6e9fbcf4ccc67d]
aws_subnet.my_subnet: Creating...
aws_subnet.my_subnet: Creation complete after 4s [id=subnet-0eb498c3fecf0f05e]
aws_elasticache_subnet_group.my_subnet_group: Creating...
aws_elasticache_subnet_group.my_subnet_group: Creation complete after 5s [id=turbottest40310]
aws_elasticache_cluster.named_test_resource: Creating...
aws_elasticache_cluster.named_test_resource: Still creating... [10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m0s elapsed]
aws_elasticache_cluster.named_test_resource: Creation complete after 6m0s [id=turbottest40310]
data.template_file.resource_aka: Reading...
data.template_file.resource_aka: Read complete after 0s [id=d439ba6c182b426086eff21e850e911df0c8c6bc3004aa8d62c33848b234dc55]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

account_id = "986325076436"
cache_cluster_id = "turbottest40310"
resource_aka = "arn:aws:elasticache:us-east-1:986325076436:cluster:turbottest40310"
resource_id = "turbottest40310"
resource_name = "turbottest40310"

Running SQL query: test-get-query.sql
[
  {
    "cache_cluster_id": "turbottest40310",
    "cache_node_type": "cache.t2.micro",
    "engine": "memcached",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest40310"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:elasticache:us-east-1:986325076436:cluster:turbottest40310"
    ],
    "cache_cluster_id": "turbottest40310",
    "tags": {
      "name": "turbottest40310"
    },
    "title": "turbottest40310"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:elasticache:us-east-1:986325076436:cluster:turbottest40310"
    ],
    "cache_cluster_id": "turbottest40310",
    "cache_node_type": "cache.t2.micro",
    "engine": "memcached",
    "title": "turbottest40310"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

POSTTEST: tests/aws_elasticache_cluster

TEARDOWN: tests/aws_elasticache_cluster

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select
  cache_cluster_id,
  cache_node_type,
  at_rest_encryption_enabled,
  snapshot_retention_limit
from
  aws_elasticache_cluster
where
  snapshot_retention_limit > 15;
```
+------------------+-----------------+----------------------------+--------------------------+
| cache_cluster_id | cache_node_type | at_rest_encryption_enabled | snapshot_retention_limit |
+------------------+-----------------+----------------------------+--------------------------+
+------------------+-----------------+----------------------------+--------------------------+
```
