### PR TITLE
Fix the "no such host" error in the aws_workspaces_workspace table closes #830

### DIFF
--- a/aws/table_aws_workspaces_workspace.go
+++ b/aws/table_aws_workspaces_workspace.go
@@ -151,10 +151,6 @@ func listWorkspaces(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	// Create Session
 	svc, err := WorkspacesService(ctx, d)
 	if err != nil {
-		// AWS workspaces is not available in every region yet. This section of code handles the errors that we get when the API call tries to use unsupported regions endpoint (it throws "no such host" error message)
-		if strings.Contains(err.Error(), "no such host") {
-			return nil, nil
-		}
 		return nil, err
 	}
 
@@ -168,6 +164,12 @@ func listWorkspaces(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 			return !isLast
 		},
 	)
+	if err != nil {
+		// AWS workspaces is not available in every region yet. This section of code handles the errors that we get when the API call tries to use unsupported regions endpoint (it throws "no such host" error message)
+		if strings.Contains(err.Error(), "no such host") {
+			return nil, nil
+		}
+	}
 	return nil, err
 }
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
select * from aws_workspaces_workspace
+--------------+------+-----+-----------+--------------+-------+------------+---------------+------------+--------------------------------+-----------+-----------+--------------------------------+-----------------------+----------------
| workspace_id | name | arn | bundle_id | directory_id | state | error_code | error_message | ip_address | root_volume_encryption_enabled | subnet_id | user_name | user_volume_encryption_enabled | volume_encryption_key | modification_st
+--------------+------+-----+-----------+--------------+-------+------------+---------------+------------+--------------------------------+-----------+-----------+--------------------------------+-----------------------+-----------
```
</details>
