### PR TITLE
Add policy and policy_std columns to the aws_secretsmanager_secret table. Closes #721

### DIFF
--- a/aws/table_aws_secretsmanager_secret.go
+++ b/aws/table_aws_secretsmanager_secret.go
@@ -18,6 +18,7 @@ func tableAwsSecretsManagerSecret(_ context.Context) *plugin.Table {
 		Description: "AWS Secrets Manager Secret",
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("arn"),
+			ShouldIgnoreError: isNotFoundError([]string{"ValidationException", "InvalidParameter", "ResourceNotFoundException"}),
 			Hydrate:    describeSecretsManagerSecret,
 		},
 		List: &plugin.ListConfig{
@@ -83,6 +84,20 @@ func tableAwsSecretsManagerSecret(_ context.Context) *plugin.Table {
 				Description: "The Region where Secrets Manager originated the secret.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     describeSecretsManagerSecret,
+			},
+			{
+				Name:        "policy",
+				Description: "A JSON-formatted string that describes the permissions that are associated with the attached secret.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getSecretsManagerSecretPolicy,
+				Transform:   transform.FromField("ResourcePolicy"),
+			},
+			{
+				Name:        "policy_std",
+				Description: "Contains the permissions that are associated with the attached secret in a canonical form for easier searching.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getSecretsManagerSecretPolicy,
+				Transform:   transform.FromField("ResourcePolicy").Transform(unescape).Transform(policyToCanonical),
 			},
 			{
 				Name:        "replication_status",
@@ -167,7 +182,7 @@ func listSecretsManagerSecrets(ctx context.Context, d *plugin.QueryData, _ *plug
 	return nil, err
 }
 
-//// HYDRATE FUNCTION
+//// HYDRATE FUNCTIONS
 
 func describeSecretsManagerSecret(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("describeSecretsManagerSecret")
@@ -199,6 +214,40 @@ func describeSecretsManagerSecret(ctx context.Context, d *plugin.QueryData, h *p
 		return nil, err
 	}
 	return op, nil
+}
+
+func getSecretsManagerSecretPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("getSecretsManagerSecretPolicy")
+
+	var arn string
+	if h.Item != nil {
+		data := secretData(h.Item)
+		arn = data["ARN"]
+	} else {
+		arn = d.KeyColumnQuals["arn"].GetStringValue()
+	}
+
+	// Create Session
+	svc, err := SecretsManagerService(ctx, d)
+	if err != nil {
+		logger.Error("getSecretsManagerSecretPolicy", "error_SecretsManagerService", err)
+		return nil, err
+	}
+
+	// Build the params
+	params := &secretsmanager.GetResourcePolicyInput{
+		SecretId: &arn,
+	}
+
+	// Get call
+	data, err := svc.GetResourcePolicy(params)
+	if err != nil {
+		logger.Error("getSecretsManagerSecretPolicy", "error_GetResourcePolicy", err)
+		return nil, err
+	}
+
+	return data, nil
 }
 
 //// TRANSFORM FUNCTION

--- a/docs/tables/aws_secretsmanager_secret.md
+++ b/docs/tables/aws_secretsmanager_secret.md
@@ -61,3 +61,14 @@ from
 where
   replication_status is null;
 ```
+
+### List policy details for the secrets
+
+```sql
+select
+  name,
+  jsonb_pretty(policy) as policy,
+  jsonb_pretty(policy_std) as policy_std
+from
+  aws_secretsmanager_secret;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro aws-test % ./tint.js aws_secretsmanager_secret
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_secretsmanager_secret []

PRETEST: tests/aws_secretsmanager_secret

TEST: tests/aws_secretsmanager_secret
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_secretsmanager_secret.named_test_resource will be created
  + resource "aws_secretsmanager_secret" "named_test_resource" {
      + arn                            = (known after apply)
      + description                    = "Test secret."
      + force_overwrite_replica_secret = false
      + id                             = (known after apply)
      + name                           = "turbottest14961"
      + name_prefix                    = (known after apply)
      + policy                         = (known after apply)
      + recovery_window_in_days        = 30
      + rotation_enabled               = (known after apply)
      + rotation_lambda_arn            = (known after apply)
      + tags                           = {
          + "foo" = "bar"
        }
      + tags_all                       = {
          + "foo" = "bar"
        }

      + replica {
          + kms_key_id         = (known after apply)
          + last_accessed_date = (known after apply)
          + region             = (known after apply)
          + status             = (known after apply)
          + status_message     = (known after apply)
        }

      + rotation_rules {
          + automatically_after_days = 7
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "632902152528"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest14961"
aws_secretsmanager_secret.named_test_resource: Creating...
aws_secretsmanager_secret.named_test_resource: Creation complete after 4s [id=arn:aws:secretsmanager:us-east-1:632902152528:secret:turbottest14961-EBSrND]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: Argument is deprecated

  with aws_secretsmanager_secret.named_test_resource,
  on variables.tf line 49, in resource "aws_secretsmanager_secret" "named_test_resource":
  49: resource "aws_secretsmanager_secret" "named_test_resource" {

Use the aws_secretsmanager_secret_rotation resource instead

(and 2 more similar warnings elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "632902152528"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:secretsmanager:us-east-1:632902152528:secret:turbottest14961-EBSrND"
resource_name = "turbottest14961"

Running SQL query: test-get-query.sql
[
  {
    "account_id": "632902152528",
    "akas": [
      "arn:aws:secretsmanager:us-east-1:632902152528:secret:turbottest14961-EBSrND"
    ],
    "arn": "arn:aws:secretsmanager:us-east-1:632902152528:secret:turbottest14961-EBSrND",
    "deleted_date": null,
    "description": "Test secret.",
    "kms_key_id": null,
    "last_accessed_date": null,
    "last_rotated_date": null,
    "name": "turbottest14961",
    "owning_service": null,
    "partition": "aws",
    "primary_region": null,
    "region": "us-east-1",
    "replication_status": null,
    "rotation_enabled": null,
    "rotation_lambda_arn": null,
    "rotation_rules": null,
    "secret_versions_to_stages": null,
    "tags": {
      "foo": "bar"
    },
    "tags_src": [
      {
        "Key": "foo",
        "Value": "bar"
      }
    ],
    "title": "turbottest14961"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:secretsmanager:us-east-1:632902152528:secret:turbottest14961-EBSrND",
    "name": "turbottest14961",
    "region": "us-east-1"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "632902152528",
    "akas": [
      "arn:aws:secretsmanager:us-east-1:632902152528:secret:turbottest14961-EBSrND"
    ],
    "arn": "arn:aws:secretsmanager:us-east-1:632902152528:secret:turbottest14961-EBSrND",
    "name": "turbottest14961",
    "region": "us-east-1",
    "tags": {
      "foo": "bar"
    },
    "title": "turbottest14961"
  }
]
✔ PASSED

POSTTEST: tests/aws_secretsmanager_secret

TEARDOWN: tests/aws_secretsmanager_secret

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  created_date,
  description,
  last_accessed_date
from
  aws_secretsmanager_secret;
+-------------+---------------------+---------------------------------+--------------------+
| name        | created_date        | description                     | last_accessed_date |
+-------------+---------------------+---------------------------------+--------------------+
| testSecret2 | 2021-11-09 08:56:04 | This is another secret for test | <null>             |
| testSecret  | 2021-11-09 07:46:54 | This is a test secret           | <null>             |
+-------------+---------------------+---------------------------------+--------------------+
> select
  name,
  created_date,
  description,
  rotation_enabled
from
  aws_secretsmanager_secret
where
  not rotation_enabled;
+------+--------------+-------------+------------------+
| name | created_date | description | rotation_enabled |
+------+--------------+-------------+------------------+
+------+--------------+-------------+------------------+
> select
  name,
  created_date,
  description,
  rotation_enabled,
  rotation_rules
from
  aws_secretsmanager_secret
where
  rotation_rules -> 'AutomaticallyAfterDays' > '7';
+------+--------------+-------------+------------------+----------------+
| name | created_date | description | rotation_enabled | rotation_rules |
+------+--------------+-------------+------------------+----------------+
+------+--------------+-------------+------------------+----------------+
> select
  name,
  created_date,
  description,
  replication_status
from
  aws_secretsmanager_secret
where
  replication_status is null;
+-------------+---------------------+---------------------------------+--------------------+
| name        | created_date        | description                     | replication_status |
+-------------+---------------------+---------------------------------+--------------------+
| testSecret2 | 2021-11-09 08:56:04 | This is another secret for test | <null>             |
| testSecret  | 2021-11-09 07:46:54 | This is a test secret           | <null>             |
+-------------+---------------------+---------------------------------+--------------------+
> select
  name,
  jsonb_pretty(policy) as policy,
  jsonb_pretty(policy_std) as policy_std
from
  aws_secretsmanager_secret;
+-------------+---------------------------------------------------------+------------------------------------------------------+
| name        | policy                                                  | policy_std                                           |
+-------------+---------------------------------------------------------+------------------------------------------------------+
| testSecret2 | <null>                                                  | <null>                                               |
| testSecret  | {                                                       | {                                                    |
|             |     "Version": "2012-10-17",                            |     "Version": "2012-10-17",                         |
|             |     "Statement": [                                      |     "Statement": [                                   |
|             |         {                                               |         {                                            |
|             |             "Action": "secretsmanager:GetSecretValue",  |             "Action": [                              |
|             |             "Effect": "Allow",                          |                 "secretsmanager:getsecretvalue"      |
|             |             "Resource": "*",                            |             ],                                       |
|             |             "Principal": {                              |             "Effect": "Allow",                       |
|             |                 "AWS": "arn:aws:iam::632902152528:root" |             "Resource": [                            |
|             |             }                                           |                 "*"                                  |
|             |         }                                               |             ],                                       |
|             |     ]                                                   |             "Principal": {                           |
|             | }                                                       |                 "AWS": [                             |
|             |                                                         |                     "arn:aws:iam::632902152528:root" |
|             |                                                         |                 ]                                    |
|             |                                                         |             }                                        |
|             |                                                         |         }                                            |
|             |                                                         |     ]                                                |
|             |                                                         | }                                                    |
+-------------+---------------------------------------------------------+------------------------------------------------------+
```
</details>
