### PR TITLE
Improve error message from aws_iam_credential_report when no credential report exists. Closes #509

### DIFF
--- a/aws/table_aws_iam_credential_report.go
+++ b/aws/table_aws_iam_credential_report.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/gocarina/gocsv"
+	"github.com/ttacon/chalk"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -213,11 +214,20 @@ func listCredentialReports(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	if err != nil {
 		if a, ok := err.(awserr.Error); ok {
 			if helpers.StringSliceContains([]string{"ReportNotPresent"}, a.Code()) {
-				return nil, errors.New("no credential report was found. you can generate one with 'aws iam generate-credential-report'")
+				return nil, errors.New("No credential report was found. You can generate one with " + chalk.Bold.TextStyle("aws iam generate-credential-report"))
 			}
 		}
 		return nil, err
 	}
+	//if err != nil {
+	//	if err.Error() == "ReportExpired" {
+	//		return nil, errors.New("Existing credential report expired. Requested generation of report - please try again shortly")
+	//	}
+	//	if err.Error() == "ReportInProgress" {
+	//		return nil, errors.New("Credential report generation in progress. Please try again shortly")
+	//	}
+	//	return nil, err
+	//}
 
 	content := string(resp.Content[:])
 

--- a/aws/table_aws_iam_credential_report.go
+++ b/aws/table_aws_iam_credential_report.go
@@ -2,10 +2,13 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/gocarina/gocsv"
+	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -46,7 +49,6 @@ func tableAwsIamCredentialReport(_ context.Context) *plugin.Table {
 			Hydrate: listCredentialReports,
 		},
 		Columns: awsColumns([]*plugin.Column{
-			// "Key" Columns
 			{
 				Name:        "user_name",
 				Description: "The friendly name of the user.",
@@ -209,20 +211,13 @@ func listCredentialReports(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 
 	resp, err := svc.GetCredentialReport(&iam.GetCredentialReportInput{})
 	if err != nil {
+		if a, ok := err.(awserr.Error); ok {
+			if helpers.StringSliceContains([]string{"ReportNotPresent"}, a.Code()) {
+				return nil, errors.New("no credential report was found. you can generate one with 'aws iam generate-credential-report'")
+			}
+		}
 		return nil, err
 	}
-	//if err != nil {
-	//	if err.Error() == "ReportNotPresent" {
-	//		return nil, errors.New("No credential report present. Requested generation of report - please try again shortly")
-	//	}
-	//	if err.Error() == "ReportExpired" {
-	//		return nil, errors.New("Existing credential report expired. Requested generation of report - please try again shortly")
-	//	}
-	//	if err.Error() == "ReportInProgress" {
-	//		return nil, errors.New("Credential report generation in progress. Please try again shortly")
-	//	}
-	//	return nil, err
-	//}
 
 	content := string(resp.Content[:])
 

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/aws/aws-sdk-go v1.38.27
 	github.com/gocarina/gocsv v0.0.0-20201208093247-67c824bc04d4
 	github.com/golang/protobuf v1.4.3
+	github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31
 	github.com/turbot/go-kit v0.1.1
 	github.com/turbot/steampipe-plugin-sdk v0.2.10
 )

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tkrajina/go-reflector v0.5.4 h1:dS9aJEa/eYNQU/fwsb5CSiATOxcNyA/gG/A7a582D5s=
 github.com/tkrajina/go-reflector v0.5.4/go.mod h1:9PyLgEOzc78ey/JmQQHbW8cQJ1oucLlNQsg8yFvkVk8=
+github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31 h1:OXcKh35JaYsGMRzpvFkLv/MEyPuL49CThT1pZ8aSml4=
+github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31/go.mod h1:onvgF043R+lC5RZ8IT9rBXDaEDnpnw/Cl+HFiw+v/7Q=
 github.com/turbot/go-kit v0.1.1 h1:JkLUyVp8m8jEj45C52dzh7Tj9jpxHP90y9+m8cpW1mo=
 github.com/turbot/go-kit v0.1.1/go.mod h1:hO/mY90fJXLWAJnAoDkYMvi3LVZ/r+z1tiz3E1uPSNA=
 github.com/turbot/steampipe-plugin-sdk v0.2.10 h1:Q6871ITL9RW3iCSk2R5J9gmcCKP8n+Ku3KvN71iBoFQ=


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>

![image](https://user-images.githubusercontent.com/38218418/123627691-edd2a680-d82f-11eb-83c6-456d7129de07.png)
