### PR TITLE
Update default region for `us-gov` and `cn` partition. #595

### DIFF
--- a/aws/service.go
+++ b/aws/service.go
@@ -1597,6 +1597,7 @@ func GetDefaultAwsRegion(d *plugin.QueryData) string {
 		panic("\nconnection config have invalid \"regions\": " + strings.Join(invalidPatterns, ", ") + ". Edit your connection configuration file and then restart Steampipe")
 	}
 
+	// most of the global services (like IAM, s3, Route53, etc..) in both cloud are the targeting the respective regions
 	if strings.HasPrefix(region, "us-gov") && !helpers.StringSliceContains(allAwsRegions, region) {
 		region = "us-gov-west-1"
 	} else if strings.HasPrefix(region, "cn") && !helpers.StringSliceContains(allAwsRegions, region) {

--- a/aws/service.go
+++ b/aws/service.go
@@ -1598,9 +1598,9 @@ func GetDefaultAwsRegion(d *plugin.QueryData) string {
 	}
 
 	if strings.HasPrefix(region, "us-gov") && !helpers.StringSliceContains(allAwsRegions, region) {
-		region = "us-gov-east-1"
+		region = "us-gov-west-1"
 	} else if strings.HasPrefix(region, "cn") && !helpers.StringSliceContains(allAwsRegions, region) {
-		region = "cn-north-1"
+		region = "cn-northwest-1"
 	} else if !helpers.StringSliceContains(allAwsRegions, region) {
 		region = "us-east-1"
 	}


### PR DESCRIPTION
Because most of the global services (like IAM, s3, Route53, etc..) in both cloud are the targeting the respective regions