### PR TITLE
Add filter example queries Closes #744

### DIFF
--- a/docs/tables/aws_cloudwatch_log_event.md
+++ b/docs/tables/aws_cloudwatch_log_event.md
@@ -107,8 +107,8 @@ from
 where
   log_group_name = 'cis/test-log-grp'
   and filter = '{$.eventName = "AuthorizeSecurityGroupIngress"}'
-  and region='us-east-1'
-  and timestamp >= now() - interval '2 hours'
+  and region = 'us-east-1'
+  and timestamp >= now() - interval '3 hours'
 ```
 
 ### List events containing either of the **eventName** in the pattern
@@ -125,8 +125,8 @@ from
   aws_cloudwatch_log_event
 where
   log_group_name = 'cis/test-log-grp'
-  and filter = '{ ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup) }'
-  and region='us-east-1'
+  and filter = '{($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup)}'
+  and region = 'us-east-1'
   and timestamp >= now() - interval '1 hour'
 
 ```

--- a/docs/tables/aws_cloudwatch_log_event.md
+++ b/docs/tables/aws_cloudwatch_log_event.md
@@ -7,7 +7,7 @@ This table lists events from a CloudWatch log group.
 **Important notes:**
 
 - You **_must_** specify `log_group_name` in a `where` clause in order to use this table.
-- This table supports optional quals. Queries with optional quals are optimised to used CloudWatch filters. Optional quals are supported for the following columns:
+- This table supports optional quals. Queries with optional quals are optimised to use CloudWatch filters. Optional quals are supported for the following columns:
   - `filter`
   - `log_stream_name`
   - `region`
@@ -72,7 +72,7 @@ from
   aws_cloudwatch_log_event
 where
   log_group_name = 'cis/test-log-grp'
-  and filter = '{$.eventName="DescribeVpcs"}'
+  and filter = '{$.eventName="DescribeVpcs"}';
 ```
 
 ### List events with filter pattern based on **errorCode**
@@ -89,7 +89,7 @@ from
   aws_cloudwatch_log_event
 where
   log_group_name = 'cis/test-log-grp'
-  and filter = '{ ($.errorCode = "*UnauthorizedOperation") || ($.errorCode = "AccessDenied*") }'
+  and filter = '{ ($.errorCode = "*UnauthorizedOperation") || ($.errorCode = "AccessDenied*") }';
 ```
 
 ### List events with specific time frame in hour(s)
@@ -108,7 +108,7 @@ where
   log_group_name = 'cis/test-log-grp'
   and filter = '{$.eventName = "AuthorizeSecurityGroupIngress"}'
   and region = 'us-east-1'
-  and timestamp >= now() - interval '3 hours'
+  and timestamp >= now() - interval '3 hours';
 ```
 
 ### List events containing either of the **eventName** in the pattern
@@ -127,8 +127,7 @@ where
   log_group_name = 'cis/test-log-grp'
   and filter = '{($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup)}'
   and region = 'us-east-1'
-  and timestamp >= now() - interval '1 hour'
-
+  and timestamp >= now() - interval '1 hour';
 ```
 
 ### List events with specific attributes
@@ -146,5 +145,5 @@ from
 where
   log_group_name = 'cis/test-log-grp'
   and filter = '{$.userIdentity.sessionContext.sessionIssuer.userName="turbot_superuser"}'
-  and timestamp >= now() - interval '1 day'
+  and timestamp >= now() - interval '1 day';
 ```

--- a/docs/tables/aws_cloudwatch_log_event.md
+++ b/docs/tables/aws_cloudwatch_log_event.md
@@ -35,10 +35,6 @@ where
   log_group_name = '/aws/lambda/myfunction';
 ```
 
