### PR TITLE
Fix aws_cloudtrail_trail table queries fail to get organization trails. Closes #577

### DIFF
--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -21,10 +21,11 @@ func tableAwsCloudtrailTrail(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns:        plugin.AnyColumn([]string{"name", "arn"}),
 			Hydrate:           getCloudtrailTrail,
-			ShouldIgnoreError: isNotFoundError([]string{"InvalidTrailNameException", "TrailNotFoundException"}),
+			ShouldIgnoreError: isNotFoundError([]string{"InvalidTrailNameException", "TrailNotFoundException", "CloudTrailARNInvalidException"}),
 		},
 		List: &plugin.ListConfig{
-			Hydrate: listCloudtrailTrails,
+			Hydrate:           listCloudtrailTrails,
+			ShouldIgnoreError: isNotFoundError([]string{"InvalidTrailNameException", "TrailNotFoundException", "CloudTrailARNInvalidException"}),
 		},
 		GetMatrixItem: BuildRegionList,
 		Columns: awsRegionalColumns([]*plugin.Column{

--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -321,11 +321,6 @@ func getCloudtrailTrailStatus(ctx context.Context, d *plugin.QueryData, h *plugi
 	// List resource tags
 	item, err := svc.GetTrailStatus(params)
 	if err != nil {
-		// if awsErr, ok := err.(awserr.Error); ok {
-		// 	if awsErr.Code() == "TrailNotFoundException" {
-		// 		return nil, nil
-		// 	}
-		// }
 		return nil, err
 	}
 	return item, nil
@@ -368,11 +363,6 @@ func getCloudtrailTrailEventSelector(ctx context.Context, d *plugin.QueryData, h
 	// List resource tags
 	item, err := svc.GetEventSelectors(params)
 	if err != nil {
-		// if awsErr, ok := err.(awserr.Error); ok {
-		// 	if awsErr.Code() == "TrailNotFoundException" {
-		// 		return nil, nil
-		// 	}
-		// }
 		return nil, err
 	}
 	return item, nil
@@ -390,10 +380,12 @@ func getCloudtrailTrailTags(ctx context.Context, d *plugin.QueryData, h *plugin.
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	trail := h.Item.(*cloudtrail.Trail)
 
+	var traiTag []*cloudtrail.Tag
+
 	// Avoid api call if accountId is not equal to the accountId available in arn
 	accountId := arnToAccountId(*trail.TrailARN)
 	if commonColumnData.AccountId != accountId {
-		return nil, nil
+		return traiTag, nil
 	}
 
 	// Avoid api call if home_region is not equal to current region
@@ -401,7 +393,6 @@ func getCloudtrailTrailTags(ctx context.Context, d *plugin.QueryData, h *plugin.
 	if region != homeRegion {
 		return []*cloudtrail.Tag{}, nil
 	}
-	//var trailTag []*cloudtrail.Tag
 
 	// Create session
 	svc, err := CloudTrailService(ctx, d)
@@ -415,11 +406,6 @@ func getCloudtrailTrailTags(ctx context.Context, d *plugin.QueryData, h *plugin.
 
 	resp, err := svc.ListTags(params)
 	if err != nil {
-		// if awsErr, ok := err.(awserr.Error); ok {
-		// 	if awsErr.Code() == "CloudTrailARNInvalidException" {
-		// 		return trailTag, nil
-		// 	}
-		// }
 		return nil, err
 	}
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,region, home_region,arn, is_organization_trail, is_multi_region_trail, tags_src, tags from awsagg.aws_cloudtrail_trail
+--------------------------------+----------------+-------------+--------------------------------------------------------------------------------+-----------------------+-----------------------+----------
| name                           | region         | home_region | arn                                                                            | is_organization_trail | is_multi_region_trail | tags_src 
+--------------------------------+----------------+-------------+--------------------------------------------------------------------------------+-----------------------+-----------------------+----------
| cody-test-organizational-trail | ap-south-1     | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | ap-southeast-1 | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | ap-southeast-1 | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | ap-south-1     | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | sa-east-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | sa-east-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| turbot-acc-us-east-1-trail     | ap-northeast-3 | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| turbot-acc-us-east-1-trail     | ap-northeast-2 | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | ap-northeast-3 | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | eu-west-3      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | eu-central-1   | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| cody-test-organizational-trail | ap-northeast-2 | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| cody-test-organizational-trail | eu-west-3      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| cody-test-organizational-trail | eu-west-2      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | eu-west-2      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | ap-southeast-2 | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | ap-southeast-2 | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| turbot-acc-us-east-1-trail     | ap-northeast-1 | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| turbot-acc-us-east-1-trail     | eu-north-1     | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | ap-northeast-1 | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| cody-test-organizational-trail | eu-north-1     | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| cody-test-organizational-trail | us-east-2      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | us-east-2      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | us-east-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | <null>   
| cody-test-organizational-trail | eu-west-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | us-west-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | ca-central-1   | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | ca-central-1   | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | us-west-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | eu-central-1   | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| turbot-acc-us-east-1-trail     | eu-west-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| turbot-acc-us-east-1-trail     | us-east-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | us-west-2      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | us-west-2      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
+--------------------------------+----------------+-------------+--------------------------------------------------------------------------------+-----------------------+-----------------------+----------


> select name,region, home_region,arn, is_organization_trail, is_multi_region_trail, tags_src, tags from awsagg.aws_cloudtrail_trail
+--------------------------------+----------------+-------------+--------------------------------------------------------------------------------+-----------------------+-----------------------+----------
| name                           | region         | home_region | arn                                                                            | is_organization_trail | is_multi_region_trail | tags_src 
+--------------------------------+----------------+-------------+--------------------------------------------------------------------------------+-----------------------+-----------------------+----------
| cody-test-organizational-trail | ap-south-1     | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | ap-southeast-1 | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | ap-southeast-1 | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | ap-south-1     | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | sa-east-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | sa-east-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| turbot-acc-us-east-1-trail     | ap-northeast-3 | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| turbot-acc-us-east-1-trail     | ap-northeast-2 | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | ap-northeast-3 | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | eu-west-3      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | eu-central-1   | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| cody-test-organizational-trail | ap-northeast-2 | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| cody-test-organizational-trail | eu-west-3      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| cody-test-organizational-trail | eu-west-2      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | eu-west-2      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | ap-southeast-2 | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | ap-southeast-2 | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| turbot-acc-us-east-1-trail     | ap-northeast-1 | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| turbot-acc-us-east-1-trail     | eu-north-1     | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | ap-northeast-1 | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| cody-test-organizational-trail | eu-north-1     | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| cody-test-organizational-trail | us-east-2      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | us-east-2      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | us-east-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | <null>   
| cody-test-organizational-trail | eu-west-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | us-west-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | ca-central-1   | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | ca-central-1   | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | us-west-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | eu-central-1   | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| turbot-acc-us-east-1-trail     | eu-west-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| turbot-acc-us-east-1-trail     | us-east-1      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
| cody-test-organizational-trail | us-west-2      | us-east-1   | arn:aws:cloudtrail:us-east-1:936717460871:trail/cody-test-organizational-trail | true                  | true                  | []       
| turbot-acc-us-east-1-trail     | us-west-2      | us-east-1   | arn:aws:cloudtrail:us-east-1:673371606365:trail/turbot-acc-us-east-1-trail     | false                 | true                  | []       
+--------------------------------+----------------+-------------+--------------------------------------------------------------------------------+-----------------------+-----------------------+----------

```
</details>
