### PR TITLE
Add max_concurrent and max_per_second config options

### DIFF
--- a/aws/connection_config.go
+++ b/aws/connection_config.go
@@ -11,6 +11,8 @@ type awsConfig struct {
 	AccessKey    *string  `cty:"access_key"`
 	SecretKey    *string  `cty:"secret_key"`
 	SessionToken *string  `cty:"session_token"`
+	MaxConcurrent *int      `cty:"max_concurrent"`
+	MaxPerSecond  *int      `cty:"max_per_second"`
 }
 
 var ConfigSchema = map[string]*schema.Attribute{
@@ -29,6 +31,12 @@ var ConfigSchema = map[string]*schema.Attribute{
 	},
 	"session_token": {
 		Type: schema.TypeString,
+	},
+	"max_concurrent": {
+		Type: schema.TypeInt,
+	},
+	"max_per_second": {
+		Type: schema.TypeInt,
 	},
 }
 

--- a/aws/service_test.go
+++ b/aws/service_test.go
@@ -1,0 +1,195 @@
+package aws
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"testing"
+	"time"
+)
+
+func TestSessionLimiter_Concurrent(t *testing.T) {
+	type args struct {
+		sess          *session.Session
+		maxConcurrent *int
+		maxPerSecond  *int
+	}
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Handlers: request.Handlers{
+			Validate: request.HandlerList{},
+			Complete: request.HandlerList{},
+		},
+	})
+	if err != nil {
+		t.Errorf("failed to create session: %s", err)
+	}
+	tests := []struct {
+		name    string
+		args    args
+		runLoop int
+		nextShouldBlock bool
+	}{
+		{
+			"second request blocks when maxConcurrent is set to 1",
+			args{
+				sess.Copy(),
+				aws.Int(1),
+				aws.Int(100),
+			},
+			1,
+			true,
+		},
+		{
+			"fifth request blocks when maxConcurrent is set to 4",
+			args{
+				sess.Copy(),
+				aws.Int(4),
+				aws.Int(100),
+			},
+			4,
+			true,
+		},
+		{
+			"fifty requests should run without blocking when maxConcurrent is set to 0",
+			args{
+				sess.Copy(),
+				aws.Int(0),
+				aws.Int(100),
+			},
+			50,
+			false,
+		},
+		// TODO: Add test cases.
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SessionLimiter(tt.args.sess, tt.args.maxConcurrent, tt.args.maxPerSecond)
+			go func(){
+				time.Sleep(10 * time.Second)
+				t.Errorf("timed out, this is most likely caused by the handler unexpectedly blocking")
+				t.Fail()
+			}()
+
+			for i := 0; i < tt.runLoop; i++ {
+				tt.args.sess.Handlers.Validate.Run(&request.Request{})
+			}
+
+			done := make(chan int, 1)
+			running := true
+			// The next call to Validate should block, if it doesn't fail.
+			go func() {
+				tt.args.sess.Handlers.Validate.Run(&request.Request{})
+				if running && tt.nextShouldBlock {
+					t.Failed()
+				}
+				done <- 0
+			}()
+
+			// Give the goroutine a chance to run, if t.Failed() hasn't been called in this time we
+			// consider the test passed, free up a slot, then wait for the goroutine to finish.
+			time.Sleep(time.Millisecond * 100)
+			running = false // prevents t.Failed() from being called in goroutine
+			tt.args.sess.Handlers.Complete.Run(&request.Request{})
+			<- done
+		})
+	}
+}
+
+
+func TestSessionLimiter_PerSecond(t *testing.T) {
+	type args struct {
+		sess          *session.Session
+		maxConcurrent *int
+		maxPerSecond  *int
+	}
+	sess, err := session.NewSessionWithOptions(session.Options{
+		Handlers: request.Handlers{
+			Validate: request.HandlerList{},
+			Complete: request.HandlerList{},
+		},
+	})
+	if err != nil {
+		t.Errorf("failed to create session: %s", err)
+	}
+	tests := []struct {
+		name           string
+		args           args
+		maxReqsASecond int
+	}{
+		{
+			"no more then two requests are run in a second when maxConcurrent is 1 and maxPerSecond is 1",
+			args{
+				sess.Copy(),
+				aws.Int(1),
+				aws.Int(1),
+			},
+			2,
+		},
+		{
+			"no more then two requests are run in a second when maxConcurrent is 100 and maxPerSecond is 1",
+			args{
+				sess.Copy(),
+				aws.Int(100),
+				aws.Int(1),
+			},
+			2,
+		},
+		{
+			"no more then 5 requests are run in a second when maxConcurrent is 1 and maxPerSecond is 4",
+			args{
+				sess.Copy(),
+				aws.Int(1),
+				aws.Int(4),
+			},
+			5,
+		},
+		{
+			"no more then 12 requests are run in a second when maxConcurrent is 1 and maxPerSecond is 10",
+			args{
+				sess.Copy(),
+				aws.Int(1),
+				aws.Int(10),
+			},
+			12,
+		},
+		{
+			"no more then 23 requests are run in a second when maxConcurrent is 1 and maxPerSecond is 20",
+			args{
+				sess.Copy(),
+				aws.Int(1),
+				aws.Int(20),
+			},
+			23,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			SessionLimiter(tt.args.sess, tt.args.maxConcurrent, tt.args.maxPerSecond)
+
+			go func(){
+				time.Sleep(10 * time.Second)
+				t.Errorf("timed out, this is most likely caused by the handler unexpectedly blocking")
+				t.Fail()
+			}()
+
+			// Check the number of loops executed in the goroutine after a second, it should
+			// not exceed maxReqsASecond.
+			var i int
+			done := false
+			go func() {
+				for !done {
+					tt.args.sess.Handlers.Validate.Run(&request.Request{})
+					tt.args.sess.Handlers.Complete.Run(&request.Request{})
+					i++
+				}
+			}()
+			time.Sleep(time.Second)
+			done = true
+
+			if i > tt.maxReqsASecond {
+				t.Logf("number of executions: %d", i)
+				t.Fail()
+			}
+		})
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -9,4 +9,5 @@ require (
 	github.com/ttacon/chalk v0.0.0-20160626202418-22c06c80ed31
 	github.com/turbot/go-kit v0.3.0
 	github.com/turbot/steampipe-plugin-sdk v1.6.2
+	go.uber.org/ratelimit v0.2.0
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpH
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
 github.com/agext/levenshtein v1.2.1 h1:QmvMAjj2aEICytGiWzmxoE0x2KZvE0fvmqMOfy2tjT8=
 github.com/agext/levenshtein v1.2.1/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129 h1:MzBOUgng9orim59UnfUTLRjMpd09C5uEVQ6RPGeCaVI=
+github.com/andres-erbsen/clock v0.0.0-20160526145045-9e14626cd129/go.mod h1:rFgpPQZYZ8vdbc+48xibu8ALc3yeyd64IhHS+PU6Yyg=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3 h1:ZSTrOEhiM5J5RFxEaFvMZVEAM1KvT1YzbEOwB2EAGjA=
 github.com/apparentlymart/go-dump v0.0.0-20180507223929-23540a00eaa3/go.mod h1:oL81AME2rN47vu18xqj1S1jPIPuN7afo62yKTNn3XMM=
 github.com/apparentlymart/go-textseg v1.0.0 h1:rRmlIsPEEhUTIKQb7T++Nz/A5Q6C9IuX2wFoYVvnCs0=
@@ -144,6 +146,10 @@ github.com/zclconf/go-cty v1.8.0/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUA
 github.com/zclconf/go-cty v1.8.2 h1:u+xZfBKgpycDnTNjPhGiTEYZS5qS/Sb5MqSfm7vzcjg=
 github.com/zclconf/go-cty v1.8.2/go.mod h1:vVKLxnk3puL4qRAv72AO+W99LUD4da90g3uUAzyuvAk=
 github.com/zclconf/go-cty-debug v0.0.0-20191215020915-b22d67c1ba0b/go.mod h1:ZRKQfBXbGkpdV6QMzT3rU1kSTAnfu1dO8dPKjYprgj8=
+go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
+go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
+go.uber.org/ratelimit v0.2.0 h1:UQE2Bgi7p2B85uP5dC2bbRtig0C+OeNRnNEafLjsLPA=
+go.uber.org/ratelimit v0.2.0/go.mod h1:YYBV4e4naJvhpitQrWJu1vCpgB7CboMe0qhltKt6mUg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190426145343-a29dc8fdc734/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=


### PR DESCRIPTION
I still need to retest this, update the docs, as well as figure out how to run the integration tests. Going ahead and opening this as a work in progress PR for the moment though since it's pretty close to being ready to merge and I'd be interested in suggestions anyone has on this. It's worth noting that this is not a replacement for the backoff request limiting that was merged recently, that change should benefit anyone who uses Steampipe (less likely to crash and plays fairer with the rate-limiting quotas), where this change is targeted twards users that are particularly paranoid about causing disruptions in an their environment.

This adds the max_concurrent and max_per_second config options, both which affect client side rate-limiting of AWS API requests. These settings are useful in cases where you need to ensure the server side rate-limiting won't be triggered. Since AWS shares the API quotas across all services in an account a query against the environment from one user can potentially cause RequestLimitExceeded error responses to be returned from the API to an unrelated service.

In general applications should handle this error code gracefully and in an ideal world this would not cause any problems. However it's not uncommon to come across production apps that will crash when this happens. While you likely want to fix this issue in your code, it is still useful to be able to limit requests when you want to be extra careful in a production environment that you are not familiar with.

The max_concurrent setting here will prevent at most X number of requests from being in flight at the same time. Limiting concurrent requests should prevent any bursty request patterns, going through the allotted requests per second all at the same time. 

Setting max_per_second will allow X number of requests to be made every second. Since AWS does not offer any metrics on the current API quota, it is difficult to know what this needs to be set to, you can however monitor CloudTrail for failed requests and adjust this as needed.

# Integration test logs
TODO: run these
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
N/A