-## Filter Examples
-
-For more information on CloudWatch log filters, please refer to [Filter Pattern Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html).
-
 ### List events for the last 1 hour
 
 ```sql
@@ -56,4 +52,99 @@ where
   timestamp > ('now'::timestamp - interval '1 hr')
 order by
   timestamp asc;
+```
+
+## Filter Examples
+
+For more information on CloudWatch log filters, please refer to [Filter Pattern Syntax](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/FilterAndPatternSyntax.html).
+
+### List events with specific filter pattern based on **eventName**
+
+```sql
+select
+  log_group_name,
+  log_stream_name,
+  event_id,
+  timestamp,
+  ingestion_time,
+  message
+from
+  aws_cloudwatch_log_event
+where
+  log_group_name = 'cis/test-log-grp'
+  and filter = '{$.eventName="DescribeVpcs"}'
+```
+
+### List events with filter pattern based on **errorCode**
+
+```sql
+select
+  log_group_name,
+  log_stream_name,
+  event_id,
+  timestamp,
+  ingestion_time,
+  message
+from
+  aws_cloudwatch_log_event
+where
+  log_group_name = 'cis/test-log-grp'
+  and filter = '{ ($.errorCode = "*UnauthorizedOperation") || ($.errorCode = "AccessDenied*") }'
+```
+
+### List events with specific time frame in hour(s)
+
+```sql
+select
+  log_group_name,
+  log_stream_name,
+  event_id,
+  timestamp,
+  ingestion_time,
+  message
+from
+  aws_cloudwatch_log_event
+where
+  log_group_name = 'cis/test-log-grp'
+  and filter = '{$.eventName = "AuthorizeSecurityGroupIngress"}'
+  and region='us-east-1'
+  and timestamp >= now() - interval '2 hours'
+```
+
+### List events containing either of the **eventName** in the pattern
+
+```sql
+select
+  log_group_name,
+  log_stream_name,
+  event_id,
+  timestamp,
+  ingestion_time,
+  message
+from
+  aws_cloudwatch_log_event
+where
+  log_group_name = 'cis/test-log-grp'
+  and filter = '{ ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup) }'
+  and region='us-east-1'
+  and timestamp >= now() - interval '1 hour'
+
+```
+
+### List events with specific attributes
+
+```sql
+select
+  log_group_name,
+  log_stream_name,
+  event_id,
+  timestamp,
+  ingestion_time,
+  message
+from
+  aws_cloudwatch_log_event
+where
+  log_group_name = 'cis/test-log-grp'
+  and filter = '{$.userIdentity.sessionContext.sessionIssuer.userName="turbot_superuser"}'
+  and timestamp >= now() - interval '1 day'
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  log_group_name,
  log_stream_name,
  event_id,
  timestamp,
  ingestion_time,
  message
from
  aws_cloudwatch_log_event
where
  log_group_name = 'raj-test-cis-4.2' and filter = '{ ($.eventName = AuthorizeSecurityGroupIngress) || ($.eventName = AuthorizeSecurityGroupEgress) || ($.eventName = RevokeSecurityGroupIngress) || ($.eventName = RevokeSecurityGroupEgress) || ($.eventName = CreateSecurityGroup) || ($.eventName = DeleteSecurityGroup) }'
  and region='us-east-1'
  and timestamp >= now() - interval '1 hour'
+------------------+-------------------------------------+----------------------------------------------------------+----------------------+----------------------+-------------------------------------------------
| log_group_name   | log_stream_name                     | event_id                                                 | timestamp            | ingestion_time       | message                                         
+------------------+-------------------------------------+----------------------------------------------------------+----------------------+----------------------+-------------------------------------------------
| raj-test-cis-4.2 | 556793682495_CloudTrail_us-east-1_3 | 36494365165152644600776787039832720274149703442300076263 | 2021-11-09T13:18:51Z | 2021-11-09T13:18:51Z | {"eventVersion":"1.08","userIdentity":{"type":"A
|                  |                                     |                                                          |                      |                      | }]}},"responseElements":{"requestId":"d623ec8f-1
| raj-test-cis-4.2 | 556793682495_CloudTrail_us-east-1_3 | 36494365165130343855578256416691184555877055080794095821 | 2021-11-09T13:18:51Z | 2021-11-09T13:18:51Z | {"eventVersion":"1.08","userIdentity":{"type":"F
|                  |                                     |                                                          |                      |                      | 22,"groups":{},"ipRanges":{"items":[{"cidrIp":"1
| raj-test-cis-4.2 | 556793682495_CloudTrail_us-east-1   | 36494443477564521020839546259049035079702891080155922527 | 2021-11-09T14:17:23Z | 2021-11-09T14:17:23Z | {"eventVersion":"1.08","userIdentity":{"type":"F
|                  |                                     |                                                          |                      |                      | n":true},"requestID":"350b5a73-781c-452a-b74d-78
| raj-test-cis-4.2 | 556793682495_CloudTrail_us-east-1   | 36494443477497618785243954389624427924884945995637981233 | 2021-11-09T14:17:23Z | 2021-11-09T14:17:23Z | {"eventVersion":"1.08","userIdentity":{"type":"F
|                  |                                     |                                                          |                      |                      | ements":{"requestId":"325bab67-6a1a-4995-b774-c0
+------------------+-------------------------------------+----------------------------------------------------------+----------------------+----------------------+-------------------------------------------------
>
```

```
select
  log_group_name,
  log_stream_name,
  event_id,
  timestamp,
  ingestion_time,
  message
from
  aws_cloudwatch_log_event
where
  log_group_name = 'raj-test-cis-4.2' and filter = '{$.eventName = "AuthorizeSecurityGroupIngress"}'
  and region='us-east-1' and timestamp >= now() - interval '1 hrs'
+------------------+-------------------------------------+----------------------------------------------------------+----------------------+----------------------+-------------------------------------------------
| log_group_name   | log_stream_name                     | event_id                                                 | timestamp            | ingestion_time       | message                                         
+------------------+-------------------------------------+----------------------------------------------------------+----------------------+----------------------+-------------------------------------------------
| raj-test-cis-4.2 | 531233682495_CloudTrail_us-east-1_3 | 36494365165130343855578256416691184555877055080794095821 | 2021-11-09T13:18:51Z | 2021-11-09T13:18:51Z | {"eventVersion":"1.08","userIdentity":{"type":"F
|                  |                                     |                                                          |                      |                      | 22,"groups":{},"ipRanges":{"items":[{"cidrIp":"1
+------------------+-------------------------------------+----------------------------------------------------------+----------------------+----------------------+-------------------------------------------------
```
</details>
