### PR TITLE
Handle invalid UTF-8 user data in aws_ec2_instance table

### DIFF
--- a/aws/utils.go
+++ b/aws/utils.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/sagemaker"
@@ -151,8 +152,12 @@ func lastPathElement(_ context.Context, d *transform.TransformData) (interface{}
 
 func base64DecodedData(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	data, err := base64.StdEncoding.DecodeString(types.SafeString(d.Value))
+	// check if CorruptInputError or invalid UTF-8
+	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-add-user-data.html
 	if err != nil {
 		return nil, nil
+	} else if utf8.Valid(data) == false {
+		return types.SafeString(d.Value), nil
 	}
 	return data, nil
 }

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -156,7 +156,7 @@ func base64DecodedData(_ context.Context, d *transform.TransformData) (interface
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-add-user-data.html
 	if err != nil {
 		return nil, nil
-	} else if utf8.Valid(data) == false {
+	} else if !utf8.Valid(data) {
 		return types.SafeString(d.Value), nil
 	}
 	return data, nil


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
#invalid UTF-8
```
> select instance_id,user_data from aws_ec2_instance where instance_id = 'i-0319a7264d4208b4a'
+---------------------+----------------------------------------------------------------------------------------------------------------------+
| instance_id         | user_data                                                                                                            |
+---------------------+----------------------------------------------------------------------------------------------------------------------+
| i-0319a7264d4208b4a | bmFu5yBFc2FzbGFyICAgIHwKfCAgICAgICAgICAgICAgICAgICAgIHwgxLBuYW6nIEVzYXNsYXLEIHwKfCAgICAgICAgICAgICAgICAgICAgIHwgICA= |
+---------------------+----------------------------------------------------------------------------------------------------------------------+
```

#valid UTF-8
```
> select instance_id,user_data from aws_ec2_instance where instance_id = 'i-06ee361370a9141a7'
+---------------------+-------------------------------------------------------------------------------------------------+
| instance_id         | user_data                                                                                       |
+---------------------+-------------------------------------------------------------------------------------------------+
| i-06ee361370a9141a7 | #!/bin/bash                                                                                     |
|                     | echo ECS_CLUSTER=test-ec2 >> /etc/ecs/ecs.config;echo ECS_BACKEND_HOST= >> /etc/ecs/ecs.config; |
+---------------------+-------------------------------------------------------------------------------------------------+
```
</details>
