### PR TITLE
Tags for ECS services are always null closes #696

### DIFF
--- a/aws/table_aws_ecs_service.go
+++ b/aws/table_aws_ecs_service.go
@@ -317,14 +317,14 @@ func getEcsServiceTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 
 func getEcsServiceTurbotTags(_ context.Context, d *transform.TransformData) (interface{},
 	error) {
-	data := d.HydrateItem.([]*ecs.Tag)
+	tags := d.HydrateItem.([]*ecs.Tag)
 
-	if len(data) == 0{
+	if len(tags) == 0{
 		return nil, nil
 	}
 
 	turbotTagsMap := map[string]string{}
-	for _, i := range data {
+	for _, i := range tags {
 		turbotTagsMap[*i.Key] = *i.Value
 	}
 	return turbotTagsMap, nil


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ecs_service []

PRETEST: tests/aws_ecs_service

TEST: tests/aws_ecs_service
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_partition.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_ecs_cluster.named_test_resource: Creating...
aws_ecs_task_definition.named_test_resource: Creating...
aws_ecs_task_definition.named_test_resource: Creation complete after 3s [id=turbottest13689]
aws_ecs_cluster.named_test_resource: Still creating... [10s elapsed]
aws_ecs_cluster.named_test_resource: Creation complete after 14s [id=arn:aws:ecs:us-east-1:632902152528:cluster/turbottest13689]
aws_ecs_service.named_test_resource: Creating...
aws_ecs_service.named_test_resource: Creation complete after 4s [id=arn:aws:ecs:us-east-1:632902152528:service/turbottest13689/turbottest13689]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

cluster_arn = arn:aws:ecs:us-east-1:632902152528:cluster/turbottest13689
resource_aka = arn:aws:ecs:us-east-1:632902152528:service/turbottest13689/turbottest13689
resource_name = turbottest13689
task_definition_arn = arn:aws:ecs:us-east-1:632902152528:task-definition/turbottest13689:1

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:ecs:us-east-1:632902152528:service/turbottest13689/turbottest13689",
    "cluster_arn": "arn:aws:ecs:us-east-1:632902152528:cluster/turbottest13689",
    "desired_count": 3,
    "enable_ecs_managed_tags": false,
    "enable_execute_command": false,
    "placement_constraints": [
      {
        "Expression": "attribute:ecs.availability-zone in [us-west-2a, us-west-2b]",
        "Type": "memberOf"
      }
    ],
    "placement_strategy": [
      {
        "Field": "CPU",
        "Type": "binpack"
      }
    ],
    "service_name": "turbottest13689",
    "task_definition": "arn:aws:ecs:us-east-1:632902152528:task-definition/turbottest13689:1"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:ecs:us-east-1:632902152528:service/turbottest13689/turbottest13689"
    ],
    "title": "turbottest13689"
  }
]
✔ PASSED

POSTTEST: tests/aws_ecs_service

TEARDOWN: tests/aws_ecs_service

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select service_name, tags_src, tags from aws_ecs_service
+--------------------+-------------------------------------------------------------+-----------------------------+
| service_name       | tags_src                                                    | tags                        |
+--------------------+-------------------------------------------------------------+-----------------------------+
| sample-app-service | [{"Key":"Foo1","Value":"Bar1"},{"Key":"Foo","Value":"Bar"}] | {"Foo":"Bar","Foo1":"Bar1"} |
| test2              | []                                                          | <null>                      |
+--------------------+-------------------------------------------------------------+-----------------------------+

```
</details>
