### PR TITLE
Add column arn in table aws_vpc_nat_gateway. Closes #539

### DIFF
--- a/aws-test/tests/aws_vpc_nat_gateway/test-get-expected.json
+++ b/aws-test/tests/aws_vpc_nat_gateway/test-get-expected.json
@@ -1,13 +1,14 @@
 [
   {
+    "arn": "{{ output.resource_aka.value }}",
     "nat_gateway_addresses": [
       {
-       "AllocationId": "{{ output.allocation_id.value }}",
-       "NetworkInterfaceId": "{{ output.network_interface_id.value }}",
-       "PrivateIp": "{{ output.private_ip.value }}",
-       "PublicIp": "{{ output.public_ip.value }}"
+        "AllocationId": "{{ output.allocation_id.value }}",
+        "NetworkInterfaceId": "{{ output.network_interface_id.value }}",
+        "PrivateIp": "{{ output.private_ip.value }}",
+        "PublicIp": "{{ output.public_ip.value }}"
       }
-     ],
+    ],
     "nat_gateway_id": "{{ output.resource_id.value }}",
     "subnet_id": "{{ output.subnet_id.value }}",
     "tags_src": [

--- a/aws-test/tests/aws_vpc_nat_gateway/test-get-query.sql
+++ b/aws-test/tests/aws_vpc_nat_gateway/test-get-query.sql
@@ -1,3 +1,3 @@
-select nat_gateway_id, nat_gateway_addresses, vpc_id, subnet_id, tags_src
+select arn, nat_gateway_id, nat_gateway_addresses, vpc_id, subnet_id, tags_src
 from aws.aws_vpc_nat_gateway
-where nat_gateway_id = '{{ output.resource_id.value }}'
+where nat_gateway_id = '{{ output.resource_id.value }}';

--- a/aws-test/tests/aws_vpc_nat_gateway/test-hydrate-expected.json
+++ b/aws-test/tests/aws_vpc_nat_gateway/test-hydrate-expected.json
@@ -1,8 +1,6 @@
 [
   {
-    "akas": [
-      "{{ output.resource_aka.value }}"
-    ],
+    "akas": ["{{ output.resource_aka.value }}"],
     "nat_gateway_id": "{{ output.resource_id.value }}",
     "tags": {
       "Name": "{{resourceName}}"

--- a/aws-test/tests/aws_vpc_nat_gateway/test-hydrate-query.sql
+++ b/aws-test/tests/aws_vpc_nat_gateway/test-hydrate-query.sql
@@ -1,3 +1,3 @@
 select nat_gateway_id, akas, tags, title
 from aws.aws_vpc_nat_gateway
-where nat_gateway_id = '{{ output.resource_id.value }}'
+where nat_gateway_id = '{{ output.resource_id.value }}';

--- a/aws-test/tests/aws_vpc_nat_gateway/test-list-expected.json
+++ b/aws-test/tests/aws_vpc_nat_gateway/test-list-expected.json
@@ -1,8 +1,6 @@
 [
   {
-    "akas": [
-      "{{ output.resource_aka.value }}"
-    ],
+    "akas": ["{{ output.resource_aka.value }}"],
     "nat_gateway_id": "{{ output.resource_id.value }}",
     "tags": {
       "Name": "{{resourceName}}"

--- a/aws-test/tests/aws_vpc_nat_gateway/test-list-query.sql
+++ b/aws-test/tests/aws_vpc_nat_gateway/test-list-query.sql
@@ -1,3 +1,3 @@
 select nat_gateway_id, vpc_id, tags, title, akas
 from aws.aws_vpc_nat_gateway
-where nat_gateway_id = '{{ output.resource_id.value }}'
+where nat_gateway_id = '{{ output.resource_id.value }}';

--- a/aws/table_aws_vpc_nat_gateway.go
+++ b/aws/table_aws_vpc_nat_gateway.go
@@ -16,7 +16,7 @@ func tableAwsVpcNatGateway(_ context.Context) *plugin.Table {
 		Description: "AWS VPC Network Address Translation Gateway",
 		Get: &plugin.GetConfig{
 			KeyColumns:        plugin.SingleColumn("nat_gateway_id"),
-			ShouldIgnoreError: isNotFoundError([]string{"NatGatewayMalformed"}),
+			ShouldIgnoreError: isNotFoundError([]string{"NatGatewayMalformed", "NatGatewayNotFound"}),
 			Hydrate:           getVpcNatGateway,
 		},
 		List: &plugin.ListConfig{
@@ -28,6 +28,13 @@ func tableAwsVpcNatGateway(_ context.Context) *plugin.Table {
 				Name:        "nat_gateway_id",
 				Description: "The ID of the NAT gateway.",
 				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "arn",
+				Description: "The Amazon Resource Name (ARN) specifying the NAT gateway.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getVpcNatGatewayARN,
+				Transform:   transform.FromValue(),
 			},
 			{
 				Name:        "nat_gateway_addresses",
@@ -97,8 +104,8 @@ func tableAwsVpcNatGateway(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getVpcNatGatewayTurbotAkas,
-				Transform:   transform.FromValue(),
+				Hydrate:     getVpcNatGatewayARN,
+				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
 			},
 		}),
 	}
@@ -173,8 +180,9 @@ func getVpcNatGateway(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 	return nil, nil
 }
 
-func getVpcNatGatewayTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getVpcNatGatewayTurbotAkas")
+func getVpcNatGatewayARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getVpcNatGatewayARN")
+
 	natGateway := h.Item.(*ec2.NatGateway)
 	commonData, err := getCommonColumns(ctx, d, h)
 	if err != nil {
@@ -182,10 +190,10 @@ func getVpcNatGatewayTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plu
 	}
 	commonColumnData := commonData.(*awsCommonColumnData)
 
-	// Get data for turbot defined properties
-	akas := []string{"arn:" + commonColumnData.Partition + ":ec2:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":natgateway/" + *natGateway.NatGatewayId}
+	// Build ARN
+	arn := "arn:" + commonColumnData.Partition + ":ec2:" + commonColumnData.Region + ":" + commonColumnData.AccountId + ":natgateway/" + *natGateway.NatGatewayId
 
-	return akas, nil
+	return arn, nil
 }
 
 //// TRANSFORM FUNCTIONS


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/aws_vpc_nat_gateway []

PRETEST: tests/aws_vpc_nat_gateway

TEST: tests/aws_vpc_nat_gateway
Running terraform
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_region.alternate: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_eip.example: Creating...
aws_vpc.main: Creating...
aws_eip.example: Creation complete after 2s [id=eipalloc-06d0502a7635c2553]
aws_vpc.main: Still creating... [10s elapsed]
aws_vpc.main: Creation complete after 12s [id=vpc-0b60348a9acb6e5b8]
aws_internet_gateway.gw: Creating...
aws_subnet.example: Creating...
aws_subnet.example: Creation complete after 4s [id=subnet-0e9a18450ac14a04a]
aws_internet_gateway.gw: Creation complete after 6s [id=igw-080c3f199a9b6993c]
aws_nat_gateway.named_test_resource: Creating...
aws_nat_gateway.named_test_resource: Still creating... [10s elapsed]
aws_nat_gateway.named_test_resource: Still creating... [20s elapsed]
aws_nat_gateway.named_test_resource: Still creating... [30s elapsed]
aws_nat_gateway.named_test_resource: Still creating... [40s elapsed]
aws_nat_gateway.named_test_resource: Still creating... [50s elapsed]
aws_nat_gateway.named_test_resource: Still creating... [1m0s elapsed]
aws_nat_gateway.named_test_resource: Still creating... [1m10s elapsed]
aws_nat_gateway.named_test_resource: Still creating... [1m20s elapsed]
aws_nat_gateway.named_test_resource: Still creating... [1m30s elapsed]
aws_nat_gateway.named_test_resource: Still creating... [1m40s elapsed]
aws_nat_gateway.named_test_resource: Creation complete after 1m42s [id=nat-077052d91eed0157b]
data.template_file.resource_aka: Refreshing state...

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

allocation_id = eipalloc-06d0502a7635c2553
network_interface_id = eni-0ca204a35abe98c25
private_ip = 10.0.1.173
public_ip = 50.16.33.23
resource_aka = arn:aws:ec2:us-east-1:123456789012:natgateway/nat-077052d91eed0157b
resource_id = nat-077052d91eed0157b
resource_name = turbottest37867
subnet_id = subnet-0e9a18450ac14a04a
vpc_id = vpc-0b60348a9acb6e5b8

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:ec2:us-east-1:123456789012:natgateway/nat-077052d91eed0157b",
    "nat_gateway_addresses": [
      {
        "AllocationId": "eipalloc-06d0502a7635c2553",
        "NetworkInterfaceId": "eni-0ca204a35abe98c25",
        "PrivateIp": "10.0.1.173",
        "PublicIp": "50.16.33.23"
      }
    ],
    "nat_gateway_id": "nat-077052d91eed0157b",
    "subnet_id": "subnet-0e9a18450ac14a04a",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest37867"
      }
    ],
    "vpc_id": "vpc-0b60348a9acb6e5b8"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:123456789012:natgateway/nat-077052d91eed0157b"
    ],
    "nat_gateway_id": "nat-077052d91eed0157b",
    "tags": {
      "Name": "turbottest37867"
    },
    "title": "turbottest37867"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:123456789012:natgateway/nat-077052d91eed0157b"
    ],
    "nat_gateway_id": "nat-077052d91eed0157b",
    "tags": {
      "Name": "turbottest37867"
    },
    "title": "turbottest37867",
    "vpc_id": "vpc-0b60348a9acb6e5b8"
  }
]
✔ PASSED

POSTTEST: tests/aws_vpc_nat_gateway

TEARDOWN: tests/aws_vpc_nat_gateway

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>
