### PR TITLE
Handle InvalidParameterValueException  and ClusterNotFoundFault exceptions in aws_dax_cluster table. Fixes #782

### DIFF
--- a/aws/table_aws_dax_cluster.go
+++ b/aws/table_aws_dax_cluster.go
@@ -23,7 +23,8 @@ func tableAwsDaxCluster(_ context.Context) *plugin.Table {
 			Hydrate:           getDaxCluster,
 		},
 		List: &plugin.ListConfig{
-			Hydrate: listDaxClusters,
+			ShouldIgnoreError: isNotFoundError([]string{"ClusterNotFoundFault"}),
+			Hydrate:           listDaxClusters,
 		},
 		GetMatrixItem: BuildRegionList,
 		Columns: awsRegionalColumns([]*plugin.Column{

--- a/aws/table_aws_dax_cluster.go
+++ b/aws/table_aws_dax_cluster.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"strings"
 
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
@@ -135,7 +136,7 @@ func tableAwsDaxCluster(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getDaxClusterTags,
-				Transform:   transform.From(daxClusterTurbotData),
+				Transform:   transform.FromValue().Transform(daxClusterTurbotData),
 			},
 			{
 				Name:        "akas",
@@ -224,6 +225,9 @@ func getDaxClusterTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 
 	clusterdata, err := svc.ListTags(params)
 	if err != nil {
+		if strings.Contains(err.Error(), "ClusterNotFoundFault") {
+			return nil, nil
+		}
 		return nil, err
 	}
 

--- a/aws/table_aws_dax_cluster.go
+++ b/aws/table_aws_dax_cluster.go
@@ -136,7 +136,7 @@ func tableAwsDaxCluster(_ context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getDaxClusterTags,
-				Transform:   transform.FromValue().Transform(daxClusterTurbotData),
+				Transform:   transform.From(daxClusterTurbotData),
 			},
 			{
 				Name:        "akas",
@@ -163,6 +163,11 @@ func listDaxClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	for pagesLeft {
 		result, err := svc.DescribeClusters(params)
 		if err != nil {
+			// Dax Cluster is not available in all regions yet and throws exceptions for those regions
+			// https://aws.amazon.com/about-aws/whats-new/2018/04/amazon-dynamodb-accelerator-regional-expansion/
+			if strings.Contains(err.Error(), "InvalidParameterValueException") || strings.Contains(err.Error(), "no such host") {
+				return nil, nil
+			}
 			return nil, err
 		}
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  cluster_name,
  description,
  active_nodes,
  iam_role_arn,
  status,
  region
from
  aws_dax_cluster;
+--------------+-------------+--------------+-----------------------------------------------------------+-----------+-----------+
| cluster_name | description | active_nodes | iam_role_arn                                              | status    | region    |
+--------------+-------------+--------------+-----------------------------------------------------------+-----------+-----------+
| test         | <null>      | 1            | arn:aws:iam::533793682495:role/service-role/DAXtoDynamoDB | available | us-east-1 |
+--------------+-------------+--------------+-----------------------------------------------------------+-----------+-----------+
> select
  cluster_name,
  description,
  sse_description ->> 'Status' as sse_status
from
  aws_dax_cluster
where
  sse_description ->> 'Status' = 'DISABLED';
+--------------+-------------+------------+
| cluster_name | description | sse_status |
+--------------+-------------+------------+
+--------------+-------------+------------+
> select
  cluster_name,
  subnet_group,
  sg ->> 'SecurityGroupIdentifier' as sg_id,
  n ->> 'AvailabilityZone' as az_name,
  cluster_discovery_endpoint ->> 'Address' as cluster_discovery_endpoint_address,
  cluster_discovery_endpoint ->> 'Port' as cluster_discovery_endpoint_port
from
  aws_dax_cluster,
  jsonb_array_elements(security_groups) as sg,
  jsonb_array_elements(nodes) as n;
+--------------+--------------+----------------------+------------+--------------------------------------------------+---------------------------------+
| cluster_name | subnet_group | sg_id                | az_name    | cluster_discovery_endpoint_address               | cluster_discovery_endpoint_port |
+--------------+--------------+----------------------+------------+--------------------------------------------------+---------------------------------+
| test         | tere         | sg-026dfd56c57c75ec2 | us-east-1a | test.s4fxzh.dax-clusters.us-east-1.amazonaws.com | 9111                            |
+--------------+--------------+----------------------+------------+--------------------------------------------------+---------------------------------+
```
</details>
