### PR TITLE
Fix: table aws_ec2_instance to handle empty value for StateTransitionReason. Fixes #575

### DIFF
--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -577,12 +577,15 @@ func getEc2InstanceTurbotTitle(_ context.Context, d *transform.TransformData) (i
 
 func ec2InstanceStateChangeTime(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	data := d.HydrateItem.(*ec2.Instance)
-	if helpers.StringSliceContains([]string{"shutting-down", "stopped", "stopping", "terminated"}, *data.State.Name) {
-		// User initiated (2019-09-12 16:38:34 GMT)
-		regexExp := regexp.MustCompile(`\((.*?) *\)`)
-		stateTransitionTime := regexExp.FindStringSubmatch(*data.StateTransitionReason)[1]
-		stateTransitionTimeInUTC := strings.Replace(strings.Replace(stateTransitionTime, " ", "T", 1), " GMT", "Z", 1)
-		return stateTransitionTimeInUTC, nil
+
+	if *data.StateTransitionReason != "" {
+		if helpers.StringSliceContains([]string{"shutting-down", "stopped", "stopping", "terminated"}, *data.State.Name) {
+			// User initiated (2019-09-12 16:38:34 GMT)
+			regexExp := regexp.MustCompile(`\((.*?) *\)`)
+			stateTransitionTime := regexExp.FindStringSubmatch(*data.StateTransitionReason)[1]
+			stateTransitionTimeInUTC := strings.Replace(strings.Replace(stateTransitionTime, " ", "T", 1), " GMT", "Z", 1)
+			return stateTransitionTimeInUTC, nil
+		}
 	}
 	return data.LaunchTime, nil
 }

--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -582,9 +582,13 @@ func ec2InstanceStateChangeTime(_ context.Context, d *transform.TransformData) (
 		if helpers.StringSliceContains([]string{"shutting-down", "stopped", "stopping", "terminated"}, *data.State.Name) {
 			// User initiated (2019-09-12 16:38:34 GMT)
 			regexExp := regexp.MustCompile(`\((.*?) *\)`)
-			stateTransitionTime := regexExp.FindStringSubmatch(*data.StateTransitionReason)[1]
-			stateTransitionTimeInUTC := strings.Replace(strings.Replace(stateTransitionTime, " ", "T", 1), " GMT", "Z", 1)
-			return stateTransitionTimeInUTC, nil
+			stateTransitionTime := regexExp.FindStringSubmatch(*data.StateTransitionReason)
+			if len(stateTransitionTime) >= 1 {
+				stateTransitionTimeInUTC := strings.Replace(strings.Replace(stateTransitionTime[1], " ", "T", 1), " GMT", "Z", 1)
+				return stateTransitionTimeInUTC, nil
+			} else {
+				return data.LaunchTime, nil
+			}
 		}
 	}
 	return data.LaunchTime, nil

--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -586,9 +586,7 @@ func ec2InstanceStateChangeTime(_ context.Context, d *transform.TransformData) (
 			if len(stateTransitionTime) >= 1 {
 				stateTransitionTimeInUTC := strings.Replace(strings.Replace(stateTransitionTime[1], " ", "T", 1), " GMT", "Z", 1)
 				return stateTransitionTimeInUTC, nil
-			} else {
-				return data.LaunchTime, nil
-			}
+			} 
 		}
 	}
 	return data.LaunchTime, nil


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select instance_id,instance_state,launch_time,state_transition_time,region,account_id from awsagg.aws_ec2_instance where instance_state <> 'running'
+---------------------+----------------+---------------------+-----------------------+------------+--------------+
| instance_id         | instance_state | launch_time         | state_transition_time | region     | account_id   |
+---------------------+----------------+---------------------+-----------------------+------------+--------------+
| i-0680816e3feed28b0 | stopped        | 2021-07-29 03:55:24 | 2021-07-29 04:14:29   | ap-south-1 | 013122550996 |
| i-0bd0fba70e1c158c9 | stopped        | 2019-10-31 14:13:38 | 2019-11-14 05:27:26   | us-east-1  | 828685001623 |
| i-0eb8936103e4590f9 | stopped        | 2018-10-04 08:23:04 | 2021-03-22 13:38:30   | us-east-1  | 693374561973 |
| i-02eb353bc6c079f70 | stopped        | 2019-05-19 14:45:12 | 2019-10-23 15:42:15   | us-east-1  | 693374561973 |
| i-06e0de1b8436a1f50 | stopped        | 2020-01-06 14:04:11 | 2020-02-21 05:00:02   | us-east-1  | 828685001623 |
| i-01d761357ff204fca | stopped        | 2021-07-02 03:08:02 | 2021-07-02 03:09:09   | us-east-1  | 533793682495 |
| i-0013264431cce2014 | stopped        | 2021-01-25 11:31:33 | 2021-01-25 12:52:10   | us-east-1  | 693374561973 |
| i-0c45aff829a879f49 | stopped        | 2019-05-19 14:45:14 | 2021-03-22 13:38:23   | us-east-1  | 693374561973 |
| i-076c621c9eafe3bd8 | stopped        | 2019-10-08 15:01:11 | 2019-10-08 15:51:37   | us-east-1  | 828685001623 |
| i-0e31039a58e5b9623 | stopped        | 2021-06-02 14:12:11 | 2021-06-02 14:13:47   | us-east-1  | 828685001623 |
| i-0b0b8528c8de308a2 | terminated     | 2021-07-29 04:22:48 | 2021-07-29 05:19:02   | us-east-1  | 828685001623 |
| i-006ae642663c062d2 | stopped        | 2020-11-23 07:21:41 | 2020-12-03 07:05:49   | us-east-1  | 533793682495 |
| i-0607a37dc00e5b670 | stopped        | 2021-07-19 14:17:34 | 2021-07-20 06:40:32   | us-east-1  | 533793682495 |
| i-019277aa029bc153f | stopped        | 2021-01-27 10:37:36 | 2021-01-27 10:49:19   | us-east-2  | 533793682495 |
| i-01d374202295d62c3 | stopped        | 2021-01-27 10:29:20 | 2021-01-27 10:37:14   | us-east-2  | 533793682495 |
| i-05f4da52cce623709 | stopped        | 2019-06-07 19:55:14 | 2019-06-25 02:34:57   | us-east-2  | 533793682495 |
| i-0d57b0adc7d38c7aa | stopped        | 2019-10-15 18:50:04 | 2019-10-15 21:09:21   | us-east-2  | 533793682495 |
| i-079fe88a8a1cf793d | stopped        | 2018-05-03 20:29:52 | 2018-05-03 20:29:52   | eu-west-1  | 533793682495 |
+---------------------+----------------+---------------------+-----------------------+------------+--------------+
> select instance_id,instance_state,launch_time,state_transition_time,region,account_id from awsagg.aws_ec2_instance
+---------------------+----------------+---------------------+-----------------------+------------+--------------+
| instance_id         | instance_state | launch_time         | state_transition_time | region     | account_id   |
+---------------------+----------------+---------------------+-----------------------+------------+--------------+
| i-03c09093b86a6be6d | running        | 2021-07-29 03:55:24 | 2021-07-29 03:55:24   | ap-south-1 | 013122550996 |
| i-0788beb0505a02f95 | running        | 2021-06-15 15:11:46 | 2021-06-15 15:11:46   | ap-south-1 | 533793682495 |
| i-0680816e3feed28b0 | stopped        | 2021-07-29 03:55:24 | 2021-07-29 04:14:29   | ap-south-1 | 013122550996 |
| i-05e18a7e05053005b | running        | 2021-06-29 13:56:06 | 2021-06-29 13:56:06   | ap-south-1 | 828685001623 |
| i-079fe88a8a1cf793d | stopped        | 2018-05-03 20:29:52 | 2018-05-03 20:29:52   | eu-west-1  | 533793682495 |
| i-006ae642663c062d2 | stopped        | 2020-11-23 07:21:41 | 2020-12-03 07:05:49   | us-east-1  | 533793682495 |
| i-01d761357ff204fca | stopped        | 2021-07-02 03:08:02 | 2021-07-02 03:09:09   | us-east-1  | 533793682495 |
| i-0607a37dc00e5b670 | stopped        | 2021-07-19 14:17:34 | 2021-07-20 06:40:32   | us-east-1  | 533793682495 |
| i-01d374202295d62c3 | stopped        | 2021-01-27 10:29:20 | 2021-01-27 10:37:14   | us-east-2  | 533793682495 |
| i-05f4da52cce623709 | stopped        | 2019-06-07 19:55:14 | 2019-06-25 02:34:57   | us-east-2  | 533793682495 |
| i-0f44f247bef809ba1 | running        | 2021-07-01 06:17:52 | 2021-07-01 06:17:52   | us-east-2  | 533793682495 |
| i-019277aa029bc153f | stopped        | 2021-01-27 10:37:36 | 2021-01-27 10:49:19   | us-east-2  | 533793682495 |
| i-0d57b0adc7d38c7aa | stopped        | 2019-10-15 18:50:04 | 2019-10-15 21:09:21   | us-east-2  | 533793682495 |
| i-0ec8862389e34b75e | running        | 2021-06-01 16:26:30 | 2021-06-01 16:26:30   | us-east-2  | 533793682495 |
| i-06e0de1b8436a1f50 | stopped        | 2020-01-06 14:04:11 | 2020-02-21 05:00:02   | us-east-1  | 828685001623 |
| i-076c621c9eafe3bd8 | stopped        | 2019-10-08 15:01:11 | 2019-10-08 15:51:37   | us-east-1  | 828685001623 |
| i-0bd0fba70e1c158c9 | stopped        | 2019-10-31 14:13:38 | 2019-11-14 05:27:26   | us-east-1  | 828685001623 |
| i-0e31039a58e5b9623 | stopped        | 2021-06-02 14:12:11 | 2021-06-02 14:13:47   | us-east-1  | 828685001623 |
| i-089fb9e5f5bf64f9e | running        | 2021-07-29 04:22:48 | 2021-07-29 04:22:48   | us-east-1  | 828685001623 |
| i-0222ce35133c8d080 | running        | 2021-07-29 04:22:48 | 2021-07-29 04:22:48   | us-east-1  | 828685001623 |
| i-0b0b8528c8de308a2 | terminated     | 2021-07-29 04:22:48 | 2021-07-29 05:19:02   | us-east-1  | 828685001623 |
| i-0013264431cce2014 | stopped        | 2021-01-25 11:31:33 | 2021-01-25 12:52:10   | us-east-1  | 693374561973 |
| i-0db0830d9a856b2f1 | running        | 2021-07-15 04:58:22 | 2021-07-15 04:58:22   | us-east-1  | 693374561973 |
| i-0c45aff829a879f49 | stopped        | 2019-05-19 14:45:14 | 2021-03-22 13:38:23   | us-east-1  | 693374561973 |
| i-072cfb489189f58ed | running        | 2021-07-15 04:58:22 | 2021-07-15 04:58:22   | us-east-1  | 693374561973 |
| i-0e8b4da9d82701ca1 | running        | 2021-07-13 12:20:38 | 2021-07-13 12:20:38   | us-east-1  | 693374561973 |
| i-02eb353bc6c079f70 | stopped        | 2019-05-19 14:45:12 | 2019-10-23 15:42:15   | us-east-1  | 693374561973 |
| i-0b197453fea6c32ad | running        | 2021-07-13 12:23:25 | 2021-07-13 12:23:25   | us-east-1  | 693374561973 |
| i-0eb8936103e4590f9 | stopped        | 2018-10-04 08:23:04 | 2021-03-22 13:38:30   | us-east-1  | 693374561973 |
| i-080e1073008d3f1a2 | running        | 2021-07-13 12:20:41 | 2021-07-13 12:20:41   | us-east-1  | 693374561973 |
+---------------------+----------------+---------------------+-----------------------+------------+--------------+

```
</details>
