### PR TITLE
Add table aws_redshift_cluster arn. Closes #452

### DIFF
--- a/aws-test/tests/aws_redshift_cluster/test-get-expected.json
+++ b/aws-test/tests/aws_redshift_cluster/test-get-expected.json
@@ -4,6 +4,7 @@
       "{{ output.resource_aka.value }}"
     ],
     "allow_version_upgrade": true,
+    "arn": "{{ output.resource_aka.value }}",
     "cluster_identifier": "{{ output.resource_name.value }}"
   }
 ]

--- a/aws-test/tests/aws_redshift_cluster/test-get-query.sql
+++ b/aws-test/tests/aws_redshift_cluster/test-get-query.sql
@@ -1,3 +1,3 @@
-select cluster_identifier, akas, allow_version_upgrade
+select cluster_identifier, akas, arn, allow_version_upgrade
 from aws.aws_redshift_cluster
 where cluster_identifier = '{{ output.resource_name.value }}';

--- a/aws-test/tests/aws_redshift_cluster/test-hydrate-expected.json
+++ b/aws-test/tests/aws_redshift_cluster/test-hydrate-expected.json
@@ -4,6 +4,7 @@
       "{{ output.resource_aka.value }}"
     ],
     "allow_version_upgrade": true,
+    "arn": "{{ output.resource_aka.value }}",
     "cluster_identifier": "{{ output.resource_name.value }}"
   }
 ]

--- a/aws-test/tests/aws_redshift_cluster/test-hydrate-query.sql
+++ b/aws-test/tests/aws_redshift_cluster/test-hydrate-query.sql
@@ -1,3 +1,3 @@
-select cluster_identifier, akas, allow_version_upgrade
+select cluster_identifier, akas, arn, allow_version_upgrade
 from aws.aws_redshift_cluster
 where cluster_identifier = '{{ output.resource_name.value }}';

--- a/aws/table_aws_redshift_cluster.go
+++ b/aws/table_aws_redshift_cluster.go
@@ -34,6 +34,13 @@ func tableAwsRedshiftCluster(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "arn",
+				Description: "The Amazon Resource Name (ARN) specifying the redshift cluster.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getRedshiftClusterARN,
+				Transform:   transform.FromValue(),
+			},
+			{
 				Name:        "cluster_namespace_arn",
 				Description: "The namespace Amazon Resource Name (ARN) of the cluster.",
 				Type:        proto.ColumnType_STRING,
@@ -277,13 +284,8 @@ func tableAwsRedshiftCluster(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("Tags"),
 			},
-			// Standard columns
-			{
-				Name:        "tags",
-				Description: resourceInterfaceDescription("tags"),
-				Type:        proto.ColumnType_JSON,
-				Transform:   transform.From(getRedshiftClusterTurbotTags),
-			},
+
+			// Steampipe standard columns
 			{
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
@@ -291,11 +293,17 @@ func tableAwsRedshiftCluster(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("ClusterIdentifier"),
 			},
 			{
+				Name:        "tags",
+				Description: resourceInterfaceDescription("tags"),
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.From(getRedshiftClusterTurbotTags),
+			},
+			{
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getRedshiftClusterAkas,
-				Transform:   transform.FromValue(),
+				Hydrate:     getRedshiftClusterARN,
+				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
 			},
 		}),
 	}
@@ -408,8 +416,8 @@ func getRedshiftLoggingDetails(ctx context.Context, d *plugin.QueryData, h *plug
 	return op, nil
 }
 
-func getRedshiftClusterAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getRedshiftClusterAkas")
+func getRedshiftClusterARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getRedshiftClusterARN")
 	cluster := h.Item.(*redshift.Cluster)
 
 	c, err := getCommonColumns(ctx, d, h)
@@ -418,9 +426,9 @@ func getRedshiftClusterAkas(ctx context.Context, d *plugin.QueryData, h *plugin.
 	}
 
 	commonColumnData := c.(*awsCommonColumnData)
-	aka := []string{"arn:" + commonColumnData.Partition + ":redshift:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":cluster:" + *cluster.ClusterIdentifier}
+	arn := "arn:" + commonColumnData.Partition + ":redshift:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":cluster:" + *cluster.ClusterIdentifier
 
-	return aka, nil
+	return arn, nil
 }
 
 //// TRANSFORM FUNCTIONS ////

