### PR TITLE
Handle AccessDeniedException - macie is not enabled

### DIFF
--- a/aws/table_aws_macie2_classification_job.go
+++ b/aws/table_aws_macie2_classification_job.go
@@ -163,8 +163,7 @@ func listMacie2ClassificationJobs(ctx context.Context, d *plugin.QueryData, _ *p
 			return !isLast
 		},
 	)
-	// Generate AccessDeniedException when macie is not enabled for a single region
-	// It Should return the value if for any of the region macie is enabled and has job
+	// Throws AccessDeniedException when AWS Macie is not enabled in a region
 	if a, ok := err.(awserr.Error); ok {
 		if helpers.StringSliceContains([]string{"AccessDeniedException"}, a.Code()) {
 			return nil, nil
@@ -200,7 +199,7 @@ func getMacie2ClassificationJob(ctx context.Context, d *plugin.QueryData, h *plu
 	// Get call
 	op, err := svc.DescribeClassificationJob(params)
 	if err != nil {
-		// Generate AccessDeniedException when macie is not enabled for a single region
+		// Throws AccessDeniedException when AWS Macie is not enabled in a region
 		// It Should return the value if for any of the region macie is enabled and has job
 		if a, ok := err.(awserr.Error); ok {
 			if helpers.StringSliceContains([]string{"AccessDeniedException"}, a.Code()) {

--- a/aws/table_aws_macie2_classification_job.go
+++ b/aws/table_aws_macie2_classification_job.go
@@ -200,7 +200,6 @@ func getMacie2ClassificationJob(ctx context.Context, d *plugin.QueryData, h *plu
 	op, err := svc.DescribeClassificationJob(params)
 	if err != nil {
 		// Throws AccessDeniedException when AWS Macie is not enabled in a region
-		// It Should return the value if for any of the region macie is enabled and has job
 		if a, ok := err.(awserr.Error); ok {
 			if helpers.StringSliceContains([]string{"AccessDeniedException"}, a.Code()) {
 				return nil, nil


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

 # with regions set as * 
```
> select * from aws_macie2_classification_job
+--------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-------------------------------------
| name         | job_id                           | arn                                                                                       | job_status | job_type | client_token                        
+--------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-------------------------------------
| bucket-audit | f9d91733ace0a93c09e8da13f598916e | arn:aws:macie2:us-east-1:533793682495:classification-job/f9d91733ace0a93c09e8da13f598916e | COMPLETE   | ONE_TIME | cf6b6918-9c3f-4a33-887b-f4f834a1046d
+--------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-------------------------------------
> select * from aws_macie2_classification_job where job_id = 'f9d91733ace0a93c09e8da13f598916e'
+--------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-------------------------------------
| name         | job_id                           | arn                                                                                       | job_status | job_type | client_token                        
+--------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-------------------------------------
| bucket-audit | f9d91733ace0a93c09e8da13f598916e | arn:aws:macie2:us-east-1:533793682495:classification-job/f9d91733ace0a93c09e8da13f598916e | COMPLETE   | ONE_TIME | cf6b6918-9c3f-4a33-887b-f4f834a1046d
+--------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-------------------------------------

```
</details>
