### PR TITLE
Handling exceptions aws_macie2_classification_job table. Closes #641

### DIFF
--- a/aws/table_aws_macie2_classification_job.go
+++ b/aws/table_aws_macie2_classification_job.go
@@ -165,6 +165,8 @@ func listMacie2ClassificationJobs(ctx context.Context, d *plugin.QueryData, _ *p
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
 			// Throws AccessDeniedException: Macie is not enabled. when AWS Macie is not enabled in a region
+			// Also the API throws AccessDeniedException if the request does not have proper permission
+			// with the below check we will only handle "Macie is not enabled"
 			if awsErr.Message() == "Macie is not enabled." {
 				return nil, nil
 			}

--- a/aws/table_aws_macie2_classification_job.go
+++ b/aws/table_aws_macie2_classification_job.go
@@ -164,8 +164,8 @@ func listMacie2ClassificationJobs(ctx context.Context, d *plugin.QueryData, _ *p
 	)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
-			// Throws AccessDeniedException: Macie is not enabled. when AWS Macie is not enabled in a region
-			// Also the API throws AccessDeniedException if the request does not have proper permission
+			// Throws "AccessDeniedException: Macie is not enabled." when AWS Macie is not enabled in a region
+			// also the API throws AccessDeniedException if the request does not have proper permission
 			// with the below check we will only handle "Macie is not enabled"
 			if awsErr.Message() == "Macie is not enabled." {
 				return nil, nil
@@ -209,7 +209,9 @@ func getMacie2ClassificationJob(ctx context.Context, d *plugin.QueryData, h *plu
 	op, err := svc.DescribeClassificationJob(params)
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok {
-			// Throws AccessDeniedException: Macie is not enabled. when AWS Macie is not enabled in a region
+			// Throws "AccessDeniedException: Macie is not enabled." when AWS Macie is not enabled in a region
+			// also the API throws AccessDeniedException if the request does not have proper permission
+			// with the below check we will only handle "Macie is not enabled"
 			if awsErr.Message() == "Macie is not enabled." {
 				return nil, nil
 			}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_macie2_classification_job where job_id = 'f9d91733ace0a93c09e8da13f598916e'
+--------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-------------------------------------
| name         | job_id                           | arn                                                                                       | job_status | job_type | client_token                        
+--------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-------------------------------------
| bucket-audit | f9d91733ace0a93c09e8da13f598916e | arn:aws:macie2:us-east-1:533793682495:classification-job/f9d91733ace0a93c09e8da13f598916e | COMPLETE   | ONE_TIME | cf6b6918-9c3f-4a33-887b-f4f834a1046d
+--------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-------------------------------------


> select * from aws_macie2_classification_job
+--------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-------------------------------------
| name         | job_id                           | arn                                                                                       | job_status | job_type | client_token                        
+--------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-------------------------------------
| bucket-audit | f9d91733ace0a93c09e8da13f598916e | arn:aws:macie2:us-east-1:533793682495:classification-job/f9d91733ace0a93c09e8da13f598916e | COMPLETE   | ONE_TIME | cf6b6918-9c3f-4a33-887b-f4f834a1046d
+--------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-------------------------------------

```

# User who do not have permission for macie -
> select * from aws_macie2_classification_job
Error: AccessDeniedException: User: arn:aws:iam::533793682495:user/test_macie is not authorized to perform: macie2:ListClassificationJobs on resource: arn:aws:macie2:ap-south-1:533793682495:*
</details>
