### PR TITLE
Add examples to IAM role docs. Closes #684

### DIFF
--- a/docs/tables/aws_iam_role.md
+++ b/docs/tables/aws_iam_role.md
@@ -83,4 +83,101 @@ where
   );
 ```
 
+### List higher level permissions for role `AWSServiceRoleForRDS`
+```sql
+select
+  r.name,
+  a.action,
+  a.access_level,
+  a.description
+from
+  aws_iam_role as r,
+  jsonb_array_elements_text(r.attached_policy_arns) as pol_arn,
+  aws_iam_policy as p,
+  jsonb_array_elements(p.policy_std -> 'Statement') as stmt,
+  jsonb_array_elements_text(stmt -> 'Action') as action_glob,
+  glob(action_glob) as action_regex
+  join aws_iam_action as a on a.action like action_regex
+where
+  pol_arn = p.arn
+  and stmt ->> 'Effect' = 'Allow'
+  and r.name = 'AWSServiceRoleForRDS'
+  and access_level not in ('List', 'Read')
+order by
+  action;
+```
 
+### List all actions (with level) in role2, not in role1
+```sql
+with role1_permissions as (
+  select
+    r.name,
+    a.action,
+    a.access_level,
+    a.description
+  from
+    aws_iam_role as r,
+    jsonb_array_elements_text(r.attached_policy_arns) as pol_arn,
+    aws_iam_policy as p,
+    jsonb_array_elements(p.policy_std -> 'Statement') as stmt,
+    jsonb_array_elements_text(stmt -> 'Action') as action_glob,
+    glob(action_glob) as action_regex
+    join aws_iam_action a ON a.action LIKE action_regex
+  where
+    pol_arn = p.arn
+    and stmt ->> 'Effect' = 'Allow'
+    and r.name = 'AWSServiceRoleForSSO'
+),
+role2_permissions as (
+  select
+    r.name,
+    a.action,
+    a.access_level,
+    a.description
+  from
+    aws_iam_role as r,
+    jsonb_array_elements_text(r.attached_policy_arns) as pol_arn,
+    aws_iam_policy as p,
+    jsonb_array_elements(p.policy_std -> 'Statement') as stmt,
+    jsonb_array_elements_text(stmt -> 'Action') as action_glob,
+    glob(action_glob) as action_regex
+    join aws_iam_action a ON a.action LIKE action_regex
+  where
+    pol_arn = p.arn
+    and stmt ->> 'Effect' = 'Allow'
+    and r.name = 'AWSServiceRoleForRDS'
+)
+select
+  *
+from
+  role2_permissions
+where
+  action not in (select action from role1_permissions)
+order by
+  action;
+```
+
+### List role with wildcard principal in trust policy(maintenance-role) and role(admin-role) that have trust relationship with maintenance-role
+```sql
+select
+  maintenance.name,
+  admin.name,
+  jsonb_pretty(maintenance_stmt),
+  jsonb_pretty(admin_stmt)
+from
+  -- use the account to get the organization_id
+  aws_account as a,
+  -- check any role as the "maintenance-role"
+  aws_iam_role as maintenance,
+  -- Combine via join with any role as the "admin-role"
+  aws_iam_role as admin,
+  jsonb_array_elements(maintenance.assume_role_policy_std -> 'Statement') as maintenance_stmt,
+  jsonb_array_elements(admin.assume_role_policy_std -> 'Statement') as admin_stmt
+where
+  -- maintenance role can be assumed by any AWS principal
+  maintenance_stmt -> 'Principal' -> 'AWS' ? '*'
+  -- maintenance role principal must be in same account
+  and maintenance_stmt -> 'Condition' -> 'StringEquals' -> 'aws:principalorgid' ? a.organization_id
+  -- admin role specifically allow maintenance role
+  and admin_stmt -> 'Principal' -> 'AWS' ? maintenance.arn;
+```

--- a/docs/tables/aws_iam_role.md
+++ b/docs/tables/aws_iam_role.md
@@ -61,7 +61,7 @@ order by
   r.name;
 ```
 
