### PR TITLE
Remove use of deprecated function ItemFromKey from table aws_redshift_cluster. Closes #513

### DIFF
--- a/aws/table_aws_redshift_cluster.go
+++ b/aws/table_aws_redshift_cluster.go
@@ -20,7 +20,6 @@ func tableAwsRedshiftCluster(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns:        plugin.SingleColumn("cluster_identifier"),
 			ShouldIgnoreError: isNotFoundError([]string{"ClusterNotFound"}),
-			ItemFromKey:       clusterIdentifierFromKey,
 			Hydrate:           getRedshiftCluster,
 		},
 		List: &plugin.ListConfig{
@@ -309,17 +308,6 @@ func tableAwsRedshiftCluster(_ context.Context) *plugin.Table {
 	}
 }
 
-//// BUILD HYDRATE INPUT
-
-func clusterIdentifierFromKey(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	quals := d.KeyColumnQuals
-	clusterIdentifier := quals["cluster_identifier"].GetStringValue()
-	item := &redshift.Cluster{
-		ClusterIdentifier: &clusterIdentifier,
-	}
-	return item, nil
-}
-
 //// LIST FUNCTION
 
 func listRedshiftClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
@@ -353,18 +341,10 @@ func listRedshiftClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 //// HYDRATE FUNCTIONS
 
 func getRedshiftCluster(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	// TODO Put me in helper function
 	var region string
 	matrixRegion := plugin.GetMatrixItem(ctx)[matrixKeyRegion]
 	if matrixRegion != nil {
 		region = matrixRegion.(string)
-	}
-
-	var name string
-	if h.Item != nil {
-		name = *h.Item.(*redshift.Cluster).ClusterIdentifier
-	} else {
-		name = d.KeyColumnQuals["cluster_identifier"].GetStringValue()
 	}
 
 	// Create service
@@ -372,7 +352,14 @@ func getRedshiftCluster(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	if err != nil {
 		return nil, err
 	}
+	name := d.KeyColumnQuals["cluster_identifier"].GetStringValue()
 
+	// Return nil, if no input provided
+	if name == "" {
+		return nil, nil
+	}
+
+	// Build params
 	params := &redshift.DescribeClustersInput{
 		ClusterIdentifier: aws.String(name),
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/aws_redshift_cluster []

PRETEST: tests/aws_redshift_cluster

TEST: tests/aws_redshift_cluster
Running terraform
data.aws_caller_identity.current: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_region.alternate: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Still creating... [10s elapsed]
aws_vpc.my_vpc: Creation complete after 12s [id=vpc-09466eea9c63b4916]
aws_internet_gateway.igw: Creating...
aws_internet_gateway.igw: Creation complete after 6s [id=igw-0b0bb8935f2e0ad13]
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet2: Creation complete after 4s [id=subnet-06ef41c544f58d6e1]
aws_subnet.my_subnet1: Creation complete after 4s [id=subnet-0c43ce4ef6b294205]
aws_redshift_subnet_group.my_subnet_group: Creating...
aws_redshift_subnet_group.my_subnet_group: Creation complete after 3s [id=turbottest34705]
aws_redshift_cluster.named_test_resource: Creating...
aws_redshift_cluster.named_test_resource: Still creating... [10s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [20s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [30s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [40s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [50s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m0s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m10s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m20s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m30s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m40s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [1m50s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m0s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m10s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m20s elapsed]
aws_redshift_cluster.named_test_resource: Still creating... [2m30s elapsed]
aws_redshift_cluster.named_test_resource: Creation complete after 2m32s [id=turbottest34705]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Outputs:

account_id = 123456789012
aws_partition = aws
region_name = us-east-1
resource_aka = arn:aws:redshift:us-east-1:123456789012:cluster:turbottest34705
resource_name = turbottest34705

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:redshift:us-east-1:123456789012:cluster:turbottest34705"
    ],
    "allow_version_upgrade": true,
    "arn": "arn:aws:redshift:us-east-1:123456789012:cluster:turbottest34705",
    "cluster_identifier": "turbottest34705"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:redshift:us-east-1:123456789012:cluster:turbottest34705"
    ],
    "allow_version_upgrade": true,
    "arn": "arn:aws:redshift:us-east-1:123456789012:cluster:turbottest34705",
    "cluster_identifier": "turbottest34705"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:redshift:us-east-1:123456789012:cluster:turbottest34705"
    ],
    "cluster_identifier": "turbottest34705"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:redshift:us-east-1:123456789012:cluster:turbottest34705"
    ],
    "cluster_identifier": "turbottest34705",
    "tags": {
      "name": "turbottest34705"
    },
    "title": "turbottest34705"
  }
]
✔ PASSED

POSTTEST: tests/aws_redshift_cluster

TEARDOWN: tests/aws_redshift_cluster

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>
