### PR TITLE
Add policy and policy_std columns to table aws_lambda_version. Closes #775

### DIFF
--- a/docs/tables/aws_lambda_version.md
+++ b/docs/tables/aws_lambda_version.md
@@ -16,7 +16,6 @@ from
   aws_lambda_version;
 ```
 
-
 ### List of lambda versions where code run timout is more than 2 mins
 
 ```sql
@@ -30,7 +29,6 @@ where
   timeout :: int > 120;
 ```
 
-
 ### VPC info of each lambda version
 
 ```sql
@@ -40,6 +38,16 @@ select
   vpc_id,
   vpc_security_group_ids,
   vpc_subnet_ids
+from
+  aws_lambda_version;
+```
+
+### List policy details
+
+```sql
+select
+  jsonb_pretty(policy) as policy,
+  jsonb_pretty(policy_std) as policy_std
 from
   aws_lambda_version;
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro aws-test % ./tint.js aws_lambda_version
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_lambda_version []

PRETEST: tests/aws_lambda_version

TEST: tests/aws_lambda_version
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.archive_file.zip will be read during apply
  # (config refers to values not yet known)
 <= data "archive_file" "zip"  {
      + id                  = (known after apply)
      + output_base64sha256 = (known after apply)
      + output_md5          = (known after apply)
      + output_path         = "/private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/aws_lambda_version/terraform/test/../../test.zip"
      + output_sha          = (known after apply)
      + output_size         = (known after apply)
      + source_file         = "/private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/aws_lambda_version/terraform/test/../../test.py"
      + type                = "zip"
    }

  # aws_iam_role.aws_lambda_function will be created
  + resource "aws_iam_role" "aws_lambda_function" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "lambda.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest80013"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_lambda_function.named_test_resource will be created
  + resource "aws_lambda_function" "named_test_resource" {
      + architectures                  = (known after apply)
      + arn                            = (known after apply)
      + filename                       = "/private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/aws_lambda_version/terraform/test/../../test.zip"
      + function_name                  = "turbottest80013"
      + handler                        = "test.test"
      + id                             = (known after apply)
      + invoke_arn                     = (known after apply)
      + last_modified                  = (known after apply)
      + memory_size                    = 128
      + package_type                   = "Zip"
      + publish                        = false
      + qualified_arn                  = (known after apply)
      + reserved_concurrent_executions = -1
      + role                           = (known after apply)
      + runtime                        = "python3.7"
      + signing_job_arn                = (known after apply)
      + signing_profile_version_arn    = (known after apply)
      + source_code_hash               = (known after apply)
      + source_code_size               = (known after apply)
      + tags                           = {
          + "name" = "turbottest80013"
        }
      + tags_all                       = {
          + "name" = "turbottest80013"
        }
      + timeout                        = 3
      + version                        = (known after apply)

      + tracing_config {
          + mode = (known after apply)
        }
    }

  # local_file.python_file will be created
  + resource "local_file" "python_file" {
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "/private/var/folders/df/957ty4t146vfy54wm4254kp40000gp/T/tests/aws_lambda_version/terraform/test/../../test.py"
      + id                   = (known after apply)
      + sensitive_content    = (sensitive value)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "632902112348"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest80013"
local_file.python_file: Creating...
local_file.python_file: Creation complete after 0s [id=31a055a187e07d0bd8fca8ceb1f633aa4497fe53]
data.archive_file.zip: Reading...
data.archive_file.zip: Read complete after 0s [id=3d2780bc13324b697460b666c413908a395d952e]
aws_iam_role.aws_lambda_function: Creating...
aws_iam_role.aws_lambda_function: Creation complete after 4s [id=turbottest80013]
aws_lambda_function.named_test_resource: Creating...
aws_lambda_function.named_test_resource: Still creating... [10s elapsed]
aws_lambda_function.named_test_resource: Creation complete after 15s [id=turbottest80013]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "632902112348"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:lambda:us-east-1:632902112348:function:turbottest80013"
resource_name = "turbottest80013"

Running SQL query: query.sql
[
  {
    "arn": "arn:aws:lambda:us-east-1:632902112348:function:turbottest80013:$LATEST",
    "function_name": "turbottest80013",
    "version": "$LATEST"
  }
]
✔ PASSED

Running SQL query: test-get-call-query.sql
[
  {
    "akas": [
      "arn:aws:lambda:us-east-1:632902112348:function:turbottest80013:$LATEST"
    ],
    "arn": "arn:aws:lambda:us-east-1:632902112348:function:turbottest80013:$LATEST",
    "function_name": "turbottest80013",
    "runtime": "python3.7",
    "title": "$LATEST",
    "version": "$LATEST"
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "akas": [
      "arn:aws:lambda:us-east-1:632902112348:function:turbottest80013:$LATEST"
    ],
    "arn": "arn:aws:lambda:us-east-1:632902112348:function:turbottest80013:$LATEST",
    "function_name": "turbottest80013",
    "runtime": "python3.7",
    "title": "$LATEST",
    "version": "$LATEST"
  }
]
✔ PASSED

POSTTEST: tests/aws_lambda_version

TEARDOWN: tests/aws_lambda_version

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  function_name,
  version,
  runtime,
  handler
from
  aws_lambda_version;
+----------------------+---------+------------+--------------------------------+
| function_name        | version | runtime    | handler                        |
+----------------------+---------+------------+--------------------------------+
| old-func             | $LATEST | python2.7  | lambda_function.lambda_handler |
| testFunction         | 1       | nodejs14.x | index.handler                  |
| testFunction         | $LATEST | nodejs14.x | index.handler                  |
| function-without-vpc | $LATEST | nodejs12.x | index.handler                  |
| func-encrypted       | $LATEST | nodejs14.x | index.handler                  |
| function-test        | $LATEST | nodejs12.x | index.handler                  |
| testFunction         | $LATEST | nodejs14.x | index.handler                  |
+----------------------+---------+------------+--------------------------------+
> select
  function_name,
  version,
  timeout
from
  aws_lambda_version
where
  timeout :: int > 120;
+---------------+---------+---------+
| function_name | version | timeout |
+---------------+---------+---------+
+---------------+---------+---------+
> select
  function_name,
  version,
  vpc_id,
  vpc_security_group_ids,
  vpc_subnet_ids
from
  aws_lambda_version;
+----------------------+---------+--------------+--------------------------+---------------------------------------+
| function_name        | version | vpc_id       | vpc_security_group_ids   | vpc_subnet_ids                        |
+----------------------+---------+--------------+--------------------------+---------------------------------------+
| old-func             | $LATEST | <null>       | <null>                   | <null>                                |
| testFunction         | 1       | <null>       | <null>                   | <null>                                |
| testFunction         | $LATEST | <null>       | <null>                   | <null>                                |
| function-without-vpc | $LATEST | <null>       | <null>                   | <null>                                |
| func-encrypted       | $LATEST | <null>       | <null>                   | <null>                                |
| function-test        | $LATEST | vpc-3ac89d40 | ["sg-003f0b56b3aa60569"] | ["subnet-e82e29c6","subnet-e889c5d6"] |
| testFunction         | $LATEST | <null>       | <null>                   | <null>                                |
+----------------------+---------+--------------+--------------------------+---------------------------------------+
> select
  jsonb_pretty(policy) as policy,
  jsonb_pretty(policy_std) as policy_std
from
  aws_lambda_version;
+------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+
| policy                                                                                   | policy_std                                                                      |
+------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+
| <null>                                                                                   | <null>                                                                          |
| {                                                                                        | {                                                                               |
|     "Id": "default",                                                                     |     "Id": "default",                                                            |
|     "Version": "2012-10-17",                                                             |     "Version": "2012-10-17",                                                    |
|     "Statement": [                                                                       |     "Statement": [                                                              |
|         {                                                                                |         {                                                                       |
|             "Sid": "version-publish",                                                    |             "Sid": "version-publish",                                           |
|             "Action": "lambda:PublishVersion",                                           |             "Action": [                                                         |
|             "Effect": "Allow",                                                           |                 "lambda:publishversion"                                         |
|             "Resource": "arn:aws:lambda:us-east-1:632902112348:function:testFunction:1", |             ],                                                                  |
|             "Principal": {                                                               |             "Effect": "Allow",                                                  |
|                 "AWS": "arn:aws:iam::632902112348:user/test1"                            |             "Resource": [                                                       |
|             }                                                                            |                 "arn:aws:lambda:us-east-1:632902112348:function:testFunction:1" |
|         }                                                                                |             ],                                                                  |
|     ]                                                                                    |             "Principal": {                                                      |
| }                                                                                        |                 "AWS": [                                                        |
|                                                                                          |                     "arn:aws:iam::632902112348:user/test1"                      |
|                                                                                          |                 ]                                                               |
|                                                                                          |             }                                                                   |
|                                                                                          |         }                                                                       |
|                                                                                          |     ]                                                                           |
|                                                                                          | }                                                                               |
| <null>                                                                                   | <null>                                                                          |
| <null>                                                                                   | <null>                                                                          |
| <null>                                                                                   | <null>                                                                          |
| <null>                                                                                   | <null>                                                                          |
| <null>                                                                                   | <null>                                                                          |
+------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------+
```
</details>
