### PR TITLE
Fix integration tests for steampipe-plugin-sdk v1.8.0 closes #768

### DIFF
--- a/aws-test/tests/aws_accessanalyzer_analyzer/variables.tf
+++ b/aws-test/tests/aws_accessanalyzer_analyzer/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "integration-tests"
+  default     = "default"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_ec2_application_load_balancer/test-hydrate-expected.json
+++ b/aws-test/tests/aws_ec2_application_load_balancer/test-hydrate-expected.json
@@ -31,11 +31,19 @@
         "Value": "false"
       },
       {
+        "Key": "routing.http.xff_client_port.enabled",
+        "Value": "false"
+      },
+      {
         "Key": "routing.http.desync_mitigation_mode",
         "Value": "defensive"
       },
       {
         "Key": "waf.fail_open.enabled",
+        "Value": "false"
+      },
+      {
+        "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
         "Value": "false"
       }
     ],

--- a/aws-test/tests/aws_ec2_application_load_balancer/variables.tf
+++ b/aws-test/tests/aws_ec2_application_load_balancer/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "integration-tests"
+  default     = "default"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_ec2_autoscaling_group/test-hydrate-expected.json
+++ b/aws-test/tests/aws_ec2_autoscaling_group/test-hydrate-expected.json
@@ -15,6 +15,7 @@
         "PolicyARN": "{{ output.policy_arn.value }}",
         "PolicyName": "{{resourceName}}",
         "PolicyType": "SimpleScaling",
+        "PredictiveScalingConfiguration": null,
         "ScalingAdjustment": 4,
         "StepAdjustments": null,
         "TargetTrackingConfiguration": null

--- a/aws-test/tests/aws_elastic_beanstalk_environment/test-get-expected.json
+++ b/aws-test/tests/aws_elastic_beanstalk_environment/test-get-expected.json
@@ -6,20 +6,11 @@
     "environment_name": "{{ output.resource_name.value }}",
     "partition": "{{ output.aws_partition.value }}",
     "region": "{{ output.aws_region.value }}",
-    "tags": [
-      {
-        "Key": "elasticbeanstalk:environment-name",
-        "Value": "{{ output.resource_name.value }}"
-      },
-      {
-        "Key": "elasticbeanstalk:environment-id",
-        "Value": "{{ output.resource_id.value }}"
-      },
-      {
-        "Key": "Name",
-        "Value": "{{ output.resource_name.value }}"
-      }
-    ],
+    "tags": {
+      "Name": "{{ output.resource_name.value }}",
+      "elasticbeanstalk:environment-id": "{{ output.resource_id.value }}",
+      "elasticbeanstalk:environment-name": "{{ output.resource_name.value }}"
+    },
     "title": "{{ output.resource_name.value }}"
   }
 ]

--- a/aws-test/tests/aws_elastic_beanstalk_environment/test-hydrate-expected.json
+++ b/aws-test/tests/aws_elastic_beanstalk_environment/test-hydrate-expected.json
@@ -2,20 +2,11 @@
   {
     "akas": ["{{output.resource_aka.value}}"],
     "environment_name": "{{ output.resource_name.value }}",
-    "tags": [
-      {
-        "Key": "elasticbeanstalk:environment-name",
-        "Value": "{{ output.resource_name.value }}"
-      },
-      {
-        "Key": "elasticbeanstalk:environment-id",
-        "Value": "{{ output.resource_id.value }}"
-      },
-      {
-        "Key": "Name",
-        "Value": "{{ output.resource_name.value }}"
-      }
-    ],
+    "tags": {
+      "Name": "{{ output.resource_name.value }}",
+      "elasticbeanstalk:environment-id": "{{ output.resource_id.value }}",
+      "elasticbeanstalk:environment-name": "{{ output.resource_name.value }}"
+    },
     "title": "{{ output.resource_name.value }}"
   }
 ]

--- a/aws-test/tests/aws_elastic_beanstalk_environment/variables.tf
+++ b/aws-test/tests/aws_elastic_beanstalk_environment/variables.tf
@@ -126,13 +126,6 @@ resource "aws_security_group" "ssh-allowed" {
     }
 }
 
