### PR TITLE
Handling <root_account> password_enabled check in table_aws_iam_credential_report table.Closes #656

### DIFF
--- a/aws/table_aws_iam_credential_report.go
+++ b/aws/table_aws_iam_credential_report.go
@@ -251,7 +251,7 @@ func listCredentialReports(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 func passwordEnabledToBool(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	enabled := types.SafeString(d.Value)
 	if enabled == "not_supported" {
-		return true, nil
+		return false, nil
 	}
 	if enabled == "true" {
 		return true, nil


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select user_name,user_arn,password_enabled from aws_iam_credential_report where user_name = '<root_account>'
+----------------+--------------------------------+------------------+
| user_name      | user_arn                       | password_enabled |
+----------------+--------------------------------+------------------+
| <root_account> | arn:aws:iam::632902152528:root | false            |
+----------------+--------------------------------+------------------+```
</details>
