### PR TITLE
Fix GET request for table aws_lambda_alias. Closes #777

### DIFF
--- a/aws-test/tests/aws_lambda_alias/query.sql
+++ b/aws-test/tests/aws_lambda_alias/query.sql
@@ -1,3 +1,3 @@
 select name, function_name
 from aws.aws_lambda_alias
-where name = '{{resourceName}}' and function_name = '{{resourceName}}'
+where name = '{{resourceName}}' and function_name = '{{resourceName}}';

--- a/aws-test/tests/aws_lambda_alias/test-get-call-query.sql
+++ b/aws-test/tests/aws_lambda_alias/test-get-call-query.sql
@@ -1,3 +1,3 @@
 select alias_arn, description, function_name, function_version, name, akas, title
 from aws.aws_lambda_alias
-where name = '{{resourceName}}' and function_name = '{{resourceName}}' and region = "{{ output.region.value }}";
+where name = '{{resourceName}}' and function_name = '{{resourceName}}' and region = '{{ output.region_name.value }}';

--- a/aws-test/tests/aws_lambda_alias/test-get-call-query.sql
+++ b/aws-test/tests/aws_lambda_alias/test-get-call-query.sql
@@ -1,3 +1,3 @@
 select alias_arn, description, function_name, function_version, name, akas, title
 from aws.aws_lambda_alias
-where name = '{{resourceName}}' and function_name = '{{resourceName}}'
+where name = '{{resourceName}}' and function_name = '{{resourceName}}' and region = "{{ output.region.value }}";

--- a/aws-test/tests/aws_lambda_alias/test-list-call-query.sql
+++ b/aws-test/tests/aws_lambda_alias/test-list-call-query.sql
@@ -1,3 +1,3 @@
 select alias_arn, description, function_name, function_version, name, akas, title
 from aws.aws_lambda_alias
-where akas::text = '["{{ output.resource_aka.value }}"]'
+where akas::text = '["{{ output.resource_aka.value }}"]';