-#  aws_iam_service_linked_role is managed by AWS itself we can not create/modify/delete it.
-# https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html?icmpid=docs_iam_console#iam-term-service-linked-role
-
-# resource "aws_iam_service_linked_role" "elasticbeanstalk" {
-#    aws_service_name = "elasticbeanstalk.amazonaws.com"
-#    }
-
 resource "aws_elastic_beanstalk_application" "application_test" {
   name = var.resource_name
   appversion_lifecycle {

--- a/aws-test/tests/aws_elastic_beanstalk_environment/variables.tf
+++ b/aws-test/tests/aws_elastic_beanstalk_environment/variables.tf
@@ -52,7 +52,7 @@ resource "aws_iam_instance_profile" "instance_profile" {
 }
 
 resource "aws_iam_role" "role" {
-  name = "test_role"
+  name = var.resource_name
   path = "/"
 
   assume_role_policy = <<EOF
@@ -126,21 +126,24 @@ resource "aws_security_group" "ssh-allowed" {
     }
 }
 
-resource "aws_iam_service_linked_role" "elasticbeanstalk" {
-   aws_service_name = "elasticbeanstalk.amazonaws.com"
-   }
+#  aws_iam_service_linked_role is managed by AWS itself we can not create/modify/delete it.
+# https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_terms-and-concepts.html?icmpid=docs_iam_console#iam-term-service-linked-role
+
+# resource "aws_iam_service_linked_role" "elasticbeanstalk" {
+#    aws_service_name = "elasticbeanstalk.amazonaws.com"
+#    }
 
 resource "aws_elastic_beanstalk_application" "application_test" {
   name = var.resource_name
   appversion_lifecycle {
-    service_role = "${aws_iam_service_linked_role.elasticbeanstalk.arn}"
+    service_role = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/aws-service-role/elasticbeanstalk.amazonaws.com/AWSServiceRoleForElasticBeanstalk"
   }
 }
 
 resource "aws_elastic_beanstalk_environment" "named_test_resource" {
   name                   = var.resource_name
   application            = "${aws_elastic_beanstalk_application.application_test.name}"
-  solution_stack_name    = "64bit Amazon Linux 2 v3.2.0 running Go 1"
+  solution_stack_name    = "64bit Amazon Linux 2 v3.4.2 running Go 1"
   wait_for_ready_timeout = "45m"
   setting {
     namespace = "aws:autoscaling:launchconfiguration"

--- a/aws-test/tests/aws_elasticache_replication_group/variables.tf
+++ b/aws-test/tests/aws_elasticache_replication_group/variables.tf
@@ -67,7 +67,7 @@ resource "aws_elasticache_replication_group" "named_test_resource" {
   node_type                     = "cache.t2.micro"
   number_cache_clusters         = 2
   parameter_group_name          = "default.redis5.0"
-  engine_version                = "5.0"
+  engine_version                = "5.0.6"
   port                          = 6379
   subnet_group_name             = aws_elasticache_subnet_group.my_subnet_group.id
 }

--- a/aws-test/tests/aws_guardduty_finding/variables.tf
+++ b/aws-test/tests/aws_guardduty_finding/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "integration-tests"
+  default     = "default"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_kinesis_firehose_delivery_stream/variables.tf
+++ b/aws-test/tests/aws_kinesis_firehose_delivery_stream/variables.tf
@@ -6,13 +6,13 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "integration-tests"
+  default     = "default"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 
 variable "aws_region" {
   type        = string
-  default     = "us-east-1"
+  default     = "ap-southeast-1"
   description = "AWS region used for the test. Does not work with default region in config, so must be defined here."
 }
 
@@ -47,7 +47,7 @@ data "null_data_source" "resource" {
 }
 
 resource "aws_s3_bucket" "firehose_bucket" {
-  bucket = "tf-firehose-bucket"
+  bucket = var.resource_name
   acl    = "private"
 }
 

--- a/aws-test/tests/aws_s3_bucket/test-hydrate-expected.json
+++ b/aws-test/tests/aws_s3_bucket/test-hydrate-expected.json
@@ -32,12 +32,12 @@
             "Prefix": "log/",
             "Tags": [
               {
-                "Key": "rule",
-                "Value": "log"
-              },
-              {
                 "Key": "autoclean",
                 "Value": "true"
+              },
+              {
+                "Key": "rule",
+                "Value": "log"
               }
             ]
           },

--- a/aws-test/tests/aws_s3_bucket/test-list-expected.json
+++ b/aws-test/tests/aws_s3_bucket/test-list-expected.json
@@ -20,12 +20,12 @@
             "Prefix": "log/",
             "Tags": [
               {
-                "Key": "rule",
-                "Value": "log"
-              },
-              {
                 "Key": "autoclean",
                 "Value": "true"
+              },
+              {
+                "Key": "rule",
+                "Value": "log"
               }
             ]
           },

--- a/aws-test/tests/aws_ssm_managed_instance/test-list-expected.json
+++ b/aws-test/tests/aws_ssm_managed_instance/test-list-expected.json
@@ -5,7 +5,7 @@
     "instance_id": "{{ output.resource_id.value }}",
     "platform_name": "Amazon Linux",
     "platform_type": "Linux",
-    "platform_version": 2,
+    "platform_version": "2",
     "resource_type": "EC2Instance"
   }
 ]

