### PR TITLE
Add wildcarding support for passing regions in connections for plugin. Closes #528

### DIFF
--- a/aws/multi_region.go
+++ b/aws/multi_region.go
@@ -2,29 +2,56 @@ package aws
 
 import (
 	"context"
+	"path"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/turbot/go-kit/helpers"
+	"github.com/turbot/steampipe-plugin-sdk/connection"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 )
 
 const matrixKeyRegion = "region"
 
+var pluginQueryData *plugin.QueryData
+
+func init() {
+	pluginQueryData = &plugin.QueryData{
+		ConnectionManager: connection.NewManager(),
+	}
+}
+
 // BuildRegionList :: return a list of matrix items, one per region specified in the connection config
-func BuildRegionList(_ context.Context, connection *plugin.Connection) []map[string]interface{} {
+func BuildRegionList(ctx context.Context, connection *plugin.Connection) []map[string]interface{} {
 	// retrieve regions from connection config
 	awsConfig := GetConfig(connection)
+	pluginQueryData.Connection = connection
+
+	validRegions, _ := listRegions(ctx, pluginQueryData)
+	var allRegions []string
 
 	if awsConfig.Regions != nil {
-		regions := GetConfig(connection).Regions
+		for _, pattern := range awsConfig.Regions {
+			for _, validRegion := range validRegions {
+				if ok, _ := path.Match(pattern, validRegion); ok {
+					allRegions = append(allRegions, validRegion)
+				}
+			}
+		}
+	}
 
-		if len(getInvalidRegions(regions)) > 0 {
-			panic("\n\nConnection config have invalid regions: " + strings.Join(getInvalidRegions(regions), ","))
+	if allRegions != nil {
+		uniqueRegions := unique(allRegions)
+		// regions := GetConfig(connection).Regions
+
+		if len(getInvalidRegions(uniqueRegions)) > 0 {
+			panic("\n\nConnection config have invalid regions: " + strings.Join(getInvalidRegions(uniqueRegions), ","))
 		}
 
 		// validate regions list
-		matrix := make([]map[string]interface{}, len(regions))
-		for i, region := range regions {
+		matrix := make([]map[string]interface{}, len(uniqueRegions))
+		for i, region := range uniqueRegions {
 			matrix[i] = map[string]interface{}{matrixKeyRegion: region}
 		}
 		return matrix
@@ -72,4 +99,74 @@ func BuildWafRegionList(_ context.Context, connection *plugin.Connection) []map[
 	return []map[string]interface{}{
 		{matrixKeyRegion: GetDefaultRegion()},
 	}
+}
+
+func listRegions(ctx context.Context, d *plugin.QueryData) ([]string, error) {
+	cacheKey := "listRegions"
+
+	// if found in cache, return the result
+	if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
+		return cachedData.([]string), nil
+	}
+
+	awsCommercialRegions := []string{
+		"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2"}
+
+	awsUsGovRegions := []string{"us-gov-east-1", "us-gov-west-1"}
+
+	awsChinaGovRegions := []string{"cn-north-1", "cn-northwest-1"}
+
+	defaultRegion := GetDefaultAwsRegion(d)
+
+	defaultRegions := awsCommercialRegions
+
+	if strings.HasPrefix(defaultRegion, "us-gov") {
+		defaultRegions = awsUsGovRegions
+	} else if strings.HasPrefix(defaultRegion, "cn") {
+		defaultRegions = awsChinaGovRegions
+	}
+
+	// Create Session
+	svc, err := Ec2Service(ctx, d, defaultRegion)
+	if err != nil {
+		// handle in case user doesn't have access to ec2 service
+		// save to extension cache
+		d.ConnectionManager.Cache.Set(cacheKey, defaultRegions)
+		return defaultRegions, nil
+	}
+
+	params := &ec2.DescribeRegionsInput{
+		AllRegions: aws.Bool(true),
+	}
+
+	// execute list call
+	resp, err := svc.DescribeRegions(params)
+	if err != nil {
+		// handle in case user doesn't have access to ec2 service
+		d.ConnectionManager.Cache.Set(cacheKey, defaultRegions)
+		return defaultRegions, nil
+	}
+
+	var activeRegions []string
+	for _, region := range resp.Regions {
+		if *region.OptInStatus != "not-opted-in" {
+			activeRegions = append(activeRegions, *region.RegionName)
+		}
+	}
+
+	// save to extension cache
+	d.ConnectionManager.Cache.Set(cacheKey, activeRegions)
+	return activeRegions, err
+}
+
+func unique(stringSlice []string) []string {
+	keys := make(map[string]bool)
+	list := []string{}
+	for _, entry := range stringSlice {
+		if _, value := keys[entry]; !value {
+			keys[entry] = true
+			list = append(list, entry)
+		}
+	}
+	return list
 }

--- a/aws/service.go
+++ b/aws/service.go
@@ -1483,11 +1483,6 @@ func GetDefaultAwsRegion(d *plugin.QueryData) string {
 	} else {
 		// Set the first region in regions list to be default region
 		region = regions[0]
-
-		// // check if it is a valid region
-		// if len(getInvalidRegions([]string{region})) > 0 {
-		// 	panic("\n\nConnection config have invalid region: " + region + ". Edit your connection configuration file and then restart Steampipe")
-		// }
 	}
 
 	if region == "" {

--- a/aws/service.go
+++ b/aws/service.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -1472,7 +1473,7 @@ func GetDefaultAwsRegion(d *plugin.QueryData) string {
 		regions = awsConfig.Regions
 	}
 
-	if len(getInvalidRegions(regions)) < 1 {
+	if len(regions) < 1 {
 		os.Setenv("AWS_SDK_LOAD_CONFIG", "1")
 		session, err := session.NewSession(aws.NewConfig())
 		if err != nil {
@@ -1483,14 +1484,23 @@ func GetDefaultAwsRegion(d *plugin.QueryData) string {
 		// Set the first region in regions list to be default region
 		region = regions[0]
 
-		// check if it is a valid region
-		if len(getInvalidRegions([]string{region})) > 0 {
-			panic("\n\nConnection config have invalid region: " + region + ". Edit your connection configuration file and then restart Steampipe")
-		}
+		// // check if it is a valid region
+		// if len(getInvalidRegions([]string{region})) > 0 {
+		// 	panic("\n\nConnection config have invalid region: " + region + ". Edit your connection configuration file and then restart Steampipe")
+		// }
 	}
 
 	if region == "" {
 		region = "us-east-1"
+	} else if strings.Contains(region, "*") {
+		if strings.HasPrefix(region, "us-gov") {
+			region = "us-gov-east-1"
+		} else if strings.HasPrefix(region, "cn") {
+			region = "cn-north-1"
+		} else {
+			region = "us-east-1"
+		}
 	}
+
 	return region
 }


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>


```
cat ~/.steampipe/config/aws.spc

connection "usgov" {
  plugin     = "aws"
  access_key = "redacted"
  secret_key = "redacted"
  regions = ["us-gov*"]
}

steampipe query "select name, region, partition from usgov.aws_s3_bucket"
+---------------------------------------------+---------------+------------+
| name                                        | region        | partition  |
+---------------------------------------------+---------------+------------+
| cody-test-us-east-bucket                    | us-gov-east-1 | aws-us-gov |
| elasticbeanstalk-us-gov-west-1-727379816578 | us-gov-west-1 | aws-us-gov |
| turbot-727379816578-us-gov-east-1           | us-gov-east-1 | aws-us-gov |
| test-poller-actor-lalit                     | us-gov-west-1 | aws-us-gov |
| turbot1                                     | us-gov-west-1 | aws-us-gov |
| turbot-727379816578-us-gov-west-1           | us-gov-west-1 | aws-us-gov |
+---------------------------------------------+---------------+------------+

Time: 3.177480915s

steampipe query "select title, partition, region from usgov.aws_sns_topic order by region" 
+------------------------+------------+---------------+
| title                  | partition  | region        |
+------------------------+------------+---------------+
| turbot_aws_api_handler | aws-us-gov | us-gov-east-1 |
| test_steampipe         | aws-us-gov | us-gov-west-1 |
+------------------------+------------+---------------+

steampipe query "select group_name, group_id, vpc_id, partition, region from usgov.aws_vpc_security_group"       
+---------------------+----------------------+-----------------------+------------+---------------+
| group_name          | group_id             | vpc_id                | partition  | region        |
+---------------------+----------------------+-----------------------+------------+---------------+
| default             | sg-0f2f8f9be2137faa0 | vpc-05707a5f76d1ee132 | aws-us-gov | us-gov-east-1 |
| default             | sg-08dd932b18109d1db | vpc-075d5a31d18fa0169 | aws-us-gov | us-gov-east-1 |
| default             | sg-31080559          | vpc-9f11e5f6          | aws-us-gov | us-gov-east-1 |
| default             | sg-0d46f326b628156d2 | vpc-050eb20f6238419a0 | aws-us-gov | us-gov-west-1 |
| rds-launch-wizard   | sg-00cbeac0e138d962d | vpc-f7e30790          | aws-us-gov | us-gov-west-1 |
| rds-launch-wizard-1 | sg-0d624f538207a541b | vpc-f7e30790          | aws-us-gov | us-gov-west-1 |
| default             | sg-2725ab5e          | vpc-f7e30790          | aws-us-gov | us-gov-west-1 |
| rds-launch-wizard-2 | sg-00e2fd30375c5a649 | vpc-f7e30790          | aws-us-gov | us-gov-west-1 |
+---------------------+----------------------+-----------------------+------------+---------------+
```

```
connection "aws" {
  plugin     = "aws"
  access_key = "redacted"
  secret_key = "redacted"
  regions = [ "*" ]
}

steampipe query "select title, partition, region from aws_sns_topic order by region" 
+---------------------------------+-----------+----------------+
| title                           | partition | region         |
+---------------------------------+-----------+----------------+
| turbot_aws_api_handler          | aws       | ap-northeast-1 |
| turbot_aws_api_handler          | aws       | ap-northeast-2 |
| topic-public                    | aws       | ap-south-1     |
| dynamodb                        | aws       | ap-south-1     |
| public_topic.fifo               | aws       | ap-south-1     |
| Default_CloudWatch_Alarms_Topic | aws       | ap-south-1     |
| config-topic                    | aws       | ap-south-1     |
| turbot_aws_api_handler          | aws       | ap-southeast-1 |
| turbot_aws_api_handler          | aws       | ca-central-1   |
| turbot_aws_api_handler          | aws       | eu-central-1   |
| turbot_aws_api_handler          | aws       | eu-north-1     |
| turbot_aws_api_handler          | aws       | eu-west-1      |
| turbot_aws_api_handler          | aws       | eu-west-2      |
| turbot_aws_api_handler          | aws       | eu-west-3      |
| turbot_aws_api_handler          | aws       | sa-east-1      |
| Billing_NAGRAJ                  | aws       | us-east-1      |
| Default_CloudWatch_Alarms_Topic | aws       | us-east-1      |
| turbot_aws_api_handler          | aws       | us-east-1      |
| turbot_aws_api_handler          | aws       | us-east-2      |
| test2                           | aws       | us-west-1      |
| turbot_aws_api_handler          | aws       | us-west-1      |
| turbot_aws_api_handler          | aws       | us-west-2      |
+---------------------------------+-----------+----------------+
```

```
connection "aws" {
  plugin     = "aws"
  access_key = "redacted"
  secret_key = "redacted"
  regions    = ["us-east-1", "ap-south-1", "us-east-2"]
}

steampipe query "select title, partition, region from aws_sns_topic order by region"
+---------------------------------+-----------+------------+
| title                           | partition | region     |
+---------------------------------+-----------+------------+
| topic-public                    | aws       | ap-south-1 |
| public_topic.fifo               | aws       | ap-south-1 |
| Default_CloudWatch_Alarms_Topic | aws       | ap-south-1 |
| dynamodb                        | aws       | ap-south-1 |
| config-topic                    | aws       | ap-south-1 |
| turbot_aws_api_handler          | aws       | us-east-1  |
| Billing_NAGRAJ                  | aws       | us-east-1  |
| Default_CloudWatch_Alarms_Topic | aws       | us-east-1  |
| turbot_aws_api_handler          | aws       | us-east-2  |
+---------------------------------+-----------+------------+
```

```
connection "aws" {
  plugin     = "aws"
  access_key = "redacted"
  secret_key = "redacted"
  regions = [ "us-*", "ap*" , "eu-north-1"]
}

steampipe query "select title, partition, region from aws_sns_topic order by region"
+---------------------------------+-----------+----------------+
| title                           | partition | region         |
+---------------------------------+-----------+----------------+
| turbot_aws_api_handler          | aws       | ap-northeast-1 |
| turbot_aws_api_handler          | aws       | ap-northeast-2 |
| topic-public                    | aws       | ap-south-1     |
| Default_CloudWatch_Alarms_Topic | aws       | ap-south-1     |
| public_topic.fifo               | aws       | ap-south-1     |
| config-topic                    | aws       | ap-south-1     |
| dynamodb                        | aws       | ap-south-1     |
| turbot_aws_api_handler          | aws       | ap-southeast-1 |
| turbot_aws_api_handler          | aws       | eu-north-1     |
| turbot_aws_api_handler          | aws       | us-east-1      |
| Billing_NAGRAJ                  | aws       | us-east-1      |
| Default_CloudWatch_Alarms_Topic | aws       | us-east-1      |
| turbot_aws_api_handler          | aws       | us-east-2      |
| turbot_aws_api_handler          | aws       | us-west-1      |
| test2                           | aws       | us-west-1      |
| turbot_aws_api_handler          | aws       | us-west-2      |
+---------------------------------+-----------+----------------+

```
</details>
