### PR TITLE
Add a column to store bucket-default-lock-enabled property in aws_s3_bucket table. Closes#463

### DIFF
--- a/aws-test/tests/aws_s3_bucket/test-hydrate-expected.json
+++ b/aws-test/tests/aws_s3_bucket/test-hydrate-expected.json
@@ -84,6 +84,10 @@
     ],
     "logging": null,
     "name": "{{ resourceName }}",
+    "object_lock_configuration": {
+      "ObjectLockEnabled": "Enabled",
+      "Rule": null
+    },
     "policy": {
       "Id": "MYBUCKETPOLICY",
       "Statement": [

--- a/aws-test/tests/aws_s3_bucket/test-hydrate-query.sql
+++ b/aws-test/tests/aws_s3_bucket/test-hydrate-query.sql
@@ -1,3 +1,3 @@
-select name, policy, policy_std, logging, acl, lifecycle_rules, server_side_encryption_configuration, replication, versioning_enabled, versioning_mfa_delete, bucket_policy_is_public
+select name, policy, policy_std, logging, acl, lifecycle_rules, server_side_encryption_configuration, replication, versioning_enabled, versioning_mfa_delete, bucket_policy_is_public, object_lock_configuration
 from aws.aws_s3_bucket
 where name = '{{ resourceName }}'

--- a/aws-test/tests/aws_s3_bucket/variables.tf
+++ b/aws-test/tests/aws_s3_bucket/variables.tf
@@ -125,6 +125,10 @@ resource "aws_s3_bucket" "named_test_resource" {
   tags = {
     name = var.resource_name
   }
+
+  object_lock_configuration {
+    object_lock_enabled = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_policy" "b" {

--- a/aws/table_aws_s3_bucket.go
+++ b/aws/table_aws_s3_bucket.go
@@ -63,6 +63,10 @@ func tableAwsS3Bucket(_ context.Context) *plugin.Table {
 				Func:    getBucketTagging,
 				Depends: []plugin.HydrateFunc{getBucketLocation},
 			},
+			{
+				Func:    getObjectLockConfiguration,
+				Depends: []plugin.HydrateFunc{getBucketLocation},
+			},
 		},
 		Columns: awsS3Columns([]*plugin.Column{
 			{
@@ -159,6 +163,12 @@ func tableAwsS3Bucket(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getBucketLogging,
 				Transform:   transform.FromField("LoggingEnabled"),
+			},
+			{
+				Name:        "object_lock_configuration",
+				Description: "The specified bucket's Object Lock Configuration.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getObjectLockConfiguration,
 			},
 			{
 				Name:        "policy",
@@ -588,6 +598,34 @@ func getBucketARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 	arn := "arn:" + commonColumnData.Partition + ":s3:::" + *bucket.Name
 
 	return arn, nil
+}
+
+func getObjectLockConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getObjectLockConfiguration")
+	bucket := h.Item.(*s3.Bucket)
+	location := h.HydrateResults["getBucketLocation"].(*s3.GetBucketLocationOutput)
+
+	// Create Session
+	svc, err := S3Service(ctx, d, *location.LocationConstraint)
+	if err != nil {
+		return nil, err
+	}
+
+	params := &s3.GetObjectLockConfigurationInput{
+		Bucket: bucket.Name,
+	}
+
+	data, err := svc.GetObjectLockConfiguration(params)
+	if err != nil {
+		if a, ok := err.(awserr.Error); ok {
+			if a.Code() == "ObjectLockConfigurationNotFoundError" {
+				return nil, nil
+			}
+		}
+		return nil, err
+	}
+
+	return data, nil
 }
 
 //// TRANSFORM FUNCTIONS

--- a/aws/table_aws_s3_bucket.go
+++ b/aws/table_aws_s3_bucket.go
@@ -166,7 +166,7 @@ func tableAwsS3Bucket(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "object_lock_configuration",
-				Description: "The specified bucket's Object Lock Configuration.",
+				Description: "The specified bucket's object lock configuration.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getObjectLockConfiguration,
 			},

--- a/docs/tables/aws_s3_bucket.md
+++ b/docs/tables/aws_s3_bucket.md
@@ -16,7 +16,6 @@ from
   aws_s3_bucket;
 ```
 
-
 ### List buckets with versioning disabled
 
 ```sql
@@ -31,7 +30,6 @@ where
   not versioning_enabled;
 ```
 
-
 ### List buckets with default encryption disabled
 
 ```sql
@@ -43,7 +41,6 @@ from
 where
   server_side_encryption_configuration is null;
 ```
-
 
 ### List buckets that do not block public access
 
@@ -63,7 +60,6 @@ where
   or not restrict_public_buckets;
 ```
 
-
 ### List buckets that block public access through bucket policies
 
 ```sql
@@ -76,7 +72,6 @@ where
   bucket_policy_is_public;
 ```
 
-
 ### List buckets where the server access logging destination is the same as the source bucket
 
 ```sql
@@ -88,7 +83,6 @@ from
 where
   logging ->> 'TargetBucket' = name;
 ```
-
 
 ### List buckets without the 'application' tags key
 
@@ -126,7 +120,6 @@ where
   and ssl :: bool = false;
 ```
 
-
 ### List buckets that do not enforce encryption in transit
 
 ```sql
@@ -153,8 +146,8 @@ where
   );
 ```
 
-
 ### List bucket policy statements that grant external access for each bucket
+
 ```sql
 select
   title,
@@ -174,4 +167,16 @@ where
     pa[5] != account_id
     or p = '*'
   );
+```
+
+### List buckets with enable object lock configuration
+
+```sql
+select
+  name,
+  object_lock_configuration ->> 'ObjectLockEnabled' as object_lock_enabled
+from
+  aws_s3_bucket
+where
+  object_lock_configuration ->> 'ObjectLockEnabled' = 'Enabled';
 ```

--- a/docs/tables/aws_s3_bucket.md
+++ b/docs/tables/aws_s3_bucket.md
@@ -169,7 +169,7 @@ where
   );
 ```
 
-### List buckets with enable object lock configuration
+### List buckets with object lock enabled
 
 ```sql
 select


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_s3_bucket []

PRETEST: tests/aws_s3_bucket

TEST: tests/aws_s3_bucket
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_kms_key.mykey will be created
  + resource "aws_kms_key" "mykey" {
      + arn                      = (known after apply)
      + customer_master_key_spec = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days  = 10
      + description              = "This key is used to encrypt bucket objects"
      + enable_key_rotation      = false
      + id                       = (known after apply)
      + is_enabled               = true
      + key_id                   = (known after apply)
      + key_usage                = "ENCRYPT_DECRYPT"
      + policy                   = (known after apply)
      + tags_all                 = (known after apply)
    }

  # aws_s3_bucket.named_test_resource will be created
  + resource "aws_s3_bucket" "named_test_resource" {
      + acceleration_status         = (known after apply)
      + acl                         = "private"
      + arn                         = (known after apply)
      + bucket                      = "turbottest76541"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags                        = {
          + "name" = "turbottest76541"
        }
      + tags_all                    = {
          + "name" = "turbottest76541"
        }
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = [
              + "*",
            ]
          + allowed_methods = [
              + "PUT",
              + "POST",
            ]
          + allowed_origins = [
              + "https://s3-website-test.hashicorp.com",
            ]
          + expose_headers  = [
              + "ETag",
            ]
          + max_age_seconds = 3000
        }

      + grant {
          + id          = "0a5ba5a7f5cc8fa7c3e709979205f6c650bc85629401c5b436cb94798440d2f6"
          + permissions = [
              + "FULL_CONTROL",
            ]
          + type        = "CanonicalUser"
        }

      + lifecycle_rule {
          + enabled = true
          + id      = "log"
          + prefix  = "log/"
          + tags    = {
              + "autoclean" = "true"
              + "rule"      = "log"
            }

          + expiration {
              + days = 90
            }

          + transition {
              + days          = 30
              + storage_class = "STANDARD_IA"
            }
          + transition {
              + days          = 60
              + storage_class = "GLACIER"
            }
        }
      + lifecycle_rule {
          + enabled = true
          + id      = "tmp"
          + prefix  = "tmp/"

          + expiration {
              + date = "2022-01-12"
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = "aws:kms"
                }
            }
        }

      + versioning {
          + enabled    = true
          + mfa_delete = false
        }
    }

  # aws_s3_bucket_policy.b will be created
  + resource "aws_s3_bucket_policy" "b" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id        = "986325076436"
  + aws_partition     = "aws"
  + canonical_user_id = "0a5ba5a7f5cc8fa7c3e709979205f6c650bc85629401c5b436cb94798440d2f6"
  + kms_key_id        = (known after apply)
  + resource_aka      = (known after apply)
  + resource_name     = "turbottest76541"
aws_kms_key.mykey: Creating...
aws_kms_key.mykey: Creation complete after 7s [id=dc04bb55-963e-45e9-aba5-c5e6f600f894]
aws_s3_bucket.named_test_resource: Creating...
aws_s3_bucket.named_test_resource: Still creating... [10s elapsed]
aws_s3_bucket.named_test_resource: Still creating... [20s elapsed]
aws_s3_bucket.named_test_resource: Still creating... [30s elapsed]
aws_s3_bucket.named_test_resource: Creation complete after 30s [id=turbottest76541]
aws_s3_bucket_policy.b: Creating...
aws_s3_bucket_policy.b: Creation complete after 2s [id=turbottest76541]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 48, in data "null_data_source" "resource":
  48: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "986325076436"
aws_partition = "aws"
canonical_user_id = "0a5ba5a7f5cc8fa7c3e709979205f6c650bc85629401c5b436cb94798440d2f6"
kms_key_id = "arn:aws:kms:us-east-2:986325076436:key/dc04bb55-963e-45e9-aba5-c5e6f600f894"
resource_aka = "arn:aws:s3:::turbottest76541"
resource_name = "turbottest76541"

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:s3:::turbottest76541"
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "acl": {
      "Grants": [
        {
          "Grantee": {
            "DisplayName": null,
            "EmailAddress": null,
            "ID": "0a5ba5a7f5cc8fa7c3e709979205f6c650bc85629401c5b436cb94798440d2f6",
            "Type": "CanonicalUser",
            "URI": null
          },
          "Permission": "FULL_CONTROL"
        }
      ],
      "Owner": {
        "DisplayName": null,
        "ID": "0a5ba5a7f5cc8fa7c3e709979205f6c650bc85629401c5b436cb94798440d2f6"
      }
    },
    "bucket_policy_is_public": false,
    "lifecycle_rules": [
      {
        "AbortIncompleteMultipartUpload": null,
        "Expiration": {
          "Date": null,
          "Days": 90,
          "ExpiredObjectDeleteMarker": null
        },
        "Filter": {
          "And": {
            "Prefix": "log/",
            "Tags": [
              {
                "Key": "rule",
                "Value": "log"
              },
              {
                "Key": "autoclean",
                "Value": "true"
              }
            ]
          },
          "Prefix": null,
          "Tag": null
        },
        "ID": "log",
        "NoncurrentVersionExpiration": null,
        "NoncurrentVersionTransitions": null,
        "Prefix": null,
        "Status": "Enabled",
        "Transitions": [
          {
            "Date": null,
            "Days": 30,
            "StorageClass": "STANDARD_IA"
          },
          {
            "Date": null,
            "Days": 60,
            "StorageClass": "GLACIER"
          }
        ]
      },
      {
        "AbortIncompleteMultipartUpload": null,
        "Expiration": {
          "Date": "2022-01-12T00:00:00Z",
          "Days": null,
          "ExpiredObjectDeleteMarker": null
        },
        "Filter": {
          "And": null,
          "Prefix": "tmp/",
          "Tag": null
        },
        "ID": "tmp",
        "NoncurrentVersionExpiration": null,
        "NoncurrentVersionTransitions": null,
        "Prefix": null,
        "Status": "Enabled",
        "Transitions": null
      }
    ],
    "logging": null,
    "name": "turbottest76541",
    "policy": {
      "Id": "MYBUCKETPOLICY",
      "Statement": [
        {
          "Action": "s3:*",
          "Condition": {
            "IpAddress": {
              "aws:SourceIp": "8.8.8.8/32"
            }
          },
          "Effect": "Deny",
          "Principal": "*",
          "Resource": "arn:aws:s3:::turbottest76541/*",
          "Sid": "IPAllow"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Id": "MYBUCKETPOLICY",
      "Statement": [
        {
          "Action": [
            "s3:*"
          ],
          "Condition": {
            "IpAddress": {
              "aws:sourceip": [
                "8.8.8.8/32"
              ]
            }
          },
          "Effect": "Deny",
          "Principal": {
            "AWS": [
              "*"
            ]
          },
          "Resource": [
            "arn:aws:s3:::turbottest76541/*"
          ],
          "Sid": "IPAllow"
        }
      ],
      "Version": "2012-10-17"
    },
    "replication": null,
    "server_side_encryption_configuration": {
      "Rules": [
        {
          "ApplyServerSideEncryptionByDefault": {
            "KMSMasterKeyID": "arn:aws:kms:us-east-2:986325076436:key/dc04bb55-963e-45e9-aba5-c5e6f600f894",
            "SSEAlgorithm": "aws:kms"
          },
          "BucketKeyEnabled": false
        }
      ]
    },
    "versioning_enabled": true,
    "versioning_mfa_delete": false
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:s3:::turbottest76541"
    ],
    "block_public_acls": false,
    "block_public_policy": false,
    "bucket_policy_is_public": false,
    "ignore_public_acls": false,
    "lifecycle_rules": [
      {
        "AbortIncompleteMultipartUpload": null,
        "Expiration": {
          "Date": null,
          "Days": 90,
          "ExpiredObjectDeleteMarker": null
        },
        "Filter": {
          "And": {
            "Prefix": "log/",
            "Tags": [
              {
                "Key": "rule",
                "Value": "log"
              },
              {
                "Key": "autoclean",
                "Value": "true"
              }
            ]
          },
          "Prefix": null,
          "Tag": null
        },
        "ID": "log",
        "NoncurrentVersionExpiration": null,
        "NoncurrentVersionTransitions": null,
        "Prefix": null,
        "Status": "Enabled",
        "Transitions": [
          {
            "Date": null,
            "Days": 30,
            "StorageClass": "STANDARD_IA"
          },
          {
            "Date": null,
            "Days": 60,
            "StorageClass": "GLACIER"
          }
        ]
      },
      {
        "AbortIncompleteMultipartUpload": null,
        "Expiration": {
          "Date": "2022-01-12T00:00:00Z",
          "Days": null,
          "ExpiredObjectDeleteMarker": null
        },
        "Filter": {
          "And": null,
          "Prefix": "tmp/",
          "Tag": null
        },
        "ID": "tmp",
        "NoncurrentVersionExpiration": null,
        "NoncurrentVersionTransitions": null,
        "Prefix": null,
        "Status": "Enabled",
        "Transitions": null
      }
    ],
    "logging": null,
    "name": "turbottest76541",
    "partition": "aws",
    "restrict_public_buckets": false,
    "server_side_encryption_configuration": {
      "Rules": [
        {
          "ApplyServerSideEncryptionByDefault": {
            "KMSMasterKeyID": "arn:aws:kms:us-east-2:986325076436:key/dc04bb55-963e-45e9-aba5-c5e6f600f894",
            "SSEAlgorithm": "aws:kms"
          },
          "BucketKeyEnabled": false
        }
      ]
    },
    "tags": {
      "name": "turbottest76541"
    },
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest76541"
      }
    ],
    "title": "turbottest76541",
    "versioning_enabled": true,
    "versioning_mfa_delete": false
  }
]
✔ PASSED

POSTTEST: tests/aws_s3_bucket

TEARDOWN: tests/aws_s3_bucket

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
![Screenshot 2021-06-01 at 6 05 33 PM](https://user-images.githubusercontent.com/59417312/120324265-0ec4dc00-c304-11eb-839d-4685963f1666.png)

### List buckets with enable object lock configuration

```
select
  name,
  object_lock_configuration ->> 'ObjectLockEnabled' as object_lock_enabled
from
  aws_s3_bucket
where
  object_lock_configuration ->> 'ObjectLockEnabled' = 'Enabled';
+-----------+---------------------+
| name      | object_lock_enabled |
+-----------+---------------------+
| testanisa | Enabled             |
+-----------+---------------------+

```