### PR TITLE
Add example query for aws_rds_db_instance. Closes #805

### DIFF
--- a/docs/tables/aws_rds_db_instance.md
+++ b/docs/tables/aws_rds_db_instance.md
@@ -103,3 +103,42 @@ select
 from
   aws_rds_db_instance;
 ```
+
+
+### List mysql instances with SSL disabled parameter group assigned
+
+```sql
+with db_parameter_group as (
+  select
+    name as db_parameter_group_name,
+    pg ->> 'ParameterName' as parameter_name,
+    pg ->> 'ParameterValue' as parameter_value
+  from
+    aws_rds_db_parameter_group,
+    jsonb_array_elements(parameters) as pg
+  where
+    pg ->> 'ParameterName' like 'rds.force_ssl'
+    and name not like 'default.%'
+),
+ rds_associated_parameter_group as (
+  select
+    db_instance_identifier as db_instance_identifier,
+    arn,
+    pg ->> 'DBParameterGroupName' as DBParameterGroupName
+  from
+    aws_rds_db_instance,
+    jsonb_array_elements(db_parameter_groups) as pg
+  where
+    engine like 'sqlserve%'
+)
+select
+  rds.db_instance_identifier as name,
+  rds.DBParameterGroupName,
+  parameter_name,
+  parameter_value
+from
+  rds_associated_parameter_group as rds
+  left join db_parameter_group d on rds.DBParameterGroupName = d.db_parameter_group_name
+where
+  parameter_value = '0'
+```

--- a/docs/tables/aws_rds_db_instance.md
+++ b/docs/tables/aws_rds_db_instance.md
@@ -105,7 +105,7 @@ from
 ```
 
 
-### List mysql instances with SSL disabled parameter group assigned
+### List mysql instances with SSL disabled in assigned parameter group
 
 ```sql
 with db_parameter_group as (
@@ -117,6 +117,7 @@ with db_parameter_group as (
     aws_rds_db_parameter_group,
     jsonb_array_elements(parameters) as pg
   where
+    -- The example is limited to SQL Server, this may change based on DB engine
     pg ->> 'ParameterName' like 'rds.force_ssl'
     and name not like 'default.%'
 ),


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
NA
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
### List mysql instances with SSL disabled parameter group assigned

 with db_parameter_group as (
  select
    name as db_parameter_group_name,
    pg ->> 'ParameterName' as parameter_name,
    pg ->> 'ParameterValue' as parameter_value
  from
    aws_rds_db_parameter_group,
    jsonb_array_elements(parameters) as pg
  where
    pg ->> 'ParameterName' like 'rds.force_ssl'
    and name not like 'default.%'
),
 rds_associated_parameter_group as (
  select
    db_instance_identifier as db_instance_identifier,
    arn,
    pg ->> 'DBParameterGroupName' as DBParameterGroupName
  from
    aws_rds_db_instance,
    jsonb_array_elements(db_parameter_groups) as pg
  where
    engine like 'sqlserve%'
)
select
  rds.db_instance_identifier as name,
  rds.DBParameterGroupName,
  parameter_name,
  parameter_value
from
  rds_associated_parameter_group as rds
  left join db_parameter_group d on rds.DBParameterGroupName = d.db_parameter_group_name
where
  parameter_value = '0'
+------------+----------------------+----------------+-----------------+
| name       | dbparametergroupname | parameter_name | parameter_value |
+------------+----------------------+----------------+-----------------+
| withoussl  | withoutssl           | rds.force_ssl  | 0               |
| database-1 | withoutssl           | rds.force_ssl  | 0               |
+------------+----------------------+----------------+-----------------+
```
</details>
