### PR TITLE
Add compliant status information for config rules in aws_config_rule table closes #816

### DIFF
--- a/aws/table_aws_config_rule.go
+++ b/aws/table_aws_config_rule.go
@@ -67,7 +67,7 @@ func tableAwsConfigRule(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "compliance_by_config_rule",
-				Description: "he compliance information of the config rule.",
+				Description: "The compliance information of the config rule.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getComplianceByConfigRules,
 				Transform:   transform.FromValue(),
@@ -199,6 +199,7 @@ func getComplianceByConfigRules(ctx context.Context, d *plugin.QueryData, h *plu
 	// Create Session
 	svc, err := ConfigService(ctx, d)
 	if err != nil {
+		plugin.Logger(ctx).Error("getComplianceByConfigRules", "connection", err)
 		return nil, err
 	}
 	ruleName := h.Item.(*configservice.ConfigRule).ConfigRuleName
@@ -210,6 +211,7 @@ func getComplianceByConfigRules(ctx context.Context, d *plugin.QueryData, h *plu
 
 	op, err := svc.DescribeComplianceByConfigRule(params)
 	if err != nil {
+		plugin.Logger(ctx).Error("getComplianceByConfigRules", "DescribeComplianceByConfigRule", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_config_rule.go
+++ b/aws/table_aws_config_rule.go
@@ -67,9 +67,9 @@ func tableAwsConfigRule(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "compliance_by_config_rule",
-				Description: "The compliant status of the AWS Config rule.",
+				Description: "he compliance information of the config rule.",
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getCompliantStatus,
+				Hydrate:     getComplianceByConfigRules,
 				Transform:   transform.FromValue(),
 			},
 			{
@@ -193,8 +193,8 @@ func getConfigRuleTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	return op, nil
 }
 
-func getCompliantStatus(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getCompliantStatus")
+func getComplianceByConfigRules(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getComplianceByConfigRules")
 
 	// Create Session
 	svc, err := ConfigService(ctx, d)

--- a/docs/tables/aws_config_rule.md
+++ b/docs/tables/aws_config_rule.md
@@ -45,6 +45,17 @@ where
   name Like '%s3-bucket%';
 ```
 
+### List complaince details by config rule
+
+```sql
+select 
+  jsonb_pretty(compliance_by_config_rule) as compliance_info 
+from 
+  aws_config_rule 
+where 
+  name = 'approved-amis-by-id';
+```
+
 ### List complaince types by config rule
 
 ```sql

--- a/docs/tables/aws_config_rule.md
+++ b/docs/tables/aws_config_rule.md
@@ -44,3 +44,14 @@ from
 where
   name Like '%s3-bucket%';
 ```
+
+### List complaince types by config rule
+
+```
+select
+  name as config_rule_name,
+  compliance_status -> 'Compliance' -> 'ComplianceType' as compliance_type
+from
+  aws_config_rule,
+  jsonb_array_elements(compliance_by_config_rule) as compliance_status;
+```

--- a/docs/tables/aws_config_rule.md
+++ b/docs/tables/aws_config_rule.md
@@ -47,7 +47,7 @@ where
 
 ### List complaince types by config rule
 
-```
+```sql
 select
   name as config_rule_name,
   compliance_status -> 'Compliance' -> 'ComplianceType' as compliance_type


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/aws_config_rule []

PRETEST: tests/aws_config_rule

TEST: tests/aws_config_rule
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_config_config_rule.named_test_resource: Creating...
aws_config_config_rule.named_test_resource: Creation complete after 3s [id=turbottest56118]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = 123456789012
aws_partition = aws
region_name = us-east-1
resource_aka = arn:aws:config:us-east-1:123456789012:config-rule/config-rule-xlepvf
resource_name = turbottest56118
rule_id = config-rule-xlepvf

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:config:us-east-1:123456789012:config-rule/config-rule-xlepvf"
    ],
    "arn": "arn:aws:config:us-east-1:123456789012:config-rule/config-rule-xlepvf",
    "description": null,
    "name": "turbottest56118",
    "rule_id": "config-rule-xlepvf",
    "rule_state": "ACTIVE",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest56118"
      }
    ],
    "title": "turbottest56118"
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "arn": "arn:aws:config:us-east-1:123456789012:config-rule/config-rule-xlepvf",
    "name": "turbottest56118",
    "rule_id": "config-rule-xlepvf",
    "title": "turbottest56118"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:config:us-east-1:123456789012:config-rule/config-rule-xlepvf"
    ],
    "arn": "arn:aws:config:us-east-1:123456789012:config-rule/config-rule-xlepvf",
    "tags": {
      "name": "turbottest56118"
    },
    "title": "turbottest56118"
  }
]
✔ PASSED

POSTTEST: tests/aws_config_rule

TEARDOWN: tests/aws_config_rule

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
 select
  name as config_rule_name,
  compliance_status -> 'Compliance' -> 'ComplianceType' as compliance_type
from
  aws_config_rule,
  jsonb_array_elements(compliance_by_config_rule) as compliance_status;
+--------------------------------------------+---------------------+
| config_rule_name                           | compliance_type     |
+--------------------------------------------+---------------------+
| alb-http-drop-invalid-header-enabled       | "INSUFFICIENT_DATA" |
| api-gw-ssl-enabled                         | "INSUFFICIENT_DATA" |
| api-gw-xray-enabled                        | "INSUFFICIENT_DATA" |
| alb-http-to-https-redirection-check        | "INSUFFICIENT_DATA" |
| alb-waf-enabled                            | "INSUFFICIENT_DATA" |
| autoscaling-group-elb-healthcheck-required | "INSUFFICIENT_DATA" |
+--------------------------------------------+---------------------+
```
</details>
