### PR TITLE
Update maximum result limit as per api calls closes #828

### DIFF
--- a/aws/table_aws_accessanalyzer_analyzer.go
+++ b/aws/table_aws_accessanalyzer_analyzer.go
@@ -117,8 +117,10 @@ func listAccessAnalyzers(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 		return nil, err
 	}
 
+	// The maximum number for MaxResults parameter is not defined by the API
+	// We have set the MaxResults to 1000 based on our test
 	input := &accessanalyzer.ListAnalyzersInput{
-		MaxResults: aws.Int64(100),
+		MaxResults: aws.Int64(1000),
 	}
 
 	// Additonal Filter
@@ -132,10 +134,10 @@ func listAccessAnalyzers(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxResults {
-			if *limit < 5 {
-				input.MaxResults = types.Int64(5)
+			if *limit < 1 {
+				input.MaxResults = types.Int64(1)
 			} else {
-				input.MaxResults = limit
+			input.MaxResults = limit
 			}
 		}
 	}

--- a/aws/table_aws_accessanalyzer_analyzer.go
+++ b/aws/table_aws_accessanalyzer_analyzer.go
@@ -118,7 +118,7 @@ func listAccessAnalyzers(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	input := &accessanalyzer.ListAnalyzersInput{
-		MaxResults: aws.Int64(1000),
+		MaxResults: aws.Int64(100),
 	}
 
 	// Additonal Filter

--- a/aws/table_aws_accessanalyzer_analyzer.go
+++ b/aws/table_aws_accessanalyzer_analyzer.go
@@ -137,7 +137,7 @@ func listAccessAnalyzers(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 			if *limit < 1 {
 				input.MaxResults = types.Int64(1)
 			} else {
-			input.MaxResults = limit
+				input.MaxResults = limit
 			}
 		}
 	}

--- a/aws/table_aws_acm_certificate.go
+++ b/aws/table_aws_acm_certificate.go
@@ -243,8 +243,8 @@ func listAwsAcmCertificates(ctx context.Context, d *plugin.QueryData, _ *plugin.
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxItems {
-			if *limit < 5 {
-				input.MaxItems = types.Int64(5)
+			if *limit < 1 {
+				input.MaxItems = types.Int64(1)
 			} else {
 				input.MaxItems = limit
 			}

--- a/aws/table_aws_acm_certificate.go
+++ b/aws/table_aws_acm_certificate.go
@@ -230,7 +230,7 @@ func listAwsAcmCertificates(ctx context.Context, d *plugin.QueryData, _ *plugin.
 	}
 
 	input := &acm.ListCertificatesInput{
-		MaxItems: aws.Int64(100),
+		MaxItems: aws.Int64(1000),
 	}
 
 	// Additonal Filter

--- a/aws/table_aws_acm_certificate.go
+++ b/aws/table_aws_acm_certificate.go
@@ -230,7 +230,7 @@ func listAwsAcmCertificates(ctx context.Context, d *plugin.QueryData, _ *plugin.
 	}
 
 	input := &acm.ListCertificatesInput{
-		MaxItems: aws.Int64(1000),
+		MaxItems: aws.Int64(100),
 	}
 
 	// Additonal Filter

--- a/aws/table_aws_api_gateway_api_key.go
+++ b/aws/table_aws_api_gateway_api_key.go
@@ -134,8 +134,8 @@ func listAPIKeys(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.Limit {
-			if *limit < 5 {
-				input.Limit = types.Int64(5)
+			if *limit < 1 {
+				input.Limit = types.Int64(1)
 			} else {
 				input.Limit = limit
 			}

--- a/aws/table_aws_api_gateway_rest_api.go
+++ b/aws/table_aws_api_gateway_rest_api.go
@@ -150,8 +150,8 @@ func listRestAPI(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.Limit {
-			if *limit < 5 {
-				input.Limit = types.Int64(5)
+			if *limit < 1 {
+				input.Limit = types.Int64(1)
 			} else {
 				input.Limit = limit
 			}

--- a/aws/table_aws_api_gateway_usage_plan.go
+++ b/aws/table_aws_api_gateway_usage_plan.go
@@ -104,8 +104,8 @@ func listUsagePlans(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.Limit {
-			if *limit < 5 {
-				input.Limit = types.Int64(5)
+			if *limit < 1 {
+				input.Limit = types.Int64(1)
 			} else {
 				input.Limit = limit
 			}

--- a/aws/table_aws_appautoscaling_target.go
+++ b/aws/table_aws_appautoscaling_target.go
@@ -124,8 +124,8 @@ func listAwsApplicationAutoScalingTargets(ctx context.Context, d *plugin.QueryDa
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxResults {
-			if *limit < 5 {
-				input.MaxResults = types.Int64(5)
+			if *limit < 1 {
+				input.MaxResults = types.Int64(1)
 			} else {
 				input.MaxResults = limit
 			}

--- a/aws/table_aws_appautoscaling_target.go
+++ b/aws/table_aws_appautoscaling_target.go
@@ -105,8 +105,10 @@ func listAwsApplicationAutoScalingTargets(ctx context.Context, d *plugin.QueryDa
 		return nil, err
 	}
 
+	// The maximum number for MaxResults parameter is not defined by the API
+	// We have set the MaxResults to 1000 based on our test
 	input := &applicationautoscaling.DescribeScalableTargetsInput{
-		MaxResults: aws.Int64(50),
+		MaxResults: aws.Int64(1000),
 	}
 
 	// Additonal Filter

--- a/aws/table_aws_auditmanager_assessment.go
+++ b/aws/table_aws_auditmanager_assessment.go
@@ -158,7 +158,7 @@ func listAwsAuditManagerAssessments(ctx context.Context, d *plugin.QueryData, _ 
 		return nil, err
 	}
 	input := &auditmanager.ListAssessmentsInput{
-		MaxResults: aws.Int64(1000),
+		MaxResults: aws.Int64(500),
 	}
 
 	// Limiting the results

--- a/aws/table_aws_auditmanager_assessment.go
+++ b/aws/table_aws_auditmanager_assessment.go
@@ -158,15 +158,15 @@ func listAwsAuditManagerAssessments(ctx context.Context, d *plugin.QueryData, _ 
 		return nil, err
 	}
 	input := &auditmanager.ListAssessmentsInput{
-		MaxResults: aws.Int64(500),
+		MaxResults: aws.Int64(1000),
 	}
 
 	// Limiting the results
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxResults {
-			if *limit < 5 {
-				input.MaxResults = types.Int64(5)
+			if *limit < 1 {
+				input.MaxResults = types.Int64(1)
 			} else {
 				input.MaxResults = limit
 			}

--- a/aws/table_aws_auditmanager_evidence.go
+++ b/aws/table_aws_auditmanager_evidence.go
@@ -188,8 +188,8 @@ func listAuditManagerEvidences(ctx context.Context, d *plugin.QueryData, h *plug
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxResults {
-			if *limit < 5 {
-				input.MaxResults = types.Int64(5)
+			if *limit < 1 {
+				input.MaxResults = types.Int64(1)
 			} else {
 				input.MaxResults = limit
 			}

--- a/aws/table_aws_auditmanager_evidence_folder.go
+++ b/aws/table_aws_auditmanager_evidence_folder.go
@@ -168,8 +168,8 @@ func listAuditManagerEvidenceFolders(ctx context.Context, d *plugin.QueryData, h
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxResults {
-			if *limit < 5 {
-				input.MaxResults = types.Int64(5)
+			if *limit < 1 {
+				input.MaxResults = types.Int64(1)
 			} else {
 				input.MaxResults = limit
 			}

--- a/aws/table_aws_backup_plan.go
+++ b/aws/table_aws_backup_plan.go
@@ -118,8 +118,8 @@ func listAwsBackupPlans(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxResults {
-			if *limit < 5 {
-				input.MaxResults = types.Int64(5)
+			if *limit < 1 {
+				input.MaxResults = types.Int64(1)
 			} else {
 				input.MaxResults = limit
 			}

--- a/aws/table_aws_backup_protected_resource.go
+++ b/aws/table_aws_backup_protected_resource.go
@@ -74,8 +74,8 @@ func listAwsBackupProtectedResources(ctx context.Context, d *plugin.QueryData, _
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxResults {
-			if *limit < 5 {
-				input.MaxResults = types.Int64(5)
+			if *limit < 1 {
+				input.MaxResults = types.Int64(1)
 			} else {
 				input.MaxResults = limit
 			}

--- a/aws/table_aws_backup_recovery_point.go
+++ b/aws/table_aws_backup_recovery_point.go
@@ -184,8 +184,8 @@ func listAwsBackupRecoveryPoints(ctx context.Context, d *plugin.QueryData, h *pl
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxResults {
-			if *limit < 5 {
-				input.MaxResults = types.Int64(5)
+			if *limit < 1 {
+				input.MaxResults = types.Int64(1)
 			} else {
 				input.MaxResults = limit
 			}

--- a/aws/table_aws_backup_selection.go
+++ b/aws/table_aws_backup_selection.go
@@ -124,8 +124,8 @@ func listBackupSelections(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxResults {
-			if *limit < 5 {
-				input.MaxResults = types.Int64(5)
+			if *limit < 1 {
+				input.MaxResults = types.Int64(1)
 			} else {
 				input.MaxResults = limit
 			}

--- a/aws/table_aws_backup_vault.go
+++ b/aws/table_aws_backup_vault.go
@@ -121,8 +121,8 @@ func listAwsBackupVaults(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxResults {
-			if *limit < 5 {
-				input.MaxResults = types.Int64(5)
+			if *limit < 1 {
+				input.MaxResults = types.Int64(1)
 			} else {
 				input.MaxResults = limit
 			}

--- a/aws/table_aws_cloudfront_cache_policy.go
+++ b/aws/table_aws_cloudfront_cache_policy.go
@@ -111,9 +111,11 @@ func listCloudFrontCachePolicies(ctx context.Context, d *plugin.QueryData, _ *pl
 		return nil, err
 	}
 
+	// The maximum number for MaxItems parameter is not defined by the API
+	// We have set the MaxItems to 1000 based on our test
 	// List call
 	input := &cloudfront.ListCachePoliciesInput{
-		MaxItems: aws.Int64(100),
+		MaxItems: aws.Int64(1000),
 	}
 
 	// If the requested number of items is less than the paging max limit
@@ -121,8 +123,8 @@ func listCloudFrontCachePolicies(ctx context.Context, d *plugin.QueryData, _ *pl
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxItems {
-			if *limit < 5 {
-				input.MaxItems = types.Int64(5)
+			if *limit < 1 {
+				input.MaxItems = types.Int64(1)
 			} else {
 				input.MaxItems = limit
 			}

--- a/aws/table_aws_cloudfront_cache_policy.go
+++ b/aws/table_aws_cloudfront_cache_policy.go
@@ -113,7 +113,7 @@ func listCloudFrontCachePolicies(ctx context.Context, d *plugin.QueryData, _ *pl
 
 	// List call
 	input := &cloudfront.ListCachePoliciesInput{
-		MaxItems: aws.Int64(1000),
+		MaxItems: aws.Int64(100),
 	}
 
 	// If the requested number of items is less than the paging max limit

--- a/aws/table_aws_cloudfront_distribution.go
+++ b/aws/table_aws_cloudfront_distribution.go
@@ -238,7 +238,7 @@ func listAwsCloudFrontDistributions(ctx context.Context, d *plugin.QueryData, _ 
 	}
 
 	input := &cloudfront.ListDistributionsInput{
-		MaxItems: aws.Int64(1000),
+		MaxItems: aws.Int64(100),
 	}
 	
 	// If the requested number of items is less than the paging max limit

--- a/aws/table_aws_cloudfront_distribution.go
+++ b/aws/table_aws_cloudfront_distribution.go
@@ -237,8 +237,10 @@ func listAwsCloudFrontDistributions(ctx context.Context, d *plugin.QueryData, _ 
 		return nil, err
 	}
 
+	// The maximum number for MaxItems parameter is not defined by the API
+	// We have set the MaxItems to 1000 based on our test
 	input := &cloudfront.ListDistributionsInput{
-		MaxItems: aws.Int64(100),
+		MaxItems: aws.Int64(1000),
 	}
 	
 	// If the requested number of items is less than the paging max limit
@@ -246,8 +248,8 @@ func listAwsCloudFrontDistributions(ctx context.Context, d *plugin.QueryData, _ 
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxItems {
-			if *limit < 5 {
-				input.MaxItems = types.Int64(5)
+			if *limit < 1 {
+				input.MaxItems = types.Int64(1)
 			} else {
 				input.MaxItems = limit
 			}

--- a/aws/table_aws_cloudfront_origin_access_identity.go
+++ b/aws/table_aws_cloudfront_origin_access_identity.go
@@ -94,8 +94,11 @@ func listCloudFrontOriginAccessIdentities(ctx context.Context, d *plugin.QueryDa
 	if err != nil {
 		return nil, err
 	}
+
+	// The maximum number for MaxItems parameter is not defined by the API
+	// We have set the MaxItems to 1000 based on our test
 	input := &cloudfront.ListCloudFrontOriginAccessIdentitiesInput{
-		MaxItems: aws.Int64(100),
+		MaxItems: aws.Int64(1000),
 	}
 
 	// If the requested number of items is less than the paging max limit
@@ -103,8 +106,8 @@ func listCloudFrontOriginAccessIdentities(ctx context.Context, d *plugin.QueryDa
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxItems {
-			if *limit < 5 {
-				input.MaxItems = types.Int64(5)
+			if *limit < 1 {
+				input.MaxItems = types.Int64(1)
 			} else {
 				input.MaxItems = limit
 			}

--- a/aws/table_aws_cloudfront_origin_access_identity.go
+++ b/aws/table_aws_cloudfront_origin_access_identity.go
@@ -95,7 +95,7 @@ func listCloudFrontOriginAccessIdentities(ctx context.Context, d *plugin.QueryDa
 		return nil, err
 	}
 	input := &cloudfront.ListCloudFrontOriginAccessIdentitiesInput{
-		MaxItems: aws.Int64(1000),
+		MaxItems: aws.Int64(100),
 	}
 
 	// If the requested number of items is less than the paging max limit

--- a/aws/table_aws_cloudfront_origin_request_policy.go
+++ b/aws/table_aws_cloudfront_origin_request_policy.go
@@ -108,14 +108,14 @@ func listCloudFrontOriginRequestPolicies(ctx context.Context, d *plugin.QueryDat
 
 	// List call
 	params := &cloudfront.ListOriginRequestPoliciesInput{
-		MaxItems: aws.Int64(100),
+		MaxItems: aws.Int64(1000),
 	}
 
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *params.MaxItems {
-			if *limit < 5 {
-				params.MaxItems = types.Int64(5)
+			if *limit < 1 {
+				params.MaxItems = types.Int64(1)
 			} else {
 				params.MaxItems = limit
 			}

--- a/aws/table_aws_cloudfront_origin_request_policy.go
+++ b/aws/table_aws_cloudfront_origin_request_policy.go
@@ -106,6 +106,8 @@ func listCloudFrontOriginRequestPolicies(ctx context.Context, d *plugin.QueryDat
 		return nil, err
 	}
 
+	// The maximum number for MaxResults parameter is not defined by the API
+	// We have set the MaxResults to 1000 based on our test
 	// List call
 	params := &cloudfront.ListOriginRequestPoliciesInput{
 		MaxItems: aws.Int64(1000),

--- a/aws/table_aws_cloudfront_origin_request_policy.go
+++ b/aws/table_aws_cloudfront_origin_request_policy.go
@@ -108,7 +108,7 @@ func listCloudFrontOriginRequestPolicies(ctx context.Context, d *plugin.QueryDat
 
 	// List call
 	params := &cloudfront.ListOriginRequestPoliciesInput{
-		MaxItems: aws.Int64(1000),
+		MaxItems: aws.Int64(100),
 	}
 
 	limit := d.QueryContext.Limit

--- a/aws/table_aws_cloudwatch_log_group.go
+++ b/aws/table_aws_cloudwatch_log_group.go
@@ -114,8 +114,8 @@ func listCloudwatchLogGroups(ctx context.Context, d *plugin.QueryData, _ *plugin
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.Limit {
-			if *limit < 5 {
-				input.Limit = types.Int64(5)
+			if *limit < 1 {
+				input.Limit = types.Int64(1)
 			} else {
 				input.Limit = limit
 			}

--- a/aws/table_aws_cloudwatch_log_metric_filter.go
+++ b/aws/table_aws_cloudwatch_log_metric_filter.go
@@ -130,8 +130,8 @@ func listCloudwatchLogMetricFilters(ctx context.Context, d *plugin.QueryData, _ 
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.Limit {
-			if *limit < 5 {
-				input.Limit = aws.Int64(5)
+			if *limit < 1 {
+				input.Limit = aws.Int64(1)
 			} else {
 				input.Limit = limit
 			}

--- a/aws/table_aws_cloudwatch_log_stream.go
+++ b/aws/table_aws_cloudwatch_log_stream.go
@@ -131,8 +131,8 @@ func listCloudwatchLogStreams(ctx context.Context, d *plugin.QueryData, h *plugi
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.Limit {
-			if *limit < 5 {
-				input.Limit = types.Int64(5)
+			if *limit < 1 {
+				input.Limit = types.Int64(1)
 			} else {
 				input.Limit = limit
 			}

--- a/aws/table_aws_codepipeline_pipeline.go
+++ b/aws/table_aws_codepipeline_pipeline.go
@@ -128,7 +128,7 @@ func listCodepipelinePipelines(ctx context.Context, d *plugin.QueryData, _ *plug
 	}
 
 	input := &codepipeline.ListPipelinesInput{
-		MaxResults: aws.Int64(2048),
+		MaxResults: aws.Int64(1000),
 	}
 
 	// If the requested number of items is less than the paging max limit
@@ -136,8 +136,8 @@ func listCodepipelinePipelines(ctx context.Context, d *plugin.QueryData, _ *plug
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxResults {
-			if *limit < 5 {
-				input.MaxResults = aws.Int64(5)
+			if *limit < 1 {
+				input.MaxResults = aws.Int64(1)
 			} else {
 				input.MaxResults = limit
 			}

--- a/aws/table_aws_codepipeline_pipeline.go
+++ b/aws/table_aws_codepipeline_pipeline.go
@@ -128,7 +128,7 @@ func listCodepipelinePipelines(ctx context.Context, d *plugin.QueryData, _ *plug
 	}
 
 	input := &codepipeline.ListPipelinesInput{
-		MaxResults: aws.Int64(1000),
+		MaxResults: aws.Int64(2048),
 	}
 
 	// If the requested number of items is less than the paging max limit

--- a/aws/table_aws_dax_cluster.go
+++ b/aws/table_aws_dax_cluster.go
@@ -178,8 +178,8 @@ func listDaxClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *params.MaxResults {
-			if *limit < 5 {
-				params.MaxResults = aws.Int64(5)
+			if *limit < 20 {
+				params.MaxResults = aws.Int64(20)
 			} else {
 				params.MaxResults = limit
 			}

--- a/aws/table_aws_dms_replication_instance.go
+++ b/aws/table_aws_dms_replication_instance.go
@@ -247,8 +247,8 @@ func listDmsReplicationInstances(ctx context.Context, d *plugin.QueryData, _ *pl
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.MaxRecords {
-			if *limit < 5 {
-				input.MaxRecords = aws.Int64(5)
+			if *limit < 20 {
+				input.MaxRecords = aws.Int64(20)
 			} else {
 				input.MaxRecords = limit
 			}

--- a/aws/table_aws_dynamodb_backup.go
+++ b/aws/table_aws_dynamodb_backup.go
@@ -140,8 +140,8 @@ func listDynamodbBackups(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.Limit {
-			if *limit < 5 {
-				input.Limit = types.Int64(5)
+			if *limit < 1 {
+				input.Limit = types.Int64(1)
 			} else {
 				input.Limit = limit
 			}

--- a/aws/table_aws_dynamodb_backup.go
+++ b/aws/table_aws_dynamodb_backup.go
@@ -120,7 +120,7 @@ func listDynamodbBackups(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	input := &dynamodb.ListBackupsInput{
-		Limit: aws.Int64(1000),
+		Limit: aws.Int64(100),
 	}
 
 	// Additonal Filter

--- a/aws/table_aws_dynamodb_global_table.go
+++ b/aws/table_aws_dynamodb_global_table.go
@@ -102,8 +102,8 @@ func listDynamboDbGlobalTables(ctx context.Context, d *plugin.QueryData, _ *plug
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.Limit {
-			if *limit < 5 {
-				input.Limit = types.Int64(5)
+			if *limit < 1 {
+				input.Limit = types.Int64(1)
 			} else {
 				input.Limit = limit
 			}

--- a/aws/table_aws_dynamodb_global_table.go
+++ b/aws/table_aws_dynamodb_global_table.go
@@ -88,7 +88,7 @@ func listDynamboDbGlobalTables(ctx context.Context, d *plugin.QueryData, _ *plug
 	}
 
 	input := &dynamodb.ListGlobalTablesInput{
-		Limit: aws.Int64(1000),
+		Limit: aws.Int64(100),
 	}
 
 	// Additonal Filter

--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -223,8 +223,8 @@ func listDynamboDbTables(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < *input.Limit {
-			if *limit < 5 {
-				input.Limit = types.Int64(5)
+			if *limit < 1 {
+				input.Limit = types.Int64(1)
 			} else {
 				input.Limit = limit
 			}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select * from aws_accessanalyzer_analyzer limit 0
+------+-----+--------+------+------------+------------------------+---------------------------+---------------+----------+-------+------+------+-----------+--------+------------+
| name | arn | status | type | created_at | last_resource_analyzed | last_resource_analyzed_at | status_reason | findings | title | tags | akas | partition | region | account_id |
+------+-----+--------+------+------------+------------------------+---------------------------+---------------+----------+-------+------+------+-----------+--------+------------+
+------+-----+--------+------+------------+------------------------+---------------------------+---------------+----------+-------+------+------+-----------+--------+------------+
> select * from aws_accessanalyzer_analyzer limit 10
+---------------+------------------------------------------------------------------------+--------+---------+----------------------+--------------------------------------------+---------------------------
| name          | arn                                                                    | status | type    | created_at           | last_resource_analyzed                     | last_resource_analyzed_at 
+---------------+------------------------------------------------------------------------+--------+---------+----------------------+--------------------------------------------+---------------------------
| ytrgg         | arn:aws:access-analyzer:us-east-2:632902152528:analyzer/ytrgg          | ACTIVE | ACCOUNT | 2021-05-19T10:44:07Z | arn:aws:iam::632902152528:role/turbot/user | 2021-12-14T17:09:18Z      
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
| test-analyser | arn:aws:access-analyzer:ap-south-1:632902152528:analyzer/test-analyser | ACTIVE | ACCOUNT | 2021-05-19T10:33:58Z | arn:aws:iam::632902152528:role/turbot/user | 2021-12-14T14:56:12Z      
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
+---------------+------------------------------------------------------------------------+--------+---------+----------------------+--------------------------------------------+---------------------------
> select * from aws_accessanalyzer_analyzer limit 1011
+---------------+------------------------------------------------------------------------+--------+---------+----------------------+--------------------------------------------+---------------------------
| name          | arn                                                                    | status | type    | created_at           | last_resource_analyzed                     | last_resource_analyzed_at 
+---------------+------------------------------------------------------------------------+--------+---------+----------------------+--------------------------------------------+---------------------------
| test-analyser | arn:aws:access-analyzer:ap-south-1:632902152528:analyzer/test-analyser | ACTIVE | ACCOUNT | 2021-05-19T10:33:58Z | arn:aws:iam::632902152528:role/turbot/user | 2021-12-14T14:56:12Z      
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
| ytrgg         | arn:aws:access-analyzer:us-east-2:632902152528:analyzer/ytrgg          | ACTIVE | ACCOUNT | 2021-05-19T10:44:07Z | arn:aws:iam::632902152528:role/turbot/user | 2021-12-14T17:09:18Z      
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
+---------------+------------------------------------------------------------------------+--------+---------+----------------------+--------------------------------------------+---------------------------
> select * from aws_acm_certificate limit 0
+-----------------+-------------+-------------------+-------------+---------------------------------------------+------------+---------+-------------+--------+---------------------+---------------------+-
| certificate_arn | certificate | certificate_chain | domain_name | certificate_transparency_logging_preference | created_at | subject | imported_at | issuer | signature_algorithm | extended_key_usages | 
+-----------------+-------------+-------------------+-------------+---------------------------------------------+------------+---------+-------------+--------+---------------------+---------------------+-
+-----------------+-------------+-------------------+-------------+---------------------------------------------+------------+---------+-------------+--------+---------------------+---------------------+-
> select * from aws_acm_certificate limit 10
+--------------------------------------------------------------------------------------+------------------------------------------------------------------+-------------------------------------------------
| certificate_arn                                                                      | certificate                                                      | certificate_chain                               
+--------------------------------------------------------------------------------------+------------------------------------------------------------------+-------------------------------------------------
| arn:aws:acm:ap-south-1:632902152528:certificate/c8f72e7f-f6cf-49d1-9c87-a14d4be82b5e | -----BEGIN CERTIFICATE-----                                      | -----BEGIN CERTIFICATE-----                     
|                                                                                      | MIIFZjCCBE6gAwIBAgIQAQ1yVf+q/86jnQygvA8ChDANBgkqhkiG9w0BAQsFADBG | MIIESTCCAzGgAwIBAgITBn+UV4WH6Kx33rJTMlu8mYtWDTAN
|                                                                                      | MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRUwEwYDVQQLEwxTZXJ2ZXIg | ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkw
|                                                                                      | Q0EgMUIxDzANBgNVBAMTBkFtYXpvbjAeFw0yMTAzMjMwMDAwMDBaFw0yMjA0MjEy | b24gUm9vdCBDQSAxMB4XDTE1MTAyMjAwMDAwMFoXDTI1MTAx
|                                                                                      | MzU5NTlaMCAxHjAcBgNVBAMMFSoudGVzdC50dXJib3QtZGV2LmNvbTCCASIwDQYJ | MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEVMBMGA1UE
|                                                                                      | KoZIhvcNAQEBBQADggEPADCCAQoCggEBAIXJfik89GldecK4Sl4zWlpkTmtM+d02 | IDFCMQ8wDQYDVQQDEwZBbWF6b24wggEiMA0GCSqGSIb3DQEB
|                                                                                      | kM83Hs4D8pDbP4lhgDq+hPQmW6TzCiWRH/rxKOXTxpE+IPgCCCCAhZfYfuK2o+Ah | AoIBAQDCThZn3c68asg3Wuw6MLAd5tES6BIoSMzoKcG5blPV
|                                                                                      | cKlfyLW97u9kIpK+xzvr2AGf3LLliibCRXvxnPzctjVYvJcGblx0XS9cCpwL0/ak | cMzPa43j4wNxhplty6aUKk4T1qe9BOwKFjwK6zmxxLVYo7bH
|                                                                                      | PLl3TQfdhNMlxT8Gpv93ZcPLbDdDMO1AaAui6mnwDQ5pLUTdkWRBYwWbGuY8TrFe | blDP+18x+B26A0piiQOuPkfyDyeR4xQghfj66Yo19V+emU3n
|                                                                                      | YlSR+kwlp4AqNySDkZiGXdrxmUp+byhK2Ls/npCu3MFtyA0fUg/23KAkxKl/hUXw | B5x+F2pV8xeKNR7u6azDdU5YVX1TawprmxRC1+WsAYmz6qP+
|                                                                                      | zEMzc7tl4Y4b35Byr2RPObTjycpu4xrjeDf86H7fJzSXmD52Q5AojDsCAwEAAaOC | 0IjKOtEXc/VfmtTFch5+AfGYMGMqqvJ6LcXiAhqG5TI+Dr0R
|                                                                                      | AnQwggJwMB8GA1UdIwQYMBaAFFmkZgZSoHuVkjyjlAcnlnRb+T3QMB0GA1UdDgQW | KuANaL7TiItKZYxK1MMuTJtV9IblAgMBAAGjggE7MIIBNzAS
|                                                                                      | BBRRw3xGztITsQrOM26jxoIR68ZkBTAgBgNVHREEGTAXghUqLnRlc3QudHVyYm90 | AQH/AgEAMA4GA1UdDwEB/wQEAwIBhjAdBgNVHQ4EFgQUWaRm
|                                                                                      | LWRldi5jb20wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr | dFv5PdAwHwYDVR0jBBgwFoAUhBjMhTTsvAyUlC4IWZzHshBO
|                                                                                      | BgEFBQcDAjA7BgNVHR8ENDAyMDCgLqAshipodHRwOi8vY3JsLnNjYTFiLmFtYXpv | AQEEbzBtMC8GCCsGAQUFBzABhiNodHRwOi8vb2NzcC5yb290
|                                                                                      | bnRydXN0LmNvbS9zY2ExYi5jcmwwEwYDVR0gBAwwCjAIBgZngQwBAgEwdQYIKwYB | dXN0LmNvbTA6BggrBgEFBQcwAoYuaHR0cDovL2NydC5yb290
|                                                                                      | BQUHAQEEaTBnMC0GCCsGAQUFBzABhiFodHRwOi8vb2NzcC5zY2ExYi5hbWF6b250 | dXN0LmNvbS9yb290Y2ExLmNlcjA/BgNVHR8EODA2MDSgMqAw
|                                                                                      | cnVzdC5jb20wNgYIKwYBBQUHMAKGKmh0dHA6Ly9jcnQuc2NhMWIuYW1hem9udHJ1 | LnJvb3RjYTEuYW1hem9udHJ1c3QuY29tL3Jvb3RjYTEuY3Js
|                                                                                      | c3QuY29tL3NjYTFiLmNydDAMBgNVHRMBAf8EAjAAMIIBBAYKKwYBBAHWeQIEAgSB | CAYGZ4EMAQIBMA0GCSqGSIb3DQEBCwUAA4IBAQCFkr41u3nP
|                                                                                      | 9QSB8gDwAHYAKXm+8J45OSHwVnOfY6V35b5XfZxgCvj5TV0mXCVdx4QAAAF4Xxbr | 59Gt/a6ZiqyJEi+752+a1U5y6iAwYfmXss2lJwJFqMp2PphK
|                                                                                      | awAABAMARzBFAiAfCz+zRJ5oKRgB7uUGx0W7Q/9euZPCb17xeyeJoxiIggIhALn6 | 6G7bMQcT8C8xDZNtYTd7WPD8UZiRKAJPBXa30/AbwuZe0GaF
|                                                                                      | QpJHA9SOQVQodIOE3oDekpnUYJpqbE/xR/7gcSlEAHYAIkVFB1lVJFaWP6Ev8fdt | 8/LwhBNTZTUVEWuCUUBVV18YtbAiPq3yXqMB48Oz+ctBWuZS
|                                                                                      | huAjJmOtwEt/XcaDXG7iDwIAAAF4XxbroQAABAMARzBFAiEAq8+35XaZ+UdfQ0fN | upRyzQ7qDn1X8nn8N8V7YJ6y68AtkHcNSRAnpTitxBKjtKPI
|                                                                                      | 2nfB68VWgh84s++EBXQ8KbsE3g0CIF0vS8ih4/aVPejR2rzO5azjCdht7d8KuIdC | yLyKQXhw2W2Xs0qLeC1etA+jTGDK4UfLeC0SF7FSi8o5LL21
|                                                                                      | 0uULgWMDMA0GCSqGSIb3DQEBCwUAA4IBAQBVGjbsge0xOHU+GV2jP9SXRLkb6gJo | -----END CERTIFICATE-----                       
|                                                                                      | YWuYq1VkrQLg94wlXJYV4Sv16KY6jd8NkCUfQgxMbpsvegC9+FcXDhAzzYNw3ppw | -----BEGIN CERTIFICATE-----                     
|                                                                                      | 8rqU3MJvTOrG2hYiZHX7mh4NumYSrbJ6KvUQzTC6Uy7vCk7hzjiTlrxDxa6jprRi | MIIEkjCCA3qgAwIBAgITBn+USionzfP6wq4rAfkI7rnExjAN
|                                                                                      | HivTJpMZe0i6FM7zK7uwcypx4cAAHp1Vj6YXDpwVKzTOSizkIOKl4E1NlWJbNHaq | ADCBmDELMAkGA1UEBhMCVVMxEDAOBgNVBAgTB0FyaXpvbmEx
|                                                                                      | 3Z6KU4SjZMfjBUHFoF6zuiDZI6KN+3pWbWHzMkxqD6n6PkIDVfiPcA5ezeC6RDtx | b3R0c2RhbGUxJTAjBgNVBAoTHFN0YXJmaWVsZCBUZWNobm9s
|                                                                                      | hCqXCtc9cdMKhFCNifUgvB/1N16iIx6Kl0ENliWyF7tUa5NEmdWeTu9a         | OzA5BgNVBAMTMlN0YXJmaWVsZCBTZXJ2aWNlcyBSb290IENl
|                                                                                      | -----END CERTIFICATE-----                                        | dGhvcml0eSAtIEcyMB4XDTE1MDUyNTEyMDAwMFoXDTM3MTIz
|                                                                                      |                                                                  | MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UE
|                                                                                      |                                                                  | b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
|                                                                                      |                                                                  | ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQ
|                                                                                      |                                                                  | 9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9
|                                                                                      |                                                                  | IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHhe
|                                                                                      |                                                                  | VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD
|                                                                                      |                                                                  | 93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/
|                                                                                      |                                                                  | jgSubJrIqg0CAwEAAaOCATEwggEtMA8GA1UdEwEB/wQFMAMB
|                                                                                      |                                                                  | BAQDAgGGMB0GA1UdDgQWBBSEGMyFNOy8DJSULghZnMeyEE4K
|                                                                                      |                                                                  | gBScXwDfqgHXMCs4iKK4bUqc8hGRgzB4BggrBgEFBQcBAQRs
|                                                                                      |                                                                  | MAGGImh0dHA6Ly9vY3NwLnJvb3RnMi5hbWF6b250cnVzdC5j
|                                                                                      |                                                                  | MAKGLGh0dHA6Ly9jcnQucm9vdGcyLmFtYXpvbnRydXN0LmNv
|                                                                                      |                                                                  | MD0GA1UdHwQ2MDQwMqAwoC6GLGh0dHA6Ly9jcmwucm9vdGcy
|                                                                                      |                                                                  | LmNvbS9yb290ZzIuY3JsMBEGA1UdIAQKMAgwBgYEVR0gADAN
|                                                                                      |                                                                  | AAOCAQEAYjdCXLwQtT6LLOkMm2xF4gcAevnFWAu5CIw+7bMl
|                                                                                      |                                                                  | MiGpSESrnO09tKpzbeR/FoCJbM8oAxiDR3mjEH4wW6w7sGDg
|                                                                                      |                                                                  | eyKdpwAJfqxGF4PcnCZXmTA5YpaP7dreqsXMGz7KQ2hsVxa8
|                                                                                      |                                                                  | bRRYh5TmOTFffHPLkIhqhBGWJ6bt2YFGpn6jcgAKUj6DiAdj
|                                                                                      |                                                                  | 0FE6/V1dN2RMfjCyVSRCnTawXZwXgWHxyvkQAiSr6w10kY17
|                                                                                      |                                                                  | akcjMS9cmvqtmg5iUaQqqcT5NJ0hGA==                
|                                                                                      |                                                                  | -----END CERTIFICATE-----                       
|                                                                                      |                                                                  | -----BEGIN CERTIFICATE-----                     
|                                                                                      |                                                                  | MIIEdTCCA12gAwIBAgIJAKcOSkw0grd/MA0GCSqGSIb3DQEB
|                                                                                      |                                                                  | BAYTAlVTMSUwIwYDVQQKExxTdGFyZmllbGQgVGVjaG5vbG9n
|                                                                                      |                                                                  | MAYDVQQLEylTdGFyZmllbGQgQ2xhc3MgMiBDZXJ0aWZpY2F0
|                                                                                      |                                                                  | eTAeFw0wOTA5MDIwMDAwMDBaFw0zNDA2MjgxNzM5MTZaMIGY
> select * from aws_acm_certificate limit 1089
+--------------------------------------------------------------------------------------+------------------------------------------------------------------+-------------------------------------------------
| certificate_arn                                                                      | certificate                                                      | certificate_chain                               
+--------------------------------------------------------------------------------------+------------------------------------------------------------------+-------------------------------------------------
| arn:aws:acm:ap-south-1:632902152528:certificate/c8f72e7f-f6cf-49d1-9c87-a14d4be82b5e | -----BEGIN CERTIFICATE-----                                      | -----BEGIN CERTIFICATE-----                     
|                                                                                      | MIIFZjCCBE6gAwIBAgIQAQ1yVf+q/86jnQygvA8ChDANBgkqhkiG9w0BAQsFADBG | MIIESTCCAzGgAwIBAgITBn+UV4WH6Kx33rJTMlu8mYtWDTAN
|                                                                                      | MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRUwEwYDVQQLEwxTZXJ2ZXIg | ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkw
|                                                                                      | Q0EgMUIxDzANBgNVBAMTBkFtYXpvbjAeFw0yMTAzMjMwMDAwMDBaFw0yMjA0MjEy | b24gUm9vdCBDQSAxMB4XDTE1MTAyMjAwMDAwMFoXDTI1MTAx
|                                                                                      | MzU5NTlaMCAxHjAcBgNVBAMMFSoudGVzdC50dXJib3QtZGV2LmNvbTCCASIwDQYJ | MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEVMBMGA1UE
|                                                                                      | KoZIhvcNAQEBBQADggEPADCCAQoCggEBAIXJfik89GldecK4Sl4zWlpkTmtM+d02 | IDFCMQ8wDQYDVQQDEwZBbWF6b24wggEiMA0GCSqGSIb3DQEB
|                                                                                      | kM83Hs4D8pDbP4lhgDq+hPQmW6TzCiWRH/rxKOXTxpE+IPgCCCCAhZfYfuK2o+Ah | AoIBAQDCThZn3c68asg3Wuw6MLAd5tES6BIoSMzoKcG5blPV
|                                                                                      | cKlfyLW97u9kIpK+xzvr2AGf3LLliibCRXvxnPzctjVYvJcGblx0XS9cCpwL0/ak | cMzPa43j4wNxhplty6aUKk4T1qe9BOwKFjwK6zmxxLVYo7bH
|                                                                                      | PLl3TQfdhNMlxT8Gpv93ZcPLbDdDMO1AaAui6mnwDQ5pLUTdkWRBYwWbGuY8TrFe | blDP+18x+B26A0piiQOuPkfyDyeR4xQghfj66Yo19V+emU3n
|                                                                                      | YlSR+kwlp4AqNySDkZiGXdrxmUp+byhK2Ls/npCu3MFtyA0fUg/23KAkxKl/hUXw | B5x+F2pV8xeKNR7u6azDdU5YVX1TawprmxRC1+WsAYmz6qP+
|                                                                                      | zEMzc7tl4Y4b35Byr2RPObTjycpu4xrjeDf86H7fJzSXmD52Q5AojDsCAwEAAaOC | 0IjKOtEXc/VfmtTFch5+AfGYMGMqqvJ6LcXiAhqG5TI+Dr0R
|                                                                                      | AnQwggJwMB8GA1UdIwQYMBaAFFmkZgZSoHuVkjyjlAcnlnRb+T3QMB0GA1UdDgQW | KuANaL7TiItKZYxK1MMuTJtV9IblAgMBAAGjggE7MIIBNzAS
|                                                                                      | BBRRw3xGztITsQrOM26jxoIR68ZkBTAgBgNVHREEGTAXghUqLnRlc3QudHVyYm90 | AQH/AgEAMA4GA1UdDwEB/wQEAwIBhjAdBgNVHQ4EFgQUWaRm
|                                                                                      | LWRldi5jb20wDgYDVR0PAQH/BAQDAgWgMB0GA1UdJQQWMBQGCCsGAQUFBwMBBggr | dFv5PdAwHwYDVR0jBBgwFoAUhBjMhTTsvAyUlC4IWZzHshBO
|                                                                                      | BgEFBQcDAjA7BgNVHR8ENDAyMDCgLqAshipodHRwOi8vY3JsLnNjYTFiLmFtYXpv | AQEEbzBtMC8GCCsGAQUFBzABhiNodHRwOi8vb2NzcC5yb290
|                                                                                      | bnRydXN0LmNvbS9zY2ExYi5jcmwwEwYDVR0gBAwwCjAIBgZngQwBAgEwdQYIKwYB | dXN0LmNvbTA6BggrBgEFBQcwAoYuaHR0cDovL2NydC5yb290
|                                                                                      | BQUHAQEEaTBnMC0GCCsGAQUFBzABhiFodHRwOi8vb2NzcC5zY2ExYi5hbWF6b250 | dXN0LmNvbS9yb290Y2ExLmNlcjA/BgNVHR8EODA2MDSgMqAw
|                                                                                      | cnVzdC5jb20wNgYIKwYBBQUHMAKGKmh0dHA6Ly9jcnQuc2NhMWIuYW1hem9udHJ1 | LnJvb3RjYTEuYW1hem9udHJ1c3QuY29tL3Jvb3RjYTEuY3Js
|                                                                                      | c3QuY29tL3NjYTFiLmNydDAMBgNVHRMBAf8EAjAAMIIBBAYKKwYBBAHWeQIEAgSB | CAYGZ4EMAQIBMA0GCSqGSIb3DQEBCwUAA4IBAQCFkr41u3nP
|                                                                                      | 9QSB8gDwAHYAKXm+8J45OSHwVnOfY6V35b5XfZxgCvj5TV0mXCVdx4QAAAF4Xxbr | 59Gt/a6ZiqyJEi+752+a1U5y6iAwYfmXss2lJwJFqMp2PphK
|                                                                                      | awAABAMARzBFAiAfCz+zRJ5oKRgB7uUGx0W7Q/9euZPCb17xeyeJoxiIggIhALn6 | 6G7bMQcT8C8xDZNtYTd7WPD8UZiRKAJPBXa30/AbwuZe0GaF
|                                                                                      | QpJHA9SOQVQodIOE3oDekpnUYJpqbE/xR/7gcSlEAHYAIkVFB1lVJFaWP6Ev8fdt | 8/LwhBNTZTUVEWuCUUBVV18YtbAiPq3yXqMB48Oz+ctBWuZS
|                                                                                      | huAjJmOtwEt/XcaDXG7iDwIAAAF4XxbroQAABAMARzBFAiEAq8+35XaZ+UdfQ0fN | upRyzQ7qDn1X8nn8N8V7YJ6y68AtkHcNSRAnpTitxBKjtKPI
|                                                                                      | 2nfB68VWgh84s++EBXQ8KbsE3g0CIF0vS8ih4/aVPejR2rzO5azjCdht7d8KuIdC | yLyKQXhw2W2Xs0qLeC1etA+jTGDK4UfLeC0SF7FSi8o5LL21
|                                                                                      | 0uULgWMDMA0GCSqGSIb3DQEBCwUAA4IBAQBVGjbsge0xOHU+GV2jP9SXRLkb6gJo | -----END CERTIFICATE-----                       
|                                                                                      | YWuYq1VkrQLg94wlXJYV4Sv16KY6jd8NkCUfQgxMbpsvegC9+FcXDhAzzYNw3ppw | -----BEGIN CERTIFICATE-----                     
|                                                                                      | 8rqU3MJvTOrG2hYiZHX7mh4NumYSrbJ6KvUQzTC6Uy7vCk7hzjiTlrxDxa6jprRi | MIIEkjCCA3qgAwIBAgITBn+USionzfP6wq4rAfkI7rnExjAN
|                                                                                      | HivTJpMZe0i6FM7zK7uwcypx4cAAHp1Vj6YXDpwVKzTOSizkIOKl4E1NlWJbNHaq | ADCBmDELMAkGA1UEBhMCVVMxEDAOBgNVBAgTB0FyaXpvbmEx
|                                                                                      | 3Z6KU4SjZMfjBUHFoF6zuiDZI6KN+3pWbWHzMkxqD6n6PkIDVfiPcA5ezeC6RDtx | b3R0c2RhbGUxJTAjBgNVBAoTHFN0YXJmaWVsZCBUZWNobm9s
|                                                                                      | hCqXCtc9cdMKhFCNifUgvB/1N16iIx6Kl0ENliWyF7tUa5NEmdWeTu9a         | OzA5BgNVBAMTMlN0YXJmaWVsZCBTZXJ2aWNlcyBSb290IENl
|                                                                                      | -----END CERTIFICATE-----                                        | dGhvcml0eSAtIEcyMB4XDTE1MDUyNTEyMDAwMFoXDTM3MTIz
|                                                                                      |                                                                  | MAkGA1UEBhMCVVMxDzANBgNVBAoTBkFtYXpvbjEZMBcGA1UE
|                                                                                      |                                                                  | b3QgQ0EgMTCCASIwDQYJKoZIhvcNAQEBBQADggEPADCCAQoC
|                                                                                      |                                                                  | ca9HgFB0fW7Y14h29Jlo91ghYPl0hAEvrAIthtOgQ3pOsqTQ
|                                                                                      |                                                                  | 9O6II8c+6zf1tRn4SWiw3te5djgdYZ6k/oI2peVKVuRF4fn9
|                                                                                      |                                                                  | IFAGbHrQgLKm+a/sRxmPUDgH3KKHOVj4utWp+UhnMJbulHhe
|                                                                                      |                                                                  | VOujw5H5SNz/0egwLX0tdHA114gk957EWW67c4cX8jJGKLhD
|                                                                                      |                                                                  | 93FcXmn/6pUCyziKrlA4b9v7LWIbxcceVOF34GfID5yHI9Y/
|                                                                                      |                                                                  | jgSubJrIqg0CAwEAAaOCATEwggEtMA8GA1UdEwEB/wQFMAMB
|                                                                                      |                                                                  | BAQDAgGGMB0GA1UdDgQWBBSEGMyFNOy8DJSULghZnMeyEE4K
|                                                                                      |                                                                  | gBScXwDfqgHXMCs4iKK4bUqc8hGRgzB4BggrBgEFBQcBAQRs
|                                                                                      |                                                                  | MAGGImh0dHA6Ly9vY3NwLnJvb3RnMi5hbWF6b250cnVzdC5j
|                                                                                      |                                                                  | MAKGLGh0dHA6Ly9jcnQucm9vdGcyLmFtYXpvbnRydXN0LmNv
|                                                                                      |                                                                  | MD0GA1UdHwQ2MDQwMqAwoC6GLGh0dHA6Ly9jcmwucm9vdGcy
|                                                                                      |                                                                  | LmNvbS9yb290ZzIuY3JsMBEGA1UdIAQKMAgwBgYEVR0gADAN
|                                                                                      |                                                                  | AAOCAQEAYjdCXLwQtT6LLOkMm2xF4gcAevnFWAu5CIw+7bMl
|                                                                                      |                                                                  | MiGpSESrnO09tKpzbeR/FoCJbM8oAxiDR3mjEH4wW6w7sGDg
|                                                                                      |                                                                  | eyKdpwAJfqxGF4PcnCZXmTA5YpaP7dreqsXMGz7KQ2hsVxa8
|                                                                                      |                                                                  | bRRYh5TmOTFffHPLkIhqhBGWJ6bt2YFGpn6jcgAKUj6DiAdj
|                                                                                      |                                                                  | 0FE6/V1dN2RMfjCyVSRCnTawXZwXgWHxyvkQAiSr6w10kY17
|                                                                                      |                                                                  | akcjMS9cmvqtmg5iUaQqqcT5NJ0hGA==                
|                                                                                      |                                                                  | -----END CERTIFICATE-----                       
|                                                                                      |                                                                  | -----BEGIN CERTIFICATE-----                     
|                                                                                      |                                                                  | MIIEdTCCA12gAwIBAgIJAKcOSkw0grd/MA0GCSqGSIb3DQEB
|                                                                                      |                                                                  | BAYTAlVTMSUwIwYDVQQKExxTdGFyZmllbGQgVGVjaG5vbG9n
|                                                                                      |                                                                  | MAYDVQQLEylTdGFyZmllbGQgQ2xhc3MgMiBDZXJ0aWZpY2F0
|                                                                                      |                                                                  | eTAeFw0wOTA5MDIwMDAwMDBaFw0zNDA2MjgxNzM5MTZaMIGY

> select * from aws_auditmanager_assessment limit 0
+------+----+-----+--------+-----------------+-------------------------------+------------------------------------+---------------+-------------+--------------+-------------+-------------+-----------+----
| name | id | arn | status | compliance_type | assessment_report_destination | assessment_report_destination_type | creation_time | description | last_updated | aws_account | delegations | framework | sco
+------+----+-----+--------+-----------------+-------------------------------+------------------------------------+---------------+-------------+--------------+-------------+-------------+-----------+----
+------+----+-----+--------+-----------------+-------------------------------+------------------------------------+---------------+-------------+--------------+-------------+-------------+-----------+----
> select * from aws_auditmanager_assessment limit 10
Error: AccessDeniedException: Please complete AWS Audit Manager setup from home page to enable this action in this account.
> select * from aws_auditmanager_assessment limit 1044
Error: AccessDeniedException: Please complete AWS Audit Manager setup from home page to enable this action in this account.
> select * from aws_cloudfront_cache_policy limit 0
+------+----+---------+-------------+------+---------+---------+--------------------+-------------------------------------------------+-------+------+-----------+--------+------------+
| name | id | comment | default_ttl | etag | max_ttl | min_ttl | last_modified_time | parameters_in_cache_key_and_forwarded_to_origin | title | akas | partition | region | account_id |
+------+----+---------+-------------+------+---------+---------+--------------------+-------------------------------------------------+-------+------+-----------+--------+------------+
+------+----+---------+-------------+------+---------+---------+--------------------+-------------------------------------------------+-------+------+-----------+--------+------------+
> select * from aws_cloudfront_cache_policy limit 10
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
| name                                           | id                                   | comment                                       | default_ttl | etag           | max_ttl  | min_ttl | last_modified_
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
| Managed-Elemental-MediaPackage                 | 08627262-05a9-4f76-9ded-b50ca2e3a84f | Policy for Elemental MediaPackage Origin      | 86400       | E23ZP02F085DFQ | 31536000 | 0       | 1970-01-01T00:
| Managed-CachingOptimizedForUncompressedObjects | b2884449-e4de-46a7-ac36-70bc7f1ddd6d | Default policy when compression is disabled   | 86400       | E23ZP02F085DFQ | 31536000 | 1       | 1970-01-01T00:
| Managed-CachingOptimized                       | 658327ea-f89d-4fab-a63d-7e88639e58f6 | Default policy when CF compression is enabled | 86400       | E23ZP02F085DFQ | 31536000 | 1       | 1970-01-01T00:
| Managed-CachingDisabled                        | 4135ea2d-6df8-44a3-9df3-4b5a84be39ad | Policy with caching disabled                  | 0           | E23ZP02F085DFQ | 0        | 0       | 1970-01-01T00:
| Managed-Amplify                                | 2e54312d-136d-493c-8eb9-b001f22f67d2 | Policy for Amplify Origin                     | 2           | E23ZP02F085DFQ | 600      | 2       | 1970-01-01T00:
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
> select * from aws_cloudfront_cache_policy limit 109
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
| name                                           | id                                   | comment                                       | default_ttl | etag           | max_ttl  | min_ttl | last_modified_
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
| Managed-CachingOptimized                       | 658327ea-f89d-4fab-a63d-7e88639e58f6 | Default policy when CF compression is enabled | 86400       | E23ZP02F085DFQ | 31536000 | 1       | 1970-01-01T00:
| Managed-CachingOptimizedForUncompressedObjects | b2884449-e4de-46a7-ac36-70bc7f1ddd6d | Default policy when compression is disabled   | 86400       | E23ZP02F085DFQ | 31536000 | 1       | 1970-01-01T00:
| Managed-Elemental-MediaPackage                 | 08627262-05a9-4f76-9ded-b50ca2e3a84f | Policy for Elemental MediaPackage Origin      | 86400       | E23ZP02F085DFQ | 31536000 | 0       | 1970-01-01T00:
| Managed-Amplify                                | 2e54312d-136d-493c-8eb9-b001f22f67d2 | Policy for Amplify Origin                     | 2           | E23ZP02F085DFQ | 600      | 2       | 1970-01-01T00:
| Managed-CachingDisabled                        | 4135ea2d-6df8-44a3-9df3-4b5a84be39ad | Policy with caching disabled                  | 0           | E23ZP02F085DFQ | 0        | 0       | 1970-01-01T00:
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
> select * from aws_cloudfront_distribution limit 0
+----+-----+--------+------------------+---------+---------------------+-------------+---------+-------+--------------+-----------------+----------------------------------+--------------------+-----------
| id | arn | status | caller_reference | comment | default_root_object | domain_name | enabled | e_tag | http_version | is_ipv6_enabled | in_progress_invalidation_batches | last_modified_time | price_clas
+----+-----+--------+------------------+---------+---------------------+-------------+---------+-------+--------------+-----------------+----------------------------------+--------------------+-----------
+----+-----+--------+------------------+---------+---------------------+-------------+---------+-------+--------------+-----------------+----------------------------------+--------------------+-----------
> select * from aws_cloudfront_distribution limit 10
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
| id             | arn                                                          | status   | caller_reference                     | comment | default_root_object | domain_name                  | enabled |
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
| E11MM0VVYILX2T | arn:aws:cloudfront::632902152528:distribution/E11MM0VVYILX2T | Deployed | c6b9d051-dd69-4e7e-ab4d-e70c360a19b3 |         |                     | dda3o0rsmo5cc.cloudfront.net | true    |
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
> select * from aws_cloudfront_distribution limit 108
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
| id             | arn                                                          | status   | caller_reference                     | comment | default_root_object | domain_name                  | enabled |
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
| E11MM0VVYILX2T | arn:aws:cloudfront::632902152528:distribution/E11MM0VVYILX2T | Deployed | c6b9d051-dd69-4e7e-ab4d-e70c360a19b3 |         |                     | dda3o0rsmo5cc.cloudfront.net | true    |
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
> select * from aws_cloudfront_origin_access_identity limit 0
+----+-----+----------------------+------------------+---------+------+-------+------+-----------+--------+------------+
| id | arn | s3_canonical_user_id | caller_reference | comment | etag | title | akas | partition | region | account_id |
+----+-----+----------------------+------------------+---------+------+-------+------+-----------+--------+------------+
+----+-----+----------------------+------------------+---------+------+-------+------+-----------+--------+------------+
> select * from aws_cloudfront_origin_access_identity limit 10
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
| id             | arn                                                                    | s3_canonical_user_id                                                                             | caller_refere
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
| E1HRKO9KUX8BMV | arn:aws:cloudfront::632902152528:origin-access-identity/E1HRKO9KUX8BMV | 1be043ac659864254b07f322cb62bb1aeaa12829d76b9cd294bfda6a4216c068f618687b3d4e83795292c13dbec85c2b | 1608029782467
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
> select * from aws_cloudfront_origin_access_identity limit 109
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
| id             | arn                                                                    | s3_canonical_user_id                                                                             | caller_refere
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
| E1HRKO9KUX8BMV | arn:aws:cloudfront::632902152528:origin-access-identity/E1HRKO9KUX8BMV | 1be043ac659864254b07f322cb62bb1aeaa12829d76b9cd294bfda6a4216c068f618687b3d4e83795292c13dbec85c2b | 1608029782467
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
> select * from aws_cloudfront_origin_request_policy limit 0
+------+----+---------+------+--------------------+----------------+----------------+----------------------+-------+------+-----------+--------+------------+
| name | id | comment | etag | last_modified_time | cookies_config | headers_config | query_strings_config | title | akas | partition | region | account_id |
+------+----+---------+------+--------------------+----------------+----------------+----------------------+-------+------+-----------+--------+------------+
+------+----+---------+------+--------------------+----------------+----------------+----------------------+-------+------+-----------+--------+------------+
> select * from aws_cloudfront_origin_request_policy limit 10
+-----------------------------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+---------
| name                                                | id                                   | comment                                                    | etag           | last_modified_time   | cookies_
+-----------------------------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+---------
| Managed-CORS-S3Origin                               | 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf | Policy for S3 origin with CORS                             | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-Elemental-MediaTailor-PersonalizedManifests | 775133bc-15f2-49f9-abea-afb2e0bf67d2 | Policy for Elemental MediaTailor Origin                    | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-CORS-CustomOrigin                           | 59781a5b-3903-41f3-afcb-af62929ccde1 | Policy for custom origin with CORS                         | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-AllViewer                                   | 216adef6-5c7f-47e4-b989-5492eafa07d3 | Policy with forward all parameters in viewer requests      | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-UserAgentRefererHeaders                     | acba4595-bd28-49b8-b9fe-13317c0390fa | Policy to forward user-agent and referer headers to origin | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
+-----------------------------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+---------
> select * from aws_cloudfront_origin_request_policy limit 1012
+-----------------------------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+---------
| name                                                | id                                   | comment                                                    | etag           | last_modified_time   | cookies_
+-----------------------------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+---------
| Managed-AllViewer                                   | 216adef6-5c7f-47e4-b989-5492eafa07d3 | Policy with forward all parameters in viewer requests      | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-Elemental-MediaTailor-PersonalizedManifests | 775133bc-15f2-49f9-abea-afb2e0bf67d2 | Policy for Elemental MediaTailor Origin                    | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-CORS-S3Origin                               | 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf | Policy for S3 origin with CORS                             | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-CORS-CustomOrigin                           | 59781a5b-3903-41f3-afcb-af62929ccde1 | Policy for custom origin with CORS                         | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-UserAgentRefererHeaders                     | acba4595-bd28-49b8-b9fe-13317c0390fa | Policy to forward user-agent and referer headers to origin | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
+-----------------------------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+---------
> select * from aws_codepipeline_pipeline limit 0
+------+-----+------------+----------+------------+---------+----------------+-----------------+--------+----------+-------+------+------+-----------+--------+------------+
| name | arn | created_at | role_arn | updated_at | version | encryption_key | artifact_stores | stages | tags_src | title | tags | akas | partition | region | account_id |
+------+-----+------------+----------+------------+---------+----------------+-----------------+--------+----------+-------+------+------+-----------+--------+------------+
+------+-----+------------+----------+------------+---------+----------------+-----------------+--------+----------+-------+------+------+-----------+--------+------------+
> select * from aws_codepipeline_pipeline limit 10
+------+-----+------------+----------+------------+---------+----------------+-----------------+--------+----------+-------+------+------+-----------+--------+------------+
| name | arn | created_at | role_arn | updated_at | version | encryption_key | artifact_stores | stages | tags_src | title | tags | akas | partition | region | account_id |
+------+-----+------------+----------+------------+---------+----------------+-----------------+--------+----------+-------+------+------+-----------+--------+------------+
+------+-----+------------+----------+------------+---------+----------------+-----------------+--------+----------+-------+------+------+-----------+--------+------------+
> select * from aws_codepipeline_pipeline limit 104
+------+-----+------------+----------+------------+---------+----------------+-----------------+--------+----------+-------+------+------+-----------+--------+------------+
| name | arn | created_at | role_arn | updated_at | version | encryption_key | artifact_stores | stages | tags_src | title | tags | akas | partition | region | account_id |
+------+-----+------------+----------+------------+---------+----------------+-----------------+--------+----------+-------+------+------+-----------+--------+------------+
+------+-----+------------+----------+------------+---------+----------------+-----------------+--------+----------+-------+------+------+-----------+--------+------------+
> select * from aws_dynamodb_backup limit 0
+------+-----+------------+-----------+----------+---------------+-------------+--------------------------+------------------------+-------------------+-------+------+-----------+--------+------------+
| name | arn | table_name | table_arn | table_id | backup_status | backup_type | backup_creation_datetime | backup_expiry_datetime | backup_size_bytes | title | akas | partition | region | account_id |
+------+-----+------------+-----------+----------+---------------+-------------+--------------------------+------------------------+-------------------+-------+------+-----------+--------+------------+
+------+-----+------------+-----------+----------+---------------+-------------+--------------------------+------------------------+-------------------+-------+------+-----------+--------+------------+
> select * from aws_dynamodb_backup limit 10
+----------------+--------------------------------------------------------------------------------------------+--------------+-------------------------------------------------------------+----------------
| name           | arn                                                                                        | table_name   | table_arn                                                   | table_id       
+----------------+--------------------------------------------------------------------------------------------+--------------+-------------------------------------------------------------+----------------
| dnb-backup-001 | arn:aws:dynamodb:ap-south-1:632902152528:table/table-dy-001/backup/01622184108689-e36fb586 | table-dy-001 | arn:aws:dynamodb:ap-south-1:632902152528:table/table-dy-001 | cf1b5f8c-732c-4
| mytable_backup | arn:aws:dynamodb:us-east-1:632902152528:table/mytable/backup/01597822073478-8ed58672       | mytable      | arn:aws:dynamodb:us-east-1:632902152528:table/mytable       | e0eeedd1-063c-4
+----------------+--------------------------------------------------------------------------------------------+--------------+-------------------------------------------------------------+----------------
...skipping...
+----------------+--------------------------------------------------------------------------------------------+--------------+-------------------------------------------------------------+----------------
| name           | arn                                                                                        | table_name   | table_arn                                                   | table_id       
+----------------+--------------------------------------------------------------------------------------------+--------------+-------------------------------------------------------------+----------------
| dnb-backup-001 | arn:aws:dynamodb:ap-south-1:632902152528:table/table-dy-001/backup/01622184108689-e36fb586 | table-dy-001 | arn:aws:dynamodb:ap-south-1:632902152528:table/table-dy-001 | cf1b5f8c-732c-4
| mytable_backup | arn:aws:dynamodb:us-east-1:632902152528:table/mytable/backup/01597822073478-8ed58672       | mytable      | arn:aws:dynamodb:us-east-1:632902152528:table/mytable       | e0eeedd1-063c-4
+----------------+--------------------------------------------------------------------------------------------+--------------+-------------------------------------------------------------+----------------

> select * from aws_dynamodb_backup limit 1190
+----------------+--------------------------------------------------------------------------------------------+--------------+-------------------------------------------------------------+----------------
| name           | arn                                                                                        | table_name   | table_arn                                                   | table_id       
+----------------+--------------------------------------------------------------------------------------------+--------------+-------------------------------------------------------------+----------------
| dnb-backup-001 | arn:aws:dynamodb:ap-south-1:632902152528:table/table-dy-001/backup/01622184108689-e36fb586 | table-dy-001 | arn:aws:dynamodb:ap-south-1:632902152528:table/table-dy-001 | cf1b5f8c-732c-4
| mytable_backup | arn:aws:dynamodb:us-east-1:632902152528:table/mytable/backup/01597822073478-8ed58672       | mytable      | arn:aws:dynamodb:us-east-1:632902152528:table/mytable       | e0eeedd1-063c-4
+----------------+--------------------------------------------------------------------------------------------+--------------+-------------------------------------------------------------+----------------
> select * from aws_dynamodb_global_table limit 0
+-------------------+------------------+---------------------+--------------------+-------------------+-------+------+-----------+--------+------------+
| global_table_name | global_table_arn | global_table_status | creation_date_time | replication_group | title | akas | partition | region | account_id |
+-------------------+------------------+---------------------+--------------------+-------------------+-------+------+-----------+--------+------------+
+-------------------+------------------+---------------------+--------------------+-------------------+-------+------+-----------+--------+------------+
> select * from aws_dynamodb_global_table limit 10
+-------------------+------------------+---------------------+--------------------+-------------------+-------+------+-----------+--------+------------+
| global_table_name | global_table_arn | global_table_status | creation_date_time | replication_group | title | akas | partition | region | account_id |
+-------------------+------------------+---------------------+--------------------+-------------------+-------+------+-----------+--------+------------+
+-------------------+------------------+---------------------+--------------------+-------------------+-------+------+-----------+--------+------------+
> select * from aws_dynamodb_global_table limit 107
+-------------------+------------------+---------------------+--------------------+-------------------+-------+------+-----------+--------+------------+
| global_table_name | global_table_arn | global_table_status | creation_date_time | replication_group | title | akas | partition | region | account_id |
+-------------------+------------------+---------------------+--------------------+-------------------+-------+------+-----------+--------+------------+
+-------------------+------------------+---------------------+--------------------+-------------------+-------+------+-----------+--------+------------+

```

```
 select * from aws_accessanalyzer_analyzer limit 1
+---------------+------------------------------------------------------------------------+--------+---------+----------------------+--------------------------------------------+---------------------------
| name          | arn                                                                    | status | type    | created_at           | last_resource_analyzed                     | last_resource_analyzed_at 
+---------------+------------------------------------------------------------------------+--------+---------+----------------------+--------------------------------------------+---------------------------
| test-analyser | arn:aws:access-analyzer:ap-south-1:632902152528:analyzer/test-analyser | ACTIVE | ACCOUNT | 2021-05-19T10:33:58Z | arn:aws:iam::632902152528:role/turbot/user | 2021-12-15T14:59:45Z      
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
+---------------+------------------------------------------------------------------------+--------+---------+----------------------+--------------------------------------------+---------------------------

> select * from aws_accessanalyzer_analyzer limit 50
+---------------+------------------------------------------------------------------------+--------+---------+----------------------+--------------------------------------------+---------------------------
| name          | arn                                                                    | status | type    | created_at           | last_resource_analyzed                     | last_resource_analyzed_at 
+---------------+------------------------------------------------------------------------+--------+---------+----------------------+--------------------------------------------+---------------------------
| test-analyser | arn:aws:access-analyzer:ap-south-1:632902152528:analyzer/test-analyser | ACTIVE | ACCOUNT | 2021-05-19T10:33:58Z | arn:aws:iam::632902152528:role/turbot/user | 2021-12-15T14:59:45Z      
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
| ytrgg         | arn:aws:access-analyzer:us-east-2:632902152528:analyzer/ytrgg          | ACTIVE | ACCOUNT | 2021-05-19T10:44:07Z | arn:aws:iam::632902152528:role/turbot/user | 2021-12-15T17:09:21Z      
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
|               |                                                                        |        |         |                      |                                            |                           
+---------------+------------------------------------------------------------------------+--------+---------+----------------------+--------------------------------------------+---------------------------

> select * from aws_cloudfront_cache_policy
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
| name                                           | id                                   | comment                                       | default_ttl | etag           | max_ttl  | min_ttl | last_modified_
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
| Managed-Amplify                                | 2e54312d-136d-493c-8eb9-b001f22f67d2 | Policy for Amplify Origin                     | 2           | E23ZP02F085DFQ | 600      | 2       | 1970-01-01T00:
| Managed-CachingOptimizedForUncompressedObjects | b2884449-e4de-46a7-ac36-70bc7f1ddd6d | Default policy when compression is disabled   | 86400       | E23ZP02F085DFQ | 31536000 | 1       | 1970-01-01T00:
| Managed-Elemental-MediaPackage                 | 08627262-05a9-4f76-9ded-b50ca2e3a84f | Policy for Elemental MediaPackage Origin      | 86400       | E23ZP02F085DFQ | 31536000 | 0       | 1970-01-01T00:
| Managed-CachingOptimized                       | 658327ea-f89d-4fab-a63d-7e88639e58f6 | Default policy when CF compression is enabled | 86400       | E23ZP02F085DFQ | 31536000 | 1       | 1970-01-01T00:
| Managed-CachingDisabled                        | 4135ea2d-6df8-44a3-9df3-4b5a84be39ad | Policy with caching disabled                  | 0           | E23ZP02F085DFQ | 0        | 0       | 1970-01-01T00:
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------

> select * from aws_cloudfront_cache_policy limit 1
+--------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+----------------------+--------------
| name                     | id                                   | comment                                       | default_ttl | etag           | max_ttl  | min_ttl | last_modified_time   | parameters_in
+--------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+----------------------+--------------
| Managed-CachingOptimized | 658327ea-f89d-4fab-a63d-7e88639e58f6 | Default policy when CF compression is enabled | 86400       | E23ZP02F085DFQ | 31536000 | 1       | 1970-01-01T00:00:00Z | {"CookiesConf
+--------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+----------------------+--------------

> select * from aws_cloudfront_cache_policy limit 50
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
| name                                           | id                                   | comment                                       | default_ttl | etag           | max_ttl  | min_ttl | last_modified_
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
| Managed-CachingOptimized                       | 658327ea-f89d-4fab-a63d-7e88639e58f6 | Default policy when CF compression is enabled | 86400       | E23ZP02F085DFQ | 31536000 | 1       | 1970-01-01T00:
| Managed-CachingDisabled                        | 4135ea2d-6df8-44a3-9df3-4b5a84be39ad | Policy with caching disabled                  | 0           | E23ZP02F085DFQ | 0        | 0       | 1970-01-01T00:
| Managed-Elemental-MediaPackage                 | 08627262-05a9-4f76-9ded-b50ca2e3a84f | Policy for Elemental MediaPackage Origin      | 86400       | E23ZP02F085DFQ | 31536000 | 0       | 1970-01-01T00:
| Managed-Amplify                                | 2e54312d-136d-493c-8eb9-b001f22f67d2 | Policy for Amplify Origin                     | 2           | E23ZP02F085DFQ | 600      | 2       | 1970-01-01T00:
| Managed-CachingOptimizedForUncompressedObjects | b2884449-e4de-46a7-ac36-70bc7f1ddd6d | Default policy when compression is disabled   | 86400       | E23ZP02F085DFQ | 31536000 | 1       | 1970-01-01T00:
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+--------------

> select * from aws_cloudfront_distribution
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
| id             | arn                                                          | status   | caller_reference                     | comment | default_root_object | domain_name                  | enabled |
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
| E11MM0VVYILX2T | arn:aws:cloudfront::632902152528:distribution/E11MM0VVYILX2T | Deployed | c6b9d051-dd69-4e7e-ab4d-e70c360a19b3 |         |                     | dda3o0rsmo5cc.cloudfront.net | true    |
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+

> select * from aws_cloudfront_distribution limit 50
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
| id             | arn                                                          | status   | caller_reference                     | comment | default_root_object | domain_name                  | enabled |
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
| E11MM0VVYILX2T | arn:aws:cloudfront::632902152528:distribution/E11MM0VVYILX2T | Deployed | c6b9d051-dd69-4e7e-ab4d-e70c360a19b3 |         |                     | dda3o0rsmo5cc.cloudfront.net | true    |
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
> select * from aws_cloudfront_distribution limit 1
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
| id             | arn                                                          | status   | caller_reference                     | comment | default_root_object | domain_name                  | enabled |
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+
| E11MM0VVYILX2T | arn:aws:cloudfront::632902152528:distribution/E11MM0VVYILX2T | Deployed | c6b9d051-dd69-4e7e-ab4d-e70c360a19b3 |         |                     | dda3o0rsmo5cc.cloudfront.net | true    |
+----------------+--------------------------------------------------------------+----------+--------------------------------------+---------+---------------------+------------------------------+---------+

> select * from aws_cloudfront_origin_access_identity
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
| id             | arn                                                                    | s3_canonical_user_id                                                                             | caller_refere
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
| E1HRKO9KUX8BMV | arn:aws:cloudfront::632902152528:origin-access-identity/E1HRKO9KUX8BMV | 1be043ac659864254b07f322cb62bb1aeaa12829d76b9cd294bfda6a4216c068f618687b3d4e83795292c13dbec85c2b | 1608029782467
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
> select * from aws_cloudfront_origin_access_identity limit 10
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
| id             | arn                                                                    | s3_canonical_user_id                                                                             | caller_refere
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
| E1HRKO9KUX8BMV | arn:aws:cloudfront::632902152528:origin-access-identity/E1HRKO9KUX8BMV | 1be043ac659864254b07f322cb62bb1aeaa12829d76b9cd294bfda6a4216c068f618687b3d4e83795292c13dbec85c2b | 1608029782467
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
> select * from aws_cloudfront_origin_access_identity limit 1
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
| id             | arn                                                                    | s3_canonical_user_id                                                                             | caller_refere
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------
| E1HRKO9KUX8BMV | arn:aws:cloudfront::632902152528:origin-access-identity/E1HRKO9KUX8BMV | 1be043ac659864254b07f322cb62bb1aeaa12829d76b9cd294bfda6a4216c068f618687b3d4e83795292c13dbec85c2b | 1608029782467
+----------------+------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------

> select * from aws_cloudfront_origin_request_policy
+-----------------------------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+---------
| name                                                | id                                   | comment                                                    | etag           | last_modified_time   | cookies_
+-----------------------------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+---------
| Managed-CORS-CustomOrigin                           | 59781a5b-3903-41f3-afcb-af62929ccde1 | Policy for custom origin with CORS                         | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-UserAgentRefererHeaders                     | acba4595-bd28-49b8-b9fe-13317c0390fa | Policy to forward user-agent and referer headers to origin | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-AllViewer                                   | 216adef6-5c7f-47e4-b989-5492eafa07d3 | Policy with forward all parameters in viewer requests      | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-CORS-S3Origin                               | 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf | Policy for S3 origin with CORS                             | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-Elemental-MediaTailor-PersonalizedManifests | 775133bc-15f2-49f9-abea-afb2e0bf67d2 | Policy for Elemental MediaTailor Origin                    | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
+-----------------------------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+---------
> select * from aws_cloudfront_origin_request_policy limit 50
+-----------------------------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+---------
| name                                                | id                                   | comment                                                    | etag           | last_modified_time   | cookies_
+-----------------------------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+---------
| Managed-CORS-S3Origin                               | 88a5eaf4-2fd4-4709-b370-b4c650ea3fcf | Policy for S3 origin with CORS                             | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-CORS-CustomOrigin                           | 59781a5b-3903-41f3-afcb-af62929ccde1 | Policy for custom origin with CORS                         | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-UserAgentRefererHeaders                     | acba4595-bd28-49b8-b9fe-13317c0390fa | Policy to forward user-agent and referer headers to origin | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-AllViewer                                   | 216adef6-5c7f-47e4-b989-5492eafa07d3 | Policy with forward all parameters in viewer requests      | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
| Managed-Elemental-MediaTailor-PersonalizedManifests | 775133bc-15f2-49f9-abea-afb2e0bf67d2 | Policy for Elemental MediaTailor Origin                    | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"Cookie
+-----------------------------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+---------
> select * from aws_cloudfront_origin_request_policy limit 1
+---------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+-----------------------------
| name                            | id                                   | comment                                                    | etag           | last_modified_time   | cookies_config              
+---------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+-----------------------------
| Managed-UserAgentRefererHeaders | acba4595-bd28-49b8-b9fe-13317c0390fa | Policy to forward user-agent and referer headers to origin | E23ZP02F085DFQ | 1970-01-01T00:00:00Z | {"CookieBehavior":"none","Co
+---------------------------------+--------------------------------------+------------------------------------------------------------+----------------+----------------------+-----------------------------

```

</details>
