### PR TITLE
Update the error message for table aws_iam_credential_report. Closes #755

### DIFF
--- a/aws/table_aws_iam_credential_report.go
+++ b/aws/table_aws_iam_credential_report.go
@@ -214,7 +214,7 @@ func listCredentialReports(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	if err != nil {
 		if a, ok := err.(awserr.Error); ok {
 			if helpers.StringSliceContains([]string{"ReportNotPresent"}, a.Code()) {
-				return nil, errors.New("No credential report was found. You can generate one with " + chalk.Bold.TextStyle("aws iam generate-credential-report"))
+				return nil, errors.New("Credential report not available. Please run " + chalk.Bold.TextStyle("aws iam generate-credential-report") + " to generate it and try again.")
 			}
 		}
 		return nil, err


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  -- Required Columns
  user_arn as resource,
  case
    when password_enabled and not mfa_active then 'alarm'
    else 'ok'
  end as status,
  case
    when not password_enabled then user_name || ' password login disabled.'
    when password_enabled and not mfa_active then user_name || ' password login enabled but no MFA device configured.'
    else user_name || ' password login enabled and MFA device configured.'
  end as reason,
  -- Additional Dimensions
  account_id
from
  aws_iam_credential_report;
Error: Credential report not available. Please run aws iam generate-credential-report to generate it and try again.
> 

```
</details>
