### PR TITLE
fix failed integration test for AWS tables. 

### DIFF
--- a/aws-test/tests/aws_accessanalyzer_analyzer/variables.tf
+++ b/aws-test/tests/aws_accessanalyzer_analyzer/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_appautoscaling_target/variables.tf
+++ b/aws-test/tests/aws_appautoscaling_target/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_auditmanager_assessment/posttest-variables.tf
+++ b/aws-test/tests/aws_auditmanager_assessment/posttest-variables.tf
@@ -1,6 +1,6 @@
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_auditmanager_assessment/variables.tf
+++ b/aws-test/tests/aws_auditmanager_assessment/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_auditmanager_control/posttest-variables.tf
+++ b/aws-test/tests/aws_auditmanager_control/posttest-variables.tf
@@ -1,6 +1,6 @@
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_auditmanager_control/variables.tf
+++ b/aws-test/tests/aws_auditmanager_control/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_auditmanager_framework/variables.tf
+++ b/aws-test/tests/aws_auditmanager_framework/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_backup_selection/variables.tf
+++ b/aws-test/tests/aws_backup_selection/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_cloudfront_cache_policy/variables.tf
+++ b/aws-test/tests/aws_cloudfront_cache_policy/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_cloudfront_origin_access_identity/variables.tf
+++ b/aws-test/tests/aws_cloudfront_origin_access_identity/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_cloudfront_origin_request_policy/variables.tf
+++ b/aws-test/tests/aws_cloudfront_origin_request_policy/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_cloudwatch_alarm/variables.tf
+++ b/aws-test/tests/aws_cloudwatch_alarm/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -49,15 +49,15 @@ data "null_data_source" "resource" {
 
 # Create AWS > Cloudwatch > Alarm
 resource "aws_cloudwatch_metric_alarm" "named_test_resource" {
-  alarm_name = var.resource_name
+  alarm_name          = var.resource_name
   comparison_operator = "GreaterThanOrEqualToThreshold"
-  evaluation_periods = 2
-  metric_name = "CPUUtilization"
-  namespace = "AWS/EC2"
-  period = 120
-  statistic = "Average"
-  threshold = 80
-  alarm_description = var.resource_name
+  evaluation_periods  = 2
+  metric_name         = "CPUUtilization"
+  namespace           = "AWS/EC2"
+  period              = 120
+  statistic           = "Average"
+  threshold           = 80
+  alarm_description   = var.resource_name
   tags = {
     name = var.resource_name
   }

--- a/aws-test/tests/aws_codebuild_project/variables.tf
+++ b/aws-test/tests/aws_codebuild_project/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_codebuild_source_credential/variables.tf
+++ b/aws-test/tests/aws_codebuild_source_credential/variables.tf
@@ -1,7 +1,7 @@
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_codepipeline_pipeline/vatiable.tf
+++ b/aws-test/tests/aws_codepipeline_pipeline/vatiable.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -206,7 +206,7 @@ output "role_arn" {
 }
 
 output "resource_aka" {
-  value =   aws_codepipeline.named_test_resource.arn
+  value = aws_codepipeline.named_test_resource.arn
 }
 
 output "resource_name" {

--- a/aws-test/tests/aws_config_conformance_pack/variables.tf
+++ b/aws-test/tests/aws_config_conformance_pack/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_dax_cluster/variables.tf
+++ b/aws-test/tests/aws_dax_cluster/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_dms_replication_instance/variables.tf
+++ b/aws-test/tests/aws_dms_replication_instance/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_ec2_ami/test-hydrate-expected.json
+++ b/aws-test/tests/aws_ec2_ami/test-hydrate-expected.json
@@ -7,11 +7,11 @@
     "launch_permissions": [
       {
         "Group":null,
-        "UserId":"013122550996"
+        "UserId":"388460667113"
       },
       {
         "Group":null,
-        "UserId":"388460667113"
+        "UserId":"013122550996"
       }
     ],
     "tags": {

--- a/aws-test/tests/aws_ec2_regional_settings/variables.tf
+++ b/aws-test/tests/aws_ec2_regional_settings/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -47,7 +47,7 @@ data "null_data_source" "resource" {
 }
 
 resource "aws_kms_key" "named_test_resource" {
-  description = "var.resource_name"
+  description             = "var.resource_name"
   deletion_window_in_days = 7
   tags = {
     name = var.resource_name

--- a/aws-test/tests/aws_ecr_repository/variables.tf
+++ b/aws-test/tests/aws_ecr_repository/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_ecrpublic_repository/variables.tf
+++ b/aws-test/tests/aws_ecrpublic_repository/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_ecs_cluster/variables.tf
+++ b/aws-test/tests/aws_ecs_cluster/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_ecs_task_definition/variables.tf
+++ b/aws-test/tests/aws_ecs_task_definition/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -49,7 +49,7 @@ data "null_data_source" "resource" {
 
 # Create AWS > ECS > Task Definition
 resource "aws_ecs_task_definition" "named_test_resource" {
-  family = var.resource_name
+  family                = var.resource_name
   container_definitions = <<TASK_DEFINITION
   [
     {

--- a/aws-test/tests/aws_efs_access_point/variables.tf
+++ b/aws-test/tests/aws_efs_access_point/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -59,7 +59,7 @@ resource "aws_efs_access_point" "named_test_resource" {
   file_system_id = aws_efs_file_system.file_system.id
   tags = {
     Name = var.resource_name
-    foo = "bar"
+    foo  = "bar"
   }
 }
 
@@ -68,7 +68,7 @@ output "resource_name" {
 }
 
 output "resource_aka" {
-  value      = aws_efs_access_point.named_test_resource.arn
+  value = aws_efs_access_point.named_test_resource.arn
 }
 
 output "resource_id" {

--- a/aws-test/tests/aws_efs_file_system/variables.tf
+++ b/aws-test/tests/aws_efs_file_system/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_efs_mount_target/variables.tf
+++ b/aws-test/tests/aws_efs_mount_target/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -55,7 +55,7 @@ resource "aws_vpc" "my_vpc" {
 }
 
 resource "aws_subnet" "my_subnet" {
-  vpc_id            = "${aws_vpc.my_vpc.id}"
+  vpc_id            = aws_vpc.my_vpc.id
   availability_zone = "${var.aws_region}a"
   cidr_block        = "10.0.1.0/24"
 }

--- a/aws-test/tests/aws_eks_addon/variables.tf
+++ b/aws-test/tests/aws_eks_addon/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -107,14 +107,14 @@ resource "aws_vpc" "named_test_resource" {
 }
 
 resource "aws_subnet" "named_test_resource1" {
-  vpc_id     = aws_vpc.named_test_resource.id
-  cidr_block = "172.31.0.0/20"
+  vpc_id            = aws_vpc.named_test_resource.id
+  cidr_block        = "172.31.0.0/20"
   availability_zone = "${var.aws_region}b"
 }
 
 resource "aws_subnet" "named_test_resource2" {
-  vpc_id     = aws_vpc.named_test_resource.id
-  cidr_block = "172.31.32.0/20"
+  vpc_id            = aws_vpc.named_test_resource.id
+  cidr_block        = "172.31.32.0/20"
   availability_zone = "${var.aws_region}d"
 }
 

--- a/aws-test/tests/aws_eks_addon_version/variables.tf
+++ b/aws-test/tests/aws_eks_addon_version/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_eks_cluster/variables.tf
+++ b/aws-test/tests/aws_eks_cluster/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -104,14 +104,14 @@ resource "aws_vpc" "named_test_resource" {
 }
 
 resource "aws_subnet" "named_test_resource1" {
-  vpc_id     = aws_vpc.named_test_resource.id
-  cidr_block = "172.31.0.0/20"
+  vpc_id            = aws_vpc.named_test_resource.id
+  cidr_block        = "172.31.0.0/20"
   availability_zone = "${var.aws_region}b"
 }
 
 resource "aws_subnet" "named_test_resource2" {
-  vpc_id     = aws_vpc.named_test_resource.id
-  cidr_block = "172.31.32.0/20"
+  vpc_id            = aws_vpc.named_test_resource.id
+  cidr_block        = "172.31.32.0/20"
   availability_zone = "${var.aws_region}d"
 }
 

--- a/aws-test/tests/aws_elastic_beanstalk_application/variables.tf
+++ b/aws-test/tests/aws_elastic_beanstalk_application/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -50,13 +50,13 @@ data "null_data_source" "resource" {
 # Create AWS > Elastic Beanstalk > Application
 
 resource "aws_iam_service_linked_role" "elasticbeanstalk" {
-   aws_service_name = "elasticbeanstalk.amazonaws.com"
-   }
+  aws_service_name = "elasticbeanstalk.amazonaws.com"
+}
 
 resource "aws_elastic_beanstalk_application" "named_test_resource" {
   name = var.resource_name
   appversion_lifecycle {
-    service_role = "${aws_iam_service_linked_role.elasticbeanstalk.arn}"
+    service_role = aws_iam_service_linked_role.elasticbeanstalk.arn
   }
   tags = {
     name = var.resource_name

--- a/aws-test/tests/aws_elastic_beanstalk_environment/variables.tf
+++ b/aws-test/tests/aws_elastic_beanstalk_environment/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -81,18 +81,18 @@ resource "aws_internet_gateway" "testinternetgateway" {
 }
 
 resource "aws_route_table" "route" {
-  vpc_id = "${aws_vpc.my_vpc.id}"
+  vpc_id = aws_vpc.my_vpc.id
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.testinternetgateway.id}"
+    gateway_id = aws_internet_gateway.testinternetgateway.id
   }
 }
 
 resource "aws_subnet" "my_subnet1" {
-  vpc_id            = "${aws_vpc.my_vpc.id}"
-  availability_zone = "${var.aws_region}b"
+  vpc_id                  = aws_vpc.my_vpc.id
+  availability_zone       = "${var.aws_region}b"
   map_public_ip_on_launch = "true"
-  cidr_block        = "10.0.2.0/24"
+  cidr_block              = "10.0.2.0/24"
 }
 
 resource "aws_route_table_association" "routeassociation1" {
@@ -101,45 +101,45 @@ resource "aws_route_table_association" "routeassociation1" {
 }
 
 resource "aws_security_group" "ssh-allowed" {
-    vpc_id = aws_vpc.my_vpc.id
-    egress {
-        from_port = 0
-        to_port = 0
-        protocol = -1
-        cidr_blocks = ["0.0.0.0/0"]
-    }
-    ingress {
-        from_port = 22
-        to_port = 22
-        protocol = "tcp"
-        // This means, all ip address are allowed to ssh !
-        // Do not do it in the production.
-        // Put your office or home address in it!
-        cidr_blocks = ["0.0.0.0/0"]
-    }
-    //If you do not add this rule, you can not reach the NGIX
-    ingress {
-        from_port = 80
-        to_port = 80
-        protocol = "tcp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
+  vpc_id = aws_vpc.my_vpc.id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    // This means, all ip address are allowed to ssh !
+    // Do not do it in the production.
+    // Put your office or home address in it!
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  //If you do not add this rule, you can not reach the NGIX
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
 resource "aws_iam_service_linked_role" "elasticbeanstalk" {
-   aws_service_name = "elasticbeanstalk.amazonaws.com"
-   }
+  aws_service_name = "elasticbeanstalk.amazonaws.com"
+}
 
 resource "aws_elastic_beanstalk_application" "application_test" {
   name = var.resource_name
   appversion_lifecycle {
-    service_role = "${aws_iam_service_linked_role.elasticbeanstalk.arn}"
+    service_role = aws_iam_service_linked_role.elasticbeanstalk.arn
   }
 }
 
 resource "aws_elastic_beanstalk_environment" "named_test_resource" {
   name                   = var.resource_name
-  application            = "${aws_elastic_beanstalk_application.application_test.name}"
+  application            = aws_elastic_beanstalk_application.application_test.name
   solution_stack_name    = "64bit Amazon Linux 2 v3.2.0 running Go 1"
   wait_for_ready_timeout = "45m"
   setting {
@@ -150,17 +150,17 @@ resource "aws_elastic_beanstalk_environment" "named_test_resource" {
   setting {
     namespace = "aws:ec2:vpc"
     name      = "VPCId"
-    value     = "${aws_vpc.my_vpc.id}"
+    value     = aws_vpc.my_vpc.id
   }
   setting {
     namespace = "aws:ec2:vpc"
     name      = "ELBSubnets"
-    value     = "${aws_subnet.my_subnet1.id}"
+    value     = aws_subnet.my_subnet1.id
   }
   setting {
     namespace = "aws:ec2:vpc"
     name      = "Subnets"
-    value     = "${aws_subnet.my_subnet1.id}"
+    value     = aws_subnet.my_subnet1.id
   }
 }
 

--- a/aws-test/tests/aws_elasticache_cluster/variables.tf
+++ b/aws-test/tests/aws_elasticache_cluster/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_elasticache_parameter_group/variables.tf
+++ b/aws-test/tests/aws_elasticache_parameter_group/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_elasticache_replication_group/variables.tf
+++ b/aws-test/tests/aws_elasticache_replication_group/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_elasticache_subnet_group/variables.tf
+++ b/aws-test/tests/aws_elasticache_subnet_group/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_emr_cluster/variables.tf
+++ b/aws-test/tests/aws_emr_cluster/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -65,8 +65,8 @@ resource "aws_iam_role" "iam_emr_service_role" {
 EOF
 }
 resource "aws_iam_role_policy" "iam_emr_service_policy" {
-  name = "${var.resource_name}_1"
-  role = aws_iam_role.iam_emr_service_role.id
+  name   = "${var.resource_name}_1"
+  role   = aws_iam_role.iam_emr_service_role.id
   policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -133,7 +133,7 @@ resource "aws_iam_role_policy" "iam_emr_service_policy" {
 EOF
 }
 resource "aws_iam_role" "iam_emr_profile_role" {
-  name = "${var.resource_name}_2"
+  name               = "${var.resource_name}_2"
   assume_role_policy = <<EOF
 {
   "Version": "2008-10-17",
@@ -151,12 +151,12 @@ resource "aws_iam_role" "iam_emr_profile_role" {
 EOF
 }
 resource "aws_iam_instance_profile" "emr_profile" {
-  name  = "var.resource_name"
+  name = "var.resource_name"
   role = aws_iam_role.iam_emr_profile_role.name
 }
 resource "aws_iam_role_policy" "iam_emr_profile_policy" {
-  name = "${var.resource_name}_2"
-  role = aws_iam_role.iam_emr_profile_role.id
+  name   = "${var.resource_name}_2"
+  role   = aws_iam_role.iam_emr_profile_role.id
   policy = <<EOF
 {
     "Version": "2012-10-17",
@@ -182,15 +182,15 @@ resource "aws_iam_role_policy" "iam_emr_profile_policy" {
 EOF
 }
 resource "aws_vpc" "my_vpc" {
-  cidr_block           = "168.31.0.0/16"
+  cidr_block = "168.31.0.0/16"
 }
 resource "aws_security_group" "emr_master" {
   vpc_id                 = aws_vpc.my_vpc.id
   revoke_rules_on_delete = true
   ingress {
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
+    from_port = 443
+    to_port   = 443
+    protocol  = "tcp"
   }
   egress {
     from_port   = 0
@@ -231,7 +231,7 @@ resource "aws_emr_cluster" "named_test_resource" {
   release_label = "emr-4.9.5"
   applications  = ["Spark"]
   ec2_attributes {
-    key_name = aws_key_pair.deployer.key_name
+    key_name                          = aws_key_pair.deployer.key_name
     subnet_id                         = aws_subnet.my_subnet.id
     emr_managed_master_security_group = aws_security_group.emr_master.id
     emr_managed_slave_security_group  = aws_security_group.emr_master.id
@@ -245,7 +245,7 @@ resource "aws_emr_cluster" "named_test_resource" {
     instance_count = 1
   }
   tags = {
-    name     = var.resource_name
+    name = var.resource_name
   }
   service_role = aws_iam_role.iam_emr_service_role.arn
 }

--- a/aws-test/tests/aws_glacier_vault/variables.tf
+++ b/aws-test/tests/aws_glacier_vault/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -101,7 +101,7 @@ output "resource_name" {
 }
 
 output "resource_aka" {
-  value = "${aws_glacier_vault.named_test_resource.arn}"
+  value = aws_glacier_vault.named_test_resource.arn
 }
 
 output "resource_id" {

--- a/aws-test/tests/aws_glue_catalog_database/variables.tf
+++ b/aws-test/tests/aws_glue_catalog_database/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_guardduty_detector/variables.tf
+++ b/aws-test/tests/aws_guardduty_detector/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -50,7 +50,7 @@ data "null_data_source" "resource" {
 # Create AWS > GuardDuty > Detector
 resource "aws_guardduty_detector" "named_test_resource" {
   enable = true
-   tags = {
+  tags = {
     name = var.resource_name
   }
 }
@@ -74,17 +74,17 @@ output "resource_name" {
 data "template_file" "resource_aka" {
   template = "arn:$${partition}:guardduty:$${region}:$${account_id}:detector/${aws_guardduty_detector.named_test_resource.id}"
   vars = {
-    resource_name = var.resource_name
-    partition = data.aws_partition.current.partition
-    account_id = data.aws_caller_identity.current.account_id
-    region = data.aws_region.primary.name
+    resource_name    = var.resource_name
+    partition        = data.aws_partition.current.partition
+    account_id       = data.aws_caller_identity.current.account_id
+    region           = data.aws_region.primary.name
     alternate_region = data.aws_region.alternate.name
   }
 }
 
 output "resource_aka" {
-  depends_on = [ aws_guardduty_detector.named_test_resource ]
-  value = data.template_file.resource_aka.rendered
+  depends_on = [aws_guardduty_detector.named_test_resource]
+  value      = data.template_file.resource_aka.rendered
 }
 
 output "resource_id" {

--- a/aws-test/tests/aws_guardduty_finding/variables.tf
+++ b/aws-test/tests/aws_guardduty_finding/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_guardduty_ipset/variables.tf
+++ b/aws-test/tests/aws_guardduty_ipset/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -63,11 +63,11 @@ resource "aws_s3_bucket_object" "MyIPSet" {
 }
 
 resource "aws_guardduty_ipset" "named_test_resource" {
-  name = var.resource_name
-  format = "TXT"
-  location = "https://s3.amazonaws.com/${aws_s3_bucket_object.MyIPSet.bucket}/${aws_s3_bucket_object.MyIPSet.key}"
+  name        = var.resource_name
+  format      = "TXT"
+  location    = "https://s3.amazonaws.com/${aws_s3_bucket_object.MyIPSet.bucket}/${aws_s3_bucket_object.MyIPSet.key}"
   detector_id = aws_guardduty_detector.primary.id
-  activate = "true"
+  activate    = "true"
 }
 
 output "account_id" {
@@ -91,7 +91,7 @@ output "resource_name" {
 }
 
 output "ipset_id" {
-  value = split(":",aws_guardduty_ipset.named_test_resource.id)[1]
+  value = split(":", aws_guardduty_ipset.named_test_resource.id)[1]
 }
 
 output "detector_id" {

--- a/aws-test/tests/aws_guardduty_threat_intel_set/variables.tf
+++ b/aws-test/tests/aws_guardduty_threat_intel_set/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -91,7 +91,7 @@ output "resource_aka" {
 }
 
 output "resource_id" {
-  value = split(":",aws_guardduty_threatintelset.named_test_resource.id)[1]
+  value = split(":", aws_guardduty_threatintelset.named_test_resource.id)[1]
 }
 
 output "detector_id" {

--- a/aws-test/tests/aws_inspector_assessment_target/variables.tf
+++ b/aws-test/tests/aws_inspector_assessment_target/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_inspector_assessment_template/variables.tf
+++ b/aws-test/tests/aws_inspector_assessment_template/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -61,9 +61,9 @@ resource "aws_inspector_assessment_target" "assessment_target" {
 data "aws_inspector_rules_packages" "rules" {}
 
 resource "aws_inspector_assessment_template" "named_test_resource" {
-  name       = var.resource_name
-  target_arn = aws_inspector_assessment_target.assessment_target.arn
-  duration   = 3600
+  name               = var.resource_name
+  target_arn         = aws_inspector_assessment_target.assessment_target.arn
+  duration           = 3600
   rules_package_arns = data.aws_inspector_rules_packages.rules.arns
   tags = {
     foo = "bar"

--- a/aws-test/tests/aws_kinesis_consumer/variables.tf
+++ b/aws-test/tests/aws_kinesis_consumer/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -47,16 +47,16 @@ data "null_data_source" "resource" {
 }
 
 resource "aws_kinesis_stream" "named_test_resource" {
-  name = var.resource_name
-  shard_count = 1
-  retention_period = 24
+  name                      = var.resource_name
+  shard_count               = 1
+  retention_period          = 24
   enforce_consumer_deletion = true
 }
 
 resource "null_resource" "named_test_resource" {
   depends_on = [aws_kinesis_stream.named_test_resource]
   provisioner "local-exec" {
-   command = "aws kinesis register-stream-consumer --stream-arn ${aws_kinesis_stream.named_test_resource.arn} --consumer-name ${var.resource_name} --profile ${var.aws_profile} --region  ${data.aws_region.primary.name}"
+    command = "aws kinesis register-stream-consumer --stream-arn ${aws_kinesis_stream.named_test_resource.arn} --consumer-name ${var.resource_name} --profile ${var.aws_profile} --region  ${data.aws_region.primary.name}"
   }
 }
 
@@ -78,7 +78,7 @@ data "local_file" "input" {
 
 output "resource_aka" {
   depends_on = [null_resource.output_test_resource]
-  value = jsondecode(data.local_file.input.content).Consumers[0].ConsumerARN
+  value      = jsondecode(data.local_file.input.content).Consumers[0].ConsumerARN
 }
 
 output "stream_aka" {

--- a/aws-test/tests/aws_kinesis_video_stream/variables.tf
+++ b/aws-test/tests/aws_kinesis_video_stream/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_kinesisanalyticsv2_application/variables.tf
+++ b/aws-test/tests/aws_kinesisanalyticsv2_application/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -46,9 +46,9 @@ resource "aws_iam_role" "named_test_resource" {
 }
 
 resource "aws_kinesisanalyticsv2_application" "named_test_resource" {
-  name                    = var.resource_name
-  runtime_environment     = "SQL-1_0"
-  service_execution_role  = aws_iam_role.named_test_resource.arn
+  name                   = var.resource_name
+  runtime_environment    = "SQL-1_0"
+  service_execution_role = aws_iam_role.named_test_resource.arn
   tags = {
     Name = var.resource_name
   }

--- a/aws-test/tests/aws_macie2_classification_job/variables.tf
+++ b/aws-test/tests/aws_macie2_classification_job/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -58,12 +58,12 @@ resource "aws_macie2_account" "test" {
 
 resource "aws_macie2_classification_job" "named_test_resource" {
   depends_on = [aws_macie2_account.test]
-  job_type = "ONE_TIME"
-  name     = var.resource_name
+  job_type   = "ONE_TIME"
+  name       = var.resource_name
   s3_job_definition {
     bucket_definitions {
       account_id = data.aws_caller_identity.current.account_id
-      buckets = [aws_s3_bucket.test.bucket]
+      buckets    = [aws_s3_bucket.test.bucket]
     }
   }
   tags = {

--- a/aws-test/tests/aws_redshift_cluster/variables.tf
+++ b/aws-test/tests/aws_redshift_cluster/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -79,14 +79,14 @@ resource "aws_redshift_subnet_group" "my_subnet_group" {
 }
 
 resource "aws_redshift_cluster" "named_test_resource" {
-  cluster_identifier = var.resource_name
+  cluster_identifier        = var.resource_name
   cluster_subnet_group_name = aws_redshift_subnet_group.my_subnet_group.name
-  cluster_type = "single-node"
-  database_name = "testdb"
-  master_password = "test123Q"
-  master_username = "turbottest"
-  node_type = "dc2.large"
-  skip_final_snapshot = true
+  cluster_type              = "single-node"
+  database_name             = "testdb"
+  master_password           = "test123Q"
+  master_username           = "turbottest"
+  node_type                 = "dc2.large"
+  skip_final_snapshot       = true
   tags = {
     name = var.resource_name
   }

--- a/aws-test/tests/aws_redshift_snapshot/variables.tf
+++ b/aws-test/tests/aws_redshift_snapshot/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -65,8 +65,8 @@ resource "aws_subnet" "my_subnet1" {
   availability_zone = "${var.aws_region}a"
   vpc_id            = aws_vpc.my_vpc.id
   depends_on = [
-      "aws_internet_gateway.igw"
-    ]
+    "aws_internet_gateway.igw"
+  ]
   tags = {
     Name = var.resource_name
   }
@@ -77,8 +77,8 @@ resource "aws_subnet" "my_subnet2" {
   availability_zone = "${var.aws_region}b"
   vpc_id            = aws_vpc.my_vpc.id
   depends_on = [
-      "aws_internet_gateway.igw"
-    ]
+    "aws_internet_gateway.igw"
+  ]
   tags = {
     Name = var.resource_name
   }
@@ -125,7 +125,7 @@ output "resource_id" {
 }
 
 output "resource_aka" {
-  value = "arn:${data.aws_partition.current.partition}:redshift:${data.aws_region.primary.name}:${data.aws_caller_identity.current.account_id}:snapshot:${ var.resource_name }/${ var.resource_name }"
+  value = "arn:${data.aws_partition.current.partition}:redshift:${data.aws_region.primary.name}:${data.aws_caller_identity.current.account_id}:snapshot:${var.resource_name}/${var.resource_name}"
 }
 
 output "resource_name" {

--- a/aws-test/tests/aws_redshift_subnet_group/variables.tf
+++ b/aws-test/tests/aws_redshift_subnet_group/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -59,7 +59,7 @@ resource "aws_subnet" "my_subnet" {
 resource "aws_redshift_subnet_group" "named_test_resource" {
   name        = var.resource_name
   description = "A test subnet group"
-  subnet_ids = [aws_subnet.my_subnet.id]
+  subnet_ids  = [aws_subnet.my_subnet.id]
   tags = {
     name = var.resource_name
   }

--- a/aws-test/tests/aws_route53_resolver_endpoint/variables.tf
+++ b/aws-test/tests/aws_route53_resolver_endpoint/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_route53_resolver_rule/variables.tf
+++ b/aws-test/tests/aws_route53_resolver_rule/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -48,8 +48,8 @@ data "null_data_source" "resource" {
 
 resource "aws_route53_resolver_rule" "named_test_resource" {
   domain_name = "turbot.com"
-  rule_type = "SYSTEM"
-  name = var.resource_name
+  rule_type   = "SYSTEM"
+  name        = var.resource_name
   tags = {
     name = var.resource_name
   }

--- a/aws-test/tests/aws_s3_access_point/variables.tf
+++ b/aws-test/tests/aws_s3_access_point/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_sagemaker_endpoint_configuration/variable.tf
+++ b/aws-test/tests/aws_sagemaker_endpoint_configuration/variable.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_sagemaker_model/variables.tf
+++ b/aws-test/tests/aws_sagemaker_model/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_sagemaker_notebook_instance/variables.tf
+++ b/aws-test/tests/aws_sagemaker_notebook_instance/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -64,8 +64,8 @@ resource "aws_iam_role" "my_role" {
 }
 
 resource "aws_sagemaker_notebook_instance" "named_test_resource" {
-  name = var.resource_name
-  role_arn = aws_iam_role.my_role.arn
+  name          = var.resource_name
+  role_arn      = aws_iam_role.my_role.arn
   instance_type = "ml.t2.medium"
   tags = {
     name = var.resource_name

--- a/aws-test/tests/aws_securityhub_hub/variables.tf
+++ b/aws-test/tests/aws_securityhub_hub/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_securityhub_product/variables.tf
+++ b/aws-test/tests/aws_securityhub_product/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_ssm_association/variables.tf
+++ b/aws-test/tests/aws_ssm_association/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_ssm_managed_instance/variables.tf
+++ b/aws-test/tests/aws_ssm_managed_instance/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_ssm_managed_instance_compliance/variables.tf
+++ b/aws-test/tests/aws_ssm_managed_instance_compliance/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_vpc_vpn_connection/variables.tf
+++ b/aws-test/tests/aws_vpc_vpn_connection/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_waf_rate_based_rule/variables.tf
+++ b/aws-test/tests/aws_waf_rate_based_rule/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -48,10 +48,10 @@ data "null_data_source" "resource" {
 }
 
 resource "aws_waf_rate_based_rule" "named_test_resource" {
-  name = var.resource_name
+  name        = var.resource_name
   metric_name = var.resource_name
-  rate_key = "IP"
-  rate_limit = 100
+  rate_key    = "IP"
+  rate_limit  = 100
   tags = {
     name = var.resource_name
   }

--- a/aws-test/tests/aws_wafv2_web_acl/variables.tf
+++ b/aws-test/tests/aws_wafv2_web_acl/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_wellarchitected_workload/posttest-variables.tf
+++ b/aws-test/tests/aws_wellarchitected_workload/posttest-variables.tf
@@ -1,6 +1,6 @@
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_wellarchitected_workload/pretest-variables.tf
+++ b/aws-test/tests/aws_wellarchitected_workload/pretest-variables.tf
@@ -1,13 +1,13 @@
 
 variable "resource_name" {
-  type    = string
-  default = ""
+  type        = string
+  default     = ""
   description = "Name of the resource used throughout the test."
 }
 
 variable "aws_profile" {
   type        = string
-  default     = "default"
+  default     = "integration-tests"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
@@ -64,7 +64,7 @@ data "local_file" "input" {
 
 output "resource_id" {
   depends_on = [null_resource.named_test_resource]
-  value = jsondecode(data.local_file.input.content).WorkloadId
+  value      = jsondecode(data.local_file.input.content).WorkloadId
 }
 
 output "resource_name" {
@@ -82,17 +82,17 @@ output "aws_region" {
 data "template_file" "resource_aka" {
   template = "arn:$${partition}:wellarchitected:$${region}:$${account_id}:workload/$${resource_id}"
   vars = {
-    partition = data.aws_partition.current.partition
-    account_id = data.aws_caller_identity.current.account_id
-    region = data.aws_region.primary.name
-    resource_id = jsondecode(data.local_file.input.content).WorkloadId
+    partition        = data.aws_partition.current.partition
+    account_id       = data.aws_caller_identity.current.account_id
+    region           = data.aws_region.primary.name
+    resource_id      = jsondecode(data.local_file.input.content).WorkloadId
     alternate_region = data.aws_region.alternate.name
   }
 }
 
 output "resource_aka" {
-  depends_on = [ null_resource.named_test_resource ]
-  value = data.template_file.resource_aka.rendered
+  depends_on = [null_resource.named_test_resource]
+  value      = data.template_file.resource_aka.rendered
 }
 
 output "aws_partition" {

--- a/go.mod
+++ b/go.mod
@@ -10,3 +10,5 @@ require (
 	github.com/turbot/go-kit v0.1.1
 	github.com/turbot/steampipe-plugin-sdk v0.2.10
 )
+
+replace github.com/turbot/steampipe-plugin-sdk => /home/ec2-user/steampipe-test/steampipe-plugin-sdk


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_ec2_ami []

PRETEST: tests/aws_ec2_ami

TEST: tests/aws_ec2_ami
Running terraform
aws_ebs_volume.my_volume: Creating...
aws_ebs_volume.my_volume: Still creating... [10s elapsed]
aws_ebs_volume.my_volume: Creation complete after 14s [id=vol-0e7ff924aeda25c80]
aws_ebs_snapshot.my_snapshot: Creating...
aws_ebs_snapshot.my_snapshot: Creation complete after 4s [id=snap-041f1ddbbacb58f2c]
aws_ami.named_test_resource: Creating...
aws_ami.named_test_resource: Still creating... [10s elapsed]
aws_ami.named_test_resource: Creation complete after 10s [id=ami-0a783e76067613cf2]
data.template_file.resource_aka: Reading...
aws_ami_launch_permission.deny_access: Creating...
aws_ami_launch_permission.allow_access: Creating...
data.template_file.resource_aka: Read complete after 0s [id=baa580137de94e80ad68bab1cfa8e50d25dc4a578dac71a10ab96c787e256a44]
aws_ami_launch_permission.deny_access: Creation complete after 2s [id=ami-0a783e76067613cf2-013122550996]
aws_ami_launch_permission.allow_access: Creation complete after 2s [id=ami-0a783e76067613cf2-388460667113]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "013122550996"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:ec2:us-east-1:013122550996:image/ami-0a783e76067613cf2"
resource_id = "ami-0a783e76067613cf2"
resource_name = "turbottest66790"
snapshot_id = "snap-041f1ddbbacb58f2c"

Running SQL query: query.sql
[
  {
    "image_id": "ami-0a783e76067613cf2",
    "name": "turbottest66790"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "architecture": "x86_64",
    "block_device_mappings": [
      {
        "DeviceName": "/dev/sda1",
        "Ebs": {
          "DeleteOnTermination": true,
          "Encrypted": false,
          "Iops": null,
          "KmsKeyId": null,
          "OutpostArn": null,
          "SnapshotId": "snap-041f1ddbbacb58f2c",
          "Throughput": null,
          "VolumeSize": 8,
          "VolumeType": "standard"
        },
        "NoDevice": null,
        "VirtualName": null
      }
    ],
    "description": "This is a test image.",
    "ena_support": false,
    "hypervisor": "xen",
    "image_id": "ami-0a783e76067613cf2",
    "image_location": "013122550996/turbottest66790",
    "image_type": "machine",
    "name": "turbottest66790",
    "owner_id": "013122550996",
    "platform_details": "Linux/UNIX",
    "public": false,
    "root_device_name": "/dev/sda1",
    "root_device_type": "ebs",
    "sriov_net_support": "simple",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest66790"
      }
    ],
    "usage_operation": "RunInstances",
    "virtualization_type": "hvm"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:013122550996:image/ami-0a783e76067613cf2"
    ],
    "image_id": "ami-0a783e76067613cf2",
    "launch_permissions": [
      {
        "Group": null,
        "UserId": "388460667113"
      },
      {
        "Group": null,
        "UserId": "013122550996"
      }
    ],
    "tags": {
      "Name": "turbottest66790"
    },
    "title": "turbottest66790"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "image_id": "ami-0a783e76067613cf2",
    "name": "turbottest66790"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_ami

TEARDOWN: tests/aws_ec2_ami

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>
