### PR TITLE
Fix region pattern match in service file. Closes #595

### DIFF
--- a/aws/service.go
+++ b/aws/service.go
@@ -1597,9 +1597,9 @@ func GetDefaultAwsRegion(d *plugin.QueryData) string {
 		panic("\nconnection config have invalid \"regions\": " + strings.Join(invalidPatterns, ", ") + ". Edit your connection configuration file and then restart Steampipe")
 	}
 
-	if strings.HasPrefix(region, "us-gov") {
+	if strings.HasPrefix(region, "us-gov") && !helpers.StringSliceContains(allAwsRegions, region) {
 		region = "us-gov-east-1"
-	} else if strings.HasPrefix(region, "cn") {
+	} else if strings.HasPrefix(region, "cn") && !helpers.StringSliceContains(allAwsRegions, region) {
 		region = "cn-north-1"
 	} else if !helpers.StringSliceContains(allAwsRegions, region) {
 		region = "us-east-1"

--- a/aws/service.go
+++ b/aws/service.go
@@ -77,6 +77,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/wafv2"
 	"github.com/aws/aws-sdk-go/service/wellarchitected"
 
+	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 )
 
@@ -1592,20 +1593,12 @@ func GetDefaultAwsRegion(d *plugin.QueryData) string {
 		}
 	}
 
-	if len(validPatterns) == 0 && awsConfig.Regions != nil {
+	if len(validPatterns) == 0 {
 		panic("\nconnection config have invalid \"regions\": " + strings.Join(invalidPatterns, ", ") + ". Edit your connection configuration file and then restart Steampipe")
 	}
 
-	if region == "" {
+	if !helpers.StringSliceContains(allAwsRegions, region) {
 		region = "us-east-1"
-	} else {
-		if strings.HasPrefix(region, "us-gov") {
-			region = "us-gov-east-1"
-		} else if strings.HasPrefix(region, "cn") {
-			region = "cn-north-1"
-		} else {
-			region = "us-east-1"
-		}
 	}
 
 	d.ConnectionManager.Cache.Set(serviceCacheKey, region)

--- a/aws/service.go
+++ b/aws/service.go
@@ -1597,7 +1597,11 @@ func GetDefaultAwsRegion(d *plugin.QueryData) string {
 		panic("\nconnection config have invalid \"regions\": " + strings.Join(invalidPatterns, ", ") + ". Edit your connection configuration file and then restart Steampipe")
 	}
 
-	if !helpers.StringSliceContains(allAwsRegions, region) {
+	if strings.HasPrefix(region, "us-gov") {
+		region = "us-gov-east-1"
+	} else if strings.HasPrefix(region, "cn") {
+		region = "cn-north-1"
+	} else if !helpers.StringSliceContains(allAwsRegions, region) {
 		region = "us-east-1"
 	}
 


### PR DESCRIPTION
</details>

# Example query results
<details>
  <summary>Results</summary>
  
# When region is not specified in spc but available in env
```
connection "aws" {
access_key = "*****"
secret_key = "*****"
plugin    = "aws"               
}

sourab@Souravs-MacBook-Air-3 aws-test % export AWS_REGION=ap-south-1
sourab@Souravs-MacBook-Air-3 aws-test % steampipe query             
Welcome to Steampipe v0.7.0
For more information, type .help
> select * from aws_cloudtrail_trail
+------+-------------------------------------------------------+-------------+-----------------------+-----------------------------+------------+---------------+--------------------------+----------------
| name | arn                                                   | home_region | is_multi_region_trail | log_file_validation_enabled | is_logging | log_group_arn | cloudwatch_logs_role_arn | has_custom_even
+------+-------------------------------------------------------+-------------+-----------------------+-----------------------------+------------+---------------+--------------------------+----------------
| test | arn:aws:cloudtrail:ap-south-1:013122550996:trail/test | ap-south-1  | true                  | true                        | true       | <null>        | <null>                   | false          
+------+-------------------------------------------------------+-------------+-----------------------+-----------------------------+------------+---------------+--------------------------+----------------
> select region from aws_cloudtrail_trail
+------------+
| region     |
+------------+
| ap-south-1 |
+------------+
```
# When region present in spc
```
connection "aws" {
access_key = "******"
secret_key = "****"
regions = ["us-east-?"]
plugin    = "aws"               
}

> select * from aws_cloudtrail_trail
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+-----------
| name                                | arn                                                                                 | home_region | is_multi_region_trail | log_file_validation_enabled | is_logging
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+-----------
| turbot-013122550996-us-east-1-trail | arn:aws:cloudtrail:us-east-1:013122550996:trail/turbot-013122550996-us-east-1-trail | us-east-1   | false                 | true                        | true      
| steampipe-test-trail                | arn:aws:cloudtrail:us-east-2:013122550996:trail/steampipe-test-trail                | us-east-2   | false                 | true                        | true      
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+-----------
> select region from aws_cloudtrail_trail
+-----------+
| region    |
+-----------+
| us-east-1 |
| us-east-2 |
+-----------+
```
# When region is invalid
```
connection "aws" {
access_key = "******"
secret_key = "*****"
regions = ["us-east-4"]
plugin    = "aws"               
}

> select region from aws_cloudtrail_trail
Error: connection config have invalid "regions": us-east-4. Edit your connection configuration file and then restart Steampipe
```

# When region is us-gov-*
```
connection "aws" {
access_key = "****"
secret_key = "*****"
regions = ["us-gov-*"]
plugin    = "aws"               
}
   
> select name from aws_s3_bucket
+---------------------------------------------+
| name                                        |
+---------------------------------------------+
| test-poller-actor-lalit                     |
| turbot-727379816578-us-gov-east-1           |
| turbot1                                     |
| turbot-727379816578-us-gov-west-1           |
| cody-test-us-east-bucket                    |
| elasticbeanstalk-us-gov-west-1-727379816578 |
+---------------------------------------------+

> select topic_arn, region from aws_sns_topic
+----------------------------------------------------------------------+---------------+
| topic_arn                                                            | region        |
+----------------------------------------------------------------------+---------------+
| arn:aws-us-gov:sns:us-gov-east-1:727379816578:turbot_aws_api_handler | us-gov-east-1 |
| arn:aws-us-gov:sns:us-gov-west-1:727379816578:test_steampipe         | us-gov-west-1 |
+----------------------------------------------------------------------+---------------+
```
</details>
