### PR TITLE
Added optional key qual,context cancellation in list call, page limiting for limit clause and design change in aws_sfn_state_* tables.

### DIFF
--- a/aws/table_aws_sfn_state_machine_execution.go
+++ b/aws/table_aws_sfn_state_machine_execution.go
@@ -130,6 +130,8 @@ func listStepFunctionsStateMachineExecutions(ctx context.Context, d *plugin.Quer
 		input.StatusFilter = aws.String(status)
 	}
 
+	// If the requested number of items is less than the paging max limit
+	// set the limit to that instead
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxResults {

--- a/aws/table_aws_sfn_state_machine_execution_history.go
+++ b/aws/table_aws_sfn_state_machine_execution_history.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"strconv"
 	"strings"
+	"sync"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/sfn"
+	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
@@ -17,14 +18,8 @@ func tableAwsStepFunctionsStateMachineExecutionHistory(_ context.Context) *plugi
 		Name:        "aws_sfn_state_machine_execution_history",
 		Description: "AWS Step Functions State Machine Execution History",
 		List: &plugin.ListConfig{
-			Hydrate:           listStepFunctionsStateMachineExecutionHistories,
-			ShouldIgnoreError: isNotFoundError([]string{"ExecutionDoesNotExist", "InvalidParameter", "InvalidArn"}),
-			KeyColumns: []*plugin.KeyColumn{
-				{
-					Name:    "execution_arn",
-					Require: plugin.Required,
-				},
-			},
+			Hydrate:       listStepFunctionsStateMachineExecutionHistories,
+			ParentHydrate: listStepFunctionsStateManchines,
 		},
 		GetMatrixItem: BuildRegionList,
 		Columns: awsRegionalColumns([]*plugin.Column{
@@ -225,7 +220,7 @@ func tableAwsStepFunctionsStateMachineExecutionHistory(_ context.Context) *plugi
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.From(executionHistoryAkas),
+				Transform:   transform.From(executionHistoryArn),
 			},
 		}),
 	}
@@ -245,44 +240,30 @@ func listStepFunctionsStateMachineExecutionHistories(ctx context.Context, d *plu
 		plugin.Logger(ctx).Error("listStepFunctionsStateMachineExecutionHistories", "connection_error", err)
 		return nil, err
 	}
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
-	commonData, err := getCommonColumnsCached(ctx, d, h)
-	if err != nil {
-		return nil, err
-	}
-	commonColumnData := commonData.(*awsCommonColumnData)
 
-	arn := d.KeyColumnQuals["execution_arn"].GetStringValue()
-	accountId := commonColumnData.AccountId
+	stateMachineArn := h.Item.(*sfn.StateMachineListItem).StateMachineArn
+	var executions []sfn.ExecutionListItem
 
