### PR TITLE
Add column `prefix_list_id` to `aws_vpc_security_group_rule` table

### DIFF
--- a/aws/table_aws_vpc_security_group_rule.go
+++ b/aws/table_aws_vpc_security_group_rule.go
@@ -171,7 +171,6 @@ func listSecurityGroupRules(ctx context.Context, d *plugin.QueryData, h *plugin.
 func getSecurityGroupRuleTurbotData(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	sgRule := h.Item.(*vpcSecurityGroupRulesRowData)
 	region := d.KeyColumnQualString(matrixKeyRegion)
-	plugin.Logger(ctx).Error("getSecurityGroupRuleTurbotData", *sgRule.Permission.IpProtocol)
 
 	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
@@ -197,7 +196,7 @@ func getSecurityGroupRuleTurbotData(ctx context.Context, d *plugin.QueryData, h 
 		hashCode = hashCode + "_" + *sgRule.PrefixListId.PrefixListId
 	}
 
-	// // generate aka for the rule
+	// generate aka for the rule
 	akas := []string{"arn:" + commonColumnData.Partition + ":ec2:" + region + ":" + *sgRule.Group.OwnerId + ":security-group/" + *sgRule.Group.GroupId + ":" + hashCode}
 
 	title := *sgRule.Group.GroupId + "_" + hashCode

--- a/aws/table_aws_vpc_security_group_rule.go
+++ b/aws/table_aws_vpc_security_group_rule.go
@@ -3,9 +3,8 @@ package aws
 import (
 	"context"
 
-	"github.com/turbot/go-kit/types"
-
 	"github.com/aws/aws-sdk-go/service/ec2"
+	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
@@ -118,6 +117,12 @@ func tableAwsVpcSecurityGroupRule(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("UserIDGroupPair.VpcPeeringConnectionId"),
 			},
 			{
+				Name:        "prefix_list_id",
+				Description: "The ID of the referenced prefix list.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("PrefixListId.PrefixListId"),
+			},
+			{
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
 				Type:        proto.ColumnType_STRING,
@@ -166,6 +171,7 @@ func listSecurityGroupRules(ctx context.Context, d *plugin.QueryData, h *plugin.
 func getSecurityGroupRuleTurbotData(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	sgRule := h.Item.(*vpcSecurityGroupRulesRowData)
 	region := d.KeyColumnQualString(matrixKeyRegion)
+	plugin.Logger(ctx).Error("getSecurityGroupRuleTurbotData", *sgRule.Permission.IpProtocol)
 
 	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
@@ -185,13 +191,13 @@ func getSecurityGroupRuleTurbotData(ctx context.Context, d *plugin.QueryData, h 
 		hashCode = hashCode + "_" + *sgRule.IPRange.CidrIp
 	} else if sgRule.Ipv6Range != nil && sgRule.Ipv6Range.CidrIpv6 != nil {
 		hashCode = hashCode + "_" + *sgRule.Ipv6Range.CidrIpv6
-	} else if sgRule.Group != nil && *sgRule.UserIDGroupPair.GroupId == *sgRule.Group.GroupId {
+	} else if sgRule.Group != nil && sgRule.UserIDGroupPair != nil && *sgRule.UserIDGroupPair.GroupId == *sgRule.Group.GroupId {
 		hashCode = hashCode + "_" + *sgRule.Group.GroupId
-	} else if sgRule.UserIDGroupPair != nil && *sgRule.UserIDGroupPair.GroupId == *sgRule.Group.GroupId {
-		hashCode = hashCode + "_" + *sgRule.UserIDGroupPair.GroupId
+	} else if sgRule.PrefixListId != nil && sgRule.PrefixListId.PrefixListId != nil {
+		hashCode = hashCode + "_" + *sgRule.PrefixListId.PrefixListId
 	}
 
-	// generate aka for the rule
+	// // generate aka for the rule
 	akas := []string{"arn:" + commonColumnData.Partition + ":ec2:" + region + ":" + *sgRule.Group.OwnerId + ":security-group/" + *sgRule.Group.GroupId + ":" + hashCode}
 
 	title := *sgRule.Group.GroupId + "_" + hashCode
@@ -211,6 +217,7 @@ type vpcSecurityGroupRulesRowData struct {
 	IPRange         *ec2.IpRange
 	Ipv6Range       *ec2.Ipv6Range
 	UserIDGroupPair *ec2.UserIdGroupPair
+	PrefixListId    *ec2.PrefixListId
 	Type            string
 }
 

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -89,6 +89,22 @@ func rowSourceFromIPPermission(group *ec2.SecurityGroup, permission *ec2.IpPermi
 				IPRange:         r,
 				Ipv6Range:       nil,
 				UserIDGroupPair: nil,
+				PrefixListId:    nil,
+				Type:            groupType,
+			})
+		}
+	}
+
+	// create 1 row per prefix-list Id
+	if permission.PrefixListIds != nil {
+		for _, r := range permission.PrefixListIds {
+			rowSource = append(rowSource, &vpcSecurityGroupRulesRowData{
+				Group:           group,
+				Permission:      permission,
+				IPRange:         nil,
+				Ipv6Range:       nil,
+				UserIDGroupPair: nil,
+				PrefixListId:    r,
 				Type:            groupType,
 			})
 		}
@@ -103,6 +119,7 @@ func rowSourceFromIPPermission(group *ec2.SecurityGroup, permission *ec2.IpPermi
 				IPRange:         nil,
 				Ipv6Range:       r,
 				UserIDGroupPair: nil,
+				PrefixListId:    nil,
 				Type:            groupType,
 			})
 		}
@@ -117,6 +134,7 @@ func rowSourceFromIPPermission(group *ec2.SecurityGroup, permission *ec2.IpPermi
 				IPRange:         nil,
 				Ipv6Range:       nil,
 				UserIDGroupPair: r,
+				PrefixListId:    nil,
 				Type:            groupType,
 			})
 		}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select group_name, group_id, ip_protocol, prefix_list_id from aws_vpc_security_group_rule where group_id = 'sg-005daf92f7db5ac15'
