### PR TITLE
Add policy and policy_std columns to the aws_glue_catalog_database table. Closes #719

### DIFF
--- a/docs/tables/aws_glue_catalog_database.md
+++ b/docs/tables/aws_glue_catalog_database.md
@@ -18,7 +18,6 @@ from
   aws_glue_catalog_database;
 ```
 
-
 ### Count the number of databases per catalog
 
 ```sql
@@ -29,4 +28,18 @@ from
   aws_glue_catalog_database
 group by
   catalog_id;
+```
+
+### List policy details for catalog databases
+
+```sql
+select
+  name,
+  jsonb_pretty(policy) as policy,
+  policy_create_time,
+  policy_hash,
+  jsonb_pretty(policy_std) as policy_std,
+  policy_update_time
+from
+  aws_glue_catalog_database;
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro aws-test % ./tint.js aws_glue_catalog_database
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_glue_catalog_database []

PRETEST: tests/aws_glue_catalog_database

TEST: tests/aws_glue_catalog_database
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_glue_catalog_database.named_test_resource will be created
  + resource "aws_glue_catalog_database" "named_test_resource" {
      + arn          = (known after apply)
      + catalog_id   = (known after apply)
      + description  = "integration testing"
      + id           = (known after apply)
      + location_uri = (known after apply)
      + name         = "turbottest47290"
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + aws_account   = "632912342528"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest47290"
aws_glue_catalog_database.named_test_resource: Creating...
aws_glue_catalog_database.named_test_resource: Creation complete after 2s [id=632912342528:turbottest47290]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

aws_account = "632912342528"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:glue:us-east-1:632912342528:database/turbottest47290"
resource_name = "turbottest47290"

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:glue:us-east-1:632912342528:database/turbottest47290"
    ],
    "catalog_id": "632912342528",
    "create_table_default_permissions": [
      {
        "Permissions": [
          "ALL"
        ],
        "Principal": {
          "DataLakePrincipalIdentifier": "IAM_ALLOWED_PRINCIPALS"
        }
      }
    ],
    "description": "integration testing",
    "location_uri": null,
    "name": "turbottest47290",
    "title": "turbottest47290"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:glue:us-east-1:632912342528:database/turbottest47290"
    ],
    "title": "turbottest47290"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "description": "integration testing",
    "name": "turbottest47290",
    "partition": "aws",
    "region": "us-east-1",
    "title": "turbottest47290"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:glue:us-east-1:632912342528:database/turbottest47290"
    ],
    "name": "turbottest47290",
    "region": "us-east-1",
    "title": "turbottest47290"
  }
]
✔ PASSED

POSTTEST: tests/aws_glue_catalog_database

TEARDOWN: tests/aws_glue_catalog_database

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  catalog_id,
  create_time,
  description,
  location_uri,
  create_table_default_permissions
from
  aws_glue_catalog_database;
+--------------+--------------+---------------------+-------------+--------------+------------------------------------------------------------------------------------------------+
| name         | catalog_id   | create_time         | description | location_uri | create_table_default_permissions                                                               |
+--------------+--------------+---------------------+-------------+--------------+------------------------------------------------------------------------------------------------+
| testdatabase | 632912342528 | 2021-11-12 10:40:09 | <null>      | <null>       | [{"Permissions":["ALL"],"Principal":{"DataLakePrincipalIdentifier":"IAM_ALLOWED_PRINCIPALS"}}] |
+--------------+--------------+---------------------+-------------+--------------+------------------------------------------------------------------------------------------------+
> select
  catalog_id,
  count(name) as database_count
from
  aws_glue_catalog_database
group by
  catalog_id;
+--------------+----------------+
| catalog_id   | database_count |
+--------------+----------------+
| 632912342528 | 1              |
+--------------+----------------+
> select
  name,
  jsonb_pretty(policy) as policy,
  policy_create_time,
  policy_hash,
  jsonb_pretty(policy_std) as policy_std,
  policy_update_time
from
  aws_glue_catalog_database;
+--------------+----------------------------------------------------------------------------+---------------------+--------------------------+-------------------------------------------------------------------+---------------------+
| name         | policy                                                                     | policy_create_time  | policy_hash              | policy_std                                                        | policy_update_time  |
+--------------+----------------------------------------------------------------------------+---------------------+--------------------------+-------------------------------------------------------------------+---------------------+
| testdatabase | {                                                                          | 2021-11-12 11:24:25 | oDrh8G/E4RV1234yVq9xKQ== | {                                                                 | 2021-11-12 11:24:25 |
|              |     "Version": "2012-10-17",                                               |                     |                          |     "Version": "2012-10-17",                                      |                     |
|              |     "Statement": [                                                         |                     |                          |     "Statement": [                                                |                     |
|              |         {                                                                  |                     |                          |         {                                                         |                     |
|              |             "Action": "glue:CreateTable",                                  |                     |                          |             "Action": [                                           |                     |
|              |             "Effect": "Allow",                                             |                     |                          |                 "glue:createtable"                                |                     |
|              |             "Resource": "arn:aws:glue:us-east-1:632912342528:table/db1/*", |                     |                          |             ],                                                    |                     |
|              |             "Principal": {                                                 |                     |                          |             "Effect": "Allow",                                    |                     |
|              |                 "AWS": "arn:aws:iam::632912342528:root"                    |                     |                          |             "Resource": [                                         |                     |
|              |             }                                                              |                     |                          |                 "arn:aws:glue:us-east-1:632912342528:table/db1/*" |                     |
|              |         }                                                                  |                     |                          |             ],                                                    |                     |
|              |     ]                                                                      |                     |                          |             "Principal": {                                        |                     |
|              | }                                                                          |                     |                          |                 "AWS": [                                          |                     |
|              |                                                                            |                     |                          |                     "arn:aws:iam::632912342528:root"              |                     |
|              |                                                                            |                     |                          |                 ]                                                 |                     |
|              |                                                                            |                     |                          |             }                                                     |                     |
|              |                                                                            |                     |                          |         }                                                         |                     |
|              |                                                                            |                     |                          |     ]                                                             |                     |
|              |                                                                            |                     |                          | }                                                                 |                     |
+--------------+----------------------------------------------------------------------------+---------------------+--------------------------+-------------------------------------------------------------------+---------------------+
```
</details>
