### PR TITLE
Add column `instance_lifecycle` in `aws_ec2_instance` table. Closes #616

### DIFF
--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -115,6 +115,11 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("InstanceInitiatedShutdownBehavior.Value"),
 			},
 			{
+				Name:        "instance_lifecycle",
+				Description: "Indicates whether this is a spot instance or a scheduled instance.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "kernel_id",
 				Description: "The kernel ID",
 				Type:        proto.ColumnType_STRING,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_ec2_instance []

PRETEST: tests/aws_ec2_instance

TEST: tests/aws_ec2_instance
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_instance.named_test_resource will be created
  + resource "aws_instance" "named_test_resource" {
      + ami                                  = "ami-04bdd81ca5f1191d5"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = (known after apply)
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + subnet_id                            = (known after apply)
      + tags                                 = {
          + "Name" = "turbottest46714"
        }
      + tags_all                             = {
          + "Name" = "turbottest46714"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "ddd424ea1a8baca5cbf4860d0758cfd8cd4fe667"
      + user_data_base64                     = (known after apply)
      + vpc_security_group_ids               = (known after apply)

      + capacity_reservation_specification {
          + capacity_reservation_preference = (known after apply)

          + capacity_reservation_target {
              + capacity_reservation_id = (known after apply)
            }
        }

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + snapshot_id           = (known after apply)
          + tags                  = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + enclave_options {
          + enabled = (known after apply)
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + no_device    = (known after apply)
          + virtual_name = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = (known after apply)
        }

      + network_interface {
          + delete_on_termination = (known after apply)
          + device_index          = (known after apply)
          + network_interface_id  = (known after apply)
        }

      + root_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags                  = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }
    }

  # aws_subnet.named_test_resource will be created
  + resource "aws_subnet" "named_test_resource" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = (known after apply)
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "10.0.1.0/24"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags                            = {
          + "name" = "turbottest46714"
        }
      + tags_all                        = {
          + "name" = "turbottest46714"
        }
      + vpc_id                          = (known after apply)
    }

  # aws_vpc.main will be created
  + resource "aws_vpc" "main" {
      + arn                              = (known after apply)
      + assign_generated_ipv6_cidr_block = false
      + cidr_block                       = "10.0.0.0/16"
      + default_network_acl_id           = (known after apply)
      + default_route_table_id           = (known after apply)
      + default_security_group_id        = (known after apply)
      + dhcp_options_id                  = (known after apply)
      + enable_classiclink               = (known after apply)
      + enable_classiclink_dns_support   = (known after apply)
      + enable_dns_hostnames             = (known after apply)
      + enable_dns_support               = true
      + id                               = (known after apply)
      + instance_tenancy                 = "default"
      + ipv6_association_id              = (known after apply)
      + ipv6_cidr_block                  = (known after apply)
      + main_route_table_id              = (known after apply)
      + owner_id                         = (known after apply)
      + tags                             = {
          + "name" = "turbottest46714"
        }
      + tags_all                         = {
          + "name" = "turbottest46714"
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id        = "013122550996"
  + availability_zone = (known after apply)
  + aws_partition     = "aws"
  + image_id          = "ami-04bdd81ca5f1191d5"
  + region_name       = "us-east-1"
  + resource_aka      = (known after apply)
  + resource_id       = (known after apply)
  + resource_name     = "turbottest46714"
  + subnet_id         = (known after apply)
  + vpc_id            = (known after apply)
aws_vpc.main: Creating...
aws_vpc.main: Still creating... [10s elapsed]
aws_vpc.main: Creation complete after 17s [id=vpc-0dcf00689d1ef0359]
aws_subnet.named_test_resource: Creating...
aws_subnet.named_test_resource: Creation complete after 5s [id=subnet-0472c9a755ed74696]
aws_instance.named_test_resource: Creating...
aws_instance.named_test_resource: Still creating... [10s elapsed]
aws_instance.named_test_resource: Still creating... [20s elapsed]
aws_instance.named_test_resource: Still creating... [30s elapsed]
aws_instance.named_test_resource: Still creating... [40s elapsed]
aws_instance.named_test_resource: Still creating... [50s elapsed]
aws_instance.named_test_resource: Creation complete after 55s [id=i-04abdaba7dd8a2d5a]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "013122550996"
availability_zone = "us-east-1c"
aws_partition = "aws"
image_id = "ami-04bdd81ca5f1191d5"
region_name = "us-east-1"
resource_aka = "arn:aws:ec2:us-east-1:013122550996:instance/i-04abdaba7dd8a2d5a"
resource_id = "i-04abdaba7dd8a2d5a"
resource_name = "turbottest46714"
subnet_id = "subnet-0472c9a755ed74696"
vpc_id = "vpc-0dcf00689d1ef0359"

Running SQL query: query.sql
[
  {
    "image_id": "ami-04bdd81ca5f1191d5",
    "instance_id": "i-04abdaba7dd8a2d5a"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:013122550996:instance/i-04abdaba7dd8a2d5a"
    ],
    "arn": "arn:aws:ec2:us-east-1:013122550996:instance/i-04abdaba7dd8a2d5a",
    "cpu_options_core_count": 1,
    "cpu_options_threads_per_core": 1,
    "ebs_optimized": false,
    "hypervisor": "xen",
    "image_id": "ami-04bdd81ca5f1191d5",
    "instance_id": "i-04abdaba7dd8a2d5a",
    "instance_type": "t2.micro",
    "monitoring_state": "disabled",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest46714"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:013122550996:instance/i-04abdaba7dd8a2d5a"
    ],
    "disable_api_termination": false,
    "instance_id": "i-04abdaba7dd8a2d5a",
    "instance_initiated_shutdown_behavior": "stop",
    "instance_status": {
      "AvailabilityZone": "us-east-1c",
      "Events": null,
      "InstanceId": "i-04abdaba7dd8a2d5a",
      "InstanceState": {
        "Code": 16,
        "Name": "running"
      },
      "InstanceStatus": {
        "Details": [
          {
            "ImpairedSince": null,
            "Name": "reachability",
            "Status": "initializing"
          }
        ],
        "Status": "initializing"
      },
      "OutpostArn": null,
      "SystemStatus": {
        "Details": [
          {
            "ImpairedSince": null,
            "Name": "reachability",
            "Status": "initializing"
          }
        ],
        "Status": "initializing"
      }
    },
    "kernel_id": null,
    "ram_disk_id": null,
    "sriov_net_support": "simple",
    "tags": {
      "Name": "turbottest46714"
    },
    "title": "turbottest46714",
    "user_data": "turbot"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "image_id": "ami-04bdd81ca5f1191d5",
    "instance_id": "i-04abdaba7dd8a2d5a"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_instance

TEARDOWN: tests/aws_ec2_instance

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select instance_id, arn, instance_type, instance_lifecycle from aws_ec2_instance
+---------------------+-----------------------------------------------------------------+---------------+--------------------+
| instance_id         | arn                                                             | instance_type | instance_lifecycle |
+---------------------+-----------------------------------------------------------------+---------------+--------------------+
| i-01103988eafb3c268 | arn:aws:ec2:us-east-1:632902152528:instance/i-01103988eafb3c268 | t2.micro      | spot               |
| i-03434a33ce9bccac5 | arn:aws:ec2:us-east-1:632902152528:instance/i-03434a33ce9bccac5 | t3.nano       | <null>             |
| i-0b48382883d102363 | arn:aws:ec2:us-east-1:632902152528:instance/i-0b48382883d102363 | t3.nano       | <null>             |
+---------------------+-----------------------------------------------------------------+---------------+--------------------+
> select instance_id, arn, instance_type, instance_lifecycle from aws_ec2_instance where instance_id = 'i-01103988eafb3c268'
+---------------------+-----------------------------------------------------------------+---------------+--------------------+
| instance_id         | arn                                                             | instance_type | instance_lifecycle |
+---------------------+-----------------------------------------------------------------+---------------+--------------------+
| i-01103988eafb3c268 | arn:aws:ec2:us-east-1:632902152528:instance/i-01103988eafb3c268 | t2.micro      | spot               |
+---------------------+-----------------------------------------------------------------+---------------+--------------------+

```
</details>
