### PR TITLE
Add table aws_lambda_function_metric_errors_daily. Closes #622

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -177,6 +177,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_kms_key":                                                  tableAwsKmsKey(ctx),
 			"aws_lambda_alias":                                             tableAwsLambdaAlias(ctx),
 			"aws_lambda_function":                                          tableAwsLambdaFunction(ctx),
+			"aws_lambda_function_metric_errors_daily":                      tableAwsLambdaFunctionMetricErrorsDaily(ctx),
 			"aws_lambda_version":                                           tableAwsLambdaVersion(ctx),
 			"aws_macie2_classification_job":                                tableAwsMacie2ClassificationJob(ctx),
 			"aws_rds_db_cluster":                                           tableAwsRDSDBCluster(ctx),

--- a/docs/tables/aws_lambda_function_metric_errors_daily.md
+++ b/docs/tables/aws_lambda_function_metric_errors_daily.md
@@ -1,7 +1,6 @@
 # Table: aws_lambda_function_metric_errors_daily
 
-Amazon CloudWatch Metrics provide data about the performance of your systems.  The `aws_lambda_function_metric_errors_daily` table provides metric statistics at 24 hour intervals for the last year.
-
+Amazon CloudWatch Metrics provide data about the performance of your systems. The `aws_lambda_function_metric_errors_daily` table provides metric statistics at 24 hour intervals for the last year.
 
 ## Examples
 

--- a/docs/tables/aws_lambda_function_metric_errors_daily.md
+++ b/docs/tables/aws_lambda_function_metric_errors_daily.md
@@ -1,0 +1,41 @@
+# Table: aws_lambda_function_metric_errors_daily
+
+Amazon CloudWatch Metrics provide data about the performance of your systems.  The `aws_lambda_function_metric_errors_daily` table provides metric statistics at 24 hour intervals for the last year.
+
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  timestamp,
+  minimum,
+  maximum,
+  average,
+  sample_count
+from
+  aws_lambda_function_metric_errors_daily
+order by
+  name,
+  timestamp;
+```
+
+### Lambda function daily average error less than 1
+
+```sql
+select
+  name,
+  timestamp,
+  round(minimum::numeric,2) as min_error,
+  round(maximum::numeric,2) as max_error,
+  round(average::numeric,2) as avg_error,
+  sample_count
+from
+  aws_lambda_function_metric_errors_daily
+where average < 1
+order by
+  name,
+  timestamp;
+```


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  timestamp,
  minimum,
  maximum,
  average,
  sample_count
from
  aws_lambda_function_metric_errors_daily
order by
  name,
  timestamp;
+--------------------------+---------------------+---------+---------+--------------------+--------------+
| name                     | timestamp           | minimum | maximum | average            | sample_count |
+--------------------------+---------------------+---------+---------+--------------------+--------------+
| arnab-hello-world-python | 2021-08-22 12:00:00 | 0       | 1       | 0.3333333333333333 | 6            |
| arnab-hello-world-python | 2021-08-23 12:00:00 | 1       | 1       | 1                  | 3            |
| func-encrypted           | 2021-06-30 12:00:00 | 0       | 0       | 0                  | 216          |
| function-test            | 2021-03-23 12:00:00 | 1       | 1       | 1                  | 1            |
| function-without-vpc     | 2021-08-22 12:00:00 | 0       | 0       | 0                  | 1            |
+--------------------------+---------------------+---------+---------+--------------------+--------------+
> select
  name,
  timestamp,
  round(minimum::numeric,2) as min_error,
  round(maximum::numeric,2) as max_error,
  round(average::numeric,2) as avg_error,
  sample_count
from
  aws_lambda_function_metric_errors_daily
where average < 1
order by
  name,
  timestamp;
+--------------------------+---------------------+-----------+-----------+-----------+--------------+
| name                     | timestamp           | min_error | max_error | avg_error | sample_count |
+--------------------------+---------------------+-----------+-----------+-----------+--------------+
| arnab-hello-world-python | 2021-08-22 12:00:00 | 0.00      | 1.00      | 0.33      | 6            |
| func-encrypted           | 2021-06-30 12:00:00 | 0.00      | 0.00      | 0.00      | 216          |
| function-without-vpc     | 2021-08-22 12:00:00 | 0.00      | 0.00      | 0.00      | 1            |
+--------------------------+---------------------+-----------+-----------+-----------+--------------+
> 

```
</details>
