### PR TITLE
Update column name alarm_arn to arn in aws_cloudwatch_alarm table closes #483

### DIFF
--- a/aws-test/tests/aws_cloudwatch_alarm/test-get-expected.json
+++ b/aws-test/tests/aws_cloudwatch_alarm/test-get-expected.json
@@ -1,7 +1,7 @@
 [
   {
-    "alarm_arn": "{{ output.resource_aka.value }}",
     "alarm_description": "{{ resourceName }}",
+    "arn": "{{ output.resource_aka.value }}",
     "comparison_operator": "GreaterThanOrEqualToThreshold",
     "metric_name": "CPUUtilization",
     "name": "{{ resourceName }}"

--- a/aws-test/tests/aws_cloudwatch_alarm/test-get-query.sql
+++ b/aws-test/tests/aws_cloudwatch_alarm/test-get-query.sql
@@ -1,3 +1,3 @@
-select name, alarm_arn, metric_name, comparison_operator, alarm_description
+select name, arn, metric_name, comparison_operator, alarm_description
 from aws.aws_cloudwatch_alarm
 where name = '{{ resourceName }}';

--- a/aws-test/tests/aws_cloudwatch_alarm/test-hydrate-expected.json
+++ b/aws-test/tests/aws_cloudwatch_alarm/test-hydrate-expected.json
@@ -1,10 +1,8 @@
 [
   {
-    "akas": [
-      "{{ output.resource_aka.value }}"
-    ],
-    "alarm_arn": "{{ output.resource_aka.value }}",
+    "akas": ["{{ output.resource_aka.value }}"],
     "alarm_description": "{{ resourceName }}",
+    "arn": "{{ output.resource_aka.value }}",
     "comparison_operator": "GreaterThanOrEqualToThreshold",
     "metric_name": "CPUUtilization",
     "name": "{{ resourceName }}",

--- a/aws-test/tests/aws_cloudwatch_alarm/test-hydrate-query.sql
+++ b/aws-test/tests/aws_cloudwatch_alarm/test-hydrate-query.sql
@@ -1,3 +1,3 @@
-select name, alarm_arn, metric_name, comparison_operator, alarm_description, threshold, tags, akas
+select name, arn, metric_name, comparison_operator, alarm_description, threshold, tags, akas
 from aws.aws_cloudwatch_alarm
 where name = '{{ resourceName }}';

--- a/aws-test/tests/aws_cloudwatch_alarm/test-list-call-expected.json
+++ b/aws-test/tests/aws_cloudwatch_alarm/test-list-call-expected.json
@@ -1,7 +1,7 @@
 [
   {
-    "alarm_arn": "{{ output.resource_aka.value }}",
     "alarm_description": "{{ resourceName }}",
+    "arn": "{{ output.resource_aka.value }}",
     "comparison_operator": "GreaterThanOrEqualToThreshold",
     "metric_name": "CPUUtilization",
     "name": "{{ resourceName }}"

--- a/aws-test/tests/aws_cloudwatch_alarm/test-list-call-query.sql
+++ b/aws-test/tests/aws_cloudwatch_alarm/test-list-call-query.sql
@@ -1,3 +1,3 @@
-select name, alarm_arn, metric_name, comparison_operator, alarm_description
+select name, arn, metric_name, comparison_operator, alarm_description
 from aws.aws_cloudwatch_alarm
 where akas::text = '["{{ output.resource_aka.value }}"]';

--- a/aws-test/tests/aws_cloudwatch_alarm/test-not-found-query.sql
+++ b/aws-test/tests/aws_cloudwatch_alarm/test-not-found-query.sql
@@ -1,3 +1,3 @@
-select name, alarm_arn, metric_name, comparison_operator, alarm_description
+select name, arn, metric_name, comparison_operator, alarm_description
 from aws.aws_cloudwatch_alarm
 where name = 'dummy-{{ resourceName }}';

--- a/aws-test/tests/aws_cloudwatch_alarm/test-turbot-expected.json
+++ b/aws-test/tests/aws_cloudwatch_alarm/test-turbot-expected.json
@@ -1,12 +1,10 @@
 [
   {
     "account_id": "{{ output.account_id.value }}",
-    "akas": [
-      "{{ output.resource_aka.value }}"
-    ],
-    "alarm_arn": "{{ output.resource_aka.value }}",
+    "akas": ["{{ output.resource_aka.value }}"],
+    "arn": "{{ output.resource_aka.value }}",
     "name": "{{ resourceName }}",
-    "partition":  "{{ output.aws_partition.value }}",
+    "partition": "{{ output.aws_partition.value }}",
     "region": "{{ output.region_name.value }}",
     "tags": {
       "name": "{{ resourceName }}"

--- a/aws-test/tests/aws_cloudwatch_alarm/test-turbot-query.sql
+++ b/aws-test/tests/aws_cloudwatch_alarm/test-turbot-query.sql
@@ -1,3 +1,3 @@
-select name, alarm_arn, tags, akas, title, partition, region, account_id
+select name, arn, tags, akas, title, partition, region, account_id
 from aws.aws_cloudwatch_alarm
 where akas::text = '["{{ output.resource_aka.value }}"]';

--- a/aws/table_aws_cloudwatch_alarm.go
+++ b/aws/table_aws_cloudwatch_alarm.go
@@ -17,8 +17,8 @@ func tableAwsCloudWatchAlarm(_ context.Context) *plugin.Table {
 		Name:        "aws_cloudwatch_alarm",
 		Description: "AWS CloudWatch Alarm",
 		Get: &plugin.GetConfig{
-			KeyColumns:        plugin.SingleColumn("name"),
-			Hydrate:           getCloudWatchAlarm,
+			KeyColumns: plugin.SingleColumn("name"),
+			Hydrate:    getCloudWatchAlarm,
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listCloudWatchAlarms,
@@ -32,9 +32,10 @@ func tableAwsCloudWatchAlarm(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("AlarmName"),
 			},
 			{
-				Name:        "alarm_arn",
+				Name:        "arn",
 				Description: "The Amazon Resource Name (ARN) of the alarm.",
 				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("AlarmArn"),
 			},
 			{
 				Name:        "state_value",

--- a/docs/tables/aws_cloudwatch_alarm.md
+++ b/docs/tables/aws_cloudwatch_alarm.md
@@ -25,7 +25,7 @@ from
 ```sql
 select
   name,
-  alarm_arn,
+  arn,
   state_value,
   state_reason
 from
@@ -39,7 +39,7 @@ where
 
 ```sql
 select
-  alarm_arn,
+  arn,
   actions_enabled,
   alarm_actions
 from


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_cloudwatch_alarm []

PRETEST: tests/aws_cloudwatch_alarm

TEST: tests/aws_cloudwatch_alarm
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_partition.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_cloudwatch_metric_alarm.named_test_resource: Creating...
aws_cloudwatch_metric_alarm.named_test_resource: Creation complete after 4s [id=turbottest69767]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = 986325076436
aws_partition = aws
region_name = us-east-1
resource_aka = arn:aws:cloudwatch:us-east-1:986325076436:alarm:turbottest69767
resource_name = turbottest69767

Running SQL query: test-get-query.sql
[
  {
    "alarm_description": "turbottest69767",
    "arn": "arn:aws:cloudwatch:us-east-1:986325076436:alarm:turbottest69767",
    "comparison_operator": "GreaterThanOrEqualToThreshold",
    "metric_name": "CPUUtilization",
    "name": "turbottest69767"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:cloudwatch:us-east-1:986325076436:alarm:turbottest69767"
    ],
    "alarm_description": "turbottest69767",
    "arn": "arn:aws:cloudwatch:us-east-1:986325076436:alarm:turbottest69767",
    "comparison_operator": "GreaterThanOrEqualToThreshold",
    "metric_name": "CPUUtilization",
    "name": "turbottest69767",
    "tags": {
      "name": "turbottest69767"
    },
    "threshold": 80
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "alarm_description": "turbottest69767",
    "arn": "arn:aws:cloudwatch:us-east-1:986325076436:alarm:turbottest69767",
    "comparison_operator": "GreaterThanOrEqualToThreshold",
    "metric_name": "CPUUtilization",
    "name": "turbottest69767"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "986325076436",
    "akas": [
      "arn:aws:cloudwatch:us-east-1:986325076436:alarm:turbottest69767"
    ],
    "arn": "arn:aws:cloudwatch:us-east-1:986325076436:alarm:turbottest69767",
    "name": "turbottest69767",
    "partition": "aws",
    "region": "us-east-1",
    "tags": {
      "name": "turbottest69767"
    },
    "title": "turbottest69767"
  }
]
✔ PASSED

POSTTEST: tests/aws_cloudwatch_alarm

TEARDOWN: tests/aws_cloudwatch_alarm

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
