### PR TITLE
Add policy_std column to the aws_ecr_repository table. Closes #779

### DIFF
--- a/aws/table_aws_ecr_repository.go
+++ b/aws/table_aws_ecr_repository.go
@@ -102,6 +102,13 @@ func tableAwsEcrRepository(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("PolicyText"),
 			},
 			{
+				Name:        "policy_std",
+				Description: "Contains the policy in a canonical form for easier searching.",
+				Hydrate:     getAwsEcrRepositoryPolicy,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("PolicyText").Transform(unescape).Transform(policyToCanonical),
+			},
+			{
 				Name:        "tags_src",
 				Description: "A list of tags assigned to the Repository.",
 				Type:        proto.ColumnType_JSON,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
arnab@turbotindias-MacBook-Pro aws-test % ./tint.js aws_ecr_repository
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ecr_repository []

PRETEST: tests/aws_ecr_repository

TEST: tests/aws_ecr_repository
Running terraform
aws_ecr_repository.named_test_resource: Refreshing state... [id=turbottest64716]

Note: Objects have changed outside of Terraform

Terraform detected the following changes made outside of Terraform since the
last "terraform apply":

  # aws_ecr_repository.named_test_resource has been deleted
  - resource "aws_ecr_repository" "named_test_resource" {
      - arn                  = "arn:aws:ecr:us-east-1:632902152528:repository/turbottest64716" -> null
      - id                   = "turbottest64716" -> null
      - image_tag_mutability = "MUTABLE" -> null
      - name                 = "turbottest64716" -> null
      - registry_id          = "632902152528" -> null
      - repository_url       = "632902152528.dkr.ecr.us-east-1.amazonaws.com/turbottest64716" -> null
      - tags                 = {
          - "name" = "turbottest64716"
        } -> null
      - tags_all             = {
          - "name" = "turbottest64716"
        } -> null

      - encryption_configuration {
          - encryption_type = "AES256" -> null
        }

      - image_scanning_configuration {
          - scan_on_push = false -> null
        }
    }

Unless you have made equivalent changes to your configuration, or ignored the
relevant attributes using ignore_changes, the following plan may include
actions to undo or respond to these changes.

─────────────────────────────────────────────────────────────────────────────

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ecr_repository.named_test_resource will be created
  + resource "aws_ecr_repository" "named_test_resource" {
      + arn                  = (known after apply)
      + id                   = (known after apply)
      + image_tag_mutability = "MUTABLE"
      + name                 = "turbottest44073"
      + registry_id          = (known after apply)
      + repository_url       = (known after apply)
      + tags                 = {
          + "name" = "turbottest44073"
        }
      + tags_all             = {
          + "name" = "turbottest44073"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  ~ registry_id   = "632902152528" -> (known after apply)
  ~ resource_aka  = "arn:aws:ecr:us-east-1:632902152528:repository/turbottest64716" -> (known after apply)
  ~ resource_id   = "turbottest64716" -> (known after apply)
  ~ resource_name = "turbottest64716" -> "turbottest44073"
aws_ecr_repository.named_test_resource: Creating...
aws_ecr_repository.named_test_resource: Creation complete after 3s [id=turbottest44073]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "632902152528"
aws_partition = "aws"
aws_region = "us-east-1"
registry_id = "632902152528"
resource_aka = "arn:aws:ecr:us-east-1:632902152528:repository/turbottest44073"
resource_id = "turbottest44073"
resource_name = "turbottest44073"

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:ecr:us-east-1:632902152528:repository/turbottest44073"
    ],
    "image_tag_mutability": "MUTABLE",
    "partition": "aws",
    "region": "us-east-1",
    "repository_name": "turbottest44073"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ecr:us-east-1:632902152528:repository/turbottest44073"
    ],
    "repository_name": "turbottest44073",
    "tags": {
      "name": "turbottest44073"
    },
    "title": "turbottest44073"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:ecr:us-east-1:632902152528:repository/turbottest44073",
    "image_scanning_configuration": {
      "ScanOnPush": false
    },
    "image_tag_mutability": "MUTABLE",
    "partition": "aws",
    "region": "us-east-1",
    "repository_name": "turbottest44073"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "632902152528",
    "akas": [
      "arn:aws:ecr:us-east-1:632902152528:repository/turbottest44073"
    ],
    "region": "us-east-1",
    "title": "turbottest44073"
  }
]
✔ PASSED

POSTTEST: tests/aws_ecr_repository

TEARDOWN: tests/aws_ecr_repository

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  repository_name,
  jsonb_pretty(policy) as policy,
  jsonb_pretty(policy_std) as policy_std
from
  aws_ecr_repository;
+-----------------+---------------------------------------------------------+------------------------------------------------------+
| repository_name | policy                                                  | policy_std                                           |
+-----------------+---------------------------------------------------------+------------------------------------------------------+
| test            | <null>                                                  | <null>                                               |
| turbottest64716 | {                                                       | {                                                    |
|                 |     "Version": "2012-10-17",                            |     "Version": "2012-10-17",                         |
|                 |     "Statement": [                                      |     "Statement": [                                   |
|                 |         {                                               |         {                                            |
|                 |             "Sid": "AllowCrossAccountPush",             |             "Sid": "AllowCrossAccountPush",          |
|                 |             "Action": [                                 |             "Action": [                              |
|                 |                 "ecr:BatchCheckLayerAvailability",      |                 "ecr:batchchecklayeravailability",   |
|                 |                 "ecr:CompleteLayerUpload",              |                 "ecr:completelayerupload",           |
|                 |                 "ecr:InitiateLayerUpload",              |                 "ecr:initiatelayerupload",           |
|                 |                 "ecr:PutImage",                         |                 "ecr:putimage",                      |
|                 |                 "ecr:UploadLayerPart"                   |                 "ecr:uploadlayerpart"                |
|                 |             ],                                          |             ],                                       |
|                 |             "Effect": "Allow",                          |             "Effect": "Allow",                       |
|                 |             "Principal": {                              |             "Principal": {                           |
|                 |                 "AWS": "arn:aws:iam::632902152528:root" |                 "AWS": [                             |
|                 |             }                                           |                     "arn:aws:iam::632902152528:root" |
|                 |         }                                               |                 ]                                    |
|                 |     ]                                                   |             }                                        |
|                 | }                                                       |         }                                            |
|                 |                                                         |     ]                                                |
|                 |                                                         | }                                                    |
+-----------------+---------------------------------------------------------+------------------------------------------------------+
> select
  repository_name,
  registry_id,
  arn,
  repository_uri,
  created_at,
  region,
  account_id
