### PR TITLE
Add Logs details in table aws_elasticsearch_domain. Closes #582

### DIFF
--- a/aws/table_aws_elasticsearch_domain.go
+++ b/aws/table_aws_elasticsearch_domain.go
@@ -61,6 +61,12 @@ func tableAwsElasticsearchDomain(_ context.Context) *plugin.Table {
 				Hydrate:     getAwsElasticsearchDomain,
 			},
 			{
+				Name:        "access_policies",
+				Description: "IAM access policy as a JSON-formatted string.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsElasticsearchDomain,
+			},
+			{
 				Name:        "created",
 				Description: "The domain creation status.",
 				Type:        proto.ColumnType_BOOL,
@@ -90,12 +96,6 @@ func tableAwsElasticsearchDomain(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_BOOL,
 				Hydrate:     getAwsElasticsearchDomain,
 				Transform:   transform.FromField("NodeToNodeEncryptionOptions.Enabled"),
-			},
-			{
-				Name:        "access_policies",
-				Description: "IAM access policy attach with domain.",
-				Type:        proto.ColumnType_JSON,
-				Hydrate:     getAwsElasticsearchDomain,
 			},
 			{
 				Name:        "policy_std",
@@ -150,6 +150,12 @@ func tableAwsElasticsearchDomain(_ context.Context) *plugin.Table {
 			{
 				Name:        "encryption_at_rest_options",
 				Description: "Specifies the status of the EncryptionAtRestOptions.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsElasticsearchDomain,
+			},
+			{
+				Name:        "log_publishing_options",
+				Description: "Log publishing options for the given domain.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsElasticsearchDomain,
 			},

--- a/docs/tables/aws_elasticsearch_domain.md
+++ b/docs/tables/aws_elasticsearch_domain.md
@@ -95,3 +95,28 @@ where
   p = '*'
   and s ->> 'Effect' = 'Allow';
 ```
+
+
+### List domain log publishing options
+
+```sql
+select
+  domain_name,
+  domain_id,
+  log_publishing_options
+from
+  aws_elasticsearch_domain;
+```
+
+
+### List domain Search slow logs details
+
+```sql
+select
+  domain_name,
+  domain_id,
+  log_publishing_options -> 'SEARCH_SLOW_LOGS' -> 'Enabled' as enabled,
+  log_publishing_options -> 'SEARCH_SLOW_LOGS' -> 'CloudWatchLogsLogGroupArn' as cloud_watch_logs_log_group_arn
+from
+  aws_elasticsearch_domain;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro aws-test % ./tint.js aws_elasticsearch_domain
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_elasticsearch_domain []

PRETEST: tests/aws_elasticsearch_domain

TEST: tests/aws_elasticsearch_domain
Running terraform
aws_elasticsearch_domain.named_test_resource: Creating...
aws_elasticsearch_domain.named_test_resource: Still creating... [10s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [20s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [30s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [40s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [50s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [1m0s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [1m10s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [1m20s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [1m30s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [1m40s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [1m50s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [2m0s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [2m10s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [2m20s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [2m30s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [2m40s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [2m50s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [3m0s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [3m10s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [3m20s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [3m30s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [3m40s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [3m50s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [4m0s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [4m10s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [4m20s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [4m30s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [4m40s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [4m50s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [5m0s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [5m10s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [5m20s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [5m30s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [5m40s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [5m50s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [6m0s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [6m10s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [6m20s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [6m30s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [6m40s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [6m50s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [7m0s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [7m10s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [7m20s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [7m30s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [7m40s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [7m50s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [8m0s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [8m10s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [8m20s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [8m30s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [8m40s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [8m50s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [9m0s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [9m10s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [9m20s elapsed]
aws_elasticsearch_domain.named_test_resource: Still creating... [9m30s elapsed]
aws_elasticsearch_domain.named_test_resource: Creation complete after 9m39s [id=arn:aws:es:us-east-1:013122550996:domain/turbottest59879]

Warning: Deprecated Resource

  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "013122550996"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:es:us-east-1:013122550996:domain/turbottest59879"
resource_name = "turbottest59879"

Running SQL query: test-get-query.sql
[
  {
    "account_id": "013122550996",
    "akas": [
      "arn:aws:es:us-east-1:013122550996:domain/turbottest59879"
    ],
    "domain_name": "turbottest59879",
    "ebs_options": {
      "EBSEnabled": true,
      "Iops": null,
      "VolumeSize": 10,
      "VolumeType": "gp2"
    },
    "elasticsearch_version": "5.6",
    "partition": "aws",
    "region": "us-east-1",
    "snapshot_options": {
      "AutomatedSnapshotStartHour": 23
    }
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "account_id": "013122550996",
    "akas": [
      "arn:aws:es:us-east-1:013122550996:domain/turbottest59879"
    ],
    "domain_name": "turbottest59879",
    "ebs_options": {
      "EBSEnabled": true,
      "Iops": null,
      "VolumeSize": 10,
      "VolumeType": "gp2"
    },
    "elasticsearch_version": "5.6",
    "partition": "aws",
    "region": "us-east-1",
    "snapshot_options": {
      "AutomatedSnapshotStartHour": 23
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "account_id": "013122550996",
    "akas": [
      "arn:aws:es:us-east-1:013122550996:domain/turbottest59879"
    ],
    "domain_name": "turbottest59879",
    "partition": "aws",
    "region": "us-east-1"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:es:us-east-1:013122550996:domain/turbottest59879"
    ],
    "title": "turbottest59879"
  }
]
✔ PASSED

POSTTEST: tests/aws_elasticsearch_domain

TEARDOWN: tests/aws_elasticsearch_domain

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  domain_name,
  domain_id,
  log_publishing_options
from
  aws_elasticsearch_domain;
+---------------------------+----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------
| domain_name               | domain_id                              | log_publishing_options                                                                                                               
+---------------------------+----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------
| turbottest59879           | 013122550996/turbottest59879           | <null>                                                                                                                               
| arnab-elastisearch-domain | 013122550996/arnab-elastisearch-domain | {"ES_APPLICATION_LOGS":{"CloudWatchLogsLogGroupArn":null,"Enabled":false},"INDEX_SLOW_LOGS":{"CloudWatchLogsLogGroupArn":null,"Enable
+---------------------------+----------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------
> select
  domain_name,
  domain_id,
  log_publishing_options -> 'SEARCH_SLOW_LOGS' -> 'Enabled' as enabled,
  log_publishing_options -> 'SEARCH_SLOW_LOGS' -> 'CloudWatchLogsLogGroupArn' as cloud_watch_logs_log_group_arn
from
  aws_elasticsearch_domain;
+---------------------------+----------------------------------------+---------+----------------------------------------------------------------------------+
| domain_name               | domain_id                              | enabled | cloud_watch_logs_log_group_arn                                             |
+---------------------------+----------------------------------------+---------+----------------------------------------------------------------------------+
| turbottest59879           | 013122550996/turbottest59879           | <null>  | <null>                                                                     |
| arnab-elastisearch-domain | 013122550996/arnab-elastisearch-domain | true    | "arn:aws:logs:us-east-1:013122550996:log-group:/aws/codebuild/ProjectTest" |
+---------------------------+----------------------------------------+---------+----------------------------------------------------------------------------+
> 
```
</details>
