### PR TITLE
Fix: plugin to not retry (as it makes query to hang for long) in case the provided credentials are not valid or credentials are not available.

### DIFF
--- a/aws/service.go
+++ b/aws/service.go
@@ -1793,21 +1793,21 @@ func (r ConnectionErrRetryer) ShouldRetry(req *request.Request) bool {
 		if strings.Contains(req.Error.Error(), "connection reset by peer") {
 			return true
 		}
-	}
-	var awsErr awserr.Error
-	if errors.As(req.Error, &awsErr) {
 
-		/*
-			If no credentials are set or an invalid profile is provided, the AWS SDK
-			will attempt to authenticate using all known methods. This takes a while
-			since it will attempt to reach the EC2 metadata service and will continue
-			to retry on connection errors, e.g.,
-			awsErr.OrigErr()="Put "http://169.254.169.254/latest/api/token": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
-			awsErr.OrigErr()="Get "http://169.254.169.254/latest/meta-data/iam/security-credentials/": dial tcp 169.254.169.254:80: connect: no route to host"
-			To reduce the time to fail, limit the number of retries for these errors specifically.
-		*/
-		if strings.Contains(awsErr.OrigErr().Error(), "http://169.254.169.254/latest") && req.RetryCount > 3 {
-			return false
+		var awsErr awserr.Error
+		if errors.As(req.Error, &awsErr) {
+			/*
+				If no credentials are set or an invalid profile is provided, the AWS SDK
+				will attempt to authenticate using all known methods. This takes a while
+				since it will attempt to reach the EC2 metadata service and will continue
+				to retry on connection errors, e.g.,
+				awsErr.OrigErr()="Put "http://169.254.169.254/latest/api/token": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+				awsErr.OrigErr()="Get "http://169.254.169.254/latest/meta-data/iam/security-credentials/": dial tcp 169.254.169.254:80: connect: no route to host"
+				To reduce the time to fail, limit the number of retries for these errors specifically.
+			*/
+			if strings.Contains(awsErr.OrigErr().Error(), "http://169.254.169.254/latest") && req.RetryCount > 3 {
+				return false
+			}
 		}
 	}
 

--- a/aws/service.go
+++ b/aws/service.go
@@ -582,20 +582,6 @@ func Ec2Service(ctx context.Context, d *plugin.QueryData, region string) (*ec2.E
 		return nil, err
 	}
 	svc := ec2.New(sess)
-	// svc.Config.CredentialsChainVerboseErrors = aws.Bool(true)
-	// svc.Config.
-
-	// plugin.Logger(ctx).Info("Ec2Service", "############### Config.CredentialsChainVerboseErrors", svc.Config.CredentialsChainVerboseErrors)
-	// creds := svc.Config.Credentials
-	// _, err = creds.GetWithContext(ctx)
-	// if err != nil {
-	// 	plugin.Logger(ctx).Info("Ec2Service", "############### err", err)
-	// }
-	// creds1 := svc.Config.
-	// _, err = creds.GetWithContext(ctx)
-	// if err != nil {
-	// 	plugin.Logger(ctx).Info("Ec2Service", "############### err", err)
-	// }
 	d.ConnectionManager.Cache.Set(serviceCacheKey, svc)
 
 	return svc, nil

--- a/aws/service.go
+++ b/aws/service.go
@@ -1692,64 +1692,10 @@ func getSessionWithMaxRetries(ctx context.Context, d *plugin.QueryData, region s
 		return nil, err
 	}
 
-	// Adding this check to avoid retrying in case aws sdk could resolve the credentials
-	valid, err := validateCredentials(ctx, region, d)
-	if !valid {
-		return nil, err
-	}
-
 	// save session in cache
 	d.ConnectionManager.Cache.Set(sessionCacheKey, sess)
 
 	return sess, nil
-}
-
-// Check for the AWS Plugin credential setup.
-// If sdk is unable to resolve/find any credentials for AWS. It throws NoCredentialProviders error.
-// In this case plugin should not retry and just through out the error
-func validateCredentials(ctx context.Context, region string, d *plugin.QueryData) (bool, error) {
-	awsConfig := GetConfig(d.Connection)
-
-	// session default configuration
-	sessionOptions := session.Options{
-		SharedConfigState: session.SharedConfigEnable,
-		Config: aws.Config{
-			Region:     &region,
-			MaxRetries: aws.Int(1),
-		},
-	}
-
-	if awsConfig.Profile != nil {
-		sessionOptions.Profile = *awsConfig.Profile
-	}
-
-	if awsConfig.AccessKey != nil && awsConfig.SecretKey != nil {
-		sessionOptions.Config.Credentials = credentials.NewStaticCredentials(
-			*awsConfig.AccessKey, *awsConfig.SecretKey, "",
-		)
-
-		if awsConfig.SessionToken != nil {
-			sessionOptions.Config.Credentials = credentials.NewStaticCredentials(
-				*awsConfig.AccessKey, *awsConfig.SecretKey, *awsConfig.SessionToken,
-			)
-		}
-	}
-
-	sess, err := session.NewSessionWithOptions(sessionOptions)
-	if err != nil {
-		return false, err
-	}
-
-	_, err = sess.Config.Credentials.GetWithContext(ctx)
-	if err != nil {
-		var awsErr awserr.Error
-		if errors.As(err, &awsErr) {
-			if awsErr.Code() == "NoCredentialProviders" {
-				return false, err
-			}
-		}
-	}
-	return true, nil
 }
 
 // GetDefaultAwsRegion returns the default region for AWS partiton
