### PR TITLE
Fix aws_ebs_snapshot table to use owner_id as an optional key qual

### DIFF
--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -175,7 +175,7 @@ func tableAwsEBSSnapshot(_ context.Context) *plugin.Table {
 
 //// LIST FUNCTION
 
-func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	plugin.Logger(ctx).Trace("listAwsEBSSnapshots", "AWS_REGION", region)
 
@@ -186,15 +186,12 @@ func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	}
 
 	input := &ec2.DescribeSnapshotsInput{
-		OwnerIds:   []*string{aws.String("self")},
 		MaxResults: aws.Int64(1000),
 	}
 
 	// Build filter for ebs snapshot
-	filters := buildEbsSnapshotFilter(d.KeyColumnQuals)
-	if len(filters) > 0 {
-		input.Filters = filters
-	}
+	filters := buildEbsSnapshotFilter(ctx, d, h, d.KeyColumnQuals)
+	input.Filters = filters
 
 	// If the requested number of items is less than the paging max limit
 	// set the limit to that instead
@@ -264,12 +261,21 @@ func getAwsEBSSnapshotCreateVolumePermissions(ctx context.Context, d *plugin.Que
 	plugin.Logger(ctx).Trace("getAwsEBSSnapshotCreateVolumePermissions")
 	snapshotData := h.Item.(*ec2.Snapshot)
 	region := d.KeyColumnQualString(matrixKeyRegion)
-
+	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
+	c, err := getCommonColumnsCached(ctx, d, h)
+	if err != nil {
+		return nil, err
+	}
+	commonColumnData := c.(*awsCommonColumnData)
+	if *snapshotData.OwnerId != commonColumnData.AccountId {
+		return nil, nil
+	}
 	// Create session
 	svc, err := Ec2Service(ctx, d, region)
 	if err != nil {
 		return nil, err
 	}
+
 
 	// Build params
 	params := &ec2.DescribeSnapshotAttributeInput{
@@ -297,7 +303,7 @@ func getEBSSnapshotARN(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	commonColumnData := c.(*awsCommonColumnData)
 
 	// Get the resource arn
-	arn := "arn:" + commonColumnData.Partition + ":ec2:" + region + ":" + commonColumnData.AccountId + ":snapshot/" + *snapshotData.SnapshotId
+	arn := "arn:" + commonColumnData.Partition + ":ec2:" + region + ":" + *snapshotData.OwnerId + ":snapshot/" + *snapshotData.SnapshotId
 
 	return arn, nil
 }
@@ -311,7 +317,7 @@ func ec2SnapshotTurbotTags(_ context.Context, d *transform.TransformData) (inter
 
 //// UTILITY FUNCTION
 // build ebs snapshot list call input filter
-func buildEbsSnapshotFilter(equalQuals plugin.KeyColumnEqualsQualMap) []*ec2.Filter {
+func buildEbsSnapshotFilter(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, equalQuals plugin.KeyColumnEqualsQualMap) []*ec2.Filter {
 	filters := make([]*ec2.Filter, 0)
 
 	filterQuals := map[string]string{
@@ -339,5 +345,22 @@ func buildEbsSnapshotFilter(equalQuals plugin.KeyColumnEqualsQualMap) []*ec2.Fil
 			filters = append(filters, &filter)
 		}
 	}
+	ownerFilter := ec2.Filter{}
+	if equalQuals["owner_id"] != nil {
+		ownerFilter.Name = types.String("owner-id")
+		ownerFilter.Values = []*string{types.String(equalQuals["owner_id"].GetStringValue())}
+	} else {
+		// Use this section later and compare the results
+		getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
+		c, err := getCommonColumnsCached(ctx, d, h)
+		if err != nil {
+			return filters
+		}
+		commonColumnData := c.(*awsCommonColumnData)
+		ownerFilter.Name = types.String("owner-id")
+		ownerFilter.Values = []*string{aws.String(commonColumnData.AccountId)}
+	}
+
+	filters = append(filters, &ownerFilter)
 	return filters
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_ebs_snapshot []

PRETEST: tests/aws_ebs_snapshot

TEST: tests/aws_ebs_snapshot
Running terraform
aws_ebs_volume.test_volume: Creating...
aws_ebs_volume.test_volume: Still creating... [10s elapsed]
aws_ebs_volume.test_volume: Creation complete after 15s [id=vol-0e3ac6780e5445870]
aws_ebs_snapshot.named_test_resource: Creating...
aws_ebs_snapshot.named_test_resource: Creation complete after 4s [id=snap-0b466018061d8ae5e]
aws_snapshot_create_volume_permission.example_perm: Creating...
aws_snapshot_create_volume_permission.example_perm: Still creating... [10s elapsed]
aws_snapshot_create_volume_permission.example_perm: Creation complete after 14s [id=snap-0b466018061d8ae5e-388460667113]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "xxxxxxxxxx"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:ec2:us-east-1::snapshot/snap-0b466018061d8ae5e"
resource_name = "turbottest62408"
snapshot_id = "snap-0b466018061d8ae5e"
volume_id = "vol-0e3ac6780e5445870"

Running SQL query: test-get-query.sql
[
  {
    "description": "Test snapshot",
    "encrypted": false,
    "owner_id": "xxxxxxxxxx",
    "snapshot_id": "snap-0b466018061d8ae5e",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest62408"
      }
    ],
    "volume_id": "vol-0e3ac6780e5445870",
    "volume_size": 1
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:xxxxxxxxxx:snapshot/snap-0b466018061d8ae5e"
    ],
    "create_volume_permissions": [
      {
        "Group": null,
        "UserId": "388460667113"
      }
    ],
    "snapshot_id": "snap-0b466018061d8ae5e",
    "tags": {
      "Name": "turbottest62408"
    },
    "title": "snap-0b466018061d8ae5e"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "snapshot_id": "snap-0b466018061d8ae5e",
    "volume_id": "vol-0e3ac6780e5445870"
  }
]
✔ PASSED

POSTTEST: tests/aws_ebs_snapshot

TEARDOWN: tests/aws_ebs_snapshot

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select *  from aws_ebs_snapshot where owner_id = '01312255xxxx'
+------------------------+--------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+----------------------+-------------+------------+---
| snapshot_id            | arn                                                                | state     | volume_size | volume_id             | encrypted | start_time           | description | kms_key_id | da
+------------------------+--------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+----------------------+-------------+------------+---
| snap-0d1f9bfc9a9fadc0c | arn:aws:ec2:us-east-1:01312255xxxx:snapshot/snap-0d1f9bfc9a9fadc0c | completed | 1           | vol-01cbe6ca3cafe80e8 | false     | 2021-12-20T09:08:14Z | delete      | <null>     | <n
+------------------------+--------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+----------------------+-------------+------------+---
> select * from aws_ebs_snapshot
+------------------------+-------------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+----------------------+-------------------------
| snapshot_id            | arn                                                                     | state     | volume_size | volume_id             | encrypted | start_time           | description             
+------------------------+-------------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+----------------------+-------------------------
| snap-038b5e41284975e85 | arn:aws:ec2:ap-south-1:63290215xxxx:snapshot/snap-038b5e41284975e85     | completed | 20          | vol-0c6978b09d36fb8da | true      | 2021-03-18T04:25:28Z | test                    
| snap-009f2ffae82714cab | arn:aws:ec2:ap-south-1:63290215xxxx:snapshot/snap-009f2ffae82714cab     | completed | 6           | vol-02776515d142986a3 | false     | 2020-11-30T03:31:29Z | turbot/volumeBackup/#vol
| snap-0ca806b1a2b580ea0 | arn:aws:ec2:ap-southeast-2:63290215xxxx:snapshot/snap-0ca806b1a2b580ea0 | completed | 1           | vol-0e15795b4633a3eb7 | false     | 2021-12-17T17:48:31Z | delete                  
| snap-0a06c542a5190d9a4 | arn:aws:ec2:us-east-1:63290215xxxx:snapshot/snap-0a06c542a5190d9a4      | completed | 8           | vol-0f8ac71218f448742 | false     | 2019-11-13T11:53:16Z | Created by CreateImage(i
+------------------------+-------------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+----------------------+-------------------------
> select * from aws_ebs_snapshot where owner_id = '63290215xxxx'
+------------------------+-------------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+----------------------+-------------------------
| snapshot_id            | arn                                                                     | state     | volume_size | volume_id             | encrypted | start_time           | description             
+------------------------+-------------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+----------------------+-------------------------
| snap-038b5e41284975e85 | arn:aws:ec2:ap-south-1:63290215xxxx:snapshot/snap-038b5e41284975e85     | completed | 20          | vol-0c6978b09d36fb8da | true      | 2021-03-18T04:25:28Z | test                    
| snap-009f2ffae82714cab | arn:aws:ec2:ap-south-1:63290215xxxx:snapshot/snap-009f2ffae82714cab     | completed | 6           | vol-02776515d142986a3 | false     | 2020-11-30T03:31:29Z | turbot/volumeBackup/#vol
| snap-0ca806b1a2b580ea0 | arn:aws:ec2:ap-southeast-2:63290215xxxx:snapshot/snap-0ca806b1a2b580ea0 | completed | 1           | vol-0e15795b4633a3eb7 | false     | 2021-12-17T17:48:31Z | delete                  
| snap-0a06c542a5190d9a4 | arn:aws:ec2:us-east-1:63290215xxxx:snapshot/snap-0a06c542a5190d9a4      | completed | 8           | vol-0f8ac71218f448742 | false     | 2019-11-13T11:53:16Z | Created by CreateImage(i
+------------------------+-------------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+----------------------
```
</details>
