### PR TITLE
Update column name table_arn to arn in aws_dynamodb_table table closes #487

### DIFF
--- a/aws-test/tests/aws_dynamodb_table/test-get-expected.json
+++ b/aws-test/tests/aws_dynamodb_table/test-get-expected.json
@@ -1,6 +1,6 @@
 [
   {
-    "name": "{{ resourceName }}",
-    "table_arn": "{{ output.resource_aka.value }}"
+    "arn": "{{ output.resource_aka.value }}",
+    "name": "{{ resourceName }}"
   }
 ]

--- a/aws-test/tests/aws_dynamodb_table/test-get-query.sql
+++ b/aws-test/tests/aws_dynamodb_table/test-get-query.sql
@@ -1,3 +1,3 @@
-select name, table_arn
+select name, arn
 from aws.aws_dynamodb_table
 where name = '{{ resourceName }}'

--- a/aws-test/tests/aws_dynamodb_table/test-list-expected.json
+++ b/aws-test/tests/aws_dynamodb_table/test-list-expected.json
@@ -1,5 +1,6 @@
 [
   {
+    "arn": "{{output.resource_aka.value}}",
     "attribute_definitions": [
       {
         "AttributeName": "userId",
@@ -14,7 +15,6 @@
     ],
     "name": "{{resourceName}}",
     "read_capacity": 20,
-    "table_arn": "{{output.resource_aka.value}}",
     "write_capacity": 20
   }
 ]

--- a/aws-test/tests/aws_dynamodb_table/test-list-query.sql
+++ b/aws-test/tests/aws_dynamodb_table/test-list-query.sql
@@ -1,3 +1,3 @@
-select table_arn, name, attribute_definitions, write_capacity, read_capacity, key_schema
+select arn, name, attribute_definitions, write_capacity, read_capacity, key_schema
 from aws.aws_dynamodb_table
 where akas::text = '["{{output.resource_aka.value}}"]'

--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -187,7 +187,7 @@ func tableAwsDynamoDBTable(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getDynamboDbTable,
-				Transform:   transform.From(getDdbTurbotAkas),
+				Transform:   transform.FromField("TableArn").Transform(transform.EnsureStringArray),
 			},
 		}),
 	}
@@ -365,7 +365,7 @@ func getTableTurbotTags(_ context.Context, d *transform.TransformData) (interfac
 }
 
 // getDdbTurbotAkas returns akas for this item
-func getDdbTurbotAkas(_ context.Context, d *transform.TransformData) (interface{}, error) {
-	table := d.HydrateItem.(*dynamodb.TableDescription)
-	return []string{*table.TableArn}, nil
-}
+// func getDdbTurbotAkas(_ context.Context, d *transform.TransformData) (interface{}, error) {
+// 	table := d.HydrateItem.(*dynamodb.TableDescription)
+// 	return []string{*table.TableArn}, nil
+// }

--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -363,9 +363,3 @@ func getTableTurbotTags(_ context.Context, d *transform.TransformData) (interfac
 
 	return turbotTagsMap, nil
 }
-
-// getDdbTurbotAkas returns akas for this item
-// func getDdbTurbotAkas(_ context.Context, d *transform.TransformData) (interface{}, error) {
-// 	table := d.HydrateItem.(*dynamodb.TableDescription)
-// 	return []string{*table.TableArn}, nil
-// }

--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -34,7 +34,7 @@ func tableAwsDynamoDBTable(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("TableName"),
 			},
 			{
-				Name:        "table_arn",
+				Name:        "arn",
 				Description: "The Amazon Resource Name (ARN) that uniquely identifies the table.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getDynamboDbTable,


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```

SETUP: tests/aws_dynamodb_table []

PRETEST: tests/aws_dynamodb_table

TEST: tests/aws_dynamodb_table
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_dynamodb_table.named_test_resource: Creating...
aws_dynamodb_table.named_test_resource: Still creating... [10s elapsed]
aws_dynamodb_table.named_test_resource: Creation complete after 13s [id=turbottest92110]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = 986325076436
aws_partition = aws
aws_region = us-east-1
resource_aka = arn:aws:dynamodb:us-east-1:986325076436:table/turbottest92110
resource_name = turbottest92110

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:dynamodb:us-east-1:986325076436:table/turbottest92110",
    "name": "turbottest92110"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "continuous_backups_status": "ENABLED",
    "point_in_time_recovery_description": {
      "EarliestRestorableDateTime": null,
      "LatestRestorableDateTime": null,
      "PointInTimeRecoveryStatus": "DISABLED"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:dynamodb:us-east-1:986325076436:table/turbottest92110",
    "attribute_definitions": [
      {
        "AttributeName": "userId",
        "AttributeType": "S"
      }
    ],
    "key_schema": [
      {
        "AttributeName": "userId",
        "KeyType": "HASH"
      }
    ],
    "name": "turbottest92110",
    "read_capacity": 20,
    "write_capacity": 20
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "986325076436",
    "akas": [
      "arn:aws:dynamodb:us-east-1:986325076436:table/turbottest92110"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "title": "turbottest92110"
  }
]
✔ PASSED

POSTTEST: tests/aws_dynamodb_table

TEARDOWN: tests/aws_dynamodb_table

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
