### PR TITLE
Workspaces "no such host" errrors closes #830

### DIFF
--- a/aws/table_aws_workspaces_workspace.go
+++ b/aws/table_aws_workspaces_workspace.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/workspaces"
@@ -150,6 +151,10 @@ func listWorkspaces(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	// Create Session
 	svc, err := WorkspacesService(ctx, d)
 	if err != nil {
+		// AWS workspaces is not available in every region yet. This section of code handles the errors that we get when the API call tries to use unsupported regions endpoint (it throws "no such host" error message)
+		if strings.Contains(err.Error(), "no such host") {
+			return nil, nil
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Before - 
 select * from aws_workspaces_workspace
Error: RequestError: send request failed
caused by: Post "https://workspaces.us-east-2.amazonaws.com/": dial tcp: lookup workspaces.us-east-2.amazonaws.com: no such host

After the fix -

> select * from aws_workspaces_workspace
+--------------+------+-----+-----------+--------------+-------+------------+---------------+------------+--------------------------------+-----------+-----------+--------------------------------+------
| workspace_id | name | arn | bundle_id | directory_id | state | error_code | error_message | ip_address | root_volume_encryption_enabled | subnet_id | user_name | user_volume_encryption_enabled | volum
+--------------+------+-----+-----------+--------------+-------+------------+---------------+------------+--------------------------------+-----------+-----------+--------------------------------+------
+--------------+------+-----+-----------+--------------+-------+------------+---------------+------------+--------------------------------+-----------+-----------+--------------------------------+------
```
</details>