--- a/aws/table_aws_redshift_cluster.go
+++ b/aws/table_aws_redshift_cluster.go
@@ -35,7 +35,7 @@ func tableAwsRedshiftCluster(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "arn",
-				Description: "The Amazon Resource Name (ARN) specifying the redshift cluster.",
+				Description: "The Amazon Resource Name (ARN) specifying the cluster.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getRedshiftClusterARN,
 				Transform:   transform.FromValue(),

--- a/docs/tables/aws_redshift_cluster.md
+++ b/docs/tables/aws_redshift_cluster.md
@@ -9,7 +9,7 @@ A cluster is a fully managed data warehouse that consists of a set of compute no
 ```sql
 select
   cluster_identifier,
-  akas,
+  arn,
   node_type,
   region
 from


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_redshift_cluster []

PRETEST: tests/aws_redshift_cluster

TEST: tests/aws_redshift_cluster
Running terraform
aws_vpc.my_vpc: Refreshing state... [id=vpc-0b1a0e5b13ad8c64a]
aws_internet_gateway.igw: Refreshing state... [id=igw-074e9de833bbd7bea]
aws_subnet.my_subnet1: Refreshing state... [id=subnet-0368deefa845c0cf6]
aws_subnet.my_subnet2: Refreshing state... [id=subnet-0b7a8ceb19eb982ee]
aws_redshift_subnet_group.my_subnet_group: Refreshing state... [id=turbottest88863]
aws_redshift_cluster.named_test_resource: Refreshing state... [id=turbottest88863]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the
last "terraform apply":

  # aws_internet_gateway.igw has been changed
  ~ resource "aws_internet_gateway" "igw" {
        id       = "igw-074e9de833bbd7bea"
      + tags     = {}
        # (4 unchanged attributes hidden)
    }
  # aws_subnet.my_subnet2 has been changed
  ~ resource "aws_subnet" "my_subnet2" {
        id                              = "subnet-0b7a8ceb19eb982ee"
      + tags                            = {}
        # (10 unchanged attributes hidden)
    }
  # aws_vpc.my_vpc has been changed
  ~ resource "aws_vpc" "my_vpc" {
        id                               = "vpc-0b1a0e5b13ad8c64a"
      + tags                             = {}
        # (15 unchanged attributes hidden)
    }
  # aws_subnet.my_subnet1 has been changed
  ~ resource "aws_subnet" "my_subnet1" {
        id                              = "subnet-0368deefa845c0cf6"
      + tags                            = {}
        # (10 unchanged attributes hidden)
    }
  # aws_redshift_subnet_group.my_subnet_group has been changed
  ~ resource "aws_redshift_subnet_group" "my_subnet_group" {
        id          = "turbottest88863"
        name        = "turbottest88863"
      + tags        = {}
        # (4 unchanged attributes hidden)
    }

Unless you have made equivalent changes to your configuration, or ignored the
relevant attributes using ignore_changes, the following plan may include
actions to undo or respond to these changes.

─────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_redshift_cluster.named_test_resource must be replaced
-/+ resource "aws_redshift_cluster" "named_test_resource" {
      ~ arn                                 = "arn:aws:redshift:us-east-1:986325076436:cluster:turbottest88863" -> (known after apply)
      ~ availability_zone                   = "us-east-1a" -> (known after apply)
      ~ cluster_identifier                  = "turbottest88863" -> "turbottest29368" # forces replacement
      ~ cluster_parameter_group_name        = "default.redshift-1.0" -> (known after apply)
      ~ cluster_public_key                  = <<-EOT
            ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCKiQVFUWpw9qPs8xUVWwJkjWSJms0BQStLnwV6UzbggiBCkkvwKZ/Kfw7irirGxJqLl+CXSk1BEJJchpjg0BRC0k/TlIOCHHXhFNztLH3kGnHBO4dqs7OWlK5MPYUVvZJnGxfRzopLeiSNuyq7danUbnYc84QvD0+3Ujtud0NwtTx+SkopAvWrkonl8Qwmd2GSFqKNg56+8CGWQmLheKIeH6skUO7/6x7X5wTCErYcdd5i2r8bA0SrbaI+jt9yVV0AmTFf1FU0hFSfQmh6NvFtxEYqEGFQH+63kEq1bWmcQIdZAr++CSKXFVA7UdI9dY17xf23gGG/rHRfpUaJgfk9 Amazon-Redshift
        EOT -> (known after apply)
      ~ cluster_revision_number             = "26742" -> (known after apply)
      ~ cluster_security_groups             = [] -> (known after apply)
      ~ cluster_subnet_group_name           = "turbottest88863" -> "turbottest29368" # forces replacement
      ~ dns_name                            = "turbottest88863.c0muailme6kb.us-east-1.redshift.amazonaws.com" -> (known after apply)
      ~ endpoint                            = "turbottest88863.c0muailme6kb.us-east-1.redshift.amazonaws.com:5439" -> (known after apply)
      ~ enhanced_vpc_routing                = false -> (known after apply)
      ~ iam_roles                           = [] -> (known after apply)
      ~ id                                  = "turbottest88863" -> (known after apply)
      + kms_key_id                          = (known after apply)
      ~ preferred_maintenance_window        = "tue:03:30-tue:04:00" -> (known after apply)
      ~ tags                                = {
          ~ "name" = "turbottest88863" -> "turbottest29368"
        }
      ~ tags_all                            = {
          ~ "name" = "turbottest88863" -> "turbottest29368"
        }
      ~ vpc_security_group_ids              = [
          - "sg-0248ea2ae0e6ab92b",
        ] -> (known after apply)
        # (13 unchanged attributes hidden)

      - logging {
          - enable = false -> null
        }
    }

  # aws_redshift_subnet_group.my_subnet_group must be replaced
-/+ resource "aws_redshift_subnet_group" "my_subnet_group" {
      ~ arn         = "arn:aws:redshift:us-east-1:986325076436:subnetgroup:turbottest88863" -> (known after apply)
      ~ id          = "turbottest88863" -> (known after apply)
      ~ name        = "turbottest88863" -> "turbottest29368" # forces replacement
      - tags        = {} -> null
      ~ tags_all    = {} -> (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 2 to add, 0 to change, 2 to destroy.

Changes to Outputs:
  ~ resource_aka  = "arn:aws:redshift:us-east-1:986325076436:cluster:turbottest88863" -> (known after apply)
  ~ resource_name = "turbottest88863" -> "turbottest29368"
aws_redshift_cluster.named_test_resource: Destroying... [id=turbottest88863]
aws_redshift_cluster.named_test_resource: Still destroying... [id=turbottest88863, 10s elapsed]
aws_redshift_cluster.named_test_resource: Still destroying... [id=turbottest88863, 20s elapsed]
aws_redshift_cluster.named_test_resource: Still destroying... [id=turbottest88863, 30s elapsed]
aws_redshift_cluster.named_test_resource: Still destroying... [id=turbottest88863, 40s elapsed]
aws_redshift_cluster.named_test_resource: Still destroying... [id=turbottest88863, 50s elapsed]
aws_redshift_cluster.named_test_resource: Still destroying... [id=turbottest88863, 1m0s elapsed]
aws_redshift_cluster.named_test_resource: Still destroying... [id=turbottest88863, 1m10s elapsed]
aws_redshift_cluster.named_test_resource: Still destroying... [id=turbottest88863, 1m20s elapsed]
aws_redshift_cluster.named_test_resource: Still destroying... [id=turbottest88863, 1m30s elapsed]
aws_redshift_cluster.named_test_resource: Still destroying... [id=turbottest88863, 1m40s elapsed]
aws_redshift_cluster.named_test_resource: Still destroying... [id=turbottest88863, 1m50s elapsed]
aws_redshift_cluster.named_test_resource: Still destroying... [id=turbottest88863, 2m0s elapsed]
aws_redshift_cluster.named_test_resource: Destruction complete after 2m4s
aws_redshift_subnet_group.my_subnet_group: Destroying... [id=turbottest88863]
aws_redshift_subnet_group.my_subnet_group: Destruction complete after 1s
aws_redshift_subnet_group.my_subnet_group: Creating...
aws_redshift_subnet_group.my_subnet_group: Creation complete after 4s [id=turbottest29368]
aws_redshift_cluster.named_test_resource: Creating...
aws_redshift_cluster.named_test_resource: Still creating... [10s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [20s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [30s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [40s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [50s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m0s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m10s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m20s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m30s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m40s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m50s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m0s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m10s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m20s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m30s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m40s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m50s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [3m0s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [3m10s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [3m20s elapsed]
aws_redshift_cluster.named_test_resource: Creation complete after 3m21s [id=turbottest29368]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 2 destroyed.

Outputs:

account_id = "986325076436"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:redshift:us-east-1:986325076436:cluster:turbottest29368"
resource_name = "turbottest29368"

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:redshift:us-east-1:986325076436:cluster:turbottest29368"
    ],
    "allow_version_upgrade": true,
    "arn": "arn:aws:redshift:us-east-1:986325076436:cluster:turbottest29368",
    "cluster_identifier": "turbottest29368"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:redshift:us-east-1:986325076436:cluster:turbottest29368"
    ],
    "allow_version_upgrade": true,
    "arn": "arn:aws:redshift:us-east-1:986325076436:cluster:turbottest29368",
    "cluster_identifier": "turbottest29368"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:redshift:us-east-1:986325076436:cluster:turbottest29368"
    ],
    "cluster_identifier": "turbottest29368"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:redshift:us-east-1:986325076436:cluster:turbottest29368"
    ],
    "cluster_identifier": "turbottest29368",
    "tags": {
      "name": "turbottest29368"
    },
    "title": "turbottest29368"
  }
]
✔ PASSED

POSTTEST: tests/aws_redshift_cluster

TEARDOWN: tests/aws_redshift_cluster

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select
  cluster_identifier,
  arn,
  node_type,
  region
from
  aws_redshift_cluster;
+--------------------+-----------------------------------------------------------------+-----------+-----------+
| cluster_identifier | arn                                                             | node_type | region    |
+--------------------+-----------------------------------------------------------------+-----------+-----------+
| turbottest88863    | arn:aws:redshift:us-east-1:986325076436:cluster:turbottest88863 | dc2.large | us-east-1 |
+--------------------+-----------------------------------------------------------------+-----------+-----------+
```
</details>