-	// check if the arn is empty or it contains a valid accountId
-	if arn == "" || accountId != strings.Split(arn, ":")[4] {
-		return nil, nil
-	}
-
-	params := &sfn.GetExecutionHistoryInput{
-		ExecutionArn: aws.String(arn),
-		MaxResults:   aws.Int64(1000),
+	input := &sfn.ListExecutionsInput{
+		MaxResults:      types.Int64(100),
+		StateMachineArn: stateMachineArn,
 	}
 
 	// If the requested number of items is less than the paging max limit
 	// set the limit to that instead
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
-		if *limit < *params.MaxResults {
-			params.MaxResults = limit
+		if *limit < *input.MaxResults {
+			input.MaxResults = limit
 		}
 	}
 
-	err = svc.GetExecutionHistoryPages(
-		params,
-		func(page *sfn.GetExecutionHistoryOutput, isLast bool) bool {
-			for _, events := range page.Events {
-				d.StreamListItem(ctx, historyInfo{*events, arn})
-				// Context can be cancelled due to manual cancellation or the limit has been hit
-				if d.QueryStatus.RowsRemaining(ctx) == 0 {
-					return false
-				}
+	// List call
+	err = svc.ListExecutionsPages(
+		input,
+		func(page *sfn.ListExecutionsOutput, isLast bool) bool {
+			for _, execution := range page.Executions {
+				executions = append(executions, *execution)
 			}
 			return !isLast
 		},
@@ -293,13 +274,77 @@ func listStepFunctionsStateMachineExecutionHistories(ctx context.Context, d *plu
 		return nil, err
 	}
 
+	var wg sync.WaitGroup
+	executionCh := make(chan []historyInfo, len(executions))
+	errorCh := make(chan error, len(executions))
+
+	// Iterating all the available executions
+	for _, item := range executions {
+		wg.Add(1)
+		go getRowDataForExecutionHistoryAsync(ctx, d, *item.ExecutionArn, &wg, executionCh, errorCh)
+	}
+
+	// wait for all executions to be processed
+	wg.Wait()
+	close(executionCh)
+	close(errorCh)
+
+	for err := range errorCh {
+		plugin.Logger(ctx).Error("listStepFunctionsStateMachineExecutionHistories", "getRowDataForExecutionHistoryAsync_error", err)
+		return nil, err
+	}
+
+	for item := range executionCh {
+		for _, data := range item {
+			d.StreamLeafListItem(ctx, historyInfo{data.HistoryEvent, data.ExecutionArn})
+		}
+	}
+
 	return nil, nil
+}
+
+func getRowDataForExecutionHistoryAsync(ctx context.Context, d *plugin.QueryData, arn string, wg *sync.WaitGroup, executionCh chan []historyInfo, errorCh chan error) {
+	defer wg.Done()
+
+	rowData, err := getRowDataForExecutionHistory(ctx, d, arn)
+	if err != nil {
+		errorCh <- err
+	} else if rowData != nil {
+		executionCh <- rowData
+	}
+}
+
+func getRowDataForExecutionHistory(ctx context.Context, d *plugin.QueryData, arn string) ([]historyInfo, error) {
+	// Create session
+	svc, err := StepFunctionsService(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("getRowDataForExecutionHistory", "connection_error", err)
+		return nil, err
+	}
+
+	params := &sfn.GetExecutionHistoryInput{
+		ExecutionArn: types.String(arn),
+	}
+
+	var items []historyInfo
+
+	listHistory, err := svc.GetExecutionHistory(params)
+	if err != nil {
+		plugin.Logger(ctx).Error("getRowDataForExecutionHistory", "GetExecutionHistory_error", err)
+		return nil, err
+	}
+
+	for _, event := range listHistory.Events {
+		items = append(items, historyInfo{*event, arn})
+	}
+
+	return items, nil
 }
 
 //// Transform Function
 
-func executionHistoryAkas(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("executionHistoryAkas")
+func executionHistoryArn(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("executionHistoryArn")
 	history := d.HydrateItem.(historyInfo)
 
 	// For State Machine, ARN format is arn:aws:states:us-east-1:632902152528:stateMachine:HelloWorld

--- a/docs/tables/aws_sfn_state_machine_execution_history.md
+++ b/docs/tables/aws_sfn_state_machine_execution_history.md
@@ -14,7 +14,9 @@ select
   timestamp,
   type
 from
-  aws_sfn_state_machine_execution_history;
+  aws_sfn_state_machine_execution_history
+where
+  execution_arn = 'arn:aws:states:us-east-1:53372495:execution:test:728691df-de37-2ea8-445';
 ```
 
 ### List execution started event details
@@ -29,5 +31,6 @@ select
 from
   aws_sfn_state_machine_execution_history
 where
-  type = 'ExecutionStarted';
+  type = 'ExecutionStarted' and 
+  execution_arn = 'arn:aws:states:us-east-1:53372495:execution:test:728691df-de37-2ea8-445';
 ```

--- a/docs/tables/aws_sfn_state_machine_execution_history.md
+++ b/docs/tables/aws_sfn_state_machine_execution_history.md
@@ -14,9 +14,7 @@ select
   timestamp,
   type
 from
-  aws_sfn_state_machine_execution_history
-where
-  execution_arn = 'arn:aws:states:us-east-1:53372495:execution:test:728691df-de37-2ea8-445';
+  aws_sfn_state_machine_execution_history;
 ```
 
 ### List execution started event details
@@ -31,6 +29,5 @@ select
 from
   aws_sfn_state_machine_execution_history
 where
-  type = 'ExecutionStarted' and 
-  execution_arn = 'arn:aws:states:us-east-1:53372495:execution:test:728691df-de37-2ea8-445';
+  type = 'ExecutionStarted';
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_sfn_state_machine_execution []

PRETEST: tests/aws_sfn_state_machine_execution

TEST: tests/aws_sfn_state_machine_execution
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.input will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "input"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/aws_sfn_state_machine_execution/terraform/test/output.json"
      + id             = (known after apply)
    }

  # aws_iam_role.sfn_role will be created
  + resource "aws_iam_role" "sfn_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "states.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest73280"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_sfn_state_machine.named_test_resource will be created
  + resource "aws_sfn_state_machine" "named_test_resource" {
      + arn           = (known after apply)
      + creation_date = (known after apply)
      + definition    = jsonencode(
            {
              + Comment = "A Hello World example of the Amazon States Language using Pass states"
              + StartAt = "Hello"
              + States  = {
                  + Hello = {
                      + Next   = "World"
                      + Result = "Hello"
                      + Type   = "Pass"
                    }
                  + World = {
                      + End    = true
                      + Result = "World"
                      + Type   = "Pass"
                    }
                }
            }
        )
      + id            = (known after apply)
      + name          = "turbottest73280"
      + role_arn      = (known after apply)
      + status        = (known after apply)
      + tags          = {
          + "name" = "turbottest73280"
        }
      + tags_all      = {
          + "name" = "turbottest73280"
        }
      + type          = "STANDARD"

      + logging_configuration {
          + include_execution_data = (known after apply)
          + level                  = (known after apply)
          + log_destination        = (known after apply)
        }

      + tracing_configuration {
          + enabled = (known after apply)
        }
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + execution_arn     = (known after apply)
  + state_machine_arn = (known after apply)
aws_iam_role.sfn_role: Creating...
aws_iam_role.sfn_role: Still creating... [10s elapsed]
aws_iam_role.sfn_role: Still creating... [20s elapsed]
aws_iam_role.sfn_role: Still creating... [30s elapsed]
aws_iam_role.sfn_role: Still creating... [40s elapsed]
aws_iam_role.sfn_role: Creation complete after 46s [id=turbottest73280]
aws_sfn_state_machine.named_test_resource: Creating...
aws_sfn_state_machine.named_test_resource: Creation complete after 4s [id=arn:aws:states:us-east-1:53379368:stateMachine:turbottest73280]
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "aws stepfunctions start-execution --state-machine-arn arn:aws:states:us-east-1:53379368:stateMachine:turbottest73280  --output json > /private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/aws_sfn_state_machine_execution/terraform/test/output.json"]
null_resource.named_test_resource: Creation complete after 3s [id=3341651681576740334]
data.local_file.input: Reading...
data.local_file.input: Read complete after 0s [id=333fed95684065d326bb82f6f1c2610f35d47ab9]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

execution_arn = "arn:aws:states:us-east-1:53379368:execution:turbottest73280:97c55bbc-9ab3-400c-8e38-5edd5179bd85"
state_machine_arn = "arn:aws:states:us-east-1:53379368:stateMachine:turbottest73280"

Running SQL query: test-get-call-query.sql
[
  {
    "akas": [
      "arn:aws:states:us-east-1:53379368:execution:turbottest73280:97c55bbc-9ab3-400c-8e38-5edd5179bd85"
    ],
    "execution_arn": "arn:aws:states:us-east-1:53379368:execution:turbottest73280:97c55bbc-9ab3-400c-8e38-5edd5179bd85",
    "state_machine_arn": "arn:aws:states:us-east-1:53379368:stateMachine:turbottest73280"
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "akas": [
      "arn:aws:states:us-east-1:53379368:execution:turbottest73280:97c55bbc-9ab3-400c-8e38-5edd5179bd85"
    ],
    "execution_arn": "arn:aws:states:us-east-1:53379368:execution:turbottest73280:97c55bbc-9ab3-400c-8e38-5edd5179bd85",
    "state_machine_arn": "arn:aws:states:us-east-1:53379368:stateMachine:turbottest73280"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:states:us-east-1:53379368:execution:turbottest73280:97c55bbc-9ab3-400c-8e38-5edd5179bd85"
    ]
  }
]
✔ PASSED

POSTTEST: tests/aws_sfn_state_machine_execution

TEARDOWN: tests/aws_sfn_state_machine_execution

SUMMARY:

1/1 passed.

SETUP: tests/aws_sfn_state_machine_execution_history []

PRETEST: tests/aws_sfn_state_machine_execution_history

TEST: tests/aws_sfn_state_machine_execution_history
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.execution will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "execution"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/aws_sfn_state_machine_execution_history/terraform/test/execution_path.json"
      + id             = (known after apply)
    }

  # data.local_file.execution_history will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "execution_history"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/aws_sfn_state_machine_execution_history/terraform/test/execution_history_path.json"
      + id             = (known after apply)
    }

  # aws_iam_role.sfn_role will be created
  + resource "aws_iam_role" "sfn_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "states.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest33614"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_sfn_state_machine.named_test_resource will be created
  + resource "aws_sfn_state_machine" "named_test_resource" {
      + arn           = (known after apply)
      + creation_date = (known after apply)
      + definition    = jsonencode(
            {
              + Comment = "A Hello World example of the Amazon States Language using Pass states"
              + StartAt = "Hello"
              + States  = {
                  + Hello = {
                      + Next   = "World"
                      + Result = "Hello"
                      + Type   = "Pass"
                    }
                  + World = {
                      + End    = true
                      + Result = "World"
                      + Type   = "Pass"
                    }
                }
            }
        )
      + id            = (known after apply)
      + name          = "turbottest33614"
      + role_arn      = (known after apply)
      + status        = (known after apply)
      + tags          = {
          + "name" = "turbottest33614"
        }
      + tags_all      = {
          + "name" = "turbottest33614"
        }
      + type          = "STANDARD"

      + logging_configuration {
          + include_execution_data = (known after apply)
          + level                  = (known after apply)
          + log_destination        = (known after apply)
        }

      + tracing_configuration {
          + enabled = (known after apply)
        }
    }

  # null_resource.execution will be created
  + resource "null_resource" "execution" {
      + id = (known after apply)
    }

  # null_resource.execution_history will be created
  + resource "null_resource" "execution_history" {
      + id = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + akas          = (known after apply)
  + execution_arn = (known after apply)
  + id            = (known after apply)
  + type          = (known after apply)
aws_iam_role.sfn_role: Creating...
aws_iam_role.sfn_role: Still creating... [10s elapsed]
aws_iam_role.sfn_role: Still creating... [20s elapsed]
aws_iam_role.sfn_role: Still creating... [30s elapsed]
aws_iam_role.sfn_role: Still creating... [40s elapsed]
aws_iam_role.sfn_role: Creation complete after 46s [id=turbottest33614]
aws_sfn_state_machine.named_test_resource: Creating...
aws_sfn_state_machine.named_test_resource: Creation complete after 4s [id=arn:aws:states:us-east-1:53379368:stateMachine:turbottest33614]
null_resource.execution: Creating...
null_resource.execution: Provisioning with 'local-exec'...
null_resource.execution (local-exec): Executing: ["/bin/sh" "-c" "aws stepfunctions start-execution --state-machine-arn arn:aws:states:us-east-1:53379368:stateMachine:turbottest33614  --output json > /private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/aws_sfn_state_machine_execution_history/terraform/test/execution_path.json"]
null_resource.execution: Creation complete after 3s [id=1200021576433130769]
data.local_file.execution: Reading...
data.local_file.execution: Read complete after 0s [id=272ef4c7d0ca275ac6db1ddc01e698e7f6c89b87]
null_resource.execution_history: Creating...
null_resource.execution_history: Provisioning with 'local-exec'...
null_resource.execution_history (local-exec): Executing: ["/bin/sh" "-c" "aws stepfunctions get-execution-history --execution-arn arn:aws:states:us-east-1:53379368:execution:turbottest33614:889f7d09-4dfa-49c6-9583-cecc5869eaed  --output json > /private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/aws_sfn_state_machine_execution_history/terraform/test/execution_history_path.json"]
null_resource.execution_history: Creation complete after 1s [id=8573756793071923316]
data.local_file.execution_history: Reading...
data.local_file.execution_history: Read complete after 0s [id=7a4f65cd15478339162976bfe20aef67305a8003]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

akas = "arn:aws:states:us-east-1:53379368:executionHistory:turbottest33614:889f7d09-4dfa-49c6-9583-cecc5869eaed:1"
execution_arn = "arn:aws:states:us-east-1:53379368:execution:turbottest33614:889f7d09-4dfa-49c6-9583-cecc5869eaed"
id = 1
type = "ExecutionStarted"

Running SQL query: test-list-call-query.sql
[
  {
    "akas": [
      "arn:aws:states:us-east-1:53379368:executionHistory:turbottest33614:889f7d09-4dfa-49c6-9583-cecc5869eaed:1"
    ],
    "execution_arn": "arn:aws:states:us-east-1:53379368:execution:turbottest33614:889f7d09-4dfa-49c6-9583-cecc5869eaed",
    "id": "1",
    "type": "ExecutionStarted"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:states:us-east-1:53379368:executionHistory:turbottest33614:889f7d09-4dfa-49c6-9583-cecc5869eaed:1"
    ],
    "title": "1"
  }
]
✔ PASSED

POSTTEST: tests/aws_sfn_state_machine_execution_history

TEARDOWN: tests/aws_sfn_state_machine_execution_history

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
#Before the changes 

> select * from aws_sfn_state_machine_execution limit 2

Time: 14.908949363s
+--------------------------------------+-------------------------------------------------------------------------------------------------------------------------+-----------+------------------------------
| name                                 | execution_arn                                                                                                           | status    | input                        
+--------------------------------------+-------------------------------------------------------------------------------------------------------------------------+-----------+------------------------------
| dac2f806-3567-af2c-5e64-2a84766496f4 | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:dac2f806-3567-af2c-5e64-2a84766496f4                      | FAILED    | {                            
|                                      |                                                                                                                         |           |     "Comment": "Insert your J
|                                      |                                                                                                                         |           | }                            
| eea0f8c8-bff7-aa9b-94d2-e99b6e18baa5 | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:eea0f8c8-bff7-aa9b-94d2-e99b6e18baa5 | SUCCEEDED | {                            
|                                      |                                                                                                                         |           |   "topic": "arn:aws:sns:us-ea
|                                      |                                                                                                                         |           |   "message": "HelloWorld",   
|                                      |                                                                                                                         |           |   "timer_seconds": 5         
|                                      |                                                                                                                         |           | }                            
+--------------------------------------+-------------------------------------------------------------------------------------------------------------------------+-----------+------------------------------


> select * from aws_sfn_state_machine_execution where status = 'FAILED'

Time: 2.77138514s
+---------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------+----------------------------------------
| name                                        | execution_arn                                                                                             | status | input                                  
+---------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------+----------------------------------------
| 3d552e81-b721-9ca9-ff7a-9ba354a8e88c-newone | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:3d552e81-b721-9ca9-ff7a-9ba354a8e88c-newone | FAILED | {                                      
|                                             |                                                                                                           |        |     "Comment": "Insert your JSON here a
|                                             |                                                                                                           |        | }                                      
| dac2f806-3567-af2c-5e64-2a84766496f4        | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:dac2f806-3567-af2c-5e64-2a84766496f4        | FAILED | {                                      
|                                             |                                                                                                           |        |     "Comment": "Insert your JSON here" 
|                                             |                                                                                                           |        | }                                      
| 1535597a-0644-cb19-c9fd-d59b58eba178        | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:1535597a-0644-cb19-c9fd-d59b58eba178        | FAILED | {                                      
|                                             |                                                                                                           |        |     "Comment": "Insert your JSON here f
|                                             |                                                                                                           |        | }                                      
+---------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------+----------------------------------------

#after the changes

> select * from aws_sfn_state_machine_execution where status = 'FAILED'

Time: 1.425884551s
+---------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------+----------------------------------------
| name                                        | execution_arn                                                                                             | status | input                                  
+---------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------+----------------------------------------
| dac2f806-3567-af2c-5e64-2a84766496f4        | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:dac2f806-3567-af2c-5e64-2a84766496f4        | FAILED | {                                      
|                                             |                                                                                                           |        |     "Comment": "Insert your JSON here" 
|                                             |                                                                                                           |        | }                                      
| 3d552e81-b721-9ca9-ff7a-9ba354a8e88c-newone | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:3d552e81-b721-9ca9-ff7a-9ba354a8e88c-newone | FAILED | {                                      
|                                             |                                                                                                           |        |     "Comment": "Insert your JSON here a
|                                             |                                                                                                           |        | }                                      
| 1535597a-0644-cb19-c9fd-d59b58eba178        | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:1535597a-0644-cb19-c9fd-d59b58eba178        | FAILED | {                                      
|                                             |                                                                                                           |        |     "Comment": "Insert your JSON here f
|                                             |                                                                                                           |        | }                                      
+---------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------+----------------------------------------


> select * from aws_sfn_state_machine_execution limit 2

Time: 1.183431052s
+---------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------+----------------------------------------
| name                                        | execution_arn                                                                                             | status | input                                  
+---------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------+----------------------------------------
| 3d552e81-b721-9ca9-ff7a-9ba354a8e88c-newone | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:3d552e81-b721-9ca9-ff7a-9ba354a8e88c-newone | FAILED | {                                      
|                                             |                                                                                                           |        |     "Comment": "Insert your JSON here a
|                                             |                                                                                                           |        | }                                      
| dac2f806-3567-af2c-5e64-2a84766496f4        | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:dac2f806-3567-af2c-5e64-2a84766496f4        | FAILED | {                                      
|                                             |                                                                                                           |        |     "Comment": "Insert your JSON here" 
|                                             |                                                                                                           |        | }                                      
+---------------------------------------------+-----------------------------------------------------------------------------------------------------------+--------+----------------------------------------



> select * from aws_sfn_state_machine limit 1
+---------------+------------------------------------------------------------------+--------+----------+----------------------+-----------------------------------------------------------------------------
| name          | arn                                                              | status | type     | creation_date        | definition                                                                  
+---------------+------------------------------------------------------------------+--------+----------+----------------------+-----------------------------------------------------------------------------
| RajHelloWorld | arn:aws:states:us-east-1:53379368:stateMachine:RajHelloWorld | ACTIVE | STANDARD | 2021-11-02T10:34:17Z | {                                                                           
|               |                                                                  |        |          |                      |   "Comment": "A Hello World example demonstrating various state types of the
|               |                                                                  |        |          |                      |   "StartAt": "Pass",                                                        
|               |                                                                  |        |          |                      |   "States": {                                                               
|               |                                                                  |        |          |                      |     "Pass": {                                                               
|               |                                                                  |        |          |                      |       "Comment": "A Pass state passes its input to its output, without perfo
|               |                                                                  |        |          |                      |       "Type": "Pass",                                                       
|               |                                                                  |        |          |                      |       "Next": "Hello World example?"                                        
|               |                                                                  |        |          |                      |     },                                                                      
|               |                                                                  |        |          |                      |     "Hello World example?": {                                               
|               |                                                                  |        |          |                      |       "Comment": "A Choice state adds branching logic to a state machine. Ch
|               |                                                                  |        |          |                      |       "Type": "Choice",                                                     
|               |                                                                  |        |          |                      |       "Choices": [                                                          
|               |                                                                  |        |          |                      |         {                                                                   
|               |                                                                  |        |          |                      |           "Variable": "$.IsHelloWorldExample",                              
|               |                                                                  |        |          |                      |           "BooleanEquals": true,                                            
|               |                                                                  |        |          |                      |           "Next": "Yes"                                                     
|               |                                                                  |        |          |                      |         },                                                                  
|               |                                                                  |        |          |                      |         {                                                                   
|               |                                                                  |        |          |                      |           "Variable": "$.IsHelloWorldExample",                              
|               |                                                                  |        |          |                      |           "BooleanEquals": false,                                           
|               |                                                                  |        |          |                      |           "Next": "No"                                                      
|               |                                                                  |        |          |                      |         }                                                                   
|               |                                                                  |        |          |                      |       ],                                                                    
|               |                                                                  |        |          |                      |       "Default": "Yes"                                                      
|               |                                                                  |        |          |                      |     },                                                                      
|               |                                                                  |        |          |                      |     "Yes": {                                                                
|               |                                                                  |        |          |                      |       "Type": "Pass",                                                       
|               |                                                                  |        |          |                      |       "Next": "Wait 3 sec"                                                  
|               |                                                                  |        |          |                      |     },                                                                      
|               |                                                                  |        |          |                      |     "No": {                                                                 
|               |                                                                  |        |          |                      |       "Type": "Fail",                                                       
|               |                                                                  |        |          |                      |       "Cause": "Not Hello World"                                            
|               |                                                                  |        |          |                      |     },                                                                      
|               |                                                                  |        |          |                      |     "Wait 3 sec": {                                                         
|               |                                                                  |        |          |                      |       "Comment": "A Wait state delays the state machine from continuing for 
|               |                                                                  |        |          |                      |       "Type": "Wait",                                                       
|               |                                                                  |        |          |                      |       "Seconds": 3,                                                         
|               |                                                                  |        |          |                      |       "Next": "Parallel State"                                              
|               |                                                                  |        |          |                      |     },                                                                      
|               |                                                                  |        |          |                      |     "Parallel State": {                                                     
|               |                                                                  |        |          |                      |       "Comment": "A Parallel state can be used to create parallel branches o
|               |                                                                  |        |          |                      |       "Type": "Parallel",                                                   
|               |                                                                  |        |          |                      |       "Next": "Hello World",                                                
|               |                                                                  |        |          |                      |       "Branches": [                                                         
|               |                                                                  |        |          |                      |         {                                                                   
|               |                                                                  |        |          |                      |           "StartAt": "Hello",                                               
|               |                                                                  |        |          |                      |           "States": {                                                       
|               |                                                                  |        |          |                      |             "Hello": {                                                      
|               |                                                                  |        |          |                      |               "Type": "Pass",                                               
|               |                                                                  |        |          |                      |               "End": true                                                   
|               |                                                                  |        |          |                      |             }                                                               
|               |                                                                  |        |          |                      |           }                                                                 
|               |                                                                  |        |          |                      |         },                                                                  
|               |                                                                  |        |          |                      |         {                                                                   
|               |                                                                  |        |          |                      |           "StartAt": "World",                                               
|               |                                                                  |        |          |                      |           "States": {                                                       
> select * from aws_sfn_state_machine_execution_history
+----+-------------------------------------------------------------------------------------------------------------------------+-------------------+----------------------+-------------------------+-------
| id | execution_arn                                                                                                           | previous_event_id | timestamp            | type                    | activi
+----+-------------------------------------------------------------------------------------------------------------------------+-------------------+----------------------+-------------------------+-------
| 2  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:0e6ac439-e1cd-8772-98b4-bc6c1f27cce2 | 0                 | 2021-11-02T12:13:50Z | WaitStateEntered        | <null>
| 3  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:eea0f8c8-bff7-aa9b-94d2-e99b6e18baa5 | 2                 | 2021-11-02T12:21:00Z | WaitStateExited         | <null>
| 7  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:eea0f8c8-bff7-aa9b-94d2-e99b6e18baa5 | 6                 | 2021-11-02T12:21:01Z | LambdaFunctionSucceeded | <null>
| 6  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:eea0f8c8-bff7-aa9b-94d2-e99b6e18baa5 | 5                 | 2021-11-02T12:21:00Z | LambdaFunctionStarted   | <null>
| 1  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:eea0f8c8-bff7-aa9b-94d2-e99b6e18baa5 | 0                 | 2021-11-02T12:20:55Z | ExecutionStarted        | <null>
| 9  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:eea0f8c8-bff7-aa9b-94d2-e99b6e18baa5 | 8                 | 2021-11-02T12:21:01Z | ExecutionSucceeded      | <null>
| 9  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:0e6ac439-e1cd-8772-98b4-bc6c1f27cce2 | 8                 | 2021-11-02T12:14:02Z | ExecutionSucceeded      | <null>
| 1  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:0e6ac439-e1cd-8772-98b4-bc6c1f27cce2 | 0                 | 2021-11-02T12:13:50Z | ExecutionStarted        | <null>
| 5  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:eea0f8c8-bff7-aa9b-94d2-e99b6e18baa5 | 4                 | 2021-11-02T12:21:00Z | LambdaFunctionScheduled | <null>
| 5  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:0e6ac439-e1cd-8772-98b4-bc6c1f27cce2 | 4                 | 2021-11-02T12:14:00Z | LambdaFunctionScheduled | <null>
| 6  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:0e6ac439-e1cd-8772-98b4-bc6c1f27cce2 | 5                 | 2021-11-02T12:14:00Z | LambdaFunctionStarted   | <null>
| 8  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:eea0f8c8-bff7-aa9b-94d2-e99b6e18baa5 | 7                 | 2021-11-02T12:21:01Z | TaskStateExited         | <null>
| 2  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:eea0f8c8-bff7-aa9b-94d2-e99b6e18baa5 | 0                 | 2021-11-02T12:20:55Z | WaitStateEntered        | <null>
| 3  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:0e6ac439-e1cd-8772-98b4-bc6c1f27cce2 | 2                 | 2021-11-02T12:14:00Z | WaitStateExited         | <null>
| 7  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:0e6ac439-e1cd-8772-98b4-bc6c1f27cce2 | 6                 | 2021-11-02T12:14:02Z | LambdaFunctionSucceeded | <null>
| 4  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:0e6ac439-e1cd-8772-98b4-bc6c1f27cce2 | 3                 | 2021-11-02T12:14:00Z | TaskStateEntered        | <null>
| 4  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:eea0f8c8-bff7-aa9b-94d2-e99b6e18baa5 | 3                 | 2021-11-02T12:21:00Z | TaskStateEntered        | <null>
| 8  | arn:aws:states:us-east-1:53379368:execution:TaskTimerStateMachine-SmK56Uu0ge6y:0e6ac439-e1cd-8772-98b4-bc6c1f27cce2 | 7                 | 2021-11-02T12:14:02Z | TaskStateExited         | <null>
| 1  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 0                 | 2021-11-02T10:34:23Z | ExecutionStarted        | <null>
| 7  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 6                 | 2021-11-02T10:34:24Z | PassStateExited         | <null>
| 4  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:3d552e81-b721-9ca9-ff7a-9ba354a8e88c-newone               | 3                 | 2021-11-02T12:08:28Z | ChoiceStateEntered      | <null>
| 2  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 0                 | 2021-11-02T10:34:23Z | PassStateEntered        | <null>
| 18 | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 17                | 2021-11-02T10:34:27Z | PassStateEntered        | <null>
| 9  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 8                 | 2021-11-02T10:34:27Z | WaitStateExited         | <null>
| 11 | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 10                | 2021-11-02T10:34:27Z | ParallelStateStarted    | <null>
| 5  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:3d552e81-b721-9ca9-ff7a-9ba354a8e88c-newone               | 0                 | 2021-11-02T12:08:28Z | ExecutionFailed         | <null>
| 12 | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 11                | 2021-11-02T10:34:27Z | PassStateEntered        | <null>
| 5  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 4                 | 2021-11-02T10:34:24Z | ChoiceStateExited       | <null>
| 3  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 2                 | 2021-11-02T10:34:23Z | PassStateExited         | <null>
| 13 | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 12                | 2021-11-02T10:34:27Z | PassStateExited         | <null>
| 8  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 7                 | 2021-11-02T10:34:24Z | WaitStateEntered        | <null>
| 1  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:3d552e81-b721-9ca9-ff7a-9ba354a8e88c-newone               | 0                 | 2021-11-02T12:08:28Z | ExecutionStarted        | <null>
| 10 | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 9                 | 2021-11-02T10:34:27Z | ParallelStateEntered    | <null>
| 2  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:1535597a-0644-cb19-c9fd-d59b58eba178                      | 0                 | 2021-11-02T11:59:44Z | PassStateEntered        | <null>
| 6  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 5                 | 2021-11-02T10:34:24Z | PassStateEntered        | <null>
| 4  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 3                 | 2021-11-02T10:34:24Z | ChoiceStateEntered      | <null>
| 19 | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 18                | 2021-11-02T10:34:27Z | PassStateExited         | <null>
| 2  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:3d552e81-b721-9ca9-ff7a-9ba354a8e88c-newone               | 0                 | 2021-11-02T12:08:28Z | PassStateEntered        | <null>
| 3  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:1535597a-0644-cb19-c9fd-d59b58eba178                      | 2                 | 2021-11-02T11:59:44Z | PassStateExited         | <null>
| 14 | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 11                | 2021-11-02T10:34:27Z | PassStateEntered        | <null>
| 2  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:dac2f806-3567-af2c-5e64-2a84766496f4                      | 0                 | 2021-11-02T12:09:00Z | PassStateEntered        | <null>
| 20 | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 19                | 2021-11-02T10:34:27Z | ExecutionSucceeded      | <null>
| 17 | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 15                | 2021-11-02T10:34:27Z | ParallelStateExited     | <null>
| 16 | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 15                | 2021-11-02T10:34:27Z | ParallelStateSucceeded  | <null>
| 3  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:dac2f806-3567-af2c-5e64-2a84766496f4                      | 2                 | 2021-11-02T12:09:00Z | PassStateExited         | <null>
| 5  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:1535597a-0644-cb19-c9fd-d59b58eba178                      | 0                 | 2021-11-02T11:59:44Z | ExecutionFailed         | <null>
| 4  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:1535597a-0644-cb19-c9fd-d59b58eba178                      | 3                 | 2021-11-02T11:59:44Z | ChoiceStateEntered      | <null>
| 1  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:dac2f806-3567-af2c-5e64-2a84766496f4                      | 0                 | 2021-11-02T12:09:00Z | ExecutionStarted        | <null>
| 3  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:3d552e81-b721-9ca9-ff7a-9ba354a8e88c-newone               | 2                 | 2021-11-02T12:08:28Z | PassStateExited         | <null>
| 4  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:dac2f806-3567-af2c-5e64-2a84766496f4                      | 3                 | 2021-11-02T12:09:00Z | ChoiceStateEntered      | <null>
| 1  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:1535597a-0644-cb19-c9fd-d59b58eba178                      | 0                 | 2021-11-02T11:59:44Z | ExecutionStarted        | <null>
| 5  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:dac2f806-3567-af2c-5e64-2a84766496f4                      | 0                 | 2021-11-02T12:09:00Z | ExecutionFailed         | <null>
| 15 | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a                      | 14                | 2021-11-02T10:34:27Z | PassStateExited         | <null>
+----+-------------------------------------------------------------------------------------------------------------------------+-------------------+----------------------+-------------------------+-------

> select
  id,
  execution_arn,
  execution_started_event_details -> 'Input' as event_input,
  execution_started_event_details -> 'InputDetails' as event_input_details,
  execution_started_event_details ->> 'RoleArn' as event_role_arn
from
  aws_sfn_state_machine_execution_history
where
  type = 'ExecutionStarted' and 
  execution_arn = 'arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a';
+----+----------------------------------------------------------------------------------------------------+-------------------------------------------+---------------------+-------------------------------
| id | execution_arn                                                                                      | event_input                               | event_input_details | event_role_arn                
+----+----------------------------------------------------------------------------------------------------+-------------------------------------------+---------------------+-------------------------------
| 1  | arn:aws:states:us-east-1:53379368:execution:RajHelloWorld:728691df-de37-2ea8-445f-b58774300f9a | "{\n    \"IsHelloWorldExample\": true\n}" | {"Truncated":false} | arn:aws:iam::53379368:role
+----+----------------------------------------------------------------------------------------------------+-------------------------------------------+---------------------+-------------------------------
```
</details>
