### PR TITLE
added event subscriptions field

### DIFF
--- a/aws/table_aws_inspector_assessment_template.go
+++ b/aws/table_aws_inspector_assessment_template.go
@@ -91,6 +91,7 @@ func tableAwsInspectorAssessmentTemplate(_ context.Context) *plugin.Table {
 				Description: "A list of event subscriptions associated with the Assessment Template.",
 				Type:        pb.ColumnType_JSON,
 				Hydrate:     listAwsInspectorAssessmentEventSubscriptions,
+				Transform:   transform.FromValue(),
 			},
 			// Standard columns for all tables
 			{
@@ -248,19 +249,14 @@ func listAwsInspectorAssessmentEventSubscriptions(ctx context.Context, d *plugin
 	params := &inspector.ListEventSubscriptionsInput{
 		ResourceArn: &assessmentTemplateArn,
 	}
-	// Create a Struct name EventSubscriptions as the framework will use the field name to create
-	// a key from which it extracts the contents of the field
-	type AssociatedEventSubscriptions struct {
-		EventSubscriptions []*inspector.Subscription
-	}
 
-	associatedEventSubscriptions := new(AssociatedEventSubscriptions)
+	var associatedEventSubscriptions []*inspector.Subscription
 
 	err = svc.ListEventSubscriptionsPages(
 		params,
 		func(page *inspector.ListEventSubscriptionsOutput, lastPage bool) bool {
 			for _, Subscription := range page.Subscriptions {
-				associatedEventSubscriptions.EventSubscriptions = append(associatedEventSubscriptions.EventSubscriptions, Subscription)
+				associatedEventSubscriptions = append(associatedEventSubscriptions, Subscription)
 			}
 			return !lastPage
 		},


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
> select name,event_subscriptions from aws_inspector_assessment_template where name like '%POC%' or name like '%caleb%';;

                                                                                                     

```
Add example SQL query results here (please include the input queries as well)
```
+----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------
| name                       | event_subscriptions                                                                                                                                        
+----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------
| Saad-POC-Template          | [{"EventSubscriptions":[{"Event":"FINDING_REPORTED","SubscribedAt":"2020-07-24T12:25:48.06Z"}],"ResourceArn":"arn:aws:inspector:us-east-1:055850966408:targ
| wmcso-inspector-caleb-test | []                                                                                                                                                         
+----------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------
(END)
</details>
