### PR TITLE
Fix tables with missing pagination implementations. Closes #651

### DIFF
--- a/aws/table_aws_cloudfront_origin_request_policy.go
+++ b/aws/table_aws_cloudfront_origin_request_policy.go
@@ -111,13 +111,13 @@ func listCloudFrontOriginRequestPolicies(ctx context.Context, d *plugin.QueryDat
 	for pagesLeft {
 		response, err := svc.ListOriginRequestPolicies(params)
 		if err != nil {
+			plugin.Logger(ctx).Error("listCloudFrontOriginRequestPolicies", "ListOriginRequestPolicies_error", err)
 			return nil, err
 		}
 		for _, policy := range response.OriginRequestPolicyList.Items {
 			d.StreamListItem(ctx, policy)
 		}
 		if response.OriginRequestPolicyList.NextMarker != nil {
-			pagesLeft = true
 			params.Marker = response.OriginRequestPolicyList.NextMarker
 		} else {
 			pagesLeft = false
@@ -152,6 +152,7 @@ func getCloudFrontOriginRequestPolicy(ctx context.Context, d *plugin.QueryData, 
 
 	op, err := svc.GetOriginRequestPolicy(params)
 	if err != nil {
+		plugin.Logger(ctx).Error("getCloudFrontOriginRequestPolicy", "GetOriginRequestPolicy_error", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_cloudfront_origin_request_policy.go
+++ b/aws/table_aws_cloudfront_origin_request_policy.go
@@ -111,13 +111,13 @@ func listCloudFrontOriginRequestPolicies(ctx context.Context, d *plugin.QueryDat
 	for pagesLeft {
 		response, err := svc.ListOriginRequestPolicies(params)
 		if err != nil {
-			plugin.Logger(ctx).Error("listCloudFrontOriginRequestPolicies", "ListOriginRequestPolicies_error", err)
 			return nil, err
 		}
 		for _, policy := range response.OriginRequestPolicyList.Items {
 			d.StreamListItem(ctx, policy)
 		}
 		if response.OriginRequestPolicyList.NextMarker != nil {
+			pagesLeft = true
 			params.Marker = response.OriginRequestPolicyList.NextMarker
 		} else {
 			pagesLeft = false
@@ -152,7 +152,6 @@ func getCloudFrontOriginRequestPolicy(ctx context.Context, d *plugin.QueryData, 
 
 	op, err := svc.GetOriginRequestPolicy(params)
 	if err != nil {
-		plugin.Logger(ctx).Error("getCloudFrontOriginRequestPolicy", "GetOriginRequestPolicy_error", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_codepipeline_pipeline.go
+++ b/aws/table_aws_codepipeline_pipeline.go
@@ -193,8 +193,17 @@ func getPipelineTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 		ResourceArn: aws.String(pipelineArn),
 	}
 
-	tags, err := svc.ListTagsForResource(params)
+	tags := []*codepipeline.Tag{}
+
+	err = svc.ListTagsForResourcePages(
+		params,
+		func(page *codepipeline.ListTagsForResourceOutput, isLast bool) bool {
+			tags = append(tags, page.Tags...)
+			return !isLast
+		},
+	)
 	if err != nil {
+		plugin.Logger(ctx).Error("getPipelineTags", "ListTagsForResourcePages_error", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_codepipeline_pipeline.go
+++ b/aws/table_aws_codepipeline_pipeline.go
@@ -138,6 +138,10 @@ func listCodepipelinePipelines(ctx context.Context, d *plugin.QueryData, _ *plug
 		},
 	)
 
+	if err != nil {
+		plugin.Logger(ctx).Error("ListPipelinesPages", "list", err)
+	}
+
 	return nil, err
 }
 

--- a/aws/table_aws_codepipeline_pipeline.go
+++ b/aws/table_aws_codepipeline_pipeline.go
@@ -90,7 +90,7 @@ func tableAwsCodepipelinePipeline(_ context.Context) *plugin.Table {
 				Description: "A list of tag key and value pairs associated with this pipeline.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getPipelineTags,
-				Transform:   transform.FromField("Tags"),
+				Transform:   transform.FromValue(),
 			},
 
 			// Steampipe standard columns
@@ -235,15 +235,15 @@ func pipelineARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 }
 
 func codepipelineTurbotTags(_ context.Context, d *transform.TransformData) (interface{}, error) {
-	data := d.HydrateItem.(*codepipeline.ListTagsForResourceOutput)
+	tags := d.HydrateItem.([]*codepipeline.Tag)
 
-	if data.Tags == nil {
+	if tags == nil {
 		return nil, nil
 	}
 
 	// Mapping the resource tags inside turbotTags
 	turbotTagsMap := map[string]string{}
-	for _, i := range data.Tags {
+	for _, i := range tags {
 		turbotTagsMap[*i.Key] = *i.Value
 	}
 

--- a/aws/table_aws_directory_service_directory.go
+++ b/aws/table_aws_directory_service_directory.go
@@ -208,6 +208,7 @@ func listDirectoryServiceDirectories(ctx context.Context, d *plugin.QueryData, _
 	for pagesLeft {
 		result, err := svc.DescribeDirectories(params)
 		if err != nil {
+			plugin.Logger(ctx).Error("DescribeDirectories", "list", err)
 			return nil, err
 		}
 
@@ -244,6 +245,7 @@ func getDirectoryServiceDirectory(ctx context.Context, d *plugin.QueryData, _ *p
 
 	op, err := svc.DescribeDirectories(params)
 	if err != nil {
+		plugin.Logger(ctx).Error("DescribeDirectories", "get", err)
 		return nil, err
 	}
 
@@ -292,6 +294,7 @@ func getDirectoryServiceDirectoryTags(ctx context.Context, d *plugin.QueryData, 
 	for pagesLeft {
 		result, err := svc.ListTagsForResource(params)
 		if err != nil {
+			plugin.Logger(ctx).Error("ListTagsForResource", "tag", err)
 			return nil, err
 		}
 		tags = append(tags, result.Tags...)

--- a/aws/table_aws_directory_service_directory.go
+++ b/aws/table_aws_directory_service_directory.go
@@ -163,7 +163,7 @@ func tableAwsDirectoryServiceDirectory(_ context.Context) *plugin.Table {
 				Description: "A list of tags currently associated with the Directory Service Directory.",
 				Hydrate:     getDirectoryServiceDirectoryTags,
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Tags"),
+				Transform:   transform.FromValue(),
 			},
 
 			// Steampipe Standard columns

--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -167,7 +167,7 @@ func tableAwsDynamoDBTable(_ context.Context) *plugin.Table {
 				Description: "A list of tags assigned to the table.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getTableTagging,
-				Transform:   transform.FromField("Tags"),
+				Transform:   transform.FromValue(),
 			},
 			{
 				Name:        "tags",
@@ -313,7 +313,6 @@ func getTableTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 			return nil, err
 		}
 		tags = append(tags, result.Tags...)
-
 		if result.NextToken != nil {
 			params.NextToken = result.NextToken
 		} else {

--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -214,6 +214,10 @@ func listDynamboDbTables(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 		},
 	)
 
+	if err != nil {
+		plugin.Logger(ctx).Error("ListTablesPages", "list", err)
+	}
+
 	return nil, err
 }
 
@@ -310,6 +314,7 @@ func getTableTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	for pagesLeft {
 		result, err := svc.ListTagsOfResource(params)
 		if err != nil {
+			plugin.Logger(ctx).Error("ListTagsOfResource", "tag", err)
 			return nil, err
 		}
 		tags = append(tags, result.Tags...)

--- a/aws/table_aws_ec2_instance_type.go
+++ b/aws/table_aws_ec2_instance_type.go
@@ -221,14 +221,19 @@ func listAwsInstanceTypesOfferings(ctx context.Context, d *plugin.QueryData, h *
 		},
 	}
 
-	// execute list call
-	resp, err := svc.DescribeInstanceTypeOfferings(params)
-	if err != nil {
-		return nil, err
-	}
+	// List call
+	err = svc.DescribeInstanceTypeOfferingsPages(
+		params,
+		func(page *ec2.DescribeInstanceTypeOfferingsOutput, isLast bool) bool {
+			for _, instanceTypeOffering := range page.InstanceTypeOfferings {
+				d.StreamListItem(ctx, instanceTypeOffering)
+			}
+			return !isLast
+		},
+	)
 
-	for _, instanceType := range resp.InstanceTypeOfferings {
-		d.StreamListItem(ctx, instanceType)
+	if err != nil {
+		plugin.Logger(ctx).Error("listAwsInstanceTypesOfferings", "DescribeInstanceTypeOfferingsPages", err)
 	}
 
 	return nil, err
@@ -271,9 +276,10 @@ func describeInstanceType(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		InstanceTypes: []*string{aws.String(instanceType)},
 	}
 
-	// execute list call
+	// execute get call
 	op, err := svc.DescribeInstanceTypes(params)
 	if err != nil {
+		plugin.Logger(ctx).Error("describeInstanceType", "DescribeInstanceTypes", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_ec2_instance_type.go
+++ b/aws/table_aws_ec2_instance_type.go
@@ -233,7 +233,7 @@ func listAwsInstanceTypesOfferings(ctx context.Context, d *plugin.QueryData, h *
 	)
 
 	if err != nil {
-		plugin.Logger(ctx).Error("listAwsInstanceTypesOfferings", "DescribeInstanceTypeOfferingsPages", err)
+		plugin.Logger(ctx).Error("listAwsInstanceTypesOfferings", "InstanceType_DescribeInstanceTypeOfferingsPages", err)
 	}
 
 	return nil, err

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -123,6 +123,7 @@ func tableAwsKmsKey(_ context.Context) *plugin.Table {
 				Description: "A list of aliases for the key.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsKmsKeyAliases,
+				Transform:   transform.FromValue(),
 			},
 			{
 				Name:        "key_rotation_enabled",

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -336,9 +336,7 @@ func getAwsKmsKeyAliases(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	err = svc.ListAliasesPages(
 		params,
 		func(page *kms.ListAliasesOutput, lastPage bool) bool {
-			for _, aliases := range page.Aliases {
-				keyData = append(keyData, aliases)
-			}
+			keyData = append(keyData, page.Aliases...)
 			return !lastPage
 		},
 	)

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -266,6 +266,7 @@ func getAwsKmsKeyRotationStatus(ctx context.Context, d *plugin.QueryData, h *plu
 
 	keyData, err := svc.GetKeyRotationStatus(params)
 	if err != nil {
+		// For AWS managed Kms keys GetKeyRotationStatus API generate exceptions
 		if a, ok := err.(awserr.Error); ok {
 			if helpers.StringSliceContains([]string{"AccessDeniedException", "UnsupportedOperationException"}, a.Code()) {
 				return kms.GetKeyRotationStatusOutput{}, nil
@@ -296,6 +297,7 @@ func getAwsKmsKeyTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	for pagesLeft {
 		keyTags, err := svc.ListResourceTags(params)
 		if err != nil {
+			// For AWS managed Kms keys ListResourceTags API generate AccessDeniedException
 			if a, ok := err.(awserr.Error); ok {
 				if a.Code() == "AccessDeniedException" {
 					return tagsData, nil

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -266,7 +266,7 @@ func getAwsKmsKeyRotationStatus(ctx context.Context, d *plugin.QueryData, h *plu
 
 	keyData, err := svc.GetKeyRotationStatus(params)
 	if err != nil {
-		// For AWS managed Kms keys GetKeyRotationStatus API generate exceptions
+		// For AWS managed KMS keys GetKeyRotationStatus API generates exceptions
 		if a, ok := err.(awserr.Error); ok {
 			if helpers.StringSliceContains([]string{"AccessDeniedException", "UnsupportedOperationException"}, a.Code()) {
 				return kms.GetKeyRotationStatusOutput{}, nil
@@ -297,7 +297,7 @@ func getAwsKmsKeyTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	for pagesLeft {
 		keyTags, err := svc.ListResourceTags(params)
 		if err != nil {
-			// For AWS managed Kms keys ListResourceTags API generate AccessDeniedException
+			// For AWS managed KMS keys ListResourceTags API generates AccessDeniedException
 			if a, ok := err.(awserr.Error); ok {
 				if a.Code() == "AccessDeniedException" {
 					return tagsData, nil

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -295,6 +295,11 @@ func getAwsKmsKeyTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	for pagesLeft {
 		keyTags, err := svc.ListResourceTags(params)
 		if err != nil {
+			if a, ok := err.(awserr.Error); ok {
+				if a.Code() == "AccessDeniedException" {
+					return tagsData, nil
+				}
+			}
 			return nil, err
 		}
 		tags = append(tags, keyTags.Tags...)

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -290,24 +290,32 @@ func getAwsKmsKeyTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		KeyId: key.KeyId,
 	}
 
-	keyTags, err := svc.ListResourceTags(params)
-	if err != nil {
-		if a, ok := err.(awserr.Error); ok {
-			if a.Code() == "AccessDeniedException" {
-				return tagsData, nil
-			}
+	pagesLeft := true
+	tags := []*kms.Tag{}
+	for pagesLeft {
+		keyTags, err := svc.ListResourceTags(params)
+		if err != nil {
+			return nil, err
 		}
-		return nil, err
+		tags = append(tags, keyTags.Tags...)
+
+		if keyTags.NextMarker != nil {
+			params.Marker = keyTags.NextMarker
+		} else {
+			pagesLeft = false
+		}
 	}
-	if keyTags.Tags != nil {
-		tagsData["TagsSrc"] = keyTags.Tags
+
+	if tags != nil {
+		tagsData["TagsSrc"] = tags
 
 		turbotTagsMap := make(map[string]string)
-		for _, t := range keyTags.Tags {
+		for _, t := range tags {
 			turbotTagsMap[*t.TagKey] = *t.TagValue
 		}
 		tagsData["Tags"] = turbotTagsMap
 	}
+
 	return tagsData, nil
 }
 
@@ -324,10 +332,18 @@ func getAwsKmsKeyAliases(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	params := &kms.ListAliasesInput{
 		KeyId: key.KeyId,
 	}
-
-	keyData, err := svc.ListAliases(params)
+	keyData := []*kms.AliasListEntry{}
+	err = svc.ListAliasesPages(
+		params,
+		func(page *kms.ListAliasesOutput, lastPage bool) bool {
+			for _, aliases := range page.Aliases {
+				keyData = append(keyData, aliases)
+			}
+			return !lastPage
+		},
+	)
 	if err != nil {
-		return nil, err
+		plugin.Logger(ctx).Error("getAwsKmsKeyAliases", "ListAliasesPages_error", err)
 	}
 
 	return keyData, nil

--- a/aws/table_aws_sagemaker_endpoint_configuration.go
+++ b/aws/table_aws_sagemaker_endpoint_configuration.go
@@ -65,7 +65,7 @@ func tableAwsSageMakerEndpointConfiguration(_ context.Context) *plugin.Table {
 				Description: "The list of tags for the endpoint configuration.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listSageMakerEndpointConfigurationTags,
-				Transform:   transform.FromField("Tags"),
+				Transform:   transform.FromValue(),
 			},
 
 			// Steampipe standard columns

--- a/aws/table_aws_sagemaker_notebook_instance.go
+++ b/aws/table_aws_sagemaker_notebook_instance.go
@@ -159,7 +159,7 @@ func tableAwsSageMakerNotebookInstance(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listAwsSageMakerNotebookInstanceTags,
-				Transform:   transform.FromValue().Transform(sageMakerTurbotTags),
+				Transform:   transform.From(sageMakerTurbotTags),
 			},
 			{
 				Name:        "akas",

--- a/aws/table_aws_sagemaker_notebook_instance.go
+++ b/aws/table_aws_sagemaker_notebook_instance.go
@@ -144,7 +144,7 @@ func tableAwsSageMakerNotebookInstance(_ context.Context) *plugin.Table {
 				Description: "The list of tags for the notebook instance.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listAwsSageMakerNotebookInstanceTags,
-				Transform:   transform.FromField("Tags"),
+				Transform:   transform.FromValue(),
 			},
 
 			// Standard columns
@@ -159,7 +159,7 @@ func tableAwsSageMakerNotebookInstance(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listAwsSageMakerNotebookInstanceTags,
-				Transform:   transform.FromField("Tags").Transform(getAwsSageMakerNotebookInstanceTurbotTags),
+				Transform:   transform.FromValue().Transform(sageMakerTurbotTags),
 			},
 			{
 				Name:        "akas",
@@ -242,31 +242,27 @@ func listAwsSageMakerNotebookInstanceTags(ctx context.Context, d *plugin.QueryDa
 		ResourceArn: aws.String(resourceArn),
 	}
 
-	// Get call
-	op, err := svc.ListTags(params)
-	if err != nil {
-		logger.Debug("listAwsSageMakerNotebookInstanceTags", "ERROR", err)
-		return nil, err
+	pagesLeft := true
+	tags := []*sagemaker.Tag{}
+	for pagesLeft {
+		keyTags, err := svc.ListTags(params)
+		if err != nil {
+			plugin.Logger(ctx).Error("listAwsSageMakerNotebookInstanceTags", "ListTags_error", err)
+			return nil, err
+		}
+		tags = append(tags, keyTags.Tags...)
+
+		if keyTags.NextToken != nil {
+			params.NextToken = keyTags.NextToken
+		} else {
+			pagesLeft = false
+		}
 	}
 
-	return op, nil
+	return tags, nil
 }
 
 //// TRANSFORM FUNCTION
-
-func getAwsSageMakerNotebookInstanceTurbotTags(_ context.Context, d *transform.TransformData) (interface{},
-	error) {
-	data := d.HydrateItem.(*sagemaker.ListTagsOutput)
-
-	if data.Tags != nil {
-		turbotTagsMap := map[string]string{}
-		for _, i := range data.Tags {
-			turbotTagsMap[*i.Key] = *i.Value
-		}
-		return turbotTagsMap, nil
-	}
-	return nil, nil
-}
 
 func notebookInstanceARN(item interface{}) string {
 	switch item := item.(type) {

--- a/aws/table_aws_waf_rate_based_rule.go
+++ b/aws/table_aws_waf_rate_based_rule.go
@@ -155,7 +155,6 @@ func getAwsWafRateBasedRule(ctx context.Context, d *plugin.QueryData, h *plugin.
 // ListTagsForResource.NextMarker return empty string in API call
 // due to which pagination will not work properly
 // https://github.com/aws/aws-sdk-go/issues/3513
-
 func listAwsWafRateBasedRuleTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listAwsWafRateBasedRuleTags")
 

--- a/aws/table_aws_waf_rule.go
+++ b/aws/table_aws_waf_rule.go
@@ -147,6 +147,10 @@ func getAwsWAFRule(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	return data.Rule, nil
 }
 
+// ListTagsForResource.NextMarker return empty string in API call
+// due to which pagination will not work properly
+// https://github.com/aws/aws-sdk-go/issues/3513
+
 func getAwsWAFRuleTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getAwsWAFRuleTags")
 
@@ -166,8 +170,10 @@ func getAwsWAFRuleTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 
 	aka := "arn:" + commonColumnData.Partition + ":waf::" + commonColumnData.AccountId + ":rule" + "/" + id
 
+	// Build param with maximum limit set
 	params := &waf.ListTagsForResourceInput{
 		ResourceARN: &aka,
+		Limit:       aws.Int64(100),
 	}
 
 	op, err := svc.ListTagsForResource(params)

--- a/aws/table_aws_waf_rule.go
+++ b/aws/table_aws_waf_rule.go
@@ -51,7 +51,7 @@ func tableAwsWAFRule(_ context.Context) *plugin.Table {
 				Description: "A list of tags assigned to the Rule.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsWAFRuleTags,
-				Transform:   transform.FromValue(),
+				Transform:   transform.FromField("TagInfoForResource.TagList"),
 			},
 
 			// Standard columns for all tables
@@ -66,7 +66,7 @@ func tableAwsWAFRule(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsWAFRuleTags,
-				Transform:   transform.FromValue().Transform(wafTurbotTags),
+				Transform:   transform.FromField("TagInfoForResource.TagList").Transform(wafRuleTagListToTurbotTags),
 			},
 			{
 				Name:        "akas",
@@ -170,24 +170,12 @@ func getAwsWAFRuleTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 		ResourceARN: &aka,
 	}
 
-	tags := []*waf.Tag{}
-
-	pagesLeft := true
-	for pagesLeft {
-		response, err := svc.ListTagsForResource(params)
-		if err != nil {
-			plugin.Logger(ctx).Error("getAwsWAFRuleTags", "ListTagsForResource_error", err)
-			return nil, err
-		}
-		tags = append(tags, response.TagInfoForResource.TagList...)
-		if response.NextMarker != nil {
-			params.NextMarker = response.NextMarker
-		} else {
-			pagesLeft = false
-		}
+	op, err := svc.ListTagsForResource(params)
+	if err != nil {
+		return nil, err
 	}
 
-	return tags, nil
+	return op, nil
 }
 
 func getAwsWAFRuleAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -207,6 +195,26 @@ func getAwsWAFRuleAkas(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 }
 
 //// TRANSFORM FUNCTION
+
+func wafRuleTagListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("tagListToTurbotTags")
+	tagList := d.HydrateItem.(*waf.ListTagsForResourceOutput)
+
+	if tagList.TagInfoForResource.TagList == nil {
+		return nil, nil
+	}
+
+	// Mapping the resource tags inside turbotTags
+	var turbotTagsMap map[string]string
+	if tagList != nil {
+		turbotTagsMap = map[string]string{}
+		for _, i := range tagList.TagInfoForResource.TagList {
+			turbotTagsMap[*i.Key] = *i.Value
+		}
+	}
+
+	return turbotTagsMap, nil
+}
 
 func ruleData(item interface{}) string {
 	switch item := item.(type) {

--- a/aws/table_aws_waf_rule.go
+++ b/aws/table_aws_waf_rule.go
@@ -150,7 +150,6 @@ func getAwsWAFRule(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 // ListTagsForResource.NextMarker return empty string in API call
 // due to which pagination will not work properly
 // https://github.com/aws/aws-sdk-go/issues/3513
-
 func getAwsWAFRuleTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getAwsWAFRuleTags")
 

--- a/aws/table_aws_wafv2_ip_set.go
+++ b/aws/table_aws_wafv2_ip_set.go
@@ -77,7 +77,7 @@ func tableAwsWafv2IpSet(_ context.Context) *plugin.Table {
 				Description: "A list of tags associated with the resource.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listTagsForAwsWafv2IpSet,
-				Transform:   transform.FromValue(),
+				Transform:   transform.FromField("TagInfoForResource.TagList"),
 			},
 
 			// steampipe standard columns
@@ -92,7 +92,7 @@ func tableAwsWafv2IpSet(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listTagsForAwsWafv2IpSet,
-				Transform:   transform.FromValue().Transform(wafv2TurbotTags),
+				Transform:   transform.FromField("TagInfoForResource.TagList").Transform(ipSetTagListToTurbotTags),
 			},
 			{
 				Name:        "akas",
@@ -256,28 +256,15 @@ func listTagsForAwsWafv2IpSet(ctx context.Context, d *plugin.QueryData, h *plugi
 	}
 
 	// Build param
-	params := &wafv2.ListTagsForResourceInput{
+	param := &wafv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(data["Arn"]),
 	}
 
-	tags := []*wafv2.Tag{}
-
-	pagesLeft := true
-	for pagesLeft {
-		response, err := svc.ListTagsForResource(params)
-		if err != nil {
-			plugin.Logger(ctx).Error("getAwsWAFRuleTags", "ListTagsForResource_error", err)
-			return nil, err
-		}
-		tags = append(tags, response.TagInfoForResource.TagList...)
-		if response.NextMarker != nil {
-			params.NextMarker = response.NextMarker
-		} else {
-			pagesLeft = false
-		}
+	ipSetTags, err := svc.ListTagsForResource(param)
+	if err != nil {
+		return nil, err
 	}
-
-	return tags, nil
+	return ipSetTags, nil
 }
 
 //// TRANSFORM FUNCTIONS
@@ -289,6 +276,26 @@ func ipSetLocation(_ context.Context, d *transform.TransformData) (interface{}, 
 		return "REGIONAL", nil
 	}
 	return "CLOUDFRONT", nil
+}
+
+func ipSetTagListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("ipSetTagListToTurbotTags")
+	data := d.HydrateItem.(*wafv2.ListTagsForResourceOutput)
+
+	if data.TagInfoForResource.TagList == nil || len(data.TagInfoForResource.TagList) < 1 {
+		return nil, nil
+	}
+
+	// Mapping the resource tags inside turbotTags
+	var turbotTagsMap map[string]string
+	if data.TagInfoForResource.TagList != nil {
+		turbotTagsMap = map[string]string{}
+		for _, i := range data.TagInfoForResource.TagList {
+			turbotTagsMap[*i.Key] = *i.Value
+		}
+	}
+
+	return turbotTagsMap, nil
 }
 
 func ipSetRegion(ctx context.Context, d *transform.TransformData) (interface{}, error) {

--- a/aws/table_aws_wafv2_ip_set.go
+++ b/aws/table_aws_wafv2_ip_set.go
@@ -259,9 +259,10 @@ func listTagsForAwsWafv2IpSet(ctx context.Context, d *plugin.QueryData, h *plugi
 		return nil, err
 	}
 
-	// Build param
+	// Build param with maximum limit set
 	param := &wafv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(data["Arn"]),
+		Limit:       aws.Int64(100),
 	}
 
 	ipSetTags, err := svc.ListTagsForResource(param)

--- a/aws/table_aws_wafv2_ip_set.go
+++ b/aws/table_aws_wafv2_ip_set.go
@@ -236,7 +236,6 @@ func getAwsWafv2IpSet(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 // ListTagsForResource.NextMarker return empty string in API call
 // due to which pagination will not work properly
 // https://github.com/aws/aws-sdk-go/issues/3513
-
 func listTagsForAwsWafv2IpSet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listTagsForAwsWafv2IpSet")
 

--- a/aws/table_aws_wafv2_ip_set.go
+++ b/aws/table_aws_wafv2_ip_set.go
@@ -233,6 +233,10 @@ func getAwsWafv2IpSet(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	return op.IPSet, nil
 }
 
+// ListTagsForResource.NextMarker return empty string in API call
+// due to which pagination will not work properly
+// https://github.com/aws/aws-sdk-go/issues/3513
+
 func listTagsForAwsWafv2IpSet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listTagsForAwsWafv2IpSet")
 

--- a/aws/table_aws_wafv2_regex_pattern_set.go
+++ b/aws/table_aws_wafv2_regex_pattern_set.go
@@ -231,6 +231,10 @@ func getAwsWafv2RegexPatternSet(ctx context.Context, d *plugin.QueryData, h *plu
 	return op, nil
 }
 
+// ListTagsForResource.NextMarker return empty string in API call
+// due to which pagination will not work properly
+// https://github.com/aws/aws-sdk-go/issues/3513
+
 func listTagsForAwsWafv2RegexPatternSet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listTagsForAwsWafv2RegexPatternSet")
 

--- a/aws/table_aws_wafv2_regex_pattern_set.go
+++ b/aws/table_aws_wafv2_regex_pattern_set.go
@@ -75,7 +75,7 @@ func tableAwsWafv2RegexPatternSet(_ context.Context) *plugin.Table {
 				Description: "A list of tags associated with the resource.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listTagsForAwsWafv2RegexPatternSet,
-				Transform:   transform.FromValue(),
+				Transform:   transform.FromField("TagInfoForResource.TagList"),
 			},
 
 			// steampipe standard columns
@@ -90,7 +90,7 @@ func tableAwsWafv2RegexPatternSet(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listTagsForAwsWafv2RegexPatternSet,
-				Transform:   transform.FromValue().Transform(wafv2TurbotTags),
+				Transform:   transform.FromField("TagInfoForResource.TagList").Transform(regexPatternSetTagListToTurbotTags),
 			},
 			{
 				Name:        "akas",
@@ -254,28 +254,15 @@ func listTagsForAwsWafv2RegexPatternSet(ctx context.Context, d *plugin.QueryData
 	}
 
 	// Build param
-	params := &wafv2.ListTagsForResourceInput{
+	param := &wafv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(data["Arn"]),
 	}
 
-	tags := []*wafv2.Tag{}
-
-	pagesLeft := true
-	for pagesLeft {
-		response, err := svc.ListTagsForResource(params)
-		if err != nil {
-			plugin.Logger(ctx).Error("listTagsForAwsWafv2RegexPatternSet", "ListTagsForResource_error", err)
-			return nil, err
-		}
-		tags = append(tags, response.TagInfoForResource.TagList...)
-		if response.NextMarker != nil {
-			params.NextMarker = response.NextMarker
-		} else {
-			pagesLeft = false
-		}
+	regexPatternSetTags, err := svc.ListTagsForResource(param)
+	if err != nil {
+		return nil, err
 	}
-
-	return tags, nil
+	return regexPatternSetTags, nil
 }
 
 //// TRANSFORM FUNCTIONS
@@ -287,6 +274,26 @@ func regexPatternSetLocation(_ context.Context, d *transform.TransformData) (int
 		return "REGIONAL", nil
 	}
 	return "CLOUDFRONT", nil
+}
+
+func regexPatternSetTagListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("regexPatternSetTagListToTurbotTags")
+	data := d.HydrateItem.(*wafv2.ListTagsForResourceOutput)
+
+	if data.TagInfoForResource.TagList == nil || len(data.TagInfoForResource.TagList) < 1 {
+		return nil, nil
+	}
+
+	// Mapping the resource tags inside turbotTags
+	var turbotTagsMap map[string]string
+	if data.TagInfoForResource.TagList != nil {
+		turbotTagsMap = map[string]string{}
+		for _, i := range data.TagInfoForResource.TagList {
+			turbotTagsMap[*i.Key] = *i.Value
+		}
+	}
+
+	return turbotTagsMap, nil
 }
 
 func regularExpressionObjectListToRegularExpressionList(ctx context.Context, d *transform.TransformData) (interface{}, error) {

--- a/aws/table_aws_wafv2_regex_pattern_set.go
+++ b/aws/table_aws_wafv2_regex_pattern_set.go
@@ -257,9 +257,10 @@ func listTagsForAwsWafv2RegexPatternSet(ctx context.Context, d *plugin.QueryData
 		return nil, err
 	}
 
-	// Build param
+	// Build param with maximum limit set
 	param := &wafv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(data["Arn"]),
+		Limit:       aws.Int64(100),
 	}
 
 	regexPatternSetTags, err := svc.ListTagsForResource(param)

--- a/aws/table_aws_wafv2_regex_pattern_set.go
+++ b/aws/table_aws_wafv2_regex_pattern_set.go
@@ -234,7 +234,6 @@ func getAwsWafv2RegexPatternSet(ctx context.Context, d *plugin.QueryData, h *plu
 // ListTagsForResource.NextMarker return empty string in API call
 // due to which pagination will not work properly
 // https://github.com/aws/aws-sdk-go/issues/3513
-
 func listTagsForAwsWafv2RegexPatternSet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listTagsForAwsWafv2RegexPatternSet")
 

--- a/aws/table_aws_wafv2_rule_group.go
+++ b/aws/table_aws_wafv2_rule_group.go
@@ -271,9 +271,10 @@ func listTagsForAwsWafv2RuleGroup(ctx context.Context, d *plugin.QueryData, h *p
 		return nil, err
 	}
 
-	// Build param
+	// Build param with maximum limit set
 	param := &wafv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(data["Arn"]),
+		Limit:       aws.Int64(100),
 	}
 
 	ruleGroupTags, err := svc.ListTagsForResource(param)

--- a/aws/table_aws_wafv2_rule_group.go
+++ b/aws/table_aws_wafv2_rule_group.go
@@ -89,7 +89,7 @@ func tableAwsWafv2RuleGroup(_ context.Context) *plugin.Table {
 				Description: "A list of tags associated with the resource.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listTagsForAwsWafv2RuleGroup,
-				Transform:   transform.FromValue(),
+				Transform:   transform.FromField("TagInfoForResource.TagList"),
 			},
 
 			// steampipe standard columns
@@ -104,7 +104,7 @@ func tableAwsWafv2RuleGroup(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listTagsForAwsWafv2RuleGroup,
-				Transform:   transform.FromValue().Transform(wafv2TurbotTags),
+				Transform:   transform.FromField("TagInfoForResource.TagList").Transform(ruleGroupTagListToTurbotTags),
 			},
 			{
 				Name:        "akas",
@@ -268,28 +268,15 @@ func listTagsForAwsWafv2RuleGroup(ctx context.Context, d *plugin.QueryData, h *p
 	}
 
 	// Build param
-	params := &wafv2.ListTagsForResourceInput{
+	param := &wafv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(data["Arn"]),
 	}
 
-	tags := []*wafv2.Tag{}
-
-	pagesLeft := true
-	for pagesLeft {
-		response, err := svc.ListTagsForResource(params)
-		if err != nil {
-			plugin.Logger(ctx).Error("listTagsForAwsWafv2RuleGroup", "ListTagsForResource_error", err)
-			return nil, err
-		}
-		tags = append(tags, response.TagInfoForResource.TagList...)
-		if response.NextMarker != nil {
-			params.NextMarker = response.NextMarker
-		} else {
-			pagesLeft = false
-		}
+	ruleGroupTags, err := svc.ListTagsForResource(param)
+	if err != nil {
+		return nil, err
 	}
-
-	return tags, nil
+	return ruleGroupTags, nil
 }
 
 //// TRANSFORM FUNCTIONS
@@ -301,6 +288,26 @@ func ruleGroupLocation(_ context.Context, d *transform.TransformData) (interface
 		return "REGIONAL", nil
 	}
 	return "CLOUDFRONT", nil
+}
+
+func ruleGroupTagListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("ruleGroupTagListToTurbotTags")
+	data := d.HydrateItem.(*wafv2.ListTagsForResourceOutput)
+
+	if data.TagInfoForResource.TagList == nil || len(data.TagInfoForResource.TagList) < 1 {
+		return nil, nil
+	}
+
+	// Mapping the resource tags inside turbotTags
+	var turbotTagsMap map[string]string
+	if data.TagInfoForResource.TagList != nil {
+		turbotTagsMap = map[string]string{}
+		for _, i := range data.TagInfoForResource.TagList {
+			turbotTagsMap[*i.Key] = *i.Value
+		}
+	}
+
+	return turbotTagsMap, nil
 }
 
 func ruleGroupRegion(ctx context.Context, d *transform.TransformData) (interface{}, error) {

--- a/aws/table_aws_wafv2_rule_group.go
+++ b/aws/table_aws_wafv2_rule_group.go
@@ -89,7 +89,7 @@ func tableAwsWafv2RuleGroup(_ context.Context) *plugin.Table {
 				Description: "A list of tags associated with the resource.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listTagsForAwsWafv2RuleGroup,
-				Transform:   transform.FromField("TagInfoForResource.TagList"),
+				Transform:   transform.FromValue(),
 			},
 
 			// steampipe standard columns
@@ -104,7 +104,7 @@ func tableAwsWafv2RuleGroup(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listTagsForAwsWafv2RuleGroup,
-				Transform:   transform.FromField("TagInfoForResource.TagList").Transform(ruleGroupTagListToTurbotTags),
+				Transform:   transform.FromValue().Transform(wafv2TurbotTags),
 			},
 			{
 				Name:        "akas",
@@ -268,15 +268,28 @@ func listTagsForAwsWafv2RuleGroup(ctx context.Context, d *plugin.QueryData, h *p
 	}
 
 	// Build param
-	param := &wafv2.ListTagsForResourceInput{
+	params := &wafv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(data["Arn"]),
 	}
 
-	ruleGroupTags, err := svc.ListTagsForResource(param)
-	if err != nil {
-		return nil, err
+	tags := []*wafv2.Tag{}
+
+	pagesLeft := true
+	for pagesLeft {
+		response, err := svc.ListTagsForResource(params)
+		if err != nil {
+			plugin.Logger(ctx).Error("listTagsForAwsWafv2RuleGroup", "ListTagsForResource_error", err)
+			return nil, err
+		}
+		tags = append(tags, response.TagInfoForResource.TagList...)
+		if response.NextMarker != nil {
+			params.NextMarker = response.NextMarker
+		} else {
+			pagesLeft = false
+		}
 	}
-	return ruleGroupTags, nil
+
+	return tags, nil
 }
 
 //// TRANSFORM FUNCTIONS
@@ -288,26 +301,6 @@ func ruleGroupLocation(_ context.Context, d *transform.TransformData) (interface
 		return "REGIONAL", nil
 	}
 	return "CLOUDFRONT", nil
-}
-
-func ruleGroupTagListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("ruleGroupTagListToTurbotTags")
-	data := d.HydrateItem.(*wafv2.ListTagsForResourceOutput)
-
-	if data.TagInfoForResource.TagList == nil || len(data.TagInfoForResource.TagList) < 1 {
-		return nil, nil
-	}
-
-	// Mapping the resource tags inside turbotTags
-	var turbotTagsMap map[string]string
-	if data.TagInfoForResource.TagList != nil {
-		turbotTagsMap = map[string]string{}
-		for _, i := range data.TagInfoForResource.TagList {
-			turbotTagsMap[*i.Key] = *i.Value
-		}
-	}
-
-	return turbotTagsMap, nil
 }
 
 func ruleGroupRegion(ctx context.Context, d *transform.TransformData) (interface{}, error) {

--- a/aws/table_aws_wafv2_rule_group.go
+++ b/aws/table_aws_wafv2_rule_group.go
@@ -248,7 +248,6 @@ func getAwsWafv2RuleGroup(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 // ListTagsForResource.NextMarker return empty string in API call
 // due to which pagination will not work properly
 // https://github.com/aws/aws-sdk-go/issues/3513
-
 func listTagsForAwsWafv2RuleGroup(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listTagsForAwsWafv2RuleGroup")
 

--- a/aws/table_aws_wafv2_rule_group.go
+++ b/aws/table_aws_wafv2_rule_group.go
@@ -245,6 +245,10 @@ func getAwsWafv2RuleGroup(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	return op, nil
 }
 
+// ListTagsForResource.NextMarker return empty string in API call
+// due to which pagination will not work properly
+// https://github.com/aws/aws-sdk-go/issues/3513
+
 func listTagsForAwsWafv2RuleGroup(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listTagsForAwsWafv2RuleGroup")
 

--- a/aws/table_aws_wafv2_web_acl.go
+++ b/aws/table_aws_wafv2_web_acl.go
@@ -268,6 +268,10 @@ func getAwsWafv2WebAcl(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	return op.WebACL, nil
 }
 
+// ListTagsForResource.NextMarker return empty string in API call
+// due to which pagination will not work properly
+// https://github.com/aws/aws-sdk-go/issues/3513
+
 func listTagsForAwsWafv2WebAcl(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listTagsForAwsWafv2WebAcl")
 

--- a/aws/table_aws_wafv2_web_acl.go
+++ b/aws/table_aws_wafv2_web_acl.go
@@ -271,7 +271,6 @@ func getAwsWafv2WebAcl(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 // ListTagsForResource.NextMarker return empty string in API call
 // due to which pagination will not work properly
 // https://github.com/aws/aws-sdk-go/issues/3513
-
 func listTagsForAwsWafv2WebAcl(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("listTagsForAwsWafv2WebAcl")
 

--- a/aws/table_aws_wafv2_web_acl.go
+++ b/aws/table_aws_wafv2_web_acl.go
@@ -294,9 +294,10 @@ func listTagsForAwsWafv2WebAcl(ctx context.Context, d *plugin.QueryData, h *plug
 		return nil, err
 	}
 
-	// Build param
+	// Build param with maximum limit set
 	param := &wafv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(data["Arn"]),
+		Limit:       aws.Int64(100),
 	}
 
 	webAclTags, err := svc.ListTagsForResource(param)

--- a/aws/table_aws_wafv2_web_acl.go
+++ b/aws/table_aws_wafv2_web_acl.go
@@ -113,7 +113,7 @@ func tableAwsWafv2WebAcl(_ context.Context) *plugin.Table {
 				Description: "A list of tags associated with the resource.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listTagsForAwsWafv2WebAcl,
-				Transform:   transform.FromField("TagInfoForResource.TagList"),
+				Transform:   transform.FromValue(),
 			},
 
 			// Steampipe standard columns
@@ -128,7 +128,7 @@ func tableAwsWafv2WebAcl(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listTagsForAwsWafv2WebAcl,
-				Transform:   transform.FromField("TagInfoForResource.TagList").Transform(webAclTagListToTurbotTags),
+				Transform:   transform.FromValue().Transform(wafv2TurbotTags),
 			},
 			{
 				Name:        "akas",
@@ -291,15 +291,28 @@ func listTagsForAwsWafv2WebAcl(ctx context.Context, d *plugin.QueryData, h *plug
 	}
 
 	// Build param
-	param := &wafv2.ListTagsForResourceInput{
+	params := &wafv2.ListTagsForResourceInput{
 		ResourceARN: aws.String(data["Arn"]),
 	}
 
-	webAclTags, err := svc.ListTagsForResource(param)
-	if err != nil {
-		return nil, err
+	tags := []*wafv2.Tag{}
+
+	pagesLeft := true
+	for pagesLeft {
+		response, err := svc.ListTagsForResource(params)
+		if err != nil {
+			plugin.Logger(ctx).Error("listTagsForAwsWafv2WebAcl", "ListTagsForResource_error", err)
+			return nil, err
+		}
+		tags = append(tags, response.TagInfoForResource.TagList...)
+		if response.NextMarker != nil {
+			params.NextMarker = response.NextMarker
+		} else {
+			pagesLeft = false
+		}
 	}
-	return webAclTags, nil
+
+	return tags, nil
 }
 
 func getLoggingConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -350,26 +363,6 @@ func webAclLocation(_ context.Context, d *transform.TransformData) (interface{},
 		return "REGIONAL", nil
 	}
 	return "CLOUDFRONT", nil
-}
-
-func webAclTagListToTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("webAclTagListToTurbotTags")
-	data := d.HydrateItem.(*wafv2.ListTagsForResourceOutput)
-
-	if data.TagInfoForResource.TagList == nil || len(data.TagInfoForResource.TagList) < 1 {
-		return nil, nil
-	}
-
-	// Mapping the resource tags inside turbotTags
-	var turbotTagsMap map[string]string
-	if data.TagInfoForResource.TagList != nil {
-		turbotTagsMap = map[string]string{}
-		for _, i := range data.TagInfoForResource.TagList {
-			turbotTagsMap[*i.Key] = *i.Value
-		}
-	}
-
-	return turbotTagsMap, nil
 }
 
 func webAclRegion(ctx context.Context, d *transform.TransformData) (interface{}, error) {

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -10,6 +10,9 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/aws/aws-sdk-go/service/sagemaker"
+	"github.com/aws/aws-sdk-go/service/waf"
+	"github.com/aws/aws-sdk-go/service/wafv2"
 	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
 )
@@ -154,4 +157,53 @@ func base64DecodedData(_ context.Context, d *transform.TransformData) (interface
 		return nil, nil
 	}
 	return data, nil
+}
+
+func sageMakerTurbotTags(_ context.Context, d *transform.TransformData) (interface{},
+	error) {
+	tags := d.HydrateItem.([]*sagemaker.Tag)
+
+	if tags != nil {
+		turbotTagsMap := map[string]string{}
+		for _, i := range tags {
+			turbotTagsMap[*i.Key] = *i.Value
+		}
+		return turbotTagsMap, nil
+	}
+
+	return nil, nil
+}
+
+func wafTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	tagList := d.HydrateItem.([]*waf.Tag)
+	if tagList == nil {
+		return nil, nil
+	}
+
+	// Mapping the resource tags inside turbotTags
+	var turbotTagsMap map[string]string
+	if tagList != nil {
+		turbotTagsMap = map[string]string{}
+		for _, i := range tagList {
+			turbotTagsMap[*i.Key] = *i.Value
+		}
+	}
+	return turbotTagsMap, nil
+}
+
+func wafv2TurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	tagList := d.HydrateItem.([]*wafv2.Tag)
+	if tagList == nil {
+		return nil, nil
+	}
+
+	// Mapping the resource tags inside turbotTags
+	var turbotTagsMap map[string]string
+	if tagList != nil {
+		turbotTagsMap = map[string]string{}
+		for _, i := range tagList {
+			turbotTagsMap[*i.Key] = *i.Value
+		}
+	}
+	return turbotTagsMap, nil
 }

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -11,8 +11,6 @@ import (
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
-	"github.com/aws/aws-sdk-go/service/waf"
-	"github.com/aws/aws-sdk-go/service/wafv2"
 	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
 )
@@ -172,38 +170,4 @@ func sageMakerTurbotTags(_ context.Context, d *transform.TransformData) (interfa
 	}
 
 	return nil, nil
-}
-
-func wafTurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	tagList := d.HydrateItem.([]*waf.Tag)
-	if tagList == nil {
-		return nil, nil
-	}
-
-	// Mapping the resource tags inside turbotTags
-	var turbotTagsMap map[string]string
-	if tagList != nil {
-		turbotTagsMap = map[string]string{}
-		for _, i := range tagList {
-			turbotTagsMap[*i.Key] = *i.Value
-		}
-	}
-	return turbotTagsMap, nil
-}
-
-func wafv2TurbotTags(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	tagList := d.HydrateItem.([]*wafv2.Tag)
-	if tagList == nil {
-		return nil, nil
-	}
-
-	// Mapping the resource tags inside turbotTags
-	var turbotTagsMap map[string]string
-	if tagList != nil {
-		turbotTagsMap = map[string]string{}
-		for _, i := range tagList {
-			turbotTagsMap[*i.Key] = *i.Value
-		}
-	}
-	return turbotTagsMap, nil
 }

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -157,6 +157,7 @@ func base64DecodedData(_ context.Context, d *transform.TransformData) (interface
 	return data, nil
 }
 
+// Transform function for sagemaker resources tags
 func sageMakerTurbotTags(_ context.Context, d *transform.TransformData) (interface{},
 	error) {
 	tags := d.HydrateItem.([]*sagemaker.Tag)


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
## Here We have used the MaxResult/Limit parameter in the request to put a limit on the result count per page so that we can test the pagination with a small amount of data.

#Below are the tables for which pagination has been implemented -
table_aws_auditmanager_evidence
table_aws_cloudfront_cache_policy
table_aws_codepipeline_pipeline
table_aws_directory_service_directory
table_aws_dynamodb_table
table_aws_ec2_instance_availability
table_aws_ec2_instance_type
table_aws_efs_mount_target
table_aws_iam_access_key
table_aws_kinesisanalyticsv2_application
table_aws_kms_key
table_aws_sagemaker_endpoint_configuration
table_aws_sagemaker_model
table_aws_sagemaker_notebook_instance
table_aws_sagemaker_training_job
table_aws_ssm_managed_instance_compliance
table_aws_vpc_endpoint_service

#Log output to test pagination for aws_auditmanager_evidence table.

2021-09-24T13:52:11.956+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listAuditManagerEvidences: isLast=false EvidenceFoldersPerPage=50
2021-09-24T13:52:12.333+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listAuditManagerEvidences: isLast=false EvidenceFoldersPerPage=50
2021-09-24T13:52:12.762+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listAuditManagerEvidences: isLast=false EvidenceFoldersPerPage=50
2021-09-24T13:52:13.225+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listAuditManagerEvidences: isLast=false EvidenceFoldersPerPage=50
2021-09-24T13:52:13.616+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listAuditManagerEvidences: isLast=true EvidenceFoldersPerPage=48

#Steampipe output for aws_auditmanager_evidence table.

> select id,arn,assessment_id from aws_auditmanager_evidence
+--------------------------------------+-------------------------------------------------------------------------------------------+--------------------------------------+
| id                                   | arn                                                                                       | assessment_id                        |
+--------------------------------------+-------------------------------------------------------------------------------------------+--------------------------------------+
| 7240122a-636b-4786-80e8-ca8166d668bb | arn:aws:auditmanager:us-east-1:533793682495:evidence/7240122a-636b-4786-80e8-ca8166d668bb | 01940acc-fbb2-4c74-a8ab-f0e50173ad26 |
| 1dbf7710-8054-49ad-a91c-978ff5ceb7f3 | arn:aws:auditmanager:us-east-1:533793682495:evidence/1dbf7710-8054-49ad-a91c-978ff5ceb7f3 | 01940acc-fbb2-4c74-a8ab-f0e50173ad26 |
| 0363195a-18b7-4cb4-be92-2902a038d83c | arn:aws:auditmanager:us-east-1:533793682495:evidence/0363195a-18b7-4cb4-be92-2902a038d83c | 01940acc-fbb2-4c74-a8ab-f0e50173ad26 |
| 58940867-5ba7-40be-a54b-522d0c2044c4 | arn:aws:auditmanager:us-east-1:533793682495:evidence/58940867-5ba7-40be-a54b-522d0c2044c4 | 01940acc-fbb2-4c74-a8ab-f0e50173ad26 |
| e144176f-bc20-4590-9860-391cbd6909b9 | arn:aws:auditmanager:us-east-1:533793682495:evidence/e144176f-bc20-4590-9860-391cbd6909b9 | 01940acc-fbb2-4c74-a8ab-f0e50173ad26 |
| 9f0fce38-1ebc-430b-80af-ea065d48df8f | arn:aws:auditmanager:us-east-1:533793682495:evidence/9f0fce38-1ebc-430b-80af-ea065d48df8f | 01940acc-fbb2-4c74-a8ab-f0e50173ad26 |

#Log output to test pagination for aws_cloudfront_cache_policy table.

2021-09-24T14:10:03.453+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listCloudFrontCachePolicies: NextMarker=0xc006ac40e8 NextItemsCount=1
2021-09-24T14:10:03.797+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listCloudFrontCachePolicies: NextMarker=0xc006ac5e28 NextItemsCount=1
2021-09-24T14:10:04.382+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listCloudFrontCachePolicies: NextMarker=0xc006ae4928 NextItemsCount=1
2021-09-24T14:10:04.683+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listCloudFrontCachePolicies: NextMarker=0xc00036e628 NextItemsCount=1
2021-09-24T14:10:04.956+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listCloudFrontCachePolicies: NextMarker=0xc006bb2d48 NextItemsCount=1
2021-09-24T14:10:05.245+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listCloudFrontCachePolicies: NextMarker=<nil> NextItemsCount=0

#Steampipe output for aws_cloudfront_cache_policy table.

> select name,id,comment from aws_cloudfront_cache_policy
+------------------------------------------------+--------------------------------------+-----------------------------------------------+
| name                                           | id                                   | comment                                       |
+------------------------------------------------+--------------------------------------+-----------------------------------------------+
| Managed-CachingOptimized                       | 658327ea-f89d-4fab-a63d-7e88639e58f6 | Default policy when CF compression is enabled |
| Managed-CachingDisabled                        | 4135ea2d-6df8-44a3-9df3-4b5a84be39ad | Policy with caching disabled                  |
| Managed-CachingOptimizedForUncompressedObjects | b2884449-e4de-46a7-ac36-70bc7f1ddd6d | Default policy when compression is disabled   |
| Managed-Elemental-MediaPackage                 | 08627262-05a9-4f76-9ded-b50ca2e3a84f | Policy for Elemental MediaPackage Origin      |
| Managed-Amplify                                | 2e54312d-136d-493c-8eb9-b001f22f67d2 | Policy for Amplify Origin                     |
+------------------------------------------------+--------------------------------------+-----------------------------------------------+

#Log output to test pagination for tags in aws_codepipeline_pipeline table.

2021-09-24T14:31:08.995+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] getPipelineTags: isLast=true resultCountPerPage=4

#Steampipe output for tags in aws_codepipeline_pipeline table.

> select name,tags_src,tags from aws_codepipeline_pipeline
+------+---------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------+
| name | tags_src                                                                                                                        | tags                                                            |
+------+---------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------+
| test | [{"Key":"test2","Value":"test2"},{"Key":"test3","Value":"test3"},{"Key":"test","Value":"test"},{"Key":"test1","Value":"test1"}] | {"test":"test","test1":"test1","test2":"test2","test3":"test3"} |
+------+---------------------------------------------------------------------------------------------------------------------------------+-----------------------------------------------------------------+

#Steampipe output for aws_directory_service_directory table.

2021-09-24T19:00:32.196+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] DescribeDirectories: NextToken=0xc006b1e100 resultCountPerPage=1
2021-09-24T19:00:32.458+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] DescribeDirectories: NextToken=<nil> resultCountPerPage=1

#Steampipe output for aws_codepipeline_pipeline table.

> select name, directory_id, stage from aws_directory_service_directory
+---------------------------+--------------+--------+
| name                      | directory_id | stage  |
+---------------------------+--------------+--------+
| com.test.com              | d-90676e4a2f | Active |
| corp.amazonworkspaces.com | d-906702a1a7 | Active |
+---------------------------+--------------+--------+

> select name, tags_src, tags from aws_directory_service_directory where directory_id='d-906702a1a7'
+---------------------------+-----------------------------------------------------------------+---------------------------------+
| name                      | tags_src                                                        | tags                            |
+---------------------------+-----------------------------------------------------------------+---------------------------------+
| corp.amazonworkspaces.com | [{"Key":"test","Value":"test"},{"Key":"test1","Value":"test1"}] | {"test":"test","test1":"test1"} |
+---------------------------+-----------------------------------------------------------------+---------------------------------+

#Steampipe output for aws_dynamodb_table.

> select name, tags_src, tags from aws_dynamodb_table
+------+----------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------+
| name | tags_src                                                                                                       | tags                                                           |
+------+----------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------+
| test | [{"Key":"Business Unit","Value":""},{"Key":"AWSServiceAccount","Value":"test"},{"Key":"Test","Value":"test1"}] | {"AWSServiceAccount":"test","Business Unit":"","Test":"test1"} |
+------+----------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------+

#Log output to test pagination for list in aws_ec2_instance_availability table.

2021-09-26T09:37:35.008+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] DescribeInstanceTypeOfferingsPages: isLast=false resultCountPerPage=100
2021-09-26T09:37:35.427+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] DescribeInstanceTypeOfferingsPages: isLast=false resultCountPerPage=100
2021-09-26T09:37:35.932+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] DescribeInstanceTypeOfferingsPages: isLast=false resultCountPerPage=100
2021-09-26T09:37:36.390+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] DescribeInstanceTypeOfferingsPages: isLast=false resultCountPerPage=100
2021-09-26T09:37:36.929+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] DescribeInstanceTypeOfferingsPages: isLast=true resultCountPerPage=10

#Steampipe query output in aws_ec2_instance_type table.

> select instance_type,location from aws_ec2_instance_availability
+-------------------+----------------+
| instance_type     | location       |
+-------------------+----------------+
| m5a.large         | ap-south-1     |
| r5ad.12xlarge     | ap-south-1     |
| d3.4xlarge        | ap-south-1     |
| i3en.6xlarge      | ap-south-1     |
| t4g.medium        | ap-south-1     |
| i3.metal          | ap-south-1     |
| i2.2xlarge        | ap-south-1     |

#Log output to test pagination for list in aws_ec2_instance_type table.

2021-09-26T09:46:05.260+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] DescribeInstanceTypeOfferingsPages: isLast=false resultCountPerPage=200
2021-09-26T09:46:07.612+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] DescribeInstanceTypeOfferingsPages: isLast=false resultCountPerPage=200
2021-09-26T09:46:13.474+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] DescribeInstanceTypeOfferingsPages: isLast=true resultCountPerPage=10

#Steampipe query output in aws_ec2_instance_type table.

> select instance_type,auto_recovery_supported,bare_metal from aws_ec2_instance_type
+-------------------+-------------------------+------------+
| instance_type     | auto_recovery_supported | bare_metal |
+-------------------+-------------------------+------------+
| m5dn.8xlarge      | false                   | false      |
| m5a.16xlarge      | true                    | false      |
| c5d.4xlarge       | false                   | false      |
| m5ad.2xlarge      | false                   | false      |
| m5zn.3xlarge      | false                   | false      |
| c5a.xlarge        | true                    | false      |
| g4ad.2xlarge      | false                   | false      |
| r5ad.24xlarge     | false                   | false      |
| t3.large          | true                    | false      |
| x2gd.metal        | false                   | true       |

#Log output to test pagination for list in aws_efs_mount_target table.

2021-09-26T10:10:34.380+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listAwsEfsMountTargets: resultCountPerPage=1
2021-09-26T10:10:34.716+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listAwsEfsMountTargets: resultCountPerPage=1

#Steampipe query output in aws_efs_mount_target table.

> select mount_target_id,file_system_id,life_cycle_state from aws_efs_mount_target
+-----------------+----------------+------------------+
| mount_target_id | file_system_id | life_cycle_state |
+-----------------+----------------+------------------+
| fsmt-6f98d4da   | fs-3a4f458e    | available        |
| fsmt-7698d4c3   | fs-d04f4564    | available        |
+-----------------+----------------+------------------+

#Log output to test pagination for list in aws_iam_access_key table.

2021-09-26T10:44:15.294+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] ListAccessKeysPages: isLast=false resultCountPerPage=1
2021-09-26T10:44:15.655+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] ListAccessKeysPages: isLast=true resultCountPerPage=1

#Steampipe query output in aws_iam_access_key table.

> select access_key_id,user_name,create_date from aws_iam_access_key
+----------------------+-----------+---------------------+
| access_key_id        | user_name | create_date         |
+----------------------+-----------+---------------------+
| AKIAXYSEVGQ7WPIO6VP3 | sourav    | 2021-09-07 08:12:39 |
| AKIAXYSEVGQ7ZMFWFAR6 | sourav    | 2021-09-20 05:57:06 |
+----------------------+-----------+---------------------+

#Log output to test pagination for list in aws_kinesisanalyticsv2_application table.

2021-09-27T10:23:39.790+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] ListApplications: NextToken=0xc006d22fc0 resultCountPerPage=1
2021-09-27T10:23:40.052+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] ListApplications: NextToken=<nil> resultCountPerPage=1

#Steampipe query output in aws_kinesisanalyticsv2_application table.

> select application_name,application_version_id,application_arn from aws_kinesisanalyticsv2_application
+------------------+------------------------+-------------------------------------------------------------------+
| application_name | application_version_id | application_arn                                                   |
+------------------+------------------------+-------------------------------------------------------------------+
| test             | 1                      | arn:aws:kinesisanalytics:us-east-1:533793682495:application/test  |
| test1            | 1                      | arn:aws:kinesisanalytics:us-east-1:533793682495:application/test1 |
+------------------+------------------------+-------------------------------------------------------------------+

#Log output to test pagination for list in aws_kms_key table.

2021-09-27T11:24:01.042+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] getAwsKmsKeyAliases: lastPage=false resultCountPerPage=1
2021-09-27T11:24:01.338+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] getAwsKmsKeyAliases: lastPage=false resultCountPerPage=1
2021-09-27T11:24:01.594+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] getAwsKmsKeyAliases: lastPage=true resultCountPerPage=0

#Steampipe query output in aws_kms_key table.

> select id,jsonb_pretty(aliases),tags_src,tags from aws_kms_key where id = '52a8d64e-1341-494a-a478-0ccc5f496656'
+--------------------------------------+-----------------------------------------------------------------------+----------------------------------------+------------------+
| id                                   | jsonb_pretty                                                          | tags_src                               | tags             |
+--------------------------------------+-----------------------------------------------------------------------+----------------------------------------+------------------+
| 52a8d64e-1341-494a-a478-0ccc5f496656 | [                                                                     | [{"TagKey":"test","TagValue":"test1"}] | {"test":"test1"} |
|                                      |     {                                                                 |                                        |                  |
|                                      |         "AliasArn": "arn:aws:kms:us-east-1:533793682495:alias/test1", |                                        |                  |
|                                      |         "AliasName": "alias/test1",                                   |                                        |                  |
|                                      |         "TargetKeyId": "52a8d64e-1341-494a-a478-0ccc5f496656",        |                                        |                  |
|                                      |         "CreationDate": "2018-06-15T18:06:20.367Z",                   |                                        |                  |
|                                      |         "LastUpdatedDate": "2018-06-15T18:06:20.367Z"                 |                                        |                  |
|                                      |     },                                                                |                                        |                  |
|                                      |     {                                                                 |                                        |                  |
|                                      |         "AliasArn": "arn:aws:kms:us-east-1:533793682495:alias/test2", |                                        |                  |
|                                      |         "AliasName": "alias/test2",                                   |                                        |                  |
|                                      |         "TargetKeyId": "52a8d64e-1341-494a-a478-0ccc5f496656",        |                                        |                  |
|                                      |         "CreationDate": "2021-09-27T05:23:07.978Z",                   |                                        |                  |
|                                      |         "LastUpdatedDate": "2021-09-27T05:23:07.978Z"                 |                                        |                  |
|                                      |     }                                                                 |                                        |                  |
|                                      | ]                                                                     |                                        |                  |
+--------------------------------------+-----------------------------------------------------------------------+----------------------------------------+------------------+

#Log output to test pagination for list in aws_sagemaker_endpoint_configuration table.

2021-09-27T16:55:32.125+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listSageMakerEndpointConfigurationTags: NextToken=<nil> resultCountPerPage=2

#Steampipe query output in aws_sagemaker_notebook_instance table.

> select name,tags_src,tags from aws_sagemaker_endpoint_configuration
+------+-----------------------------------------------------------------+---------------------------------+
| name | tags_src                                                        | tags                            |
+------+-----------------------------------------------------------------+---------------------------------+
| test | [{"Key":"test","Value":"test"},{"Key":"test1","Value":"test1"}] | {"test":"test","test1":"test1"} |
+------+-----------------------------------------------------------------+---------------------------------+

#Steampipe query output in aws_sagemaker_notebook_instance table.

> select name,tags_src,tags from aws_sagemaker_model
+------+------------------------------------------------------------------+----------------------------------+
| name | tags_src                                                         | tags                             |
+------+------------------------------------------------------------------+----------------------------------+
| test | [{"Key":"test","Value":"test"},{"Key":"test1","Value":"test11"}] | {"test":"test","test1":"test11"} |
+------+------------------------------------------------------------------+----------------------------------+

#Steampipe query output in aws_sagemaker_notebook_instance table.

> select name,tags_src,tags from aws_sagemaker_notebook_instance
+------+-------------------------------------------------------------------------------------------------+-------------------------------------------------+
| name | tags_src                                                                                        | tags                                            |
+------+-------------------------------------------------------------------------------------------------+-------------------------------------------------+
| test | [{"Key":"test","Value":"test"},{"Key":"test1","Value":"test1"},{"Key":"test2","Value":"test2"}] | {"test":"test","test1":"test1","test2":"test2"} |
+------+-------------------------------------------------------------------------------------------------+-------------------------------------------------+

#Steampipe query output in aws_sagemaker_training_job table.

> select name,tags_src,tags from aws_sagemaker_training_job
+------+-------------------------------------------------------------------------------------------------+-------------------------------------------------+
| name | tags_src                                                                                        | tags                                            |
+------+-------------------------------------------------------------------------------------------------+-------------------------------------------------+
| test | [{"Key":"test","Value":"test"},{"Key":"test1","Value":"test1"},{"Key":"test2","Value":"test2"}] | {"test":"test","test1":"test1","test2":"test2"} |
+------+-------------------------------------------------------------------------------------------------+-------------------------------------------------+

#Log output to test pagination for list in aws_vpc_endpoint_service table.

2021-09-27T17:24:47.442+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listSsmManagedInstanceCompliances: isLast=false resultCountPerPage=5
2021-09-27T17:24:47.780+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listSsmManagedInstanceCompliances: isLast=true resultCountPerPage=3

#Steampipe query output in aws_vpc_endpoint_service table.

> select id,name,status from aws_ssm_managed_instance_compliance where resource_id = 'i-06fccd633041fe689'
+--------------------------------------+--------------------------------------+---------------+
| id                                   | name                                 | status        |
+--------------------------------------+--------------------------------------+---------------+
| 39a38ed8-34ef-492e-9581-0b676e08dea6 |                                      | COMPLIANT     |
| 9e27c2b9-2c1e-4643-a318-69b82852015a | AWS-AmazonLinux2DefaultPatchBaseline | COMPLIANT     |
| 9a4ec068-38fb-46eb-8913-3dd92fd078d9 |                                      | COMPLIANT     |
| c2a4678d-2763-4e32-a353-2d87ef3c87a0 |                                      | NON_COMPLIANT |
+--------------------------------------+--------------------------------------+---------------+

#Log output to test pagination for list in aws_vpc_endpoint_service table.

2021-09-27T14:11:41.612+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listVpcEndpointServices: NextToken=0xc0067cbbe8 resultCountPerPage=100
2021-09-27T14:11:43.258+0530 [ERROR] plugin.steampipe-plugin-aws.plugin: [ERROR] listVpcEndpointServices: NextToken=<nil> resultCountPerPage=40

#Steampipe query output in aws_vpc_endpoint_service table.

> select service_name,service_id,owner from aws_vpc_endpoint_service
+---------------------------------------------------------+----------------------------+--------------+
| service_name                                            | service_id                 | owner        |
+---------------------------------------------------------+----------------------------+--------------+
| com.amazonaws.us-east-1.greengrass                      | vpce-svc-086bf6b551522b3ed | amazon       |
| com.amazonaws.us-east-1.cassandra-fips                  | vpce-svc-06ee0acb03b0b0575 | amazon       |
| com.amazonaws.us-east-1.access-analyzer                 | vpce-svc-01192c2f53abbf891 | amazon       |
| com.amazonaws.us-east-1.clouddirectory                  | vpce-svc-04c4c52da3e222287 | amazon       |
| com.amazonaws.us-east-1.acm-pca                         | vpce-svc-0d573d21763fe4340 | amazon       |
| com.amazonaws.vpce.us-east-1.vpce-svc-0f25ac6e4ce006e71 | vpce-svc-0f25ac6e4ce006e71 | 533793682495 |
| aws.sagemaker.us-east-1.studio                          | vpce-svc-073bd5428a577ced9 | amazon       |
| com.amazonaws.us-east-1.airflow.api                     | vpce-svc-0e3da234646d19b53 | amazon       |
| com.amazonaws.us-east-1.cloudformation                  | vpce-svc-0aeaee07ba66a0bef | amazon       |

> select name,tags_src,tags from aws_wafv2_web_acl where scope = 'REGIONAL'
+------+-----------------------------------------------------------------+---------------------------------+
| name | tags_src                                                        | tags                            |
+------+-----------------------------------------------------------------+---------------------------------+
| test | [{"Key":"test","Value":"test"},{"Key":"test1","Value":"test1"}] | {"test":"test","test1":"test1"} |
+------+-----------------------------------------------------------------+---------------------------------+
```
</details>