+------------+----------------------+-------------+----------------+
| group_name | group_id             | ip_protocol | prefix_list_id |
+------------+----------------------+-------------+----------------+
| db_pair    | sg-005daf92f7db5ac15 | tcp         | <null>         |
| db_pair    | sg-005daf92f7db5ac15 | tcp         | <null>         |
| db_pair    | sg-005daf92f7db5ac15 | icmp        | pl-02cd2c6b    |
| db_pair    | sg-005daf92f7db5ac15 | tcp         | <null>         |
| db_pair    | sg-005daf92f7db5ac15 | tcp         | <null>         |
| db_pair    | sg-005daf92f7db5ac15 | tcp         | <null>         |
| db_pair    | sg-005daf92f7db5ac15 | tcp         | <null>         |
| db_pair    | sg-005daf92f7db5ac15 | tcp         | <null>         |
+------------+----------------------+-------------+----------------+



> select
  group_name,
  group_id,
  type
from
  aws_vpc_security_group_rule
where
  type = 'ingress'
  and cidr_ip = '0.0.0.0/0';
+------------------------------------------------------------------------------------------------------+----------------------+---------+
| group_name                                                                                           | group_id             | type    |
+------------------------------------------------------------------------------------------------------+----------------------+---------+
| mytest                                                                                               | sg-0f4b27b4f9729fe5f | ingress |
| mytest                                                                                               | sg-0f4b27b4f9729fe5f | ingress |
| mytest                                                                                               | sg-0f4b27b4f9729fe5f | ingress |
| mytest                                                                                               | sg-0f4b27b4f9729fe5f | ingress |
| mytest                                                                                               | sg-0f4b27b4f9729fe5f | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | ingress |
| loganrdpad                                                                                           | sg-02be290795731af16 | ingress |
| web_public                                                                                           | sg-0916754d6c8ba039f | ingress |
| turbot_load_balancer_security_group                                                                  | sg-06be2a61e7e506f2a | ingress |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-3                                                      | sg-0979b8b17dbce9853 | ingress |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-3                                                      | sg-0979b8b17dbce9853 | ingress |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-3                                                      | sg-0979b8b17dbce9853 | ingress |
| EC2ContainerService-test-ec2-EcsSecurityGroup-1EEAA9WLMD8LB                                          | sg-09885e641f90459e0 | ingress |
| launch-wizard-8                                                                                      | sg-0392d931d8045def7 | ingress |
| launch-wizard-10                                                                                     | sg-0a17287b56e639711 | ingress |
| Amazon ECS-Optimized Amazon Linux 2 AMI-2-0-20201028-AutogenByAWSMP-1                                | sg-0a2433211a2938b4f | ingress |
| WebDMZ                                                                                               | sg-0222606403c4c447b | ingress |
| Amazon ECS-Optimized Amazon Linux 2 AMI-2-0-20201028-AutogenByAWSMP-1                                | sg-0a2433211a2938b4f | ingress |
| launch-wizard-22                                                                                     | sg-0a4e1c0f0ffc82b66 | ingress |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-                                                       | sg-0652166baf5b64093 | ingress |
| launch-wizard-12                                                                                     | sg-0ae4e5f44356340ce | ingress |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-                                                       | sg-0652166baf5b64093 | ingress |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-                                                       | sg-0652166baf5b64093 | ingress |
| Amazon ECS-Optimized Amazon Linux 2 AMI-2-0-20201028-AutogenByAWSMP-                                 | sg-0b1635331fae3ba0f | ingress |
| test:1-4377                                                                                          | sg-02f78de741a529393 | ingress |
| test-154                                                                                             | sg-0aa291e24ade6e9c4 | ingress |
| test:1-5973                                                                                          | sg-0fa2055d3f5470648 | ingress |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-1                                                      | sg-04d460089fe903489 | ingress |
| d-90671c7764_controllers                                                                             | sg-0fd151b65806f362c | ingress |
| d-90671c7764_controllers                                                                             | sg-0fd151b65806f362c | ingress |
| d-90671c7764_controllers                                                                             | sg-0fd151b65806f362c | ingress |
| d-90671c7764_controllers                                                                             | sg-0fd151b65806f362c | ingress |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-1                                                      | sg-04d460089fe903489 | ingress |
| d-90671c7764_controllers                                                                             | sg-0fd151b65806f362c | ingress |
| launch-wizard-1                                                                                      | sg-050044267e3bdf718 | ingress |
| d-90671c7764_controllers                                                                             | sg-0fd151b65806f362c | ingress |
| d-90671c7764_controllers                                                                             | sg-0fd151b65806f362c | ingress |
| d-90671c7764_controllers                                                                             | sg-0fd151b65806f362c | ingress |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-1                                                      | sg-04d460089fe903489 | ingress |
| d-90671c7764_controllers                                                                             | sg-0fd151b65806f362c | ingress |
| d-90671c7764_controllers                                                                             | sg-0fd151b65806f362c | ingress |
> select
  group_name,
  group_id,
  ip_protocol,
  from_port,
  to_port,
  cidr_ip
