### PR TITLE
Add check for private hosted zones in dnssec hydrate method for aws_route53_zone table. Closes #587

### DIFF
--- a/aws/table_aws_route53_zone.go
+++ b/aws/table_aws_route53_zone.go
@@ -234,6 +234,11 @@ func getHostedZoneDNSSEC(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	plugin.Logger(ctx).Trace("getHostedZoneDNSSEC")
 	hostedZone := h.Item.(*route53.HostedZone)
 
+	// Operation is unsupported for private hosted zones.
+	if *hostedZone.Config.PrivateZone {
+		return nil, nil
+	}
+
 	// Create session
 	svc, err := Route53Service(ctx, d)
 	if err != nil {


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,dnssec_key_signing_keys,dnssec_status,private_zone from aws_route53_zone
+---------------+-------------------------+-------------------------------------------------------+--------------+
| name          | dnssec_key_signing_keys | dnssec_status                                         | private_zone |
+---------------+-------------------------+-------------------------------------------------------+--------------+
| allithub.com. | <null>                  | <null>                                                | true         |
| turbot.com.   | <null>                  | {"ServeSignature":"NOT_SIGNING","StatusMessage":null} | false        |
+---------------+-------------------------+-------------------------------------------------------+--------------+

> select name,dnssec_key_signing_keys,dnssec_status,private_zone from aws_route53_zone where private_zone
+---------------+-------------------------+---------------+--------------+
| name          | dnssec_key_signing_keys | dnssec_status | private_zone |
+---------------+-------------------------+---------------+--------------+
| allithub.com. | <null>                  | <null>        | true         |
+---------------+-------------------------+---------------+--------------+

> select name,dnssec_key_signing_keys,dnssec_status,private_zone from aws_route53_zone where not private_zone
+-------------+-------------------------+-------------------------------------------------------+--------------+
| name        | dnssec_key_signing_keys | dnssec_status                                         | private_zone |
+-------------+-------------------------+-------------------------------------------------------+--------------+
| turbot.com. | <null>                  | {"ServeSignature":"NOT_SIGNING","StatusMessage":null} | false        |
+-------------+-------------------------+-------------------------------------------------------+--------------+

> select * from aws_route53_zone
+---------------+-----------------------+--------------------------------------+---------+--------------+--------------------------+----------------------------+---------------------------+---------------
| name          | id                    | caller_reference                     | comment | private_zone | linked_service_principal | linked_service_description | resource_record_set_count | query_logging_
+---------------+-----------------------+--------------------------------------+---------+--------------+--------------------------+----------------------------+---------------------------+---------------
| allithub.com. | Z091950231SU7Z4CMNCAK | 4ba8218a-34fc-4bf7-96e6-61362368293c |         | true         | <null>                   | <null>                     | 2                         | <null>        
| turbot.com.   | Z0405066ELP2IC2M5WXB  | c4898d88-501e-44f4-933c-f9a9b34d85a1 |         | false        | <null>                   | <null>                     | 2                         | <null>        
+---------------+-----------------------+--------------------------------------+---------+--------------+--------------------------+----------------------------+---------------------------+---------------


> select * from aws_route53_zone where id = 'Z091950231SU7Z4CMNCAK'
+---------------+-----------------------+--------------------------------------+---------+--------------+--------------------------+----------------------------+---------------------------+---------------
| name          | id                    | caller_reference                     | comment | private_zone | linked_service_principal | linked_service_description | resource_record_set_count | query_logging_
+---------------+-----------------------+--------------------------------------+---------+--------------+--------------------------+----------------------------+---------------------------+---------------
| allithub.com. | Z091950231SU7Z4CMNCAK | 4ba8218a-34fc-4bf7-96e6-61362368293c |         | true         | <null>                   | <null>                     | 2                         | <null>        
+---------------+-----------------------+--------------------------------------+---------+--------------+--------------------------+----------------------------+---------------------------+---------------

> select * from aws_route53_zone where id = 'Z0405066ELP2IC2M5WXB'
+-------------+----------------------+--------------------------------------+---------+--------------+--------------------------+----------------------------+---------------------------+------------------
| name        | id                   | caller_reference                     | comment | private_zone | linked_service_principal | linked_service_description | resource_record_set_count | query_logging_con
+-------------+----------------------+--------------------------------------+---------+--------------+--------------------------+----------------------------+---------------------------+------------------
| turbot.com. | Z0405066ELP2IC2M5WXB | c4898d88-501e-44f4-933c-f9a9b34d85a1 |         | false        | <null>                   | <null>                     | 2                         | <null>           
+-------------+----------------------+--------------------------------------+---------+--------------+--------------------------+----------------------------+---------------------------+-----------------

# When there is not hosted zone 
> select * from aws_route53_zone
+------+----+------------------+---------+--------------+--------------------------+----------------------------+---------------------------+-----------------------+-------------------------+-------------
| name | id | caller_reference | comment | private_zone | linked_service_principal | linked_service_description | resource_record_set_count | query_logging_configs | dnssec_key_signing_keys | dnssec_statu
+------+----+------------------+---------+--------------+--------------------------+----------------------------+---------------------------+-----------------------+-------------------------+-------------
+------+----+------------------+---------+--------------+--------------------------+----------------------------+---------------------------+-----------------------+-------------------------+-------------
> select name,dnssec_key_signing_keys,dnssec_status,private_zone from aws_route53_zone where not private_zone
+------+-------------------------+---------------+--------------+
| name | dnssec_key_signing_keys | dnssec_status | private_zone |
+------+-------------------------+---------------+--------------+
+------+-------------------------+---------------+--------------+
> select name,dnssec_key_signing_keys,dnssec_status,private_zone from aws_route53_zone where private_zone
+------+-------------------------+---------------+--------------+
| name | dnssec_key_signing_keys | dnssec_status | private_zone |
+------+-------------------------+---------------+--------------+
+------+-------------------------+---------------+--------------+

```
</details>
