### PR TITLE
Fix table_aws_ec2_ssl_policy returning duplicate result when more than 1 region set in config. Closes #591

### DIFF
--- a/aws-test/tests/aws_ec2_ssl_policy/test-get-query.sql
+++ b/aws-test/tests/aws_ec2_ssl_policy/test-get-query.sql
@@ -7,4 +7,4 @@ select
 from 
   aws.aws_ec2_ssl_policy
 where 
-  name = '{{ resourceName }}';
+  name = '{{ resourceName }}' and region = '{{ output.region_name.value }}';

--- a/aws/table_aws_ec2_ssl_policy.go
+++ b/aws/table_aws_ec2_ssl_policy.go
@@ -18,7 +18,7 @@ func tableAwsEc2SslPolicy(_ context.Context) *plugin.Table {
 		Name:        "aws_ec2_ssl_policy",
 		Description: "AWS EC2 SSL Policy",
 		Get: &plugin.GetConfig{
-			KeyColumns:        plugin.SingleColumn("name"),
+			KeyColumns:        plugin.AllColumns([]string{"name", "region"}),
 			ShouldIgnoreError: isNotFoundError([]string{"name"}),
 			Hydrate:           getEc2SslPolicy,
 		},
@@ -101,7 +101,14 @@ func listEc2SslPolicies(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 func getEc2SslPolicy(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getEc2SslPolicy")
 
+	matrixKeyRegion := d.KeyColumnQualString(matrixKeyRegion)
 	name := d.KeyColumnQuals["name"].GetStringValue()
+	regionName := d.KeyColumnQuals["region"].GetStringValue()
+
+	// Handle empty name or regionName
+	if name == "" || regionName == "" {
+		return nil, nil
+	}
 
 	// Create service
 	svc, err := ELBv2Service(ctx, d)
@@ -114,13 +121,15 @@ func getEc2SslPolicy(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 		Names: []*string{aws.String(name)},
 	}
 
-	op, err := svc.DescribeSSLPolicies(params)
-	if err != nil {
-		return nil, err
-	}
+	if(matrixKeyRegion == regionName){
+		op, err := svc.DescribeSSLPolicies(params)
+		if err != nil {
+			return nil, err
+		}
 
-	if op.SslPolicies != nil && len(op.SslPolicies) > 0 {
-		return op.SslPolicies[0], nil
+		if op.SslPolicies != nil && len(op.SslPolicies) > 0 {
+			return op.SslPolicies[0], nil
+		}
 	}
 
 	return nil, nil

--- a/aws/table_aws_ec2_ssl_policy.go
+++ b/aws/table_aws_ec2_ssl_policy.go
@@ -19,7 +19,7 @@ func tableAwsEc2SslPolicy(_ context.Context) *plugin.Table {
 		Description: "AWS EC2 SSL Policy",
 		Get: &plugin.GetConfig{
 			KeyColumns:        plugin.AllColumns([]string{"name", "region"}),
-			ShouldIgnoreError: isNotFoundError([]string{"name"}),
+			ShouldIgnoreError: isNotFoundError([]string{"SSLPolicyNotFound"}),
 			Hydrate:           getEc2SslPolicy,
 		},
 		List: &plugin.ListConfig{
@@ -105,7 +105,7 @@ func getEc2SslPolicy(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	name := d.KeyColumnQuals["name"].GetStringValue()
 	regionName := d.KeyColumnQuals["region"].GetStringValue()
 
-	// Handle empty name or regionName
+	// Handle empty name or region
 	if name == "" || regionName == "" {
 		return nil, nil
 	}

--- a/docs/tables/aws_ec2_ssl_policy.md
+++ b/docs/tables/aws_ec2_ssl_policy.md
@@ -30,3 +30,15 @@ on
 where
   ssl_policy.ciphers @> '[{"Name":"DES-CBC3-SHA"}]';
 ```
+
+### Get SSL policy by region
+
+```sql
+select
+  name,
+  ssl_protocols
+from
+  aws_ec2_ssl_policy
+where 
+  name = 'ELBSecurityPolicy-2016-08' and region = 'us-east-1';
+```

--- a/docs/tables/aws_ec2_ssl_policy.md
+++ b/docs/tables/aws_ec2_ssl_policy.md
@@ -30,15 +30,3 @@ on
 where
   ssl_policy.ciphers @> '[{"Name":"DES-CBC3-SHA"}]';
 ```
-
-### Get SSL policy by region
-
-```sql
-select
-  name,
-  ssl_protocols
-from
-  aws_ec2_ssl_policy
-where 
-  name = 'ELBSecurityPolicy-2016-08' and region = 'us-east-1';
-```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro aws-test % ./tint.js aws_ec2_ssl_policy
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_ssl_policy []

PRETEST: tests/aws_ec2_ssl_policy

TEST: tests/aws_ec2_ssl_policy
Running terraform

Warning: Deprecated Resource

  on variables.tf line 37, in data "null_data_source" "resource":
  37: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 0 added, 0 changed, 0 destroyed.

Outputs:

account_id = "632902152528"
aws_partition = "aws"
region_name = "us-east-1"
resource_name = "ELBSecurityPolicy-2016-08"

Running SQL query: test-get-query.sql
[
  {
    "account_id": "632902152528",
    "ciphers": [
      {
        "Name": "ECDHE-ECDSA-AES128-GCM-SHA256",
        "Priority": 1
      },
      {
        "Name": "ECDHE-RSA-AES128-GCM-SHA256",
        "Priority": 2
      },
      {
        "Name": "ECDHE-ECDSA-AES128-SHA256",
        "Priority": 3
      },
      {
        "Name": "ECDHE-RSA-AES128-SHA256",
        "Priority": 4
      },
      {
        "Name": "ECDHE-ECDSA-AES128-SHA",
        "Priority": 5
      },
      {
        "Name": "ECDHE-RSA-AES128-SHA",
        "Priority": 6
      },
      {
        "Name": "ECDHE-ECDSA-AES256-GCM-SHA384",
        "Priority": 7
      },
      {
        "Name": "ECDHE-RSA-AES256-GCM-SHA384",
        "Priority": 8
      },
      {
        "Name": "ECDHE-ECDSA-AES256-SHA384",
        "Priority": 9
      },
      {
        "Name": "ECDHE-RSA-AES256-SHA384",
        "Priority": 10
      },
      {
        "Name": "ECDHE-RSA-AES256-SHA",
        "Priority": 11
      },
      {
        "Name": "ECDHE-ECDSA-AES256-SHA",
        "Priority": 12
      },
      {
        "Name": "AES128-GCM-SHA256",
        "Priority": 13
      },
      {
        "Name": "AES128-SHA256",
        "Priority": 14
      },
      {
        "Name": "AES128-SHA",
        "Priority": 15
      },
      {
        "Name": "AES256-GCM-SHA384",
        "Priority": 16
      },
      {
        "Name": "AES256-SHA256",
        "Priority": 17
      },
      {
        "Name": "AES256-SHA",
        "Priority": 18
      }
    ],
    "name": "ELBSecurityPolicy-2016-08",
    "partition": "aws",
    "ssl_protocols": [
      "TLSv1",
      "TLSv1.1",
      "TLSv1.2"
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "name": "ELBSecurityPolicy-2016-08",
    "title": "ELBSecurityPolicy-2016-08"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_ssl_policy

TEARDOWN: tests/aws_ec2_ssl_policy

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  ssl_protocols
from
  aws_ec2_ssl_policy
where 
  name = 'ELBSecurityPolicy-2016-08' and region = 'us-east-1';
+---------------------------+-------------------------------+
| name                      | ssl_protocols                 |
+---------------------------+-------------------------------+
| ELBSecurityPolicy-2016-08 | ["TLSv1","TLSv1.1","TLSv1.2"] |
+---------------------------+-------------------------------+
> 

```
</details>