--- a/aws-test/tests/aws_ssm_managed_instance/variables.tf
+++ b/aws-test/tests/aws_ssm_managed_instance/variables.tf
@@ -47,10 +47,19 @@ data "null_data_source" "resource" {
   }
 }
 
-resource "aws_default_vpc" "default" {}
+resource "aws_vpc" "main" {
+  cidr_block = "10.0.0.0/16"
+  tags = {
+    name = var.resource_name
+  }
+}
 
-resource "aws_default_subnet" "default_subnet" {
-  availability_zone = "${var.aws_region}c"
+resource "aws_subnet" "named_test_resource" {
+  vpc_id     = aws_vpc.main.id
+  cidr_block = "10.0.1.0/24"
+  tags = {
+    Name = var.resource_name
+  }
 }
 
 data "aws_ami" "linux" {
@@ -91,7 +100,7 @@ resource "aws_iam_instance_profile" "named_test_resource" {
 resource "aws_instance" "named_test_resource" {
   ami                         = data.aws_ami.linux.id
   instance_type               = "t2.micro"
-  subnet_id                   = aws_default_subnet.default_subnet.id
+  subnet_id                   = aws_subnet.named_test_resource.id
   associate_public_ip_address = true
   iam_instance_profile        = aws_iam_instance_profile.named_test_resource.name
   tags = {

--- a/aws-test/tests/aws_wafv2_rule_group/test-getGlobal-expected.json
+++ b/aws-test/tests/aws_wafv2_rule_group/test-getGlobal-expected.json
@@ -11,13 +11,16 @@
     "rules": [
       {
         "Action": {
-          "Allow": {},
+          "Allow": {
+            "CustomRequestHandling": null
+          },
           "Block": null,
           "Count": null
         },
         "Name": "rule-1",
         "OverrideAction": null,
         "Priority": 1,
+        "RuleLabels": null,
         "Statement": {
           "AndStatement": null,
           "ByteMatchStatement": null,
@@ -29,10 +32,12 @@
             "ForwardedIPConfig": null
           },
           "IPSetReferenceStatement": null,
+          "LabelMatchStatement": null,
           "ManagedRuleGroupStatement": null,
           "NotStatement": null,
           "OrStatement": null,
           "RateBasedStatement": null,
+          "RegexMatchStatement": null,
           "RegexPatternSetReferenceStatement": null,
           "RuleGroupReferenceStatement": null,
           "SizeConstraintStatement": null,

--- a/aws-test/tests/aws_wafv2_rule_group/test-getRegional-expected.json
+++ b/aws-test/tests/aws_wafv2_rule_group/test-getRegional-expected.json
@@ -11,13 +11,16 @@
     "rules": [
       {
         "Action": {
-          "Allow": {},
+          "Allow": {
+            "CustomRequestHandling": null
+          },
           "Block": null,
           "Count": null
         },
         "Name": "rule-1",
         "OverrideAction": null,
         "Priority": 1,
+        "RuleLabels": null,
         "Statement": {
           "AndStatement": null,
           "ByteMatchStatement": null,
@@ -29,10 +32,12 @@
             "ForwardedIPConfig": null
           },
           "IPSetReferenceStatement": null,
+          "LabelMatchStatement": null,
           "ManagedRuleGroupStatement": null,
           "NotStatement": null,
           "OrStatement": null,
           "RateBasedStatement": null,
+          "RegexMatchStatement": null,
           "RegexPatternSetReferenceStatement": null,
           "RuleGroupReferenceStatement": null,
           "SizeConstraintStatement": null,


### PR DESCRIPTION
- aws_dms_replication_instance
- aws_ec2_application_load_balancer 
- aws_elastic_beanstalk_environment
- aws_elasticache_replication_group
- aws_guardduty_finding
- aws_securityhub_standards_subscription
- aws_sfn_state_machine_execution_history
-  aws_ssm_managed_instance