### PR TITLE
Fix incorrect data type for platform_version in aws_ssm_managed_instance. Closes #731

### DIFF
--- a/aws/table_aws_ssm_managed_instance.go
+++ b/aws/table_aws_ssm_managed_instance.go
@@ -107,7 +107,7 @@ func tableAwsSSMManagedInstance(_ context.Context) *plugin.Table {
 			{
 				Name:        "platform_version",
 				Description: "The version of the OS platform running on your instance.",
-				Type:        proto.ColumnType_INT,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "registration_date",


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select count(*) as total from aws_ssm_managed_instance
+-------+
| total |
+-------+
| 1     |
+-------+
> select instance_id, platform_version from aws_ssm_managed_instance
+---------------------+------------------+
| instance_id         | platform_version |
+---------------------+------------------+
| i-0f69c3d430d17f714 | 2                |
+---------------------+------------------+
```
</details>
