### PR TITLE
Add table aws_lambda_layer. Closes #738

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -190,6 +190,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_lambda_function_metric_duration_daily":                    tableAwsLambdaFunctionMetricDurationDaily(ctx),
 			"aws_lambda_function_metric_errors_daily":                      tableAwsLambdaFunctionMetricErrorsDaily(ctx),
 			"aws_lambda_function_metric_invocations_daily":                 tableAwsLambdaFunctionMetricInvocationsDaily(ctx),
+			"aws_lambda_layer":                                             tableAwsLambdaLayer(ctx),
 			"aws_lambda_version":                                           tableAwsLambdaVersion(ctx),
 			"aws_macie2_classification_job":                                tableAwsMacie2ClassificationJob(ctx),
 			"aws_organizations_account":                                    tableAwsOrganizationsAccount(ctx),

--- a/aws/table_aws_lambda_layer.go
+++ b/aws/table_aws_lambda_layer.go
@@ -1,0 +1,135 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/service/lambda"
+	"github.com/turbot/go-kit/types"
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+)
+
+func tableAwsLambdaLayer(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_lambda_layer",
+		Description: "AWS Lambda Layer",
+		List: &plugin.ListConfig{
+			Hydrate: listLambdaLayers,
+		},
+		GetMatrixItem: BuildRegionList,
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "layer_name",
+				Description: "The name of the layer.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "layer_arn",
+				Description: "The Amazon Resource Name (ARN) of the function layer.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "created_date",
+				Description: "The date that the version was created, in ISO 8601 format.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LatestMatchingVersion.CreatedDate"),
+			},
+			{
+				Name:        "description",
+				Description: "The description of the version.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LatestMatchingVersion.Description"),
+			},
+			{
+				Name:        "layer_version_arn",
+				Description: "The ARN of the layer version.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LatestMatchingVersion.LayerVersionArn"),
+			},
+			{
+				Name:        "license_info",
+				Description: "The layer's open-source license.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LatestMatchingVersion.LicenseInfo"),
+			},
+			{
+				Name:        "version",
+				Description: "The version number.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("LatestMatchingVersion.Version"),
+			},
+			{
+				Name:        "compatible_architectures",
+				Description: "A list of compatible instruction set architectures.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("LatestMatchingVersion.CompatibleArchitectures"),
+			},
+			{
+				Name:        "compatible_runtimes",
+				Description: "The layer's compatible runtimes.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("LatestMatchingVersion.CompatibleRuntimes"),
+			},
+
+			// Standard columns for all tables
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LayerName"),
+			},
+			{
+				Name:        "akas",
+				Description: resourceInterfaceDescription("akas"),
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("LayerArn").Transform(arnToAkas),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listLambdaLayers(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("listLambdaLayers")
+
+	// Create service
+	svc, err := LambdaService(ctx, d)
+	if err != nil {
+		logger.Error("listLambdaLayers", "error_LambdaService", err)
+		return nil, err
+	}
+
+	// Set MaxItems to the maximum number allowed
+	input := lambda.ListLayersInput{
+		MaxItems: types.Int64(50),
+	}
+
+	// If the requested number of items is less than the paging max limit
+	// set the limit to that instead
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *input.MaxItems {
+			input.MaxItems = limit
+		}
+	}
+
+	err = svc.ListLayersPages(
+		&input,
+		func(page *lambda.ListLayersOutput, lastPage bool) bool {
+			for _, layer := range page.Layers {
+				d.StreamLeafListItem(ctx, layer)
+			}
+			return !lastPage
+		},
+	)
+
+	if err != nil {
+		logger.Error("listLambdaLayers", "error_ListLayersPages", err)
+		return nil, err
+	}
+
+	return nil, nil
+}

--- a/aws/table_aws_lambda_layer.go
+++ b/aws/table_aws_lambda_layer.go
@@ -83,7 +83,7 @@ func tableAwsLambdaLayer(_ context.Context) *plugin.Table {
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("LayerArn").Transform(arnToAkas),
+				Transform:   transform.FromField("LayerArn").Transform(transform.EnsureStringArray),
 			},
 		}),
 	}

--- a/aws/table_aws_lambda_layer.go
+++ b/aws/table_aws_lambda_layer.go
@@ -120,7 +120,7 @@ func listLambdaLayers(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		&input,
 		func(page *lambda.ListLayersOutput, lastPage bool) bool {
 			for _, layer := range page.Layers {
-				d.StreamLeafListItem(ctx, layer)
+				d.StreamListItem(ctx, layer)
 			}
 			return !lastPage
 		},

--- a/docs/tables/aws_lambda_layer.md
+++ b/docs/tables/aws_lambda_layer.md
@@ -1,0 +1,20 @@
+# Table: aws_lambda_layer
+
+A Lambda layer is an archive containing additional code, such as libraries, dependencies, or even custom runtimes. When you include a layer in a function, the contents are extracted to the /opt directory in the execution environment.
+
+## Examples
+
+### Basic Info
+
+```sql
+select
+  layer_arn,
+  layer_name,
+  layer_version_arn,
+  created_date,
+  jsonb_pretty(compatible_runtimes) as compatible_runtimes,
+  jsonb_pretty(compatible_architectures) as compatible_architectures,
+  version
+from
+  aws_lambda_layer;
+```

--- a/docs/tables/aws_lambda_layer.md
+++ b/docs/tables/aws_lambda_layer.md
@@ -1,6 +1,6 @@
 # Table: aws_lambda_layer
 
-A Lambda layer is an archive containing additional code, such as libraries, dependencies, or even custom runtimes. When you include a layer in a function, the contents are extracted to the /opt directory in the execution environment.
+A Lambda layer is a .zip file archive that can contain additional code or data. A layer can contain libraries, a custom runtime, data, or configuration files. Layers promote code sharing and separation of responsibilities so that you can iterate faster on writing business logic.
 
 ## Examples
 


### PR DESCRIPTION
An integration test is not feasible as it requires a zip file either locally or stored in a S3 bucket.

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  layer_arn,
  layer_name,
  layer_version_arn,
  created_date,
  jsonb_pretty(compatible_runtimes) as compatible_runtimes,
  jsonb_pretty(compatible_architectures) as compatible_architectures,
  version
from
  aws_lambda_layer;
+-------------------------------------------------------+------------+---------------------------------------------------------+------------------------------+---------------------+--------------------------+---------+
| layer_arn                                             | layer_name | layer_version_arn                                       | created_date                 | compatible_runtimes | compatible_architectures | version |
+-------------------------------------------------------+------------+---------------------------------------------------------+------------------------------+---------------------+--------------------------+---------+
| arn:aws:lambda:us-east-1:632902152528:layer:testLayer | testLayer  | arn:aws:lambda:us-east-1:632902152528:layer:testLayer:2 | 2021-11-08T12:21:34.937+0000 | [                   | [                        | 2       |
|                                                       |            |                                                         |                              |     "python3.7"     |     "arm64"              |         |
|                                                       |            |                                                         |                              | ]                   | ]                        |         |
+-------------------------------------------------------+------------+---------------------------------------------------------+------------------------------+---------------------+--------------------------+---------+
```
</details>
