### PR TITLE
remove verbose logging

### DIFF
--- a/aws/common_columns.go
+++ b/aws/common_columns.go
@@ -103,7 +103,6 @@ func getCommonColumns(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	if region == "" {
 		region = "global"
 	}
-	plugin.Logger(ctx).Trace("getCommonColumns", "region", region)
 
 	var commonColumnData *awsCommonColumnData
 	getCallerIdentityCached := plugin.HydrateFunc(getCallerIdentity).WithCache()


### PR DESCRIPTION
this is very verbose in the logs (when running controls): 

```
2021-11-22T21:48:19.471Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.471Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.471Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.471Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.471Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.471Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.471Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.471Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.472Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.472Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.472Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.472Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.472Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.472Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.472Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.472Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.472Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.472Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.473Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
2021-11-22T21:48:19.474Z [TRACE] steampipe-plugin-aws.plugin: [TRACE] getCommonColumns: region=global
```