from
  aws_ecr_repository;
+-----------------+--------------+---------------------------------------------------------------+--------------------------------------------------------------+----------------------+-----------+--------
| repository_name | registry_id  | arn                                                           | repository_uri                                               | created_at           | region    | account
+-----------------+--------------+---------------------------------------------------------------+--------------------------------------------------------------+----------------------+-----------+--------
| test            | 632902152528 | arn:aws:ecr:us-east-1:632902152528:repository/test            | 632902152528.dkr.ecr.us-east-1.amazonaws.com/test            | 2021-07-01T11:53:54Z | us-east-1 | 6329021
| turbottest64716 | 632902152528 | arn:aws:ecr:us-east-1:632902152528:repository/turbottest64716 | 632902152528.dkr.ecr.us-east-1.amazonaws.com/turbottest64716 | 2021-11-17T08:35:20Z | us-east-1 | 6329021
+-----------------+--------------+---------------------------------------------------------------+--------------------------------------------------------------+----------------------+-----------+--------
> select
  repository_name,
  encryption_configuration ->> 'EncryptionType' as encryption_type,
  encryption_configuration ->> 'KmsKey' as kms_key
from
  aws_ecr_repository
where
  encryption_configuration ->> 'EncryptionType' = 'AES256';
+-----------------+-----------------+---------+
| repository_name | encryption_type | kms_key |
+-----------------+-----------------+---------+
| test            | AES256          | <null>  |
| turbottest64716 | AES256          | <null>  |
+-----------------+-----------------+---------+
> select
  repository_name,
  image_scanning_configuration ->> 'ScanOnPush' as scan_on_push
from
  aws_ecr_repository
where
  image_scanning_configuration ->> 'ScanOnPush' = 'false';
+-----------------+--------------+
| repository_name | scan_on_push |
+-----------------+--------------+
| test            | false        |
| turbottest64716 | false        |
+-----------------+--------------+
> select
  repository_name,
  detail -> 'ImageScanStatus' ->> 'Status' as scan_status
from
  aws_ecr_repository,
  jsonb_array_elements(image_details) as details,
  jsonb(details) as detail
where
  detail -> 'ImageScanStatus' ->> 'Status' = 'FAILED';
+-----------------+-------------+
| repository_name | scan_status |
+-----------------+-------------+
+-----------------+-------------+
> select
  repository_name,
  image_tag_mutability
from
  aws_ecr_repository
where
  image_tag_mutability = 'IMMUTABLE';
+-----------------+----------------------+
| repository_name | image_tag_mutability |
+-----------------+----------------------+
+-----------------+----------------------+
> select
  repository_name,
  r -> 'selection' ->> 'tagStatus' as tag_status,
  r -> 'selection' ->> 'countType' as count_type
from
  aws_ecr_repository,
  jsonb_array_elements(lifecycle_policy -> 'rules') as r
where
  (
    (r -> 'selection' ->> 'tagStatus' <> 'untagged')
    and (
      r -> 'selection' ->> 'countType' <> 'sinceImagePushed'
    )
  );
+-----------------+------------+------------+
| repository_name | tag_status | count_type |
+-----------------+------------+------------+
+-----------------+------------+------------+
> select
  title,
  p as principal,
  a as action,
  s ->> 'Effect' as effect,
  s -> 'Condition' as conditions
from
  aws_ecr_repository,
  jsonb_array_elements(policy -> 'Statement') as s,
  jsonb_array_elements_text(s -> 'Principal' -> 'AWS') as p,
  jsonb_array_elements_text(s -> 'Action') as a
where
  s ->> 'Effect' = 'Allow'
  and a in ('*', 'ecr:*');
+-------+-----------+--------+--------+------------+
| title | principal | action | effect | conditions |
+-------+-----------+--------+--------+------------+
+-------+-----------+--------+--------+------------+
> select
  repository_name,
  detail -> 'ImageScanFindingsSummary' -> 'FindingSeverityCounts' ->> 'INFORMATIONAL' as informational_severity_counts,
  detail -> 'ImageScanFindingsSummary' -> 'FindingSeverityCounts' ->> 'LOW' as low_severity_counts,
  detail -> 'ImageScanFindingsSummary' -> 'FindingSeverityCounts' ->> 'MEDIUM' as medium_severity_counts
from
  aws_ecr_repository,
  jsonb_array_elements(image_details) as details,
  jsonb(details) as detail;
+-----------------+-------------------------------+---------------------+------------------------+
| repository_name | informational_severity_counts | low_severity_counts | medium_severity_counts |
+-----------------+-------------------------------+---------------------+------------------------+
+-----------------+-------------------------------+---------------------+------------------------+
```
</details>