@@ -1846,6 +1792,28 @@ func (r ConnectionErrRetryer) ShouldRetry(req *request.Request) bool {
 	if req.Error != nil {
 		if strings.Contains(req.Error.Error(), "connection reset by peer") {
 			return true
+		}
+	}
+	var awsErr awserr.Error
+	if errors.As(req.Error, &awsErr) {
+
+		// 	> select * from aws_region
+		// Error: NoCredentialProviders: no valid providers in chain. Deprecated.
+		// For verbose messaging see aws.Config.CredentialsChainVerboseErrors
+
+		// AWS GO SDK throws this error in case it could not find any valid credentials from all the possible methods
+		// 1. Steampipe aws config
+		// 2. AWS Environment variables
+		// 3. AWS assume role credentials
+		// 4. AWS profile
+		// 5. AWS SSO credentials
+
+		// awsErr.OrigErr()="Put "http://169.254.169.254/latest/api/token": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
+		// awsErr.OrigErr()="Get "http://169.254.169.254/latest/meta-data/iam/security-credentials/": dial tcp 169.254.169.254:80: connect: no route to host"
+
+		// If the error is because of invalid credentails - we should not retry
+		if strings.Contains(awsErr.OrigErr().Error(), "http://169.254.169.254/latest") {
+			return false
 		}
 	}
 

--- a/aws/table_aws_region.go
+++ b/aws/table_aws_region.go
@@ -76,11 +76,13 @@ func tableAwsRegion(_ context.Context) *plugin.Table {
 //// LIST FUNCTION
 
 func listAwsRegions(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
 	defaultRegion := GetDefaultAwsRegion(d)
 
 	// Create Session
 	svc, err := Ec2Service(ctx, d, defaultRegion)
 	if err != nil {
+		logger.Error("aws_region.listAwsRegions", "connnection.error", err)
 		return nil, err
 	}
 
@@ -91,6 +93,7 @@ func listAwsRegions(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	// execute list call
 	resp, err := svc.DescribeRegions(params)
 	if err != nil {
+		logger.Error("aws_region.listAwsRegions", "api.error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
```
➜  steampipe-plugin-aws git:(issue-698) ✗ make
go build -o  ~/.steampipe/plugins/hub.steampipe.io/plugins/turbot/aws@latest/steampipe-plugin-aws.plugin  *.go
➜  steampipe-plugin-aws git:(issue-698) ✗ steampipe query
Welcome to Steampipe v0.9.0
For more information, type .help
> selec2021-11-02T15:27:12.289+0530 [INFO]  steampipe: [Trace] SetUserSearchPath
> select

Time: 1.174077ms
> select * from aws_region
Error: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
> select * from aws_iam_group
Error: NoCredentialProviders: no valid providers in chain. Deprecated.
	For verbose messaging see aws.Config.CredentialsChainVerboseErrors
> .quit
➜  steampipe-plugin-aws git:(issue-698) ✗ aws configure list                                                                    
      Name                    Value             Type    Location
      ----                    -----             ----    --------
   profile                <not set>             None    None
access_key                <not set>             None    None
secret_key                <not set>             None    None
    region                <not set>             None    None
➜  steampipe-plugin-aws git:(issue-698) ✗ vi ~/.aws/credentials 
➜  steampipe-plugin-aws git:(issue-698) ✗ aws configure list                                                                    
      Name                    Value             Type    Location
      ----                    -----             ----    --------
   profile                <not set>             None    None
access_key     ****************OL5N shared-credentials-file    
secret_key     ****************J9UO shared-credentials-file    
    region                <not set>             None    None
➜  steampipe-plugin-aws git:(issue-698) ✗ steampipe query
Welcome to Steampipe v0.9.0
For more information, type .help
> 2021-11-02T15:34:32.673+0530 [INFO]  steampipe: [Trace] SetUserSearchPath

> select name, opt_in_status, partition from aws_region

Time: 11.203762ms
+----------------+---------------------+-----------+
| name           | opt_in_status       | partition |
+----------------+---------------------+-----------+
| eu-west-3      | opt-in-not-required | aws       |
| eu-north-1     | opt-in-not-required | aws       |
| ap-south-1     | opt-in-not-required | aws       |
| af-south-1     | opted-in            | aws       |
| eu-west-2      | opt-in-not-required | aws       |
| eu-west-1      | opt-in-not-required | aws       |
| ap-northeast-3 | opt-in-not-required | aws       |
| ap-northeast-2 | opt-in-not-required | aws       |
| me-south-1     | opted-in            | aws       |
| ap-northeast-1 | opt-in-not-required | aws       |
| us-west-1      | opt-in-not-required | aws       |
| sa-east-1      | opt-in-not-required | aws       |
| ap-southeast-2 | opt-in-not-required | aws       |
| eu-central-1   | opt-in-not-required | aws       |
| eu-south-1     | opted-in            | aws       |
| us-west-2      | opt-in-not-required | aws       |
| ca-central-1   | opt-in-not-required | aws       |
| us-east-2      | opt-in-not-required | aws       |
| ap-east-1      | not-opted-in        | aws       |
| ap-southeast-1 | opt-in-not-required | aws       |
| us-east-1      | opt-in-not-required | aws       |
+----------------+---------------------+-----------+
> 

```