from
  aws_vpc_security_group_rule
where
  type = 'ingress'
  and cidr_ip = '0.0.0.0/0'
  and (
    (
      ip_protocol = '-1' -- all traffic
      and from_port is null
    )
    or (
      from_port <= 22
      and to_port >= 22
    )
    or (
      from_port <= 3389
      and to_port >= 3389
    )
  );
+------------------------------------------------------------------------------------------------------+----------------------+-------------+-----------+---------+-----------+
| group_name                                                                                           | group_id             | ip_protocol | from_port | to_port | cidr_ip   |
+------------------------------------------------------------------------------------------------------+----------------------+-------------+-----------+---------+-----------+
| mytest                                                                                               | sg-0f4b27b4f9729fe5f | -1          | <null>    | <null>  | 0.0.0.0/0 |
| mytest                                                                                               | sg-0f4b27b4f9729fe5f | tcp         | 0         | 65535   | 0.0.0.0/0 |
| d-906702a1a7_controllers                                                                             | sg-006d0099a53dc1a26 | tcp         | 1024      | 65535   | 0.0.0.0/0 |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-3                                                      | sg-0979b8b17dbce9853 | tcp         | 3389      | 3389    | 0.0.0.0/0 |
| launch-wizard-8                                                                                      | sg-0392d931d8045def7 | tcp         | 22        | 22      | 0.0.0.0/0 |
| launch-wizard-10                                                                                     | sg-0a17287b56e639711 | tcp         | 22        | 22      | 0.0.0.0/0 |
| Amazon ECS-Optimized Amazon Linux 2 AMI-2-0-20201028-AutogenByAWSMP-1                                | sg-0a2433211a2938b4f | tcp         | 22        | 22      | 0.0.0.0/0 |
| WebDMZ                                                                                               | sg-0222606403c4c447b | -1          | <null>    | <null>  | 0.0.0.0/0 |
| launch-wizard-22                                                                                     | sg-0a4e1c0f0ffc82b66 | tcp         | 22        | 22      | 0.0.0.0/0 |
| launch-wizard-12                                                                                     | sg-0ae4e5f44356340ce | tcp         | 22        | 22      | 0.0.0.0/0 |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-                                                       | sg-0652166baf5b64093 | tcp         | 3389      | 3389    | 0.0.0.0/0 |
| Amazon ECS-Optimized Amazon Linux 2 AMI-2-0-20201028-AutogenByAWSMP-                                 | sg-0b1635331fae3ba0f | tcp         | 22        | 22      | 0.0.0.0/0 |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-1                                                      | sg-04d460089fe903489 | tcp         | 3389      | 3389    | 0.0.0.0/0 |
| launch-wizard-1                                                                                      | sg-050044267e3bdf718 | tcp         | 22        | 22      | 0.0.0.0/0 |
| d-90671c7764_controllers                                                                             | sg-0fd151b65806f362c | tcp         | 1024      | 65535   | 0.0.0.0/0 |
| launch-wizard-16                                                                                     | sg-0bc4d038fca76cc4e | tcp         | 3389      | 3389    | 0.0.0.0/0 |
| launch-wizard-13                                                                                     | sg-0d74dc641c877cade | tcp         | 22        | 22      | 0.0.0.0/0 |
| launch-wizard-6                                                                                      | sg-092ede4017187d0fe | tcp         | 22        | 22      | 0.0.0.0/0 |
| default                                                                                              | sg-05cfaa2b4daf48b37 | tcp         | 22        | 22      | 0.0.0.0/0 |
| ADFS Server Windows 2016-0-0-1-AutogenByAWSMP-2                                                      | sg-063634f2153c0cfae | tcp         | 3389      | 3389    | 0.0.0.0/0 |
| launch-wizard-14                                                                                     | sg-064a2ea3cd488c5ea | tcp         | 22        | 22      | 0.0.0.0/0 |
| siemenstest                                                                                          | sg-0c8455e0b8e1ce2b3 | tcp         | 22        | 22      | 0.0.0.0/0 |
| launch-wizard-3                                                                                      | sg-0bf35eb415a2a5120 | tcp         | 22        | 22      | 0.0.0.0/0 |
| launch-wizard-2                                                                                      | sg-0fa5ad244c986a9d8 | tcp         | 22        | 22      | 0.0.0.0/0 |
| launch-wizard-1                                                                                      | sg-0499d5c834e2a4632 | tcp         | 22        | 22      | 0.0.0.0/0 |
| launch-wizard-2                                                                                      | sg-0f62cace9bf3e985d | tcp         | 22        | 22      | 0.0.0.0/0 |
| launch-wizard-3                                                                                      | sg-0a7ae87c0a50b4171 | tcp         | 22        | 22      | 0.0.0.0/0 |
| aws-cloud9-Victor-Dev-in-Ireland-6899d33dd92e46f2aa341161e404441e-InstanceSecurityGroup-35HLNBQH8XB3 | sg-02145a327fe86c480 | tcp         | 22        | 22      | 0.0.0.0/0 |
+------------------------------------------------------------------------------------------------------+----------------------+-------------+-----------+---------+-----------+

```
</details>
