### PR TITLE
Update error handling for `GetDefaultAwsRegion` if region is not set. Closes #689

### DIFF
--- a/aws/service.go
+++ b/aws/service.go
@@ -1708,7 +1708,6 @@ func GetDefaultAwsRegion(d *plugin.QueryData) string {
 		}
 	}
 
-	validPatterns := []string{}
 	invalidPatterns := []string{}
 	for _, namePattern := range regions {
 		validRegions := []string{}
@@ -1719,12 +1718,10 @@ func GetDefaultAwsRegion(d *plugin.QueryData) string {
 		}
 		if len(validRegions) == 0 {
 			invalidPatterns = append(invalidPatterns, namePattern)
-		} else {
-			validPatterns = append(validPatterns, namePattern)
 		}
 	}
 
-	if len(validPatterns) == 0 && len(invalidPatterns) != 0 {
+	if len(invalidPatterns) > 0 {
 		panic("\nconnection config have invalid \"regions\": " + strings.Join(invalidPatterns, ", ") + ". Edit your connection configuration file and then restart Steampipe")
 	}
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
N/A
```
</details>
