### PR TITLE
Fix  no such host error in aws_ecrpublic_repository. Closes#766

### DIFF
--- a/aws/service.go
+++ b/aws/service.go
@@ -613,18 +613,15 @@ func EcrService(ctx context.Context, d *plugin.QueryData) (*ecr.ECR, error) {
 
 // EcrPublicService returns the service connection for AWS ECRPublic service
 func EcrPublicService(ctx context.Context, d *plugin.QueryData) (*ecrpublic.ECRPublic, error) {
-	region := d.KeyColumnQualString(matrixKeyRegion)
-	if region == "" {
-		return nil, fmt.Errorf("region must be passed EcrPublicService")
-	}
 	// have we already created and cached the service?
-	serviceCacheKey := fmt.Sprintf("ecrpublic-%s", region)
+	serviceCacheKey := fmt.Sprintf("ecrpublic-%s", "region")
 	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
 		return cachedData.(*ecrpublic.ECRPublic), nil
 	}
 
 	// so it was not in cache - create service
-	sess, err := getSession(ctx, d, region)
+	// DescribeRepositories command is only supported in us-east-1
+	sess, err := getSession(ctx, d, "")
 	if err != nil {
 		return nil, err
 	}

--- a/aws/service.go
+++ b/aws/service.go
@@ -613,15 +613,18 @@ func EcrService(ctx context.Context, d *plugin.QueryData) (*ecr.ECR, error) {
 
 // EcrPublicService returns the service connection for AWS ECRPublic service
 func EcrPublicService(ctx context.Context, d *plugin.QueryData) (*ecrpublic.ECRPublic, error) {
+	region := d.KeyColumnQualString(matrixKeyRegion)
+	if region == "" {
+		return nil, fmt.Errorf("region must be passed EcrPublicService")
+	}
 	// have we already created and cached the service?
-	serviceCacheKey := fmt.Sprintf("ecrpublic-%s", "region")
+	serviceCacheKey := fmt.Sprintf("ecrpublic-%s", region)
 	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
 		return cachedData.(*ecrpublic.ECRPublic), nil
 	}
 
 	// so it was not in cache - create service
-	// DescribeRepositories command is only supported in us-east-1
-	sess, err := getSession(ctx, d, "")
+	sess, err := getSession(ctx, d, region)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/table_aws_ecrpublic_repository.go
+++ b/aws/table_aws_ecrpublic_repository.go
@@ -25,7 +25,6 @@ func tableAwsEcrpublicRepository(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listAwsEcrpublicRepositories,
 		},
-		GetMatrixItem: BuildRegionList,
 		Columns: awsRegionalColumns([]*plugin.Column{
 			{
 				Name:        "repository_name",

--- a/aws/table_aws_ecrpublic_repository.go
+++ b/aws/table_aws_ecrpublic_repository.go
@@ -25,6 +25,7 @@ func tableAwsEcrpublicRepository(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listAwsEcrpublicRepositories,
 		},
+		GetMatrixItem: BuildRegionList,
 		Columns: awsRegionalColumns([]*plugin.Column{
 			{
 				Name:        "repository_name",
@@ -100,6 +101,14 @@ func tableAwsEcrpublicRepository(_ context.Context) *plugin.Table {
 //// LIST FUNCTION
 
 func listAwsEcrpublicRepositories(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	// https://docs.aws.amazon.com/AmazonECR/latest/public/getting-started-cli.html
+	// DescribeRepositories command is only supported in us-east-1
+	region := d.KeyColumnQualString(matrixKeyRegion)
+
+	if region != "us-east-1" {
+		return nil, nil
+	}
+
 	// Create Session
 	svc, err := EcrPublicService(ctx, d)
 	if err != nil {
@@ -126,6 +135,14 @@ func listAwsEcrpublicRepositories(ctx context.Context, d *plugin.QueryData, _ *p
 func getAwsEcrpublicRepository(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 	logger.Trace("getAwsEcrpublicRepository")
+
+	region := d.KeyColumnQualString(matrixKeyRegion)
+
+	// https://docs.aws.amazon.com/AmazonECR/latest/public/getting-started-cli.html
+	// DescribeRepositories command is only supported in us-east-1
+	if region != "us-east-1" {
+		return nil, nil
+	}
 
 	name := d.KeyColumnQuals["repository_name"].GetStringValue()
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_ecrpublic_repository []

PRETEST: tests/aws_ecrpublic_repository

TEST: tests/aws_ecrpublic_repository
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ecrpublic_repository.named_test_resource will be created
  + resource "aws_ecrpublic_repository" "named_test_resource" {
      + arn             = (known after apply)
      + force_destroy   = false
      + id              = (known after apply)
      + registry_id     = (known after apply)
      + repository_name = "turbottest79051"
      + repository_uri  = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "533793682495"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + registry_id   = (known after apply)
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest79051"
aws_ecrpublic_repository.named_test_resource: Creating...
aws_ecrpublic_repository.named_test_resource: Creation complete after 4s [id=turbottest79051]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "533793682495"
aws_partition = "aws"
aws_region = "us-east-1"
registry_id = "533793682495"
resource_aka = "arn:aws:ecr-public::533793682495:repository/turbottest79051"
resource_id = "turbottest79051"
resource_name = "turbottest79051"

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:ecr-public::533793682495:repository/turbottest79051"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "repository_name": "turbottest79051"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ecr-public::533793682495:repository/turbottest79051"
    ],
    "repository_name": "turbottest79051",
    "title": "turbottest79051"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:ecr-public::533793682495:repository/turbottest79051",
    "partition": "aws",
    "region": "us-east-1",
    "repository_name": "turbottest79051"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "533793682495",
    "akas": [
      "arn:aws:ecr-public::533793682495:repository/turbottest79051"
    ],
    "region": "us-east-1",
    "title": "turbottest79051"
  }
]
✔ PASSED

POSTTEST: tests/aws_ecrpublic_repository

TEARDOWN: tests/aws_ecrpublic_repository

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  repository_name,
  registry_id,
  arn,
  repository_uri,
  created_at,
  region,
  account_id
from
  aws_ecrpublic_repository;
+-----------------+--------------+---------------------------------------------------+-------------------------------+----------------------+-----------+--------------+
| repository_name | registry_id  | arn                                               | repository_uri                | created_at           | region    | account_id   |
+-----------------+--------------+---------------------------------------------------+-------------------------------+----------------------+-----------+--------------+
| test1           | 533793682495 | arn:aws:ecr-public::533793682495:repository/test1 | public.ecr.aws/t6b3c9t0/test1 | 2021-11-15T14:59:00Z | us-east-1 | 533793682495 |
| test            | 533793682495 | arn:aws:ecr-public::533793682495:repository/test  | public.ecr.aws/t6b3c9t0/test  | 2021-11-15T14:56:46Z | us-east-1 | 533793682495 |
+-----------------+--------------+---------------------------------------------------+-------------------------------+----------------------+-----------+--------------+
```
</details>
