### PR TITLE
Table aws_waf_rate_based_rule and aws_waf_rule is not listing regional rules. closes #667

### DIFF
--- a/aws/table_aws_waf_rule.go
+++ b/aws/table_aws_waf_rule.go
@@ -81,6 +81,7 @@ func tableAwsWAFRule(_ context.Context) *plugin.Table {
 
 //// LIST FUNCTION
 
+// List API request does not support scope for getting the details of regional rules till date, we can get only the global rules.
 func listAwsWAFRules(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 
 	plugin.Logger(ctx).Trace("listAwsWAFRules")


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
