### PR TITLE
Add policy and policy_std columns to table aws_lambda_alias. Closes #773

### DIFF
--- a/docs/tables/aws_lambda_alias.md
+++ b/docs/tables/aws_lambda_alias.md
@@ -10,12 +10,10 @@ A Lambda alias is like a pointer to a specific function version.
 select
   name,
   function_name,
-  function_version,
-  authorizer_credentials
+  function_version
 from
   aws_lambda_alias;
 ```
-
 
 ### Count of lambda alias per Lambda function
 
@@ -27,4 +25,14 @@ from
   aws_lambda_alias
 group by
   function_name;
+```
+
+### List policy details
+
+```sql
+select
+  jsonb_pretty(policy) as policy,
+  jsonb_pretty(policy_std) as policy_std
+from
+  aws_lambda_alias;
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro aws-test % ./tint.js aws_lambda_alias
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_lambda_alias []

PRETEST: tests/aws_lambda_alias

TEST: tests/aws_lambda_alias
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.archive_file.zip will be read during apply
  # (config refers to values not yet known)
 <= data "archive_file" "zip"  {
      + id                  = (known after apply)
      + output_base64sha256 = (known after apply)
      + output_md5          = (known after apply)
      + output_path         = "/private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/aws_lambda_alias/terraform/test/../../test.zip"
      + output_sha          = (known after apply)
      + output_size         = (known after apply)
      + source_file         = "/private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/aws_lambda_alias/terraform/test/../../test.py"
      + type                = "zip"
    }

  # aws_iam_role.aws_lambda_function will be created
  + resource "aws_iam_role" "aws_lambda_function" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "lambda.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest10089"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_lambda_alias.named_test_resource will be created
  + resource "aws_lambda_alias" "named_test_resource" {
      + arn              = (known after apply)
      + description      = "Test alias."
      + function_name    = "arn:aws:lambda:us-east-1:632902112348:function:turbottest10089"
      + function_version = "$LATEST"
      + id               = (known after apply)
      + invoke_arn       = (known after apply)
      + name             = "turbottest10089"
    }

  # aws_lambda_function.named_test_resource will be created
  + resource "aws_lambda_function" "named_test_resource" {
      + architectures                  = (known after apply)
      + arn                            = (known after apply)
      + filename                       = "/private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/aws_lambda_alias/terraform/test/../../test.zip"
      + function_name                  = "turbottest10089"
      + handler                        = "test.test"
      + id                             = (known after apply)
      + invoke_arn                     = (known after apply)
      + last_modified                  = (known after apply)
      + memory_size                    = 128
      + package_type                   = "Zip"
      + publish                        = false
      + qualified_arn                  = (known after apply)
      + reserved_concurrent_executions = -1
      + role                           = (known after apply)
      + runtime                        = "python3.7"
      + signing_job_arn                = (known after apply)
      + signing_profile_version_arn    = (known after apply)
      + source_code_hash               = (known after apply)
      + source_code_size               = (known after apply)
      + tags_all                       = (known after apply)
      + timeout                        = 3
      + version                        = (known after apply)

      + tracing_config {
          + mode = (known after apply)
        }
    }

  # local_file.python_file will be created
  + resource "local_file" "python_file" {
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "/private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/aws_lambda_alias/terraform/test/../../test.py"
      + id                   = (known after apply)
      + sensitive_content    = (sensitive value)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "632902112348"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest10089"
local_file.python_file: Creating...
local_file.python_file: Creation complete after 0s [id=dafb34f0ced09879d73bc8baab67226f2e264bac]
data.archive_file.zip: Reading...
data.archive_file.zip: Read complete after 0s [id=152a0eabdf961fb20b337a3e73afea2d10f4a088]
aws_iam_role.aws_lambda_function: Creating...
aws_iam_role.aws_lambda_function: Creation complete after 4s [id=turbottest10089]
aws_lambda_function.named_test_resource: Creating...
aws_lambda_function.named_test_resource: Still creating... [10s elapsed]
aws_lambda_function.named_test_resource: Creation complete after 17s [id=turbottest10089]
aws_lambda_alias.named_test_resource: Creating...
aws_lambda_alias.named_test_resource: Creation complete after 2s [id=arn:aws:lambda:us-east-1:632902112348:function:turbottest10089:turbottest10089]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

account_id = "632902112348"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:lambda:us-east-1:632902112348:function:turbottest10089:turbottest10089"
resource_name = "turbottest10089"

Running SQL query: query.sql
[
  {
    "function_name": "turbottest10089",
    "name": "turbottest10089"
  }
]
✔ PASSED

Running SQL query: test-get-call-query.sql
[
  {
    "akas": [
      "arn:aws:lambda:us-east-1:632902112348:function:turbottest10089:turbottest10089"
    ],
    "alias_arn": "arn:aws:lambda:us-east-1:632902112348:function:turbottest10089:turbottest10089",
    "description": "Test alias.",
    "function_name": "turbottest10089",
    "function_version": "$LATEST",
    "name": "turbottest10089",
    "title": "turbottest10089"
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "akas": [
      "arn:aws:lambda:us-east-1:632902112348:function:turbottest10089:turbottest10089"
    ],
    "alias_arn": "arn:aws:lambda:us-east-1:632902112348:function:turbottest10089:turbottest10089",
    "description": "Test alias.",
    "function_name": "turbottest10089",
    "function_version": "$LATEST",
    "name": "turbottest10089",
    "title": "turbottest10089"
  }
]
✔ PASSED

POSTTEST: tests/aws_lambda_alias

TEARDOWN: tests/aws_lambda_alias

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  function_name,
  function_version
from
  aws_lambda_alias;
+------------+---------------+------------------+
| name       | function_name | function_version |
+------------+---------------+------------------+
| testAlias  | testFunction  | $LATEST          |
| testAlias1 | testFunction  | $LATEST          |
+------------+---------------+------------------+
> select
  function_name,
  count(function_name) count
from
  aws_lambda_alias
group by
  function_name;
+---------------+-------+
| function_name | count |
+---------------+-------+
| testFunction  | 2     |
+---------------+-------+
> select
  jsonb_pretty(policy) as policy,
  jsonb_pretty(policy_std) as policy_std
from
  aws_lambda_alias;
+--------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+
| policy                                                                                           | policy_std                                                                              |
+--------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+
| <null>                                                                                           | <null>                                                                                  |
| {                                                                                                | {                                                                                       |
|     "Id": "default",                                                                             |     "Id": "default",                                                                    |
|     "Version": "2012-10-17",                                                                     |     "Version": "2012-10-17",                                                            |
|     "Statement": [                                                                               |     "Statement": [                                                                      |
|         {                                                                                        |         {                                                                               |
|             "Sid": "alias-get",                                                                  |             "Sid": "alias-get",                                                         |
|             "Action": "lambda:GetAlias",                                                         |             "Action": [                                                                 |
|             "Effect": "Allow",                                                                   |                 "lambda:getalias"                                                       |
|             "Resource": "arn:aws:lambda:us-east-1:632902112348:function:testFunction:testAlias", |             ],                                                                          |
|             "Principal": {                                                                       |             "Effect": "Allow",                                                          |
|                 "AWS": "arn:aws:iam::632902112348:user/test1"                                    |             "Resource": [                                                               |
|             }                                                                                    |                 "arn:aws:lambda:us-east-1:632902112348:function:testFunction:testAlias" |
|         },                                                                                       |             ],                                                                          |
|         {                                                                                        |             "Principal": {                                                              |
|             "Sid": "alias-list",                                                                 |                 "AWS": [                                                                |
|             "Action": "lambda:ListAliases",                                                      |                     "arn:aws:iam::632902112348:user/test1"                              |
|             "Effect": "Allow",                                                                   |                 ]                                                                       |
|             "Resource": "arn:aws:lambda:us-east-1:632902112348:function:testFunction:testAlias", |             }                                                                           |
|             "Principal": {                                                                       |         },                                                                              |
|                 "AWS": "arn:aws:iam::632902112348:user/test1"                                    |         {                                                                               |
|             }                                                                                    |             "Sid": "alias-list",                                                        |
|         }                                                                                        |             "Action": [                                                                 |
|     ]                                                                                            |                 "lambda:listaliases"                                                    |
| }                                                                                                |             ],                                                                          |
|                                                                                                  |             "Effect": "Allow",                                                          |
|                                                                                                  |             "Resource": [                                                               |
|                                                                                                  |                 "arn:aws:lambda:us-east-1:632902112348:function:testFunction:testAlias" |
|                                                                                                  |             ],                                                                          |
|                                                                                                  |             "Principal": {                                                              |
|                                                                                                  |                 "AWS": [                                                                |
|                                                                                                  |                     "arn:aws:iam::632902112348:user/test1"                              |
|                                                                                                  |                 ]                                                                       |
|                                                                                                  |             }                                                                           |
|                                                                                                  |         }                                                                               |
|                                                                                                  |     ]                                                                                   |
|                                                                                                  | }                                                                                       |
+--------------------------------------------------------------------------------------------------+-----------------------------------------------------------------------------------------+
```
</details>