-### Find any roles that allow wildcard actions 
+### Find any roles that allow wildcard actions
 ```sql
 select
   r.name as role_name,
@@ -175,6 +175,7 @@ order by
 ```
 
 ### List role with wildcard principal in trust policy(maintenance-role) and role(admin-role) that have trust relationship with maintenance-role
+[Refer here](https://twitter.com/nathanwallace/status/1442574375857922048?s=20)
 ```sql
 select
   maintenance.name,
@@ -198,3 +199,17 @@ where
   -- admin role specifically allow maintenance role
   and admin_stmt -> 'Principal' -> 'AWS' ? maintenance.arn;
 ```
+
+### List the roles that might allow other roles/users to bypass their assigned IAM permissions.
+```sql
+select
+  r.name,
+  stmt
+from
+  aws_iam_role as r,
+  jsonb_array_elements(r.assume_role_policy_std -> 'Statement') as stmt,
+  jsonb_array_elements_text(stmt -> 'Principal' -> 'AWS') as trust
+where
+  trust = '*'
+  or trust like 'arn:aws:iam::%:role/%'
+  ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
NA
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  maintenance.name,
  admin.name,
  jsonb_pretty(maintenance_stmt),
  jsonb_pretty(admin_stmt)
from
  -- use the account to get the organization_id
  aws_new.aws_account as a,
  -- check any role as the maintenance-role
  aws_new.aws_iam_role as maintenance,
  -- Combine via join with any role as the "admin-role"
  aws_new.aws_iam_role as admin,
  jsonb_array_elements(maintenance.assume_role_policy_std -> 'Statement') as maintenance_stmt,
  jsonb_array_elements(admin.assume_role_policy_std -> 'Statement') as admin_stmt
where
  -- maintenance role can be assumed by any AWS principal
  maintenance_stmt -> 'Principal' -> 'AWS' ? '*'
  -- maintenance role principal must be in same account
  and maintenance_stmt -> 'Condition' -> 'StringEquals' -> 'aws:principalorgid' ? a.organization_id
  -- admin role specifically allow maintenance role
  and admin_stmt -> 'Principal' -> 'AWS' ? maintenance.arn;
  ```
  ```
+------------------+------------+-------------------------------------+---------------------------------------------------------------+
| name             | name       | jsonb_pretty                        | jsonb_pretty                                                  |
+------------------+------------+-------------------------------------+---------------------------------------------------------------+
| maintenance-role | admin-role | {                                   | {                                                             |
|                  |            |     "Action": [                     |     "Action": [                                               |
|                  |            |         "sts:assumerole"            |         "sts:assumerole"                                      |
|                  |            |     ],                              |     ],                                                        |
|                  |            |     "Effect": "Allow",              |     "Effect": "Allow",                                        |
|                  |            |     "Condition": {                  |     "Principal": {                                            |
|                  |            |         "StringEquals": {           |         "AWS": [                                              |
|                  |            |             "aws:principalorgid": [ |             "arn:aws:iam::013122550996:role/maintenance-role" |
|                  |            |                 "o-c3a5y4wd52"      |         ]                                                     |
|                  |            |             ]                       |     }                                                         |
|                  |            |         }                           | }                                                             |
|                  |            |     },                              |                                                               |
|                  |            |     "Principal": {                  |                                                               |
|                  |            |         "AWS": [                    |                                                               |
|                  |            |             "*"                     |                                                               |
|                  |            |         ]                           |                                                               |
|                  |            |     }                               |                                                               |
|                  |            | }                                   |                                                               |
+------------------+------------+-------------------------------------+---------------------------------------------------------------+
```
```
with role1_permissions as (
  select
    r.name,
    a.action,
    a.access_level,
    a.description
  from
    aws_iam_role as r,
    jsonb_array_elements_text(r.attached_policy_arns) as pol_arn,
    aws_iam_policy as p,
    jsonb_array_elements(p.policy_std -> 'Statement') as stmt,
    jsonb_array_elements_text(stmt -> 'Action') as action_glob,
    glob(action_glob) as action_regex
    join aws_iam_action a ON a.action LIKE action_regex
  where
    pol_arn = p.arn
    and stmt ->> 'Effect' = 'Allow'
    and r.name = 'AWSServiceRoleForSSO'
),
role2_permissions as (
  select
    r.name,
    a.action,
    a.access_level,
    a.description
  from
    aws_iam_role as r,
    jsonb_array_elements_text(r.attached_policy_arns) as pol_arn,
    aws_iam_policy as p,
    jsonb_array_elements(p.policy_std -> 'Statement') as stmt,
    jsonb_array_elements_text(stmt -> 'Action') as action_glob,
    glob(action_glob) as action_regex
    join aws_iam_action a ON a.action LIKE action_regex
  where
    pol_arn = p.arn
    and stmt ->> 'Effect' = 'Allow'
    and r.name = 'AWSServiceRoleForRDS'
)
select
  *
from
  role2_permissions
where
  action not in (select action from role1_permissions)
order by
  action;
+----------------------+---------------------------------------------------+--------------+-----------------------------------------------------------------------------------------------------------------
| name                 | action                                            | access_level | description                                                                                                     
+----------------------+---------------------------------------------------+--------------+-----------------------------------------------------------------------------------------------------------------
| AWSServiceRoleForRDS | cloudwatch:putmetricdata                          | Write        | Grants permission to publish metric data points to Amazon CloudWatch                                            
| AWSServiceRoleForRDS | ec2:allocateaddress                               | Write        | Grants permission to allocate an Elastic IP address (EIP) to your account                                       
| AWSServiceRoleForRDS | ec2:assignprivateipaddresses                      | Write        | Grants permission to assign one or more secondary private IP addresses to a network interface                   
| AWSServiceRoleForRDS | ec2:associateaddress                              | Write        | Grants permission to associate an Elastic IP address (EIP) with an instance or a network interface              
| AWSServiceRoleForRDS | ec2:authorizesecuritygroupingress                 | Write        | Grants permission to add one or more inbound rules to a security group                                          
| AWSServiceRoleForRDS | ec2:createnetworkinterface                        | Write        | Grants permission to create a network interface in a subnet                                                     
| AWSServiceRoleForRDS | ec2:createsecuritygroup                           | Write        | Grants permission to create a security group                                                                    
| AWSServiceRoleForRDS | ec2:createvpcendpoint                             | Write        | Grants permission to create a VPC endpoint for an AWS service                                                   
| AWSServiceRoleForRDS | ec2:deletenetworkinterface                        | Write        | Grants permission to delete a detached network interface                                                        
| AWSServiceRoleForRDS | ec2:deletesecuritygroup                           | Write        | Grants permission to delete a security group                                                                    
| AWSServiceRoleForRDS | ec2:deletevpcendpoints                            | Write        | Grants permission to delete one or more VPC endpoints                                                           
| AWSServiceRoleForRDS | ec2:describeaddresses                             | List         | Grants permission to describe one or more Elastic IP addresses                                                  
| AWSServiceRoleForRDS | ec2:describeavailabilityzones                     | List         | Grants permission to describe one or more of the Availability Zones that are available to you                   
| AWSServiceRoleForRDS | ec2:describecoippools                             | List         | Grants permission to describe the specified customer-owned address pools or all of your customer-owned address p
| AWSServiceRoleForRDS | ec2:describeinternetgateways                      | List         | Grants permission to describe one or more internet gateways                                                     
| AWSServiceRoleForRDS | ec2:describelocalgatewayroutetables               | List         | Grants permission to describe one or more local gateway route tables                                            
| AWSServiceRoleForRDS | ec2:describelocalgatewayroutetablevpcassociations | List         | Grants permission to describe an association between VPCs and local gateway route tables                        
| AWSServiceRoleForRDS | ec2:describelocalgateways                         | List         | Grants permission to describe one or more local gateways                                                        
| AWSServiceRoleForRDS | ec2:describesecuritygroups                        | List         | Grants permission to describe one or more security groups                                                       
| AWSServiceRoleForRDS | ec2:describesubnets                               | List         | Grants permission to describe one or more subnets                                                               
| AWSServiceRoleForRDS | ec2:describevpcattribute                          | List         | Grants permission to describe an attribute of a VPC                                                             
| AWSServiceRoleForRDS | ec2:describevpcendpoints                          | List         | Grants permission to describe one or more VPC endpoints                                                         
| AWSServiceRoleForRDS | ec2:describevpcs                                  | List         | Grants permission to describe one or more VPCs                                                                  
| AWSServiceRoleForRDS | ec2:disassociateaddress                           | Write        | Grants permission to disassociate an Elastic IP address from an instance or network interface                   
| AWSServiceRoleForRDS | ec2:modifynetworkinterfaceattribute               | Write        | Grants permission to modify an attribute of a network interface                                                 
| AWSServiceRoleForRDS | ec2:modifyvpcendpoint                             | Write        | Grants permission to modify an attribute of a VPC endpoint                                                      
| AWSServiceRoleForRDS | ec2:releaseaddress                                | Write        | Grants permission to release an Elastic IP address                                                              
| AWSServiceRoleForRDS | ec2:revokesecuritygroupingress                    | Write        | Grants permission to remove one or more inbound rules from a security group                                     
| AWSServiceRoleForRDS | ec2:unassignprivateipaddresses                    | Write        | Grants permission to unassign one or more secondary private IP addresses from a network interface               
| AWSServiceRoleForRDS | kinesis:createstream                              | Write        | Creates a Amazon Kinesis stream.                                                                                
| AWSServiceRoleForRDS | kinesis:deletestream                              | Write        | Deletes a stream and all its shards and data.                                                                   
| AWSServiceRoleForRDS | kinesis:describestream                            | Read         | Describes the specified stream.                                                                                 
| AWSServiceRoleForRDS | kinesis:mergeshards                               | Write        | Merges two adjacent shards in a stream and combines them into a single shard to reduce the stream's capacity to 
| AWSServiceRoleForRDS | kinesis:putrecord                                 | Write        | Writes a single data record from a producer into an Amazon Kinesis stream.                                      
| AWSServiceRoleForRDS | kinesis:putrecords                                | Write        | Writes multiple data records from a producer into an Amazon Kinesis stream in a single call (also referred to as
| AWSServiceRoleForRDS | kinesis:splitshard                                | Write        | Description for SplitShard                                                                                      
| AWSServiceRoleForRDS | kinesis:updateshardcount                          | Write        | Updates the shard count of the specified stream to the specified number of shards.                              
| AWSServiceRoleForRDS | logs:createloggroup                               | Write        | Grants permissions to create a new log group with the specified name                                            
| AWSServiceRoleForRDS | logs:createlogstream                              | Write        | Grants permissions to create a new log stream with the specified name                                           
| AWSServiceRoleForRDS | logs:describelogstreams                           | List         | Grants permissions to return all the log streams that are associated with the specified log group               
| AWSServiceRoleForRDS | logs:putlogevents                                 | Write        | Grants permissions to upload a batch of log events to the specified log stream                                  
| AWSServiceRoleForRDS | rds:crossregioncommunication                      | Write        | Grants permission to access a resource in the remote Region when executing cross-Region operations, such as cros
| AWSServiceRoleForRDS | sns:publish                                       | Write        | Grants permission to send a message to all of a topic's subscribed endpoints                                    
+----------------------+---------------------------------------------------+--------------+-----------------------------------------------------------------------------------------------------------------
```
```
 select
  r.name,
  a.action,
  a.access_level,
  a.description
from
  aws_iam_role as r,
  jsonb_array_elements_text(r.attached_policy_arns) as pol_arn,
  aws_iam_policy as p,
  jsonb_array_elements(p.policy_std -> 'Statement') as stmt,
  jsonb_array_elements_text(stmt -> 'Action') as action_glob,
  glob(action_glob) as action_regex
  join aws_iam_action as a on a.action like action_regex
where
  pol_arn = p.arn
  and stmt ->> 'Effect' = 'Allow'
  and r.name = 'AWSServiceRoleForRDS'
  and access_level not in ('List', 'Read')
order by
  action;
+----------------------+-------------------------------------+--------------+-------------------------------------------------------------------------------------------------------------------------------
| name                 | action                              | access_level | description                                                                                                                   
+----------------------+-------------------------------------+--------------+-------------------------------------------------------------------------------------------------------------------------------
| AWSServiceRoleForRDS | cloudwatch:putmetricdata            | Write        | Grants permission to publish metric data points to Amazon CloudWatch                                                          
| AWSServiceRoleForRDS | ec2:allocateaddress                 | Write        | Grants permission to allocate an Elastic IP address (EIP) to your account                                                     
| AWSServiceRoleForRDS | ec2:assignprivateipaddresses        | Write        | Grants permission to assign one or more secondary private IP addresses to a network interface                                 
| AWSServiceRoleForRDS | ec2:associateaddress                | Write        | Grants permission to associate an Elastic IP address (EIP) with an instance or a network interface                            
| AWSServiceRoleForRDS | ec2:authorizesecuritygroupingress   | Write        | Grants permission to add one or more inbound rules to a security group                                                        
| AWSServiceRoleForRDS | ec2:createnetworkinterface          | Write        | Grants permission to create a network interface in a subnet                                                                   
| AWSServiceRoleForRDS | ec2:createsecuritygroup             | Write        | Grants permission to create a security group                                                                                  
| AWSServiceRoleForRDS | ec2:createvpcendpoint               | Write        | Grants permission to create a VPC endpoint for an AWS service                                                                 
| AWSServiceRoleForRDS | ec2:deletenetworkinterface          | Write        | Grants permission to delete a detached network interface                                                                      
| AWSServiceRoleForRDS | ec2:deletesecuritygroup             | Write        | Grants permission to delete a security group                                                                                  
| AWSServiceRoleForRDS | ec2:deletevpcendpoints              | Write        | Grants permission to delete one or more VPC endpoints                                                                         
| AWSServiceRoleForRDS | ec2:disassociateaddress             | Write        | Grants permission to disassociate an Elastic IP address from an instance or network interface                                 
| AWSServiceRoleForRDS | ec2:modifynetworkinterfaceattribute | Write        | Grants permission to modify an attribute of a network interface                                                               
| AWSServiceRoleForRDS | ec2:modifyvpcendpoint               | Write        | Grants permission to modify an attribute of a VPC endpoint                                                                    
| AWSServiceRoleForRDS | ec2:releaseaddress                  | Write        | Grants permission to release an Elastic IP address                                                                            
| AWSServiceRoleForRDS | ec2:revokesecuritygroupingress      | Write        | Grants permission to remove one or more inbound rules from a security group                                                   
| AWSServiceRoleForRDS | ec2:unassignprivateipaddresses      | Write        | Grants permission to unassign one or more secondary private IP addresses from a network interface                             
| AWSServiceRoleForRDS | kinesis:createstream                | Write        | Creates a Amazon Kinesis stream.                                                                                              
| AWSServiceRoleForRDS | kinesis:deletestream                | Write        | Deletes a stream and all its shards and data.                                                                                 
| AWSServiceRoleForRDS | kinesis:mergeshards                 | Write        | Merges two adjacent shards in a stream and combines them into a single shard to reduce the stream's capacity to ingest and tra
| AWSServiceRoleForRDS | kinesis:putrecord                   | Write        | Writes a single data record from a producer into an Amazon Kinesis stream.                                                    
| AWSServiceRoleForRDS | kinesis:putrecords                  | Write        | Writes multiple data records from a producer into an Amazon Kinesis stream in a single call (also referred to as a PutRecords 
| AWSServiceRoleForRDS | kinesis:splitshard                  | Write        | Description for SplitShard                                                                                                    
| AWSServiceRoleForRDS | kinesis:updateshardcount            | Write        | Updates the shard count of the specified stream to the specified number of shards.                                            
| AWSServiceRoleForRDS | logs:createloggroup                 | Write        | Grants permissions to create a new log group with the specified name                                                          
| AWSServiceRoleForRDS | logs:createlogstream                | Write        | Grants permissions to create a new log stream with the specified name                                                         
| AWSServiceRoleForRDS | logs:putlogevents                   | Write        | Grants permissions to upload a batch of log events to the specified log stream                                                
| AWSServiceRoleForRDS | rds:crossregioncommunication        | Write        | Grants permission to access a resource in the remote Region when executing cross-Region operations, such as cross-Region snaps
| AWSServiceRoleForRDS | sns:publish                         | Write        | Grants permission to send a message to all of a topic's subscribed endpoints                                                  
+----------------------+-------------------------------------+--------------+------------------------------------------------------------------------------------------------------------------------------
```
```
</details>
