### PR TITLE
Update the column name file_system_arn to arn for the table aws_efs_file_system closes #493

### DIFF
--- a/aws/table_aws_efs_file_system.go
+++ b/aws/table_aws_efs_file_system.go
@@ -143,7 +143,7 @@ func tableAwsElasticFileSystem(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("FileSystemArn").Transform(arnToAkas),
+				Transform:   transform.FromField("FileSystemArn").Transform(transform.EnsureStringArray),
 			},
 		}),
 	}

--- a/aws/table_aws_efs_file_system.go
+++ b/aws/table_aws_efs_file_system.go
@@ -39,9 +39,10 @@ func tableAwsElasticFileSystem(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "file_system_arn",
+				Name:        "arn",
 				Description: "The Amazon Resource Name (ARN) for the EFS file system.",
 				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("FileSystemArn"),
 			},
 			{
 				Name:        "owner_id",

--- a/docs/tables/aws_efs_file_system.md
+++ b/docs/tables/aws_efs_file_system.md
@@ -104,7 +104,7 @@ where
 select
   name,
   automatic_backups,
-  file_system_arn,
+  arn,
   file_system_id
 from
   aws_efs_file_system


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_efs_file_system []

PRETEST: tests/aws_efs_file_system

TEST: tests/aws_efs_file_system
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_efs_file_system.named_test_resource: Creating...
aws_efs_file_system.named_test_resource: Creation complete after 6s [id=fs-178b05a3]
data.template_file.resource_aka: Refreshing state...
aws_efs_file_system_policy.efs_file_system_policy: Creating...
aws_efs_file_system_policy.efs_file_system_policy: Creation complete after 2s [id=fs-178b05a3]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = arn:aws:elasticfilesystem:us-east-1:986325076436:file-system/fs-178b05a3
resource_id = fs-178b05a3
resource_name = turbottest32206

Running SQL query: test-get-query.sql
[
  {
    "encrypted": true,
    "file_system_id": "fs-178b05a3",
    "performance_mode": "maxIO",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest32206"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:elasticfilesystem:us-east-1:986325076436:file-system/fs-178b05a3"
    ],
    "file_system_id": "fs-178b05a3",
    "policy": {
      "Id": "test_policy",
      "Statement": [
        {
          "Action": [
            "elasticfilesystem:ClientMount",
            "elasticfilesystem:ClientWrite"
          ],
          "Condition": {
            "Bool": {
              "aws:SecureTransport": "true"
            }
          },
          "Effect": "Allow",
          "Principal": {
            "AWS": "*"
          },
          "Resource": "arn:aws:elasticfilesystem:us-east-1:986325076436:file-system/fs-178b05a3",
          "Sid": "__default_policy_ID"
        }
      ],
      "Version": "2012-10-17"
    },
    "tags": {
      "name": "turbottest32206"
    },
    "title": "fs-178b05a3"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:elasticfilesystem:us-east-1:986325076436:file-system/fs-178b05a3"
    ],
    "automatic_backups": "disabled",
    "encrypted": true,
    "file_system_id": "fs-178b05a3",
    "performance_mode": "maxIO",
    "tags": {
      "name": "turbottest32206"
    },
    "title": "fs-178b05a3"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

POSTTEST: tests/aws_efs_file_system

TEARDOWN: tests/aws_efs_file_system

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