--- a/aws/table_aws_lambda_alias.go
+++ b/aws/table_aws_lambda_alias.go
@@ -133,6 +133,7 @@ func getLambdaAlias(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	functionName := d.KeyColumnQuals["function_name"].GetStringValue()
 	region := d.KeyColumnQuals["region"].GetStringValue()
 
+	// Empty check
 	if name == "" || functionName == "" || region != matrixRegion {
 		return nil, nil
 	}

--- a/aws/table_aws_lambda_alias.go
+++ b/aws/table_aws_lambda_alias.go
@@ -133,7 +133,7 @@ func getLambdaAlias(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	functionName := d.KeyColumnQuals["function_name"].GetStringValue()
 	region := d.KeyColumnQuals["region"].GetStringValue()
 
-	if name == "" || functionName == "" || region == "" || region != matrixRegion {
+	if name == "" || functionName == "" || region != matrixRegion {
 		return nil, nil
 	}
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```

SETUP: tests/aws_lambda_alias []

PRETEST: tests/aws_lambda_alias

TEST: tests/aws_lambda_alias
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.archive_file.zip will be read during apply
  # (config refers to values not yet known)
 <= data "archive_file" "zip"  {
      + id                  = (known after apply)
      + output_base64sha256 = (known after apply)
      + output_md5          = (known after apply)
      + output_path         = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/aws_lambda_alias/terraform/test/../../test.zip"
      + output_sha          = (known after apply)
      + output_size         = (known after apply)
      + source_file         = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/aws_lambda_alias/terraform/test/../../test.py"
      + type                = "zip"
    }

  # aws_iam_role.aws_lambda_function will be created
  + resource "aws_iam_role" "aws_lambda_function" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "lambda.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest53067"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_lambda_alias.named_test_resource will be created
  + resource "aws_lambda_alias" "named_test_resource" {
      + arn              = (known after apply)
      + description      = "Test alias."
      + function_name    = "arn:aws:lambda:us-east-1:533793682495:function:turbottest53067"
      + function_version = "$LATEST"
      + id               = (known after apply)
      + invoke_arn       = (known after apply)
      + name             = "turbottest53067"
    }

  # aws_lambda_function.named_test_resource will be created
  + resource "aws_lambda_function" "named_test_resource" {
      + architectures                  = (known after apply)
      + arn                            = (known after apply)
      + filename                       = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/aws_lambda_alias/terraform/test/../../test.zip"
      + function_name                  = "turbottest53067"
      + handler                        = "test.test"
      + id                             = (known after apply)
      + invoke_arn                     = (known after apply)
      + last_modified                  = (known after apply)
      + memory_size                    = 128
      + package_type                   = "Zip"
      + publish                        = false
      + qualified_arn                  = (known after apply)
      + reserved_concurrent_executions = -1
      + role                           = (known after apply)
      + runtime                        = "python3.7"
      + signing_job_arn                = (known after apply)
      + signing_profile_version_arn    = (known after apply)
      + source_code_hash               = (known after apply)
      + source_code_size               = (known after apply)
      + tags_all                       = (known after apply)
      + timeout                        = 3
      + version                        = (known after apply)

      + tracing_config {
          + mode = (known after apply)
        }
    }

  # local_file.python_file will be created
  + resource "local_file" "python_file" {
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/aws_lambda_alias/terraform/test/../../test.py"
      + id                   = (known after apply)
      + sensitive_content    = (sensitive value)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "533793682495"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest53067"
local_file.python_file: Creating...
local_file.python_file: Creation complete after 0s [id=dafb34f0ced09879d73bc8baab67226f2e264bac]
data.archive_file.zip: Reading...
data.archive_file.zip: Read complete after 0s [id=152a0eabdf961fb20b337a3e73afea2d10f4a088]
aws_iam_role.aws_lambda_function: Creating...
aws_iam_role.aws_lambda_function: Creation complete after 5s [id=turbottest53067]
aws_lambda_function.named_test_resource: Creating...
aws_lambda_function.named_test_resource: Still creating... [10s elapsed]
aws_lambda_function.named_test_resource: Creation complete after 15s [id=turbottest53067]
aws_lambda_alias.named_test_resource: Creating...
aws_lambda_alias.named_test_resource: Creation complete after 3s [id=arn:aws:lambda:us-east-1:533793682495:function:turbottest53067:turbottest53067]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

account_id = "533793682495"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:lambda:us-east-1:533793682495:function:turbottest53067:turbottest53067"
resource_name = "turbottest53067"

Running SQL query: query.sql
[
  {
    "function_name": "turbottest53067",
    "name": "turbottest53067"
  }
]
✔ PASSED

Running SQL query: test-get-call-query.sql
[
  {
    "akas": [
      "arn:aws:lambda:us-east-1:533793682495:function:turbottest53067:turbottest53067"
    ],
    "alias_arn": "arn:aws:lambda:us-east-1:533793682495:function:turbottest53067:turbottest53067",
    "description": "Test alias.",
    "function_name": "turbottest53067",
    "function_version": "$LATEST",
    "name": "turbottest53067",
    "title": "turbottest53067"
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "akas": [
      "arn:aws:lambda:us-east-1:533793682495:function:turbottest53067:turbottest53067"
    ],
    "alias_arn": "arn:aws:lambda:us-east-1:533793682495:function:turbottest53067:turbottest53067",
    "description": "Test alias.",
    "function_name": "turbottest53067",
    "function_version": "$LATEST",
    "name": "turbottest53067",
    "title": "turbottest53067"
  }
]
✔ PASSED

POSTTEST: tests/aws_lambda_alias

TEARDOWN: tests/aws_lambda_alias

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  function_name,
  function_version
from
  aws_lambda_alias;
+-----------------+-----------------+------------------+
| name            | function_name   | function_version |
+-----------------+-----------------+------------------+
| turbottest44407 | turbottest44407 | $LATEST          |
+-----------------+-----------------+------------------+
```
</details>
