### PR TITLE
Add project_visibility column to aws_codebuild_project table closes #818

### DIFF
--- a/aws/table_aws_codebuild_project.go
+++ b/aws/table_aws_codebuild_project.go
@@ -134,6 +134,12 @@ func tableAwsCodeBuildProject(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
+				Name:        "project_visibility",
+				Description: "The project builds are not visible to the public.",
+				Hydrate:     getCodeBuildProject,
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "secondary_artifacts",
 				Description: "An array of ProjectArtifacts objects.",
 				Hydrate:     getCodeBuildProject,

--- a/aws/table_aws_codebuild_project.go
+++ b/aws/table_aws_codebuild_project.go
@@ -135,7 +135,7 @@ func tableAwsCodeBuildProject(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "project_visibility",
-				Description: "The project builds are not visible to the public.",
+				Description: "Visibility of the build project.",
 				Hydrate:     getCodeBuildProject,
 				Type:        proto.ColumnType_STRING,
 			},

--- a/docs/tables/aws_codebuild_project.md
+++ b/docs/tables/aws_codebuild_project.md
@@ -72,7 +72,7 @@ where
   and logs_config -> 'S3Logs' ->> 'Status' = 'DISABLED';
 ```
 
-### List projects which are private
+### List private build projects
 
 ```sql
 select

--- a/docs/tables/aws_codebuild_project.md
+++ b/docs/tables/aws_codebuild_project.md
@@ -71,3 +71,16 @@ where
   logs_config -> 'CloudWatchLogs' ->> 'Status' = 'DISABLED'
   and logs_config -> 'S3Logs' ->> 'Status' = 'DISABLED';
 ```
+
+### List private project builts
+
+```sql
+select
+  name,
+  arn,
+  project_visibility
+from
+  aws_codebuild_project
+where
+  project_visibility = 'PRIVATE';
+```

--- a/docs/tables/aws_codebuild_project.md
+++ b/docs/tables/aws_codebuild_project.md
@@ -72,7 +72,7 @@ where
   and logs_config -> 'S3Logs' ->> 'Status' = 'DISABLED';
 ```
 
-### List private project builts
+### List projects which are private
 
 ```sql
 select


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_codebuild_project []

PRETEST: tests/aws_codebuild_project

TEST: tests/aws_codebuild_project
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.my_vpc: Creating...
aws_iam_role.test_role: Creating...
aws_s3_bucket.test_bucket: Creating...
aws_s3_bucket.test_bucket: Still creating... [10s elapsed]
aws_iam_role.test_role: Still creating... [10s elapsed]
aws_vpc.my_vpc: Still creating... [10s elapsed]
aws_vpc.my_vpc: Still creating... [20s elapsed]
aws_s3_bucket.test_bucket: Still creating... [20s elapsed]
aws_iam_role.test_role: Still creating... [20s elapsed]
aws_iam_role.test_role: Creation complete after 26s [id=turbottest48279]
aws_s3_bucket.test_bucket: Still creating... [30s elapsed]
aws_vpc.my_vpc: Still creating... [30s elapsed]
aws_s3_bucket.test_bucket: Still creating... [40s elapsed]
aws_vpc.my_vpc: Still creating... [40s elapsed]
aws_vpc.my_vpc: Still creating... [50s elapsed]
aws_s3_bucket.test_bucket: Still creating... [50s elapsed]
aws_s3_bucket.test_bucket: Still creating... [1m0s elapsed]
aws_vpc.my_vpc: Still creating... [1m0s elapsed]
aws_vpc.my_vpc: Still creating... [1m10s elapsed]
aws_s3_bucket.test_bucket: Still creating... [1m10s elapsed]
aws_vpc.my_vpc: Creation complete after 1m11s [id=vpc-007a66fa8dfd15e49]
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet1: Creating...
aws_s3_bucket.test_bucket: Still creating... [1m20s elapsed]
aws_subnet.my_subnet1: Still creating... [10s elapsed]
aws_subnet.my_subnet2: Still creating... [10s elapsed]
aws_s3_bucket.test_bucket: Still creating... [1m30s elapsed]
aws_subnet.my_subnet1: Still creating... [20s elapsed]
aws_subnet.my_subnet2: Still creating... [20s elapsed]
aws_subnet.my_subnet1: Creation complete after 20s [id=subnet-02f2fdf011ab7815e]
aws_subnet.my_subnet2: Creation complete after 20s [id=subnet-0f05f70f5231dce27]
aws_s3_bucket.test_bucket: Creation complete after 1m38s [id=turbottest48279]
aws_iam_role_policy.test_role_policy: Creating...
aws_codebuild_project.named_test_resource: Creating...
aws_iam_role_policy.test_role_policy: Still creating... [10s elapsed]
aws_codebuild_project.named_test_resource: Still creating... [10s elapsed]
aws_iam_role_policy.test_role_policy: Creation complete after 13s [id=turbottest48279:terraform-20210415110038971200000001]
aws_codebuild_project.named_test_resource: Creation complete after 14s [id=arn:aws:codebuild:us-east-1:123456789012:project/turbottest48279]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: Interpolation-only expressions are deprecated

  on variables.tf line 155, in resource "aws_codebuild_project" "named_test_resource":
 155:     location = "${aws_s3_bucket.test_bucket.bucket}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.


Apply complete! Resources: 7 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = arn:aws:codebuild:us-east-1:123456789012:project/turbottest48279
resource_id = arn:aws:codebuild:us-east-1:123456789012:project/turbottest48279
resource_name = turbottest48279

Running SQL query: test-get-query.sql
[
  {
    "artifacts": {
      "ArtifactIdentifier": null,
      "EncryptionDisabled": null,
      "Location": null,
      "Name": null,
      "NamespaceType": null,
      "OverrideArtifactName": false,
      "Packaging": null,
      "Path": null,
      "Type": "NO_ARTIFACTS"
    },
    "cache": {
      "Location": "turbottest48279",
      "Modes": null,
      "Type": "S3"
    },
    "description": "Resource for testing",
    "name": "turbottest48279",
    "source": {
      "Auth": null,
      "BuildStatusConfig": null,
      "Buildspec": "",
      "GitCloneDepth": 0,
      "GitSubmodulesConfig": null,
      "InsecureSsl": false,
      "Location": "https://github.com/mitchellh/packer.git",
      "ReportBuildStatus": false,
      "SourceIdentifier": null,
      "Type": "GITHUB"
    },
    "title": "turbottest48279"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:codebuild:us-east-1:123456789012:project/turbottest48279"
    ],
    "description": "Resource for testing",
    "name": "turbottest48279",
    "tags": {
      "foo": "bar"
    },
    "title": "turbottest48279"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "artifacts": {
      "ArtifactIdentifier": null,
      "EncryptionDisabled": null,
      "Location": null,
      "Name": null,
      "NamespaceType": null,
      "OverrideArtifactName": false,
      "Packaging": null,
      "Path": null,
      "Type": "NO_ARTIFACTS"
    },
    "description": "Resource for testing",
    "name": "turbottest48279",
    "tags": {
      "foo": "bar"
    },
    "title": "turbottest48279"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

POSTTEST: tests/aws_codebuild_project

TEARDOWN: tests/aws_codebuild_project

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, arn, project_visibility from aws_codebuild_project
+----------+-----------------------------------------------------------+--------------------+
| name     | arn                                                       | project_visibility |
+----------+-----------------------------------------------------------+--------------------+
| test-123 | arn:aws:codebuild:us-east-1:632902152528:project/test-123 | PRIVATE            |
+----------+-----------------------------------------------------------+--------------------+
```

```
 select name, arn, project_visibility from aws_codebuild_project where name = 'test-123'
+----------+-----------------------------------------------------------+--------------------+
| name     | arn                                                       | project_visibility |
+----------+-----------------------------------------------------------+--------------------+
| test-123 | arn:aws:codebuild:us-east-1:632902152528:project/test-123 | PRIVATE            |
+----------+-----------------------------------------------------------+--------------------+
```

</details>
