### PR TITLE
Handle ValidationError in get call for aws_ec2_application_load_balancer table.

### DIFF
--- a/aws/table_aws_ec2_application_load_balancer.go
+++ b/aws/table_aws_ec2_application_load_balancer.go
@@ -20,7 +20,7 @@ func tableAwsEc2ApplicationLoadBalancer(_ context.Context) *plugin.Table {
 		Description: "AWS EC2 Application Load Balancer",
 		Get: &plugin.GetConfig{
 			KeyColumns:        plugin.SingleColumn("arn"),
-			ShouldIgnoreError: isNotFoundError([]string{"LoadBalancerNotFound"}),
+			ShouldIgnoreError: isNotFoundError([]string{"LoadBalancerNotFound", "ValidationError"}),
 			Hydrate:           getEc2ApplicationLoadBalancer,
 		},
 		List: &plugin.ListConfig{
@@ -171,6 +171,11 @@ func listEc2ApplicationLoadBalancers(ctx context.Context, d *plugin.QueryData, _
 
 func getEc2ApplicationLoadBalancer(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	loadBalancerArn := d.KeyColumnQuals["arn"].GetStringValue()
+
+	// check if arn is empty
+	if loadBalancerArn == "" {
+		return nil, nil
+	}
 
 	// Create service
 	svc, err := ELBv2Service(ctx, d)


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_ec2_application_load_balancer []

PRETEST: tests/aws_ec2_application_load_balancer

TEST: tests/aws_ec2_application_load_balancer
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_internet_gateway.igw will be created
  + resource "aws_internet_gateway" "igw" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + owner_id = (known after apply)
      + tags_all = (known after apply)
      + vpc_id   = (known after apply)
    }

  # aws_lb.named_test_resource will be created
  + resource "aws_lb" "named_test_resource" {
      + arn                        = (known after apply)
      + arn_suffix                 = (known after apply)
      + dns_name                   = (known after apply)
      + drop_invalid_header_fields = false
      + enable_deletion_protection = false
      + enable_http2               = true
      + id                         = (known after apply)
      + idle_timeout               = 60
      + internal                   = false
      + ip_address_type            = (known after apply)
      + load_balancer_type         = "application"
      + name                       = "turbottest5458"
      + security_groups            = (known after apply)
      + subnets                    = (known after apply)
      + tags                       = {
          + "name" = "turbottest5458"
        }
      + tags_all                   = {
          + "name" = "turbottest5458"
        }
      + vpc_id                     = (known after apply)
      + zone_id                    = (known after apply)

      + subnet_mapping {
          + allocation_id        = (known after apply)
          + ipv6_address         = (known after apply)
          + outpost_id           = (known after apply)
          + private_ipv4_address = (known after apply)
          + subnet_id            = (known after apply)
        }
    }

  # aws_subnet.my_subnet1 will be created
  + resource "aws_subnet" "my_subnet1" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "us-east-1a"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "10.0.0.0/24"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags_all                        = (known after apply)
      + vpc_id                          = (known after apply)
    }

  # aws_subnet.my_subnet2 will be created
  + resource "aws_subnet" "my_subnet2" {
      + arn                             = (known after apply)
      + assign_ipv6_address_on_creation = false
      + availability_zone               = "us-east-1b"
      + availability_zone_id            = (known after apply)
      + cidr_block                      = "10.0.1.0/24"
      + id                              = (known after apply)
      + ipv6_cidr_block_association_id  = (known after apply)
      + map_public_ip_on_launch         = false
      + owner_id                        = (known after apply)
      + tags_all                        = (known after apply)
      + vpc_id                          = (known after apply)
    }

  # aws_vpc.my_vpc will be created
  + resource "aws_vpc" "my_vpc" {
      + arn                              = (known after apply)
      + assign_generated_ipv6_cidr_block = false
      + cidr_block                       = "10.0.0.0/16"
      + default_network_acl_id           = (known after apply)
      + default_route_table_id           = (known after apply)
      + default_security_group_id        = (known after apply)
      + dhcp_options_id                  = (known after apply)
      + enable_classiclink               = (known after apply)
      + enable_classiclink_dns_support   = (known after apply)
      + enable_dns_hostnames             = (known after apply)
      + enable_dns_support               = true
      + id                               = (known after apply)
      + instance_tenancy                 = "default"
      + ipv6_association_id              = (known after apply)
      + ipv6_cidr_block                  = (known after apply)
      + main_route_table_id              = (known after apply)
      + owner_id                         = (known after apply)
      + tags_all                         = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "533793682495"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest5458"
  + vpc_id        = (known after apply)
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Still creating... [10s elapsed]
aws_vpc.my_vpc: Creation complete after 20s [id=vpc-0e022667d1549f53f]
aws_internet_gateway.igw: Creating...
aws_internet_gateway.igw: Creation complete after 5s [id=igw-0dd2deb0dbaf9a786]
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet2: Creation complete after 5s [id=subnet-05984de39e5ee275d]
aws_subnet.my_subnet1: Creation complete after 5s [id=subnet-09af9820f6defc1dc]
aws_lb.named_test_resource: Creating...
aws_lb.named_test_resource: Still creating... [10s elapsed]
aws_lb.named_test_resource: Still creating... [20s elapsed]
aws_lb.named_test_resource: Still creating... [30s elapsed]
aws_lb.named_test_resource: Still creating... [40s elapsed]
aws_lb.named_test_resource: Still creating... [50s elapsed]
aws_lb.named_test_resource: Still creating... [1m0s elapsed]
aws_lb.named_test_resource: Still creating... [1m10s elapsed]
aws_lb.named_test_resource: Still creating... [1m20s elapsed]
aws_lb.named_test_resource: Still creating... [1m30s elapsed]
aws_lb.named_test_resource: Still creating... [1m40s elapsed]
aws_lb.named_test_resource: Still creating... [1m50s elapsed]
aws_lb.named_test_resource: Still creating... [2m0s elapsed]
aws_lb.named_test_resource: Still creating... [2m10s elapsed]
aws_lb.named_test_resource: Creation complete after 2m19s [id=arn:aws:elasticloadbalancing:us-east-1:533793682495:loadbalancer/app/turbottest5458/d922cb16a3493487]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "533793682495"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:elasticloadbalancing:us-east-1:533793682495:loadbalancer/app/turbottest5458/d922cb16a3493487"
resource_id = "arn:aws:elasticloadbalancing:us-east-1:533793682495:loadbalancer/app/turbottest5458/d922cb16a3493487"
resource_name = "turbottest5458"
vpc_id = "vpc-0e022667d1549f53f"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-east-1:533793682495:loadbalancer/app/turbottest5458/d922cb16a3493487",
    "ip_address_type": "ipv4",
    "name": "turbottest5458",
    "scheme": "internet-facing",
    "state_code": "active",
    "type": "application",
    "vpc_id": "vpc-0e022667d1549f53f"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-east-1:533793682495:loadbalancer/app/turbottest5458/d922cb16a3493487",
    "load_balancer_attributes": [
      {
        "Key": "access_logs.s3.enabled",
        "Value": "false"
      },
      {
        "Key": "access_logs.s3.bucket",
        "Value": ""
      },
      {
        "Key": "access_logs.s3.prefix",
        "Value": ""
      },
      {
        "Key": "idle_timeout.timeout_seconds",
        "Value": "60"
      },
      {
        "Key": "deletion_protection.enabled",
        "Value": "false"
      },
      {
        "Key": "routing.http2.enabled",
        "Value": "true"
      },
      {
        "Key": "routing.http.drop_invalid_header_fields.enabled",
        "Value": "false"
      },
      {
        "Key": "routing.http.xff_client_port.enabled",
        "Value": "false"
      },
      {
        "Key": "routing.http.desync_mitigation_mode",
        "Value": "defensive"
      },
      {
        "Key": "waf.fail_open.enabled",
        "Value": "false"
      },
      {
        "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
        "Value": "false"
      }
    ],
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest5458"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-east-1:533793682495:loadbalancer/app/turbottest5458/d922cb16a3493487",
    "name": "turbottest5458"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:elasticloadbalancing:us-east-1:533793682495:loadbalancer/app/turbottest5458/d922cb16a3493487"
    ],
    "tags": {
      "name": "turbottest5458"
    },
    "title": "turbottest5458"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_application_load_balancer

TEARDOWN: tests/aws_ec2_application_load_balancer

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_ec2_application_load_balancer where arn = 'arn:aws:elasticloadbalancing:ap-south-1:533793682495:loadbalancer/app/test-app-elb/5518e58d070fef49'
+--------------+-----------------------------------------------------------------------------------------------------+-------------+----------+--------------------------+-----------------------+----------
| name         | arn                                                                                                 | type        | scheme   | canonical_hosted_zone_id | vpc_id                | created_t
+--------------+-----------------------------------------------------------------------------------------------------+-------------+----------+--------------------------+-----------------------+----------
| test-app-elb | arn:aws:elasticloadbalancing:ap-south-1:533793682495:loadbalancer/app/test-app-elb/5518e58d070fef49 | application | internal | ZP97RAFLXTNZK            | vpc-0ca3f256c1c1b4680 | 2021-11-1
+--------------+-----------------------------------------------------------------------------------------------------+-------------+----------+--------------------------+-----------------------+----------

```
</details>
