### PR TITLE
Queries against aws_ebs_snapshot are not returning results for aws ap-southeast-2 region closes #831

### DIFF
--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -186,16 +186,16 @@ func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	input := &ec2.DescribeSnapshotsInput{
-		OwnerIds: []*string{aws.String("self")},
+		OwnerIds:   []*string{aws.String("self")},
 		MaxResults: aws.Int64(1000),
 	}
-   
+
 	// Build filter for ebs snapshot
 	filters := buildEbsSnapshotFilter(d.KeyColumnQuals)
 	if len(filters) > 0 {
 		input.Filters = filters
 	}
-	
+
 	// If the requested number of items is less than the paging max limit
 	// set the limit to that instead
 	limit := d.QueryContext.Limit

--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -186,13 +186,16 @@ func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	input := &ec2.DescribeSnapshotsInput{
+		OwnerIds: []*string{aws.String("self")},
 		MaxResults: aws.Int64(1000),
 	}
-
+   
 	// Build filter for ebs snapshot
 	filters := buildEbsSnapshotFilter(d.KeyColumnQuals)
-	input.Filters = filters
-
+	if len(filters) > 0 {
+		input.Filters = filters
+	}
+	
 	// If the requested number of items is less than the paging max limit
 	// set the limit to that instead
 	limit := d.QueryContext.Limit
@@ -205,7 +208,6 @@ func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 			}
 		}
 	}
-
 	// List call
 	err = svc.DescribeSnapshotsPages(
 		input,
@@ -337,15 +339,5 @@ func buildEbsSnapshotFilter(equalQuals plugin.KeyColumnEqualsQualMap) []*ec2.Fil
 			filters = append(filters, &filter)
 		}
 	}
-	ownerFilter := ec2.Filter{}
-	if equalQuals["owner_id"] != nil {
-		ownerFilter.Name = types.String("owner-id")
-		ownerFilter.Values = []*string{types.String(equalQuals["owner_id"].GetStringValue())}
-	} else {
-		ownerFilter.Name = types.String("owner-id")
-		ownerFilter.Values = []*string{types.String("self")}
-	}
-
-	filters = append(filters, &ownerFilter)
 	return filters
 }


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_ebs_snapshot []

PRETEST: tests/aws_ebs_snapshot

TEST: tests/aws_ebs_snapshot
Running terraform
aws_ebs_volume.test_volume: Creating...
aws_ebs_volume.test_volume: Still creating... [10s elapsed]
aws_ebs_volume.test_volume: Creation complete after 15s [id=vol-0e3ac6780e5445870]
aws_ebs_snapshot.named_test_resource: Creating...
aws_ebs_snapshot.named_test_resource: Creation complete after 4s [id=snap-0b466018061d8ae5e]
aws_snapshot_create_volume_permission.example_perm: Creating...
aws_snapshot_create_volume_permission.example_perm: Still creating... [10s elapsed]
aws_snapshot_create_volume_permission.example_perm: Creation complete after 14s [id=snap-0b466018061d8ae5e-388460667113]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "xxxxxxxxxx"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:ec2:us-east-1::snapshot/snap-0b466018061d8ae5e"
resource_name = "turbottest62408"
snapshot_id = "snap-0b466018061d8ae5e"
volume_id = "vol-0e3ac6780e5445870"

Running SQL query: test-get-query.sql
[
  {
    "description": "Test snapshot",
    "encrypted": false,
    "owner_id": "xxxxxxxxxx",
    "snapshot_id": "snap-0b466018061d8ae5e",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest62408"
      }
    ],
    "volume_id": "vol-0e3ac6780e5445870",
    "volume_size": 1
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:xxxxxxxxxx:snapshot/snap-0b466018061d8ae5e"
    ],
    "create_volume_permissions": [
      {
        "Group": null,
        "UserId": "388460667113"
      }
    ],
    "snapshot_id": "snap-0b466018061d8ae5e",
    "tags": {
      "Name": "turbottest62408"
    },
    "title": "snap-0b466018061d8ae5e"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "snapshot_id": "snap-0b466018061d8ae5e",
    "volume_id": "vol-0e3ac6780e5445870"
  }
]
✔ PASSED

POSTTEST: tests/aws_ebs_snapshot

TEARDOWN: tests/aws_ebs_snapshot

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select * from aws_ebs_snapshot
+------------------------+-------------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+----------------------+---------------------------------------------------
| snapshot_id            | arn                                                                     | state     | volume_size | volume_id             | encrypted | start_time           | description                                       
+------------------------+-------------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+----------------------+---------------------------------------------------
| snap-0c3dae7e1928e2d3a | arn:aws:ec2:ap-southeast-2:xxxxxxxxx:snapshot/snap-0c3dae7e1928e2d3a | completed | 1           | vol-0e15795b4633a3eb7 | false     | 2021-12-17T12:12:58Z | delete later                                      
| snap-009f2ffae82714cab | arn:aws:ec2:ap-south-1:xxxxxxxxx:snapshot/snap-009f2ffae82714cab     | completed | 6           | vol-02776515d142986a3 | false     | 2020-11-30T03:31:29Z | turbot/volumeBackup/#vol-02776515d142986a3        
| snap-0a06c542a5190d9a4 | arn:aws:ec2:us-east-1:xxxxxxxx:snapshot/snap-0a06c542a5190d9a4      | completed | 8           | vol-0f8ac71218f448742 | false     | 2019-11-13T11:53:16Z | Created by CreateImage(i-08fde9ba4273c664c) for am
| snap-0e73c8e608ed4dfc8 | arn:aws:ec2:ap-southeast-2:xxxxxxxxxxx:snapshot/snap-0e73c8e608ed4dfc8 | completed | 8           | vol-06c3e434950d848da | false     | 2021-12-17T12:30:55Z | delete                                            
| snap-038b5e41284975e85 | arn:aws:ec2:ap-south-1:xxxxxxxx:snapshot/snap-038b5e41284975e85     | completed | 20          | vol-0c6978b09d36fb8da | true      | 2021-03-18T04:25:28Z | test   
```
</details>
