### PR TITLE
Update tables for better use of API filters, context cancellation in list calls and page limiting for limit clause in query phase-III closes #852

### DIFF
--- a/aws/table_aws_fsx_file_system.go
+++ b/aws/table_aws_fsx_file_system.go
@@ -165,6 +165,7 @@ func listFsxFileSystems(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		return nil, err
 	}
 
+	// https://docs.aws.amazon.com/fsx/latest/APIReference/API_DescribeFileSystems.html
 	input := &fsx.DescribeFileSystemsInput{
 		MaxResults: aws.Int64(2147483647),
 	}

--- a/aws/table_aws_fsx_file_system.go
+++ b/aws/table_aws_fsx_file_system.go
@@ -165,12 +165,33 @@ func listFsxFileSystems(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		return nil, err
 	}
 
+	input := &fsx.DescribeFileSystemsInput{
+		MaxResults: aws.Int64(2147483647),
+	}
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *input.MaxResults {
+			if *limit < 1 {
+				input.MaxResults = aws.Int64(1)
+			} else {
+				input.MaxResults = limit
+			}
+		}
+	}
+
 	// List call
 	err = svc.DescribeFileSystemsPages(
-		&fsx.DescribeFileSystemsInput{},
+		input,
 		func(page *fsx.DescribeFileSystemsOutput, isLast bool) bool {
 			for _, fileSystem := range page.FileSystems {
 				d.StreamListItem(ctx, fileSystem)
+
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !isLast
 		},

--- a/aws/table_aws_glacier_vault.go
+++ b/aws/table_aws_glacier_vault.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"context"
 	"fmt"
-	"strconv"
 	"strings"
 
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
@@ -144,12 +143,11 @@ func listGlacierVault(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		AccountId: aws.String(accountID),
 		Limit:     &maxLimit,
 	}
-	n, _ := strconv.ParseInt(maxLimit, 10, 64)
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
-		if *limit < n {
+		if *limit < 10 {
 			if *limit < 1 {
 				input.Limit = aws.String("1")
 			} else {

--- a/aws/table_aws_guardduty_finding.go
+++ b/aws/table_aws_guardduty_finding.go
@@ -2,6 +2,8 @@ package aws
 
 import (
 	"context"
+	"fmt"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/guardduty"
@@ -24,6 +26,11 @@ func tableAwsGuardDutyFinding(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			ParentHydrate: listGuardDutyDetectors,
 			Hydrate:       listGuardDutyFindings,
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "detector_id", Require: plugin.Optional},
+				{Name: "id", Require: plugin.Optional, Operators: []string{"=", "<>"}},
+				{Name: "type", Require: plugin.Optional, Operators: []string{"=", "<>"}},
+			},
 		},
 		GetMatrixItem: BuildRegionList,
 		Columns: awsRegionalColumns([]*plugin.Column{
@@ -121,12 +128,31 @@ func listGuardDutyFindings(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	}
 
 	detectorId := h.Item.(detectorInfo).DetectorID
+	equalQuals := d.KeyColumnQuals
+
+	// Minimize the api call with given detector_id
+	if equalQuals["detector_id"] != nil {
+		if equalQuals["detector_id"].GetStringValue() != "" {
+			if equalQuals["detector_id"].GetStringValue() != "" && equalQuals["detector_id"].GetStringValue() != detectorId {
+				return nil, nil
+			}
+		} else if len(getListValues(equalQuals["detector_id"].GetListValue())) > 0 {
+			if !strings.Contains(fmt.Sprint(getListValues(equalQuals["detector_id"].GetListValue())), detectorId) {
+				return nil, nil
+			}
+		}
+	}
 
 	var findingIds [][]*string
 
 	input := &guardduty.ListFindingsInput{
 		DetectorId: aws.String(detectorId),
 		MaxResults: aws.Int64(50),
+	}
+
+	filterCriteria := buildGuarddutyFindingFilterCriteria(d.Quals, ctx)
+	if filterCriteria != nil {
+		input.FindingCriteria = filterCriteria
 	}
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows
@@ -140,7 +166,7 @@ func listGuardDutyFindings(ctx context.Context, d *plugin.QueryData, h *plugin.H
 			}
 		}
 	}
-	
+
 	// execute list call
 	err = svc.ListFindingsPages(
 		input,
@@ -171,4 +197,51 @@ func listGuardDutyFindings(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	}
 
 	return nil, nil
+}
+
+//// UTILITY FUNCTION
+
+// Build guardduty finding filter param
+func buildGuarddutyFindingFilterCriteria(quals plugin.KeyColumnQualMap, ctx context.Context) *guardduty.FindingCriteria {
+
+	type FilterKeyMap struct {
+		ColumnName string
+		FilterName string
+		ColumnType string
+	}
+
+	filterCtiteria := make(map[string]*guardduty.Condition)
+	filterQuals := []FilterKeyMap{
+		{"id", "id", "string"},
+		{"type", "type", "string"},
+	}
+
+	filterValue := &guardduty.Condition{}
+
+	for _, filterMap := range filterQuals {
+		if quals[filterMap.ColumnName] != nil {
+			for _, q := range quals[filterMap.ColumnName].Quals {
+				value := getQualsValueByColumn(quals, filterMap.ColumnName, "string")
+				val, ok := value.(string)
+				switch q.Operator {
+				case "=":
+					if ok {
+						filterValue.Equals = []*string{aws.String(val)}
+					} else {
+						filterValue.Equals = value.([]*string)
+					}
+					filterCtiteria[filterMap.FilterName] = filterValue
+				case "<>":
+					if ok {
+						filterValue.NotEquals = []*string{aws.String(val)}
+					} else {
+						filterValue.NotEquals = value.([]*string)
+					}
+					filterCtiteria[filterMap.FilterName] = filterValue
+				}
+
+			}
+		}
+	}
+	return &guardduty.FindingCriteria{Criterion: filterCtiteria}
 }

--- a/aws/table_aws_guardduty_finding.go
+++ b/aws/table_aws_guardduty_finding.go
@@ -130,7 +130,7 @@ func listGuardDutyFindings(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	detectorId := h.Item.(detectorInfo).DetectorID
 	equalQuals := d.KeyColumnQuals
 
-	// Minimize the api call with given detector_id
+	// Minimize the API call with the given detector_id
 	if equalQuals["detector_id"] != nil {
 		if equalQuals["detector_id"].GetStringValue() != "" {
 			if equalQuals["detector_id"].GetStringValue() != "" && equalQuals["detector_id"].GetStringValue() != detectorId {

--- a/aws/table_aws_guardduty_ipset.go
+++ b/aws/table_aws_guardduty_ipset.go
@@ -113,7 +113,7 @@ func listAwsGuardDutyIPSets(ctx context.Context, d *plugin.QueryData, h *plugin.
 
 	equalQuals := d.KeyColumnQuals
 
-	// Minimize the api call with given detector_id
+	// Minimize the API call with the given detector_id
 	if equalQuals["detector_id"] != nil {
 		if equalQuals["detector_id"].GetStringValue() != "" {
 			if equalQuals["detector_id"].GetStringValue() != "" && equalQuals["detector_id"].GetStringValue() != id {

--- a/aws/table_aws_guardduty_threat_intel_set.go
+++ b/aws/table_aws_guardduty_threat_intel_set.go
@@ -113,7 +113,7 @@ func listGuardDutyThreatIntelSets(ctx context.Context, d *plugin.QueryData, h *p
 	}
 	equalQuals := d.KeyColumnQuals
 
-	// Minimize the api call with given detector_id
+	// Minimize the API call with the given detector_id
 	if equalQuals["detector_id"] != nil {
 		if equalQuals["detector_id"].GetStringValue() != "" {
 			if equalQuals["detector_id"].GetStringValue() != "" && equalQuals["detector_id"].GetStringValue() != detectorID {

--- a/aws/table_aws_iam_access_key.go
+++ b/aws/table_aws_iam_access_key.go
@@ -68,7 +68,7 @@ func listUserAccessKeys(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	plugin.Logger(ctx).Trace("listUserAccessKeys")
 	user := h.Item.(*iam.User)
 
-	// Minimize the api call with given user_name
+	// Minimize the API call with the given user_name
 	equalQuals := d.KeyColumnQuals
 	if equalQuals["user_name"] != nil {
 		if equalQuals["user_name"].GetStringValue() != "" {

--- a/aws/table_aws_iam_access_key.go
+++ b/aws/table_aws_iam_access_key.go
@@ -68,7 +68,7 @@ func listUserAccessKeys(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	plugin.Logger(ctx).Trace("listUserAccessKeys")
 	user := h.Item.(*iam.User)
 
-	// Minimize the api call with given detector_id
+	// Minimize the api call with given user_name
 	equalQuals := d.KeyColumnQuals
 	if equalQuals["user_name"] != nil {
 		if equalQuals["user_name"].GetStringValue() != "" {

--- a/aws/table_aws_iam_credential_report.go
+++ b/aws/table_aws_iam_credential_report.go
@@ -241,6 +241,11 @@ func listCredentialReports(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	for _, row := range rows {
 		row.GeneratedTime = resp.GeneratedTime
 		d.StreamListItem(ctx, row)
+
+		// Context may get cancelled due to manual cancellation or if the limit has been reached
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			break
+		}
 	}
 
 	return nil, nil

--- a/aws/table_aws_iam_group.go
+++ b/aws/table_aws_iam_group.go
@@ -29,7 +29,7 @@ func tableAwsIamGroup(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listIamGroups,
 			KeyColumns: []*plugin.KeyColumn{
-				{Name: "path_prefix", Require: plugin.Optional},
+				{Name: "path", Require: plugin.Optional},
 			},
 		},
 		HydrateDependencies: []plugin.HydrateDependencies{
@@ -58,13 +58,6 @@ func tableAwsIamGroup(_ context.Context) *plugin.Table {
 				Name:        "arn",
 				Description: "The Amazon Resource Name (ARN) specifying the group.",
 				Type:        proto.ColumnType_STRING,
-			},
-			{
-				Name:        "path_prefix",
-				Description: "The path prefix of the group.",
-				Type:        proto.ColumnType_STRING,
-				Hydrate:     getGroupPathPrefix,
-				Transform:   transform.FromValue(),
 			},
 			{
 				Name:        "create_date",
@@ -132,8 +125,8 @@ func listIamGroups(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 	}
 
 	equalQual := d.KeyColumnQuals
-	if equalQual["path_prefix"] != nil {
-		input.PathPrefix = aws.String(equalQual["path_prefix"].GetStringValue())
+	if equalQual["path"] != nil {
+		input.PathPrefix = aws.String(equalQual["path"].GetStringValue())
 	}
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows
@@ -355,11 +348,4 @@ func getGroupInlinePolicy(policyName *string, groupName *string, svc *iam.IAM) (
 	}
 
 	return groupPolicy, nil
-}
-
-func getGroupPathPrefix(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	if d.KeyColumnQuals["path_prefix"] != nil {
-		return d.KeyColumnQuals["path_prefix"].GetStringValue(), nil
-	}
-	return *h.Item.(*iam.Group).Path, nil
 }

--- a/aws/table_aws_iam_role.go
+++ b/aws/table_aws_iam_role.go
@@ -30,7 +30,7 @@ func tableAwsIamRole(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listIamRoles,
 			KeyColumns: []*plugin.KeyColumn{
-				{Name: "path_prefix", Require: plugin.Optional},
+				{Name: "path", Require: plugin.Optional},
 			},
 		},
 		HydrateDependencies: []plugin.HydrateDependencies{
@@ -85,13 +85,6 @@ func tableAwsIamRole(_ context.Context) *plugin.Table {
 				Name:        "path",
 				Description: "The path to the role.",
 				Type:        proto.ColumnType_STRING,
-			},
-			{
-				Name:        "path_prefix",
-				Description: "The path prefix of the role.",
-				Type:        proto.ColumnType_STRING,
-				Hydrate:     getRolePathPrefix,
-				Transform:   transform.FromValue(),
 			},
 			{
 				Name:        "permissions_boundary_arn",
@@ -206,8 +199,8 @@ func listIamRoles(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 	}
 
 	equalQual := d.KeyColumnQuals
-	if equalQual["path_prefix"] != nil {
-		input.PathPrefix = aws.String(equalQual["path_prefix"].GetStringValue())
+	if equalQual["path"] != nil {
+		input.PathPrefix = aws.String(equalQual["path"].GetStringValue())
 	}
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows
@@ -456,11 +449,4 @@ func getIamRoleTurbotTags(_ context.Context, d *transform.TransformData) (interf
 		}
 	}
 	return turbotTagsMap, nil
-}
-
-func getRolePathPrefix(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	if d.KeyColumnQuals["path_prefix"] != nil {
-		return d.KeyColumnQuals["path_prefix"].GetStringValue(), nil
-	}
-	return *h.Item.(*iam.Role).Path, nil
 }

--- a/aws/table_aws_iam_server_certificate.go
+++ b/aws/table_aws_iam_server_certificate.go
@@ -114,13 +114,34 @@ func listIamServerCertificates(ctx context.Context, d *plugin.QueryData, _ *plug
 		return nil, err
 	}
 
+	input := &iam.ListServerCertificatesInput{
+		MaxItems: aws.Int64(1000),
+	}
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *input.MaxItems {
+			if *limit < 1 {
+				input.MaxItems = aws.Int64(1)
+			} else {
+				input.MaxItems = limit
+			}
+		}
+	}
+
 	err = svc.ListServerCertificatesPages(
-		&iam.ListServerCertificatesInput{},
+		input,
 		func(page *iam.ListServerCertificatesOutput, lastPage bool) bool {
 			for _, certificate := range page.ServerCertificateMetadataList {
 				d.StreamListItem(ctx, &iam.ServerCertificate{
 					ServerCertificateMetadata: certificate,
 				})
+
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !lastPage
 		},

--- a/aws/table_aws_iam_server_certificate.go
+++ b/aws/table_aws_iam_server_certificate.go
@@ -19,6 +19,9 @@ func tableAwsIamServerCertificate(_ context.Context) *plugin.Table {
 		Description: "AWS IAM Server Certificate",
 		List: &plugin.ListConfig{
 			Hydrate: listIamServerCertificates,
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "path", Require: plugin.Optional},
+			},
 		},
 		Get: &plugin.GetConfig{
 			Hydrate:    getIamServerCertificate,
@@ -118,6 +121,11 @@ func listIamServerCertificates(ctx context.Context, d *plugin.QueryData, _ *plug
 		MaxItems: aws.Int64(1000),
 	}
 
+	equalQual := d.KeyColumnQuals
+	if equalQual["path"] != nil {
+		input.PathPrefix = aws.String(equalQual["path"].GetStringValue())
+	}
+	
 	// Reduce the basic request limit down if the user has only requested a small number of rows
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {

--- a/aws/table_aws_iam_user.go
+++ b/aws/table_aws_iam_user.go
@@ -28,7 +28,7 @@ func tableAwsIamUser(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listIamUsers,
 			KeyColumns: []*plugin.KeyColumn{
-				{Name: "path_prefix", Require: plugin.Optional},
+				{Name: "path", Require: plugin.Optional},
 			},
 		},
 		HydrateDependencies: []plugin.HydrateDependencies{
@@ -52,13 +52,6 @@ func tableAwsIamUser(_ context.Context) *plugin.Table {
 			{
 				Name:        "path",
 				Description: "The path to the user.",
-				Type:        proto.ColumnType_STRING,
-			},
-			{
-				Name:        "path_prefix",
-				Description: "The path to the user.",
-				Hydrate:     getUserPathPrefix,
-				Transform:   transform.FromValue(),
 				Type:        proto.ColumnType_STRING,
 			},
 			{
@@ -174,8 +167,8 @@ func listIamUsers(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 	}
 
 	equalQual := d.KeyColumnQuals
-	if equalQual["path_prefix"] != nil {
-		input.PathPrefix = aws.String(equalQual["path_prefix"].GetStringValue())
+	if equalQual["path"] != nil {
+		input.PathPrefix = aws.String(equalQual["path"].GetStringValue())
 	}
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows
@@ -461,13 +454,6 @@ func getUserInlinePolicy(policyName *string, userName *string, svc *iam.IAM) (ma
 	}
 
 	return userPolicy, nil
-}
-
-func getUserPathPrefix(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	if d.KeyColumnQuals["path_prefix"] != nil {
-		return d.KeyColumnQuals["path_prefix"].GetStringValue(), nil
-	}
-	return *h.Item.(*iam.User).Path, nil
 }
 
 //// TRANSFORM FUNCTION

--- a/aws/table_aws_iam_virtual_mfa_device.go
+++ b/aws/table_aws_iam_virtual_mfa_device.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
@@ -100,11 +101,32 @@ func listIamVirtualMFADevices(ctx context.Context, d *plugin.QueryData, _ *plugi
 		return nil, err
 	}
 
+	input := &iam.ListVirtualMFADevicesInput{
+		MaxItems: aws.Int64(1000),
+	}
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *input.MaxItems {
+			if *limit < 1 {
+				input.MaxItems = aws.Int64(1)
+			} else {
+				input.MaxItems = limit
+			}
+		}
+	}
+
 	err = svc.ListVirtualMFADevicesPages(
-		&iam.ListVirtualMFADevicesInput{},
+		input,
 		func(page *iam.ListVirtualMFADevicesOutput, _ bool) bool {
 			for _, mfaDevice := range page.VirtualMFADevices {
 				d.StreamListItem(ctx, mfaDevice)
+
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return true
 		},

--- a/aws/table_aws_identitystore_group.go
+++ b/aws/table_aws_identitystore_group.go
@@ -84,6 +84,19 @@ func listIdentityStoreGroups(ctx context.Context, d *plugin.QueryData, _ *plugin
 				AttributeValue: aws.String(name),
 			},
 		},
+		MaxResults: aws.Int64(50),
+	}
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *params.MaxResults {
+			if *limit < 1 {
+				params.MaxResults = aws.Int64(1)
+			} else {
+				params.MaxResults = limit
+			}
+		}
 	}
 
 	err = svc.ListGroupsPages(
@@ -95,6 +108,11 @@ func listIdentityStoreGroups(ctx context.Context, d *plugin.QueryData, _ *plugin
 					Group:           group,
 				}
 				d.StreamListItem(ctx, item)
+
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !isLast
 		},

--- a/aws/table_aws_inspector_assessment_target.go
+++ b/aws/table_aws_inspector_assessment_target.go
@@ -85,6 +85,12 @@ func listInspectorAssessmentTargets(ctx context.Context, d *plugin.QueryData, _ 
 	input := &inspector.ListAssessmentTargetsInput{
 		MaxResults: aws.Int64(500),
 	}
+	equalQuals := d.KeyColumnQuals
+	if equalQuals["name"] != nil {
+		if equalQuals["name"].GetStringValue() != "" {
+			input.Filter = &inspector.AssessmentTargetFilter{AssessmentTargetNamePattern: aws.String(equalQuals["name"].GetStringValue())}
+		}
+	}
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows
 	limit := d.QueryContext.Limit

--- a/aws/table_aws_kinesis_video_stream.go
+++ b/aws/table_aws_kinesis_video_stream.go
@@ -23,9 +23,6 @@ func tableAwsKinesisVideoStream(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listKinesisVideoStreams,
-			KeyColumns: []*plugin.KeyColumn{
-				{Name: "stream_name_prefix", Require: plugin.Optional},
-			},
 		},
 		GetMatrixItem: BuildRegionList,
 		Columns: awsRegionalColumns([]*plugin.Column{
@@ -119,14 +116,6 @@ func listKinesisVideoStreams(ctx context.Context, d *plugin.QueryData, _ *plugin
 
 	input := &kinesisvideo.ListStreamsInput{
 		MaxResults: aws.Int64(10000),
-	}
-
-	equalQuals := d.KeyColumnQuals
-	if equalQuals["stream_name_prefix"] != nil {
-		input.StreamNameCondition = &kinesisvideo.StreamNameCondition{
-			ComparisonOperator: aws.String("BEGINS_WITH"), // Currently we can specify only BEGINS_WITH operator
-			ComparisonValue:    aws.String(equalQuals["stream_name_prefix"].GetStringValue()),
-		}
 	}
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows

--- a/aws/table_aws_kinesis_video_stream.go
+++ b/aws/table_aws_kinesis_video_stream.go
@@ -38,13 +38,6 @@ func tableAwsKinesisVideoStream(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("StreamARN"),
 			},
 			{
-				Name:        "stream_name_prefix",
-				Description: "The name prefix of the stream.",
-				Type:        pb.ColumnType_STRING,
-				Hydrate:     getVideoStreamNamePrefix,
-				Transform:   transform.FromValue(),
-			},
-			{
 				Name:        "status",
 				Description: "The status of the stream.",
 				Type:        pb.ColumnType_STRING,
@@ -203,13 +196,4 @@ func listKinesisVideoStreamTags(ctx context.Context, d *plugin.QueryData, h *plu
 		return nil, err
 	}
 	return op, nil
-}
-
-func getVideoStreamNamePrefix(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	data := h.Item.(*kinesisvideo.StreamInfo)
-
-	if d.KeyColumnQuals["stream_name_prefix"] != nil {
-		return d.KeyColumnQuals["stream_name_prefix"].GetStringValue(), nil
-	}
-	return data.StreamName, nil
 }

--- a/aws/table_aws_lambda_alias.go
+++ b/aws/table_aws_lambda_alias.go
@@ -117,7 +117,7 @@ func listLambdaAliases(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	function := h.Item.(*lambda.FunctionConfiguration)
 
 	equalQuals := d.KeyColumnQuals
-	// Minimize the api call with given function name
+	// Minimize the API call with the given function name
 	if equalQuals["function_name"] != nil {
 		if equalQuals["function_name"].GetStringValue() != "" {
 			if equalQuals["function_name"].GetStringValue() != "" && equalQuals["function_name"].GetStringValue() != *function.FunctionName {

--- a/aws/table_aws_lambda_function.go
+++ b/aws/table_aws_lambda_function.go
@@ -232,8 +232,24 @@ func listAwsLambdaFunctions(ctx context.Context, d *plugin.QueryData, _ *plugin.
 		return nil, err
 	}
 
+	input := &lambda.ListFunctionsInput{
+		MaxItems: aws.Int64(10000),
+	}
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *input.MaxItems {
+			if *limit < 1 {
+				input.MaxItems = aws.Int64(1)
+			} else {
+				input.MaxItems = limit
+			}
+		}
+	}
+
 	err = svc.ListFunctionsPages(
-		&lambda.ListFunctionsInput{},
+		input,
 		func(page *lambda.ListFunctionsOutput, lastPage bool) bool {
 			for _, function := range page.Functions {
 				d.StreamListItem(ctx, function)

--- a/aws/table_aws_lambda_layer_version.go
+++ b/aws/table_aws_lambda_layer_version.go
@@ -142,7 +142,7 @@ func listLambdaLayerVersions(ctx context.Context, d *plugin.QueryData, h *plugin
 	layerName := h.Item.(*lambda.LayersListItem).LayerName
 
 	equalQuals := d.KeyColumnQuals
-	// Minimize the api call with given layer name
+	// Minimize the API call with the given layer name
 	if equalQuals["layer_name"] != nil {
 		if equalQuals["layer_name"].GetStringValue() != "" {
 			if equalQuals["layer_name"].GetStringValue() != "" && equalQuals["layer_name"].GetStringValue() != *layerName {

--- a/aws/table_aws_lambda_version.go
+++ b/aws/table_aws_lambda_version.go
@@ -180,7 +180,7 @@ func listLambdaVersions(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 
 	function := h.Item.(*lambda.FunctionConfiguration)
 	equalQuals := d.KeyColumnQuals
-	// Minimize the api call with given layer name
+	// Minimize the API call with the given function name
 	if equalQuals["function_name"] != nil {
 		if equalQuals["function_name"].GetStringValue() != "" {
 			if equalQuals["function_name"].GetStringValue() != "" && equalQuals["function_name"].GetStringValue() != *function.FunctionName {

--- a/aws/table_aws_macie2_classification_job.go
+++ b/aws/table_aws_macie2_classification_job.go
@@ -263,12 +263,12 @@ func buildMacie2ClassificationJobsFilterCriteria(quals plugin.KeyColumnQualMap) 
 	filterCriteria := &macie2.ListJobsFilterCriteria{}
 
 	filterQuals := map[string]string{
-		"name":       "ListJobsFilterKeyName",
-		"job_type":   "ListJobsFilterKeyJobType",
-		"job_status": "ListJobsFilterKeyJobStatus",
+		"name":       "name",
+		"job_type":   "jobType",
+		"job_status": "jobStatus",
 	}
 
-	for columnName, _ := range filterQuals {
+	for columnName, filterName := range filterQuals {
 		if quals[columnName] != nil {
 			for _, q := range quals[columnName].Quals {
 				value := getQualsValueByColumn(quals, columnName, "string")
@@ -284,7 +284,7 @@ func buildMacie2ClassificationJobsFilterCriteria(quals plugin.KeyColumnQualMap) 
 					filter.Values = value.([]*string)
 				}
 
-				if columnName == "name" {
+				if filterName == "name" {
 					filter.Key = aws.String(macie2.ListJobsFilterKeyName)
 					switch q.Operator {
 					case "<>":
@@ -293,7 +293,7 @@ func buildMacie2ClassificationJobsFilterCriteria(quals plugin.KeyColumnQualMap) 
 						filterCriteria.Includes = append(filterCriteria.Includes, filter)
 					}
 				}
-				if columnName == "job_type" {
+				if filterName == "jobType" {
 					filter.Key = aws.String(macie2.ListJobsFilterKeyJobType)
 					switch q.Operator {
 					case "<>":
@@ -302,7 +302,7 @@ func buildMacie2ClassificationJobsFilterCriteria(quals plugin.KeyColumnQualMap) 
 						filterCriteria.Includes = append(filterCriteria.Includes, filter)
 					}
 				}
-				if columnName == "job_status" {
+				if filterName == "jobStatus" {
 					filter.Key = aws.String(macie2.ListJobsFilterKeyJobStatus)
 					switch q.Operator {
 					case "<>":

--- a/aws/table_aws_macie2_classification_job.go
+++ b/aws/table_aws_macie2_classification_job.go
@@ -7,6 +7,7 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/service/macie2"
 )
@@ -24,6 +25,11 @@ func tableAwsMacie2ClassificationJob(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listMacie2ClassificationJobs,
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "name", Require: plugin.Optional, Operators: []string{"=", "<>"}},
+				{Name: "job_status", Require: plugin.Optional, Operators: []string{"=", "<>"}},
+				{Name: "job_type", Require: plugin.Optional, Operators: []string{"=", "<>"}},
+			},
 		},
 		GetMatrixItem: BuildRegionList,
 		Columns: awsRegionalColumns([]*plugin.Column{
@@ -152,12 +158,39 @@ func listMacie2ClassificationJobs(ctx context.Context, d *plugin.QueryData, _ *p
 		return nil, err
 	}
 
+	input := &macie2.ListClassificationJobsInput{
+		MaxResults: aws.Int64(100),
+	}
+
+	filterCriteris := buildMacie2ClassificationJobsFilterCriteria(d.Quals)
+
+	if len(filterCriteris.Excludes) > 0 || len(filterCriteris.Includes) > 0 {
+		input.FilterCriteria = filterCriteris
+	}
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *input.MaxResults {
+			if *limit < 1 {
+				input.MaxResults = aws.Int64(1)
+			} else {
+				input.MaxResults = limit
+			}
+		}
+	}
+
 	// List call
 	err = svc.ListClassificationJobsPages(
-		&macie2.ListClassificationJobsInput{},
+		input,
 		func(page *macie2.ListClassificationJobsOutput, isLast bool) bool {
 			for _, job := range page.Items {
 				d.StreamListItem(ctx, job)
+
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !isLast
 		},
@@ -221,4 +254,66 @@ func getMacie2ClassificationJob(ctx context.Context, d *plugin.QueryData, h *plu
 	}
 
 	return op, nil
+}
+
+//// UTILITY FUNCTION
+//// Build macie2 list job classification job filter
+
+func buildMacie2ClassificationJobsFilterCriteria(quals plugin.KeyColumnQualMap) *macie2.ListJobsFilterCriteria {
+	filterCriteria := &macie2.ListJobsFilterCriteria{}
+
+	filterQuals := map[string]string{
+		"name":       "ListJobsFilterKeyName",
+		"job_type":   "ListJobsFilterKeyJobType",
+		"job_status": "ListJobsFilterKeyJobStatus",
+	}
+
+	for columnName, _ := range filterQuals {
+		if quals[columnName] != nil {
+			for _, q := range quals[columnName].Quals {
+				value := getQualsValueByColumn(quals, columnName, "string")
+
+				filter := &macie2.ListJobsFilterTerm{
+					Comparator: aws.String(macie2.JobComparatorEq),
+				}
+
+				val, ok := value.(string)
+				if ok {
+					filter.Values = []*string{aws.String(val)}
+				} else {
+					filter.Values = value.([]*string)
+				}
+
+				if columnName == "name" {
+					filter.Key = aws.String(macie2.ListJobsFilterKeyName)
+					switch q.Operator {
+					case "<>":
+						filterCriteria.Excludes = append(filterCriteria.Excludes, filter)
+					case "=":
+						filterCriteria.Includes = append(filterCriteria.Includes, filter)
+					}
+				}
+				if columnName == "job_type" {
+					filter.Key = aws.String(macie2.ListJobsFilterKeyJobType)
+					switch q.Operator {
+					case "<>":
+						filterCriteria.Excludes = append(filterCriteria.Excludes, filter)
+					case "=":
+						filterCriteria.Includes = append(filterCriteria.Includes, filter)
+					}
+				}
+				if columnName == "job_status" {
+					filter.Key = aws.String(macie2.ListJobsFilterKeyJobStatus)
+					switch q.Operator {
+					case "<>":
+						filterCriteria.Excludes = append(filterCriteria.Excludes, filter)
+					case "=":
+						filterCriteria.Includes = append(filterCriteria.Includes, filter)
+					}
+				}
+			}
+		}
+	}
+
+	return filterCriteria
 }

--- a/aws/table_aws_rds_db_cluster.go
+++ b/aws/table_aws_rds_db_cluster.go
@@ -428,12 +428,9 @@ func getRDSDBClusterTurbotTags(_ context.Context, d *transform.TransformData) (i
 
 //// UTILITY FUNCTIONS
 
-// build db cluster list call input filter
+// build rdds db cluster list call input filter
 func buildRdsDbClusterFilter(quals plugin.KeyColumnQualMap) []*rds.Filter {
 	filters := make([]*rds.Filter, 0)
-	// The filter key 'db-cluster-id' is throwing an error like 
-	// InvalidParameterValue: The parameter Filter: db-cluster-id is not a valid identifier. Identifiers must begin with a letter; 
-	// must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.
 	filterQuals := map[string]string{
 		"clone_group_id": "clone-group-id",
 		"engine":         "engine",

--- a/aws/table_aws_rds_db_cluster.go
+++ b/aws/table_aws_rds_db_cluster.go
@@ -24,6 +24,10 @@ func tableAwsRDSDBCluster(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listRDSDBClusters,
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "clone_group_id", Require: plugin.Optional},
+				{Name: "engine", Require: plugin.Optional},
+			},
 		},
 		GetMatrixItem: BuildRegionList,
 		Columns: awsRegionalColumns([]*plugin.Column{
@@ -340,12 +344,40 @@ func listRDSDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 		return nil, err
 	}
 
+	input := &rds.DescribeDBClustersInput{
+		MaxRecords: aws.Int64(100),
+	}
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *input.MaxRecords {
+			if *limit < 20 {
+				input.MaxRecords = aws.Int64(20)
+			} else {
+				input.MaxRecords = limit
+			}
+		}
+	}
+
+	filters := buildRdsDbClusterFilter(d.Quals)
+
+	if len(filters) > 0 {
+		input.Filters = filters
+	}
+
 	// List call
 	err = svc.DescribeDBClustersPages(
-		&rds.DescribeDBClustersInput{},
+		input,
 		func(page *rds.DescribeDBClustersOutput, isLast bool) bool {
 			for _, dbCluster := range page.DBClusters {
 				d.StreamListItem(ctx, dbCluster)
+
+				// Check if context has been cancelled or if the limit has been reached (if specified)
+				// if there is a limit, it will return the number of rows required to reach this limit
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !isLast
 		},
@@ -392,4 +424,36 @@ func getRDSDBClusterTurbotTags(_ context.Context, d *transform.TransformData) (i
 		return turbotTagsMap, nil
 	}
 	return nil, nil
+}
+
+//// UTILITY FUNCTIONS
+
+// build db cluster list call input filter
+func buildRdsDbClusterFilter(quals plugin.KeyColumnQualMap) []*rds.Filter {
+	filters := make([]*rds.Filter, 0)
+	// The filter key 'db-cluster-id' is throwing an error like 
+	// InvalidParameterValue: The parameter Filter: db-cluster-id is not a valid identifier. Identifiers must begin with a letter; 
+	// must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.
+	filterQuals := map[string]string{
+		"clone_group_id": "clone-group-id",
+		"engine":         "engine",
+	}
+
+	for columnName, filterName := range filterQuals {
+		if quals[columnName] != nil {
+			filter := rds.Filter{
+				Name: aws.String(filterName),
+			}
+			value := getQualsValueByColumn(quals, columnName, "string")
+			val, ok := value.(string)
+			if ok {
+				filter.Values = []*string{aws.String(val)}
+			} else {
+				v := value.([]*string)
+				filter.Values = v
+			}
+			filters = append(filters, &filter)
+		}
+	}
+	return filters
 }

--- a/aws/table_aws_rds_db_instance.go
+++ b/aws/table_aws_rds_db_instance.go
@@ -517,11 +517,9 @@ func getRDSDBInstanceTurbotTags(_ context.Context, d *transform.TransformData) (
 
 //// UTILITY FUNCTIONS
 
-// build snapshots list call input filter
+// build rds db instance list call input filter
 func buildRdsDbInstanceFilter(quals plugin.KeyColumnQualMap) []*rds.Filter {
 	filters := make([]*rds.Filter, 0)
-	// In filter param the 'db-instance-id' key is not woring properly, throwing error
-	// InvalidParameterValue: The parameter Filter: db-instance-id is not a valid identifier.
 	filterQuals := map[string]string{
 		"db_cluster_identifier": "db-cluster-id",
 		"resource_id":           "dbi-resource-id",

--- a/aws/table_aws_rds_db_snapshot.go
+++ b/aws/table_aws_rds_db_snapshot.go
@@ -24,6 +24,12 @@ func tableAwsRDSDBSnapshot(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listRDSDBSnapshots,
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "db_instance_identifier", Require: plugin.Optional},
+				{Name: "dbi_resource_id", Require: plugin.Optional},
+				{Name: "engine", Require: plugin.Optional},
+				{Name: "type", Require: plugin.Optional},
+			},
 		},
 		GetMatrixItem: BuildRegionList,
 		Columns: awsRegionalColumns([]*plugin.Column{
@@ -223,12 +229,39 @@ func listRDSDBSnapshots(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		return nil, err
 	}
 
+	input := &rds.DescribeDBSnapshotsInput{
+		MaxRecords: aws.Int64(100),
+	}
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *input.MaxRecords {
+			if *limit < 20 {
+				input.MaxRecords = aws.Int64(20)
+			} else {
+				input.MaxRecords = limit
+			}
+		}
+	}
+
+	filters := buildRdsDbSnapshotFilter(d.Quals)
+	if len(filters) > 0 {
+		input.Filters = filters
+	}
+
 	// List call
 	err = svc.DescribeDBSnapshotsPages(
-		&rds.DescribeDBSnapshotsInput{},
+		input,
 		func(page *rds.DescribeDBSnapshotsOutput, isLast bool) bool {
 			for _, dbSnapshot := range page.DBSnapshots {
 				d.StreamListItem(ctx, dbSnapshot)
+
+				// Check if context has been cancelled or if the limit has been reached (if specified)
+				// if there is a limit, it will return the number of rows required to reach this limit
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !isLast
 		},
@@ -298,4 +331,35 @@ func getRDSDBSnapshotTurbotTags(_ context.Context, d *transform.TransformData) (
 		return turbotTagsMap, nil
 	}
 	return nil, nil
+}
+
+//// UTILITY FUNCTIONS
+
+// build snapshots list call input filter
+func buildRdsDbSnapshotFilter(quals plugin.KeyColumnQualMap) []*rds.Filter {
+	filters := make([]*rds.Filter, 0)
+	filterQuals := map[string]string{
+		"db_instance_identifier": "db-instance-id",
+		"dbi_resource_id":        "dbi-resource-id",
+		"engine":                 "engine",
+		"type":                   "snapshot-type",
+	}
+
+	for columnName, filterName := range filterQuals {
+		if quals[columnName] != nil {
+			filter := rds.Filter{
+				Name: aws.String(filterName),
+			}
+			value := getQualsValueByColumn(quals, columnName, "string")
+			val, ok := value.(string)
+			if ok {
+				filter.Values = []*string{aws.String(val)}
+			} else {
+				v := value.([]*string)
+				filter.Values = v
+			}
+			filters = append(filters, &filter)
+		}
+	}
+	return filters
 }


### PR DESCRIPTION

# List of table changes
1. aws_fsx_file_system
2. aws_glacier_vault
3. aws_glue_catalog_database
4. aws_guardduty_detector
5. aws_guardduty_finding
6. aws_guardduty_ipset
7. aws_guardduty_threat_intel_set
8. aws_iam_access_advisor
9. aws_iam_access_key
10. aws_iam_account_password_policy
11. aws_iam_account_summary
12. aws_iam_action
13. aws_iam_credential_report
14. aws_iam_group
15. aws_iam_policy
16. aws_iam_policy_attachment
17. aws_iam_policy_simulator
18. aws_iam_role
19. aws_iam_server_certificate
20. aws_iam_user
21. aws_iam_virtual_mfa_device
22. aws_identitystore_group
23. aws_identitystore_user
24. aws_inspector_assessment_target
25. aws_inspector_assessment_template
26. aws_kinesis_consumer
27. aws_kinesis_firehose_delivery_stream
28. aws_kinesis_stream
29. aws_kinesis_video_stream
30. aws_kinesisanalyticsv2_application
31. aws_kms_key
32. aws_lambda_alias
33. aws_lambda_function
34. aws_lambda_layer
35. aws_lambda_layer_version
36. aws_lambda_version
37. aws_macie2_classification_job
38. aws_media_store_container
39. aws_organizations_account
40. aws_rds_db_cluster
41. aws_rds_db_cluster_parameter_group
42. aws_rds_db_cluster_snapshot
43. aws_rds_db_event_subscription
44. aws_rds_db_instance
45. aws_rds_db_option_group
46. aws_rds_db_parameter_group
47. aws_rds_db_snapshot
48. aws_rds_db_subnet_group



# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_glacier_vault limit 11
+-----------------+---------------------------------------------------------------+---------------------------+---------------------+--------------------+---------------+--------------------------------
| vault_name      | vault_arn                                                     | creation_date             | last_inventory_date | number_of_archives | size_in_bytes | policy                         
+-----------------+---------------------------------------------------------------+---------------------------+---------------------+--------------------+---------------+--------------------------------
| turbottest60186 | arn:aws:glacier:us-east-1:632902152528:vaults/turbottest60186 | 2022-01-18T10:13:09+05:30 | <null>              | 0                  | 0             | {"Statement":[{"Action":["glaci
+-----------------+---------------------------------------------------------------+---------------------------+---------------------+--------------------+---------------+--------------------------------

> select * from aws_glacier_vault limit 5
+-----------------+---------------------------------------------------------------+---------------------------+---------------------+--------------------+---------------+--------------------------------
| vault_name      | vault_arn                                                     | creation_date             | last_inventory_date | number_of_archives | size_in_bytes | policy                         
+-----------------+---------------------------------------------------------------+---------------------------+---------------------+--------------------+---------------+--------------------------------
| turbottest60186 | arn:aws:glacier:us-east-1:632902152528:vaults/turbottest60186 | 2022-01-18T10:13:09+05:30 | <null>              | 0                  | 0             | {"Statement":[{"Action":["glaci
+-----------------+---------------------------------------------------------------+---------------------------+---------------------+--------------------+---------------+--------------------------------

> select * from aws_glacier_vault limit 0
+------------+-----------+---------------+---------------------+--------------------+---------------+--------+------------+-------------------+-----------------------+----------+-------+------+------+--
| vault_name | vault_arn | creation_date | last_inventory_date | number_of_archives | size_in_bytes | policy | policy_std | vault_lock_policy | vault_lock_policy_std | tags_src | title | tags | akas | p
+------------+-----------+---------------+---------------------+--------------------+---------------+--------+------------+-------------------+-----------------------+----------+-------+------+------+--
+------------+-----------+---------------+---------------------+--------------------+---------------+--------+------------+-------------------+-----------------------+----------+-------+------+-----

> select * from aws_fsx_file_system limit 1000
+----------------------+---------------------------------------------------------------------+------------------+-----------+---------------------------+-------------------------------+-----------------
| file_system_id       | arn                                                                 | file_system_type | lifecycle | creation_time             | dns_name                      | file_system_type
+----------------------+---------------------------------------------------------------------+------------------+-----------+---------------------------+-------------------------------+-----------------
| fs-0aa7392a12027c72c | arn:aws:fsx:us-east-1:632902152528:file-system/fs-0aa7392a12027c72c | WINDOWS          | CREATING  | 2022-01-18T10:35:56+05:30 | fs-0aa7392a12027c72c.test.com | <null>          
+----------------------+---------------------------------------------------------------------+------------------+-----------+---------------------------+-------------------------------+-----------------

> select * from aws_fsx_file_system limit 1
+----------------------+---------------------------------------------------------------------+------------------+-----------+---------------------------+-------------------------------+-----------------
| file_system_id       | arn                                                                 | file_system_type | lifecycle | creation_time             | dns_name                      | file_system_type
+----------------------+---------------------------------------------------------------------+------------------+-----------+---------------------------+-------------------------------+-----------------
| fs-0aa7392a12027c72c | arn:aws:fsx:us-east-1:632902152528:file-system/fs-0aa7392a12027c72c | WINDOWS          | CREATING  | 2022-01-18T10:35:56+05:30 | fs-0aa7392a12027c72c.test.com | <null>          
+----------------------+---------------------------------------------------------------------+------------------+-----------+---------------------------+-------------------------------+----------------

> select * from aws_glue_catalog_database limit 50;
+--------------+--------------+---------------------------+-------------+--------------+------------------------------------------------------------------------------------------------+------------+----
| name         | catalog_id   | create_time               | description | location_uri | create_table_default_permissions                                                               | parameters | tar
+--------------+--------------+---------------------------+-------------+--------------+------------------------------------------------------------------------------------------------+------------+----
| testdatabase | 632902152528 | 2021-11-12T16:10:09+05:30 | <null>      | us-east-1    | [{"Permissions":["ALL"],"Principal":{"DataLakePrincipalIdentifier":"IAM_ALLOWED_PRINCIPALS"}}] | <null>     | <nu
+--------------+--------------+---------------------------+-------------+--------------+------------------------------------------------------------------------------------------------+------------+----

> select * from aws_glue_catalog_database limit 500;
+--------------+--------------+---------------------------+-------------+--------------+------------------------------------------------------------------------------------------------+------------+----
| name         | catalog_id   | create_time               | description | location_uri | create_table_default_permissions                                                               | parameters | tar
+--------------+--------------+---------------------------+-------------+--------------+------------------------------------------------------------------------------------------------+------------+----
| testdatabase | 632902152528 | 2021-11-12T16:10:09+05:30 | <null>      | us-east-1    | [{"Permissions":["ALL"],"Principal":{"DataLakePrincipalIdentifier":"IAM_ALLOWED_PRINCIPALS"}}] | <null>     | <nu
+--------------+--------------+---------------------------+-------------+--------------+------------------------------------------------------------------------------------------------+------------+----

> select * from aws_glue_catalog_database limit 0;
+------+------------+-------------+-------------+--------------+----------------------------------+------------+-----------------+-------+------+-----------+--------+------------+
| name | catalog_id | create_time | description | location_uri | create_table_default_permissions | parameters | target_database | title | akas | partition | region | account_id |
+------+------------+-------------+-------------+--------------+----------------------------------+------------+-----------------+-------+------+-----------+--------+------------+
+------+------------+-------------+-------------+--------------+----------------------------------+------------+-----------------+-------+------+-----------+--------+------------+

select * from aws_iam_access_advisor where principal_arn = 'arn:aws:iam::632902152528:user/partha' limit 10;
+---------------------------------------+-------------------------------------------------------+-------------------+---------------------------+---------------------------------------+-----------------
| principal_arn                         | service_name                                          | service_namespace | last_authenticated        | last_authenticated_entity             | last_authenticat
+---------------------------------------+-------------------------------------------------------+-------------------+---------------------------+---------------------------------------+-----------------
| arn:aws:iam::632902152528:user/partha | AWS Account Management                                | account           | <null>                    | <null>                                | <null>          
| arn:aws:iam::632902152528:user/partha | Alexa for Business                                    | a4b               | <null>                    | <null>                                | <null>          
| arn:aws:iam::632902152528:user/partha | AWS IAM Access Analyzer                               | access-analyzer   | 2022-01-12T17:04:55+05:30 | arn:aws:iam::632902152528:user/partha | us-east-1       
| arn:aws:iam::632902152528:user/partha | AWS Certificate Manager                               | acm               | 2022-01-12T17:04:18+05:30 | arn:aws:iam::632902152528:user/partha | us-east-1       
| arn:aws:iam::632902152528:user/partha | AWS Amplify UI Builder                                | amplifyuibuilder  | <null>                    | <null>                                | <null>          
| arn:aws:iam::632902152528:user/partha | Amazon Managed Workflows for Apache Airflow           | airflow           | <null>                    | <null>                                | <null>          
| arn:aws:iam::632902152528:user/partha | AWS Amplify                                           | amplify           | <null>                    | <null>                                | <null>          
| arn:aws:iam::632902152528:user/partha | AWS Amplify Admin                                     | amplifybackend    | <null>                    | <null>                                | <null>          
| arn:aws:iam::632902152528:user/partha | AWS Certificate Manager Private Certificate Authority | acm-pca           | <null>                    | <null>                                | <null>          
| arn:aws:iam::632902152528:user/partha | AWS Activate                                          | activate          | <null>                    | <null>                                | <null>          
+---------------------------------------+-------------------------------------------------------+-------------------+---------------------------+---------------------------------------+-----------------


> select * from aws_iam_access_key limit 500;
+----------------------+------------------+--------+---------------------------+----------------------+------------------------------------------------------------------------------------+-----------+--
| access_key_id        | user_name        | status | create_date               | title                | akas                                                                               | partition | r
+----------------------+------------------+--------+---------------------------+----------------------+------------------------------------------------------------------------------------+-----------+--
| AKIAZGW7IOFILMM5LYNF | venu@turbot.com  | Active | 2021-11-16T17:07:34+05:30 | AKIAZGW7IOFILMM5LYNF | ["arn:aws:iam::632902152528:user/venu@turbot.com/accesskey/AKIAZGW7IOFILMM5LYNF"]  | aws       | g
| AKIAZGW7IOFIOPIFEWNL | steampipe-cloud  | Active | 2021-09-28T17:52:08+05:30 | AKIAZGW7IOFIOPIFEWNL | ["arn:aws:iam::632902152528:user/steampipe-cloud/accesskey/AKIAZGW7IOFIOPIFEWNL"]  | aws       | g
| AKIAZGW7IOFIJA4HUPXH | khushboo         | Active | 2021-08-25T12:36:13+05:30 | AKIAZGW7IOFIJA4HUPXH | ["arn:aws:iam::632902152528:user/khushboo/accesskey/AKIAZGW7IOFIJA4HUPXH"]         | aws       | g
| AKIAZGW7IOFINLXKV56Z | user-steampipe   | Active | 2021-03-02T11:29:00+05:30 | AKIAZGW7IOFINLXKV56Z | ["arn:aws:iam::632902152528:user/user-steampipe/accesskey/AKIAZGW7IOFINLXKV56Z"]   | aws       | g
| AKIAZGW7IOFIPSG2YACP | ved              | Active | 2021-08-20T13:32:26+05:30 | AKIAZGW7IOFIPSG2YACP | ["arn:aws:iam::632902152528:user/ved/accesskey/AKIAZGW7IOFIPSG2YACP"]              | aws       | g
| AKIAZGW7IOFILSLPDV6I | ved              | Active | 2021-12-17T17:44:34+05:30 | AKIAZGW7IOFILSLPDV6I | ["arn:aws:iam::632902152528:user/ved/accesskey/AKIAZGW7IOFILSLPDV6I"]              | aws       | g
| AKIAZGW7IOFIEP3FPFEQ | mike@turbot.com  | Active | 2021-11-25T17:06:34+05:30 | AKIAZGW7IOFIEP3FPFEQ | ["arn:aws:iam::632902152528:user/mike@turbot.com/accesskey/AKIAZGW7IOFIEP3FPFEQ"]  | aws       | g
| AKIAZGW7IOFILI5CPTW2 | sourav           | Active | 2021-08-20T11:25:10+05:30 | AKIAZGW7IOFILI5CPTW2 | ["arn:aws:iam::632902152528:user/sourav/accesskey/AKIAZGW7IOFILI5CPTW2"]           | aws       | g
| AKIAZGW7IOFIMCMGZE6R | lalit@turbot.com | Active | 2021-07-28T11:08:24+05:30 | AKIAZGW7IOFIMCMGZE6R | ["arn:aws:iam::632902152528:user/lalit@turbot.com/accesskey/AKIAZGW7IOFIMCMGZE6R"] | aws       | g
| AKIAZGW7IOFIPOXQJPHL | lalit@turbot.com | Active | 2021-11-16T17:02:03+05:30 | AKIAZGW7IOFIPOXQJPHL | ["arn:aws:iam::632902152528:user/lalit@turbot.com/accesskey/AKIAZGW7IOFIPOXQJPHL"] | aws       | g
| AKIAZGW7IOFICDI3XIZH | partha           | Active | 2021-08-18T21:58:01+05:30 | AKIAZGW7IOFICDI3XIZH | ["arn:aws:iam::632902152528:user/partha/accesskey/AKIAZGW7IOFICDI3XIZH"]           | aws       | g
| AKIAZGW7IOFIPWMTSXFO | raj              | Active | 2021-08-20T13:33:57+05:30 | AKIAZGW7IOFIPWMTSXFO | ["arn:aws:iam::632902152528:user/raj/accesskey/AKIAZGW7IOFIPWMTSXFO"]              | aws       | g
| AKIAZGW7IOFINTM47MDB | arnab            | Active | 2021-08-11T13:25:22+05:30 | AKIAZGW7IOFINTM47MDB | ["arn:aws:iam::632902152528:user/arnab/accesskey/AKIAZGW7IOFINTM47MDB"]            | aws       | g
+----------------------+------------------+--------+---------------------------+----------------------+------------------------------------------------------------------------------------+-----------+--

> select path, path_prefix from aws_iam_group
+----------+-------------+
| path     | path_prefix |
+----------+-------------+
| /turbot/ | /turbot/    |
| /turbot/ | /turbot/    |
| /        | /           |
| /turbot/ | /turbot/    |
| /turbot/ | /turbot/    |
| /turbot/ | /turbot/    |
| /        | /           |
| /turbot/ | /turbot/    |
| /        | /           |
| /        | /           |
| /turbot/ | /turbot/    |
+----------+-------------+

> select name, path, path_prefix from aws_iam_group where path_prefix = '/' limit 2;
+-----------+----------+-------------+
| name      | path     | path_prefix |
+-----------+----------+-------------+
| admin     | /turbot/ | /           |
| capcha6.1 | /        | /           |
+-----------+----------+-------------+

> select name, path, path_prefix from aws_iam_role where path_prefix = '/' limit 2;
+--------------------------------+----------+-------------+
| name                           | path     | path_prefix |
+--------------------------------+----------+-------------+
| admin                          | /turbot/ | /           |
| AmazonEKSClusterAutoscalerRole | /        | /           |
+--------------------------------+----------+-------------+

+-----------------------------------------------+----------------+----------------+
| name                                          | path           | path_prefix    |
+-----------------------------------------------+----------------+----------------+
| AmazonSSMRoleForInstancesQuickSetup           | /              | /              |
| AmazonSageMaker-ExecutionRole-20210611T124331 | /service-role/ | /service-role/ |
| AmazonEKSClusterAutoscalerRole                | /              | /              |
| api-gateway-cloudwattch-role                  | /              | /              |
| admin                                         | /turbot/       | /turbot/       |
+-----------------------------------------------+----------------+----------------+

> select name from aws_iam_server_certificate limit 50000;
+----------------+
| name           |
+----------------+
| my-server-test |
+----------------+

> select name from aws_iam_server_certificate limit 5;
+----------------+
| name           |
+----------------+
| my-server-test |
+----------------+

> select name, path, path_prefix from aws_iam_user where path_prefix = '/' limit 5;
+------------------+----------+-------------+
| name             | path     | path_prefix |
+------------------+----------+-------------+
| mike@turbot.com  | /turbot/ | /           |
| partha           | /        | /           |
| lalit@turbot.com | /turbot/ | /           |
| khushboo         | /        | /           |
| arnab            | /        | /           |
+------------------+----------+-------------+

> select * from aws_iam_virtual_mfa_device limit 100000;
+--------------------------------------------------+-------------+---------+-----------+--------+----------+--------+--------------------------------------------------+----------------------------------
| serial_number                                    | enable_date | user_id | user_name | user   | tags_src | tags   | title                                            | akas                             
+--------------------------------------------------+-------------+---------+-----------+--------+----------+--------+--------------------------------------------------+----------------------------------
| arn:aws:iam::632902152528:mfa/capcha-5           | <null>      | <null>  | <null>    | <null> | <null>   | <null> | arn:aws:iam::632902152528:mfa/capcha-5           | ["arn:aws:iam::632902152528:mfa/c
| arn:aws:iam::632902152528:mfa/test-user-only-cli | <null>      | <null>  | <null>    | <null> | <null>   | <null> | arn:aws:iam::632902152528:mfa/test-user-only-cli | ["arn:aws:iam::632902152528:mfa/t
+--------------------------------------------------+-------------+---------+-----------+--------+----------+--------+--------------------------------------------------+---------------------------------

> select * from aws_iam_virtual_mfa_device limit 1;
+----------------------------------------+-------------+---------+-----------+--------+----------+--------+----------------------------------------+--------------------------------------------+---------
| serial_number                          | enable_date | user_id | user_name | user   | tags_src | tags   | title                                  | akas                                       | partitio
+----------------------------------------+-------------+---------+-----------+--------+----------+--------+----------------------------------------+--------------------------------------------+---------
| arn:aws:iam::632902152528:mfa/capcha-5 | <null>      | <null>  | <null>    | <null> | <null>   | <null> | arn:aws:iam::632902152528:mfa/capcha-5 | ["arn:aws:iam::632902152528:mfa/capcha-5"] | aws     
+----------------------------------------+-------------+---------+-----------+--------+----------+--------+----------------------------------------+--------------------------------------------+---------

> select * from aws_inspector_assessment_target limit 1000;
+-----------------+------------------------------------------------------------+-------------------------------------------------------------------+---------------------------+--------------------------
| name            | arn                                                        | resource_group_arn                                                | created_at                | updated_at               
+-----------------+------------------------------------------------------------+-------------------------------------------------------------------+---------------------------+--------------------------
| turbottest67171 | arn:aws:inspector:us-east-1:632902152528:target/0-4lDRP46h | arn:aws:inspector:us-east-1:632902152528:resourcegroup/0-YI8EaNf8 | 2022-01-18T12:36:32+05:30 | 2022-01-18T12:36:32+05:30
+-----------------+------------------------------------------------------------+-------------------------------------------------------------------+---------------------------+--------------------------

> select * from aws_inspector_assessment_template limit 1000;
+-----------------+--------------------------------------------------------------------------------+----------------------+------------------------------------------------------------+------------------
| name            | arn                                                                            | assessment_run_count | assessment_target_arn                                      | created_at       
+-----------------+--------------------------------------------------------------------------------+----------------------+------------------------------------------------------------+------------------
| turbottest15234 | arn:aws:inspector:us-east-1:632902152528:target/0-rq7FzXkt/template/0-zXLOWPaM | 0                    | arn:aws:inspector:us-east-1:632902152528:target/0-rq7FzXkt | 2022-01-18T12:46:
+-----------------+--------------------------------------------------------------------------------+----------------------+------------------------------------------------------------+------------------

> select * from aws_inspector_assessment_template where name = 'turbottest15234';
+-----------------+--------------------------------------------------------------------------------+----------------------+------------------------------------------------------------+------------------
| name            | arn                                                                            | assessment_run_count | assessment_target_arn                                      | created_at       
+-----------------+--------------------------------------------------------------------------------+----------------------+------------------------------------------------------------+------------------
| turbottest15234 | arn:aws:inspector:us-east-1:632902152528:target/0-rq7FzXkt/template/0-zXLOWPaM | 0                    | arn:aws:inspector:us-east-1:632902152528:target/0-rq7FzXkt | 2022-01-18T12:46:
+-----------------+--------------------------------------------------------------------------------+----------------------+------------------------------------------------------------+------------------
> .cache off
> .cache clear
> select * from aws_inspector_assessment_template where assessment_target_arn = 'arn:aws:inspector:us-east-1:632902152528:target/0-rq7FzXkt';
+-----------------+--------------------------------------------------------------------------------+----------------------+------------------------------------------------------------+------------------
| name            | arn                                                                            | assessment_run_count | assessment_target_arn                                      | created_at       
+-----------------+--------------------------------------------------------------------------------+----------------------+------------------------------------------------------------+------------------
| test12          | arn:aws:inspector:us-east-1:632902152528:target/0-rq7FzXkt/template/0-9GF68Zw1 | 0                    | arn:aws:inspector:us-east-1:632902152528:target/0-rq7FzXkt | 2022-01-18T12:52:
| turbottest15234 | arn:aws:inspector:us-east-1:632902152528:target/0-rq7FzXkt/template/0-zXLOWPaM | 0                    | arn:aws:inspector:us-east-1:632902152528:target/0-rq7FzXkt | 2022-01-18T12:46:
+-----------------+--------------------------------------------------------------------------------+----------------------+------------------------------------------------------------+------------------
> select * from aws_inspector_assessment_template where assessment_target_arn = 'arn:aws:inspector:us-east-1:632902152528:target/0-rq7FzXkt' limit 1;
+--------+--------------------------------------------------------------------------------+----------------------+------------------------------------------------------------+---------------------------
| name   | arn                                                                            | assessment_run_count | assessment_target_arn                                      | created_at                
+--------+--------------------------------------------------------------------------------+----------------------+------------------------------------------------------------+---------------------------
| test12 | arn:aws:inspector:us-east-1:632902152528:target/0-rq7FzXkt/template/0-9GF68Zw1 | 0                    | arn:aws:inspector:us-east-1:632902152528:target/0-rq7FzXkt | 2022-01-18T12:52:28+05:30 
+--------+--------------------------------------------------------------------------------+----------------------+------------------------------------------------------------+--------------------------

> select * from aws_kinesis_consumer limit 2000;
+-----------------+---------------------------------------------------------------------------------------------------+---------------------------------------------------------------+-----------------+-
| consumer_name   | consumer_arn                                                                                      | stream_arn                                                    | consumer_status | 
+-----------------+---------------------------------------------------------------------------------------------------+---------------------------------------------------------------+-----------------+-
| turbottest32222 | arn:aws:kinesis:us-east-1:632902152528:stream/turbottest32222/consumer/turbottest32222:1642492416 | arn:aws:kinesis:us-east-1:632902152528:stream/turbottest32222 | ACTIVE          | 
| turbottest37560 | arn:aws:kinesis:us-east-1:632902152528:stream/turbottest37560/consumer/turbottest37560:1642492567 | arn:aws:kinesis:us-east-1:632902152528:stream/turbottest37560 | ACTIVE          | 
+-----------------+---------------------------------------------------------------------------------------------------+---------------------------------------------------------------+-----------------+-

 select * from aws_kinesis_consumer limit 1;
+-----------------+---------------------------------------------------------------------------------------------------+---------------------------------------------------------------+-----------------+-
| consumer_name   | consumer_arn                                                                                      | stream_arn                                                    | consumer_status | 
+-----------------+---------------------------------------------------------------------------------------------------+---------------------------------------------------------------+-----------------+-
| turbottest32222 | arn:aws:kinesis:us-east-1:632902152528:stream/turbottest32222/consumer/turbottest32222:1642492416 | arn:aws:kinesis:us-east-1:632902152528:stream/turbottest32222 | ACTIVE          | 
+-----------------+---------------------------------------------------------------------------------------------------+---------------------------------------------------------------+-----------------+-

> select * from aws_kinesis_stream limit 1;
+-----------------+---------------------------------------------------------------+---------------+---------------------------+-----------------+--------+------------------------+----------------+------
| stream_name     | stream_arn                                                    | stream_status | stream_creation_timestamp | encryption_type | key_id | retention_period_hours | consumer_count | open_
+-----------------+---------------------------------------------------------------+---------------+---------------------------+-----------------+--------+------------------------+----------------+------
| turbottest32222 | arn:aws:kinesis:us-east-1:632902152528:stream/turbottest32222 | ACTIVE        | 2022-01-18T13:23:08+05:30 | NONE            | <null> | 24                     | 1              | 1    
+-----------------+---------------------------------------------------------------+---------------+---------------------------+-----------------+--------+------------------------+----------------+------

 select * from aws_kinesis_stream limit 18877;
+-----------------+---------------------------------------------------------------+---------------+---------------------------+-----------------+--------+------------------------+----------------+------
| stream_name     | stream_arn                                                    | stream_status | stream_creation_timestamp | encryption_type | key_id | retention_period_hours | consumer_count | open_
+-----------------+---------------------------------------------------------------+---------------+---------------------------+-----------------+--------+------------------------+----------------+------
| turbottest32222 | arn:aws:kinesis:us-east-1:632902152528:stream/turbottest32222 | ACTIVE        | 2022-01-18T13:23:08+05:30 | NONE            | <null> | 24                     | 1              | 1    
| turbottest37560 | arn:aws:kinesis:us-east-1:632902152528:stream/turbottest37560 | ACTIVE        | 2022-01-18T13:25:40+05:30 | NONE            | <null> | 24                     | 1              | 1    
+-----------------+---------------------------------------------------------------+---------------+---------------------------+-----------------+--------+------------------------+----------------+------

> select * from aws_kinesis_firehose_delivery_stream limit 10000;
+----------------------+---------------------------------------------------------------------+------------------------+-----------------------+------------+---------------------------+------------------
| delivery_stream_name | arn                                                                 | delivery_stream_status | delivery_stream_type  | version_id | create_timestamp          | has_more_destinat
+----------------------+---------------------------------------------------------------------+------------------------+-----------------------+------------+---------------------------+------------------
| KDS-S3-XyuRH         | arn:aws:firehose:us-east-1:632902152528:deliverystream/KDS-S3-XyuRH | ACTIVE                 | KinesisStreamAsSource | 1          | 2022-01-18T14:51:51+05:30 | false            
|                      |                                                                     |                        |                       |            |                           |                  
+----------------------+---------------------------------------------------------------------+------------------------+-----------------------+------------+---------------------------+------------------

> select * from aws_kinesis_firehose_delivery_stream where delivery_stream_type = 'KinesisStreamAsSource';
+----------------------+---------------------------------------------------------------------+------------------------+-----------------------+------------+---------------------------+------------------
| delivery_stream_name | arn                                                                 | delivery_stream_status | delivery_stream_type  | version_id | create_timestamp          | has_more_destinat
+----------------------+---------------------------------------------------------------------+------------------------+-----------------------+------------+---------------------------+------------------
| KDS-S3-XyuRH         | arn:aws:firehose:us-east-1:632902152528:deliverystream/KDS-S3-XyuRH | ACTIVE                 | KinesisStreamAsSource | 1          | 2022-01-18T14:51:51+05:30 | false            
|                      |                                                                     |                        |                       |            |                           |                  
+----------------------+---------------------------------------------------------------------+------------------------+-----------------------+------------+---------------------------+------------------

> select * from aws_kinesis_video_stream where stream_name_prefix = 'test'
+-------------+-----------------------------------------------------------------------------+--------------------+--------+----------------------+--------------------------------------------------------
| stream_name | stream_arn                                                                  | stream_name_prefix | status | version              | kms_key_id                                             
+-------------+-----------------------------------------------------------------------------+--------------------+--------+----------------------+--------------------------------------------------------
| test-video  | arn:aws:kinesisvideo:us-east-1:632902152528:stream/test-video/1642497882687 | test               | ACTIVE | afCy7Qhrw5GhuEJ7Pvdn | arn:aws:kms:us-east-1:632902152528:alias/aws/kinesisvid
+-------------+-----------------------------------------------------------------------------+--------------------+--------+----------------------+--------------------------------------------------------

> select * from aws_kinesisanalyticsv2_application limit 73;
+------------------+------------------------+----------------------------------------------------------------------+--------------------+---------------------------+-------------------------+-----------
| application_name | application_version_id | application_arn                                                      | application_status | create_timestamp          | application_description | last_updat
+------------------+------------------------+----------------------------------------------------------------------+--------------------+---------------------------+-------------------------+-----------
| test_app         | 1                      | arn:aws:kinesisanalytics:us-east-1:632902152528:application/test_app | READY              | 2022-01-18T14:58:42+05:30 | <null>                  | 2022-01-18
+------------------+------------------------+----------------------------------------------------------------------+--------------------+---------------------------+-------------------------+-----------

select * from aws_kinesisanalyticsv2_application limit 1;
+------------------+------------------------+----------------------------------------------------------------------+--------------------+---------------------------+-------------------------+-----------
| application_name | application_version_id | application_arn                                                      | application_status | create_timestamp          | application_description | last_updat
+------------------+------------------------+----------------------------------------------------------------------+--------------------+---------------------------+-------------------------+-----------
| test_app         | 1                      | arn:aws:kinesisanalytics:us-east-1:632902152528:application/test_app | READY              | 2022-01-18T14:58:42+05:30 | <null>                  | 2022-01-18
+------------------+------------------------+----------------------------------------------------------------------+--------------------+---------------------------+-------------------------+-----------

 select * from aws_kms_key limit 2000;
+--------------------------------------+-----------------------------------------------------------------------------+-------------+---------------------------+----------------+---------+---------------
| id                                   | arn                                                                         | key_manager | creation_date             | aws_account_id | enabled | customer_maste
+--------------------------------------+-----------------------------------------------------------------------------+-------------+---------------------------+----------------+---------+---------------
| c4c0f3b8-466c-42f7-ab9c-63803818bb35 | arn:aws:kms:us-east-1:632902152528:key/c4c0f3b8-466c-42f7-ab9c-63803818bb35 | AWS         | 2020-05-11T11:34:20+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 31ae8c64-bb51-4292-bbf2-bfe04079241a | arn:aws:kms:us-east-1:632902152528:key/31ae8c64-bb51-4292-bbf2-bfe04079241a | AWS         | 2021-10-21T16:32:26+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| bf5acb19-d4a7-499c-80d5-b435ebc0cd90 | arn:aws:kms:us-east-1:632902152528:key/bf5acb19-d4a7-499c-80d5-b435ebc0cd90 | AWS         | 2019-12-25T18:30:05+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 0df1b095-dc6e-40d7-87ac-60f42cc3fe0c | arn:aws:kms:us-east-1:632902152528:key/0df1b095-dc6e-40d7-87ac-60f42cc3fe0c | AWS         | 2020-05-11T11:34:20+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| d53482cb-aac5-4123-9bc8-0caf762a9fb0 | arn:aws:kms:us-east-1:632902152528:key/d53482cb-aac5-4123-9bc8-0caf762a9fb0 | AWS         | 2020-05-11T11:34:20+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 6f9bca28-4765-492b-a85b-249b9b02f562 | arn:aws:kms:us-east-1:632902152528:key/6f9bca28-4765-492b-a85b-249b9b02f562 | AWS         | 2020-05-11T11:34:20+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 80e0e625-2267-4471-8ff4-bb71f9957b39 | arn:aws:kms:us-east-1:632902152528:key/80e0e625-2267-4471-8ff4-bb71f9957b39 | AWS         | 2021-10-26T12:28:11+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 6ca54ca7-e105-43ba-9a4a-5daf30636f59 | arn:aws:kms:us-east-1:632902152528:key/6ca54ca7-e105-43ba-9a4a-5daf30636f59 | AWS         | 2021-05-03T20:30:12+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| af024c01-6bc6-4aa4-8835-6725795986bf | arn:aws:kms:us-east-1:632902152528:key/af024c01-6bc6-4aa4-8835-6725795986bf | CUSTOMER    | 2021-03-17T17:01:19+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 3effca79-41e9-4bd8-9c4f-d90f3747608e | arn:aws:kms:us-east-1:632902152528:key/3effca79-41e9-4bd8-9c4f-d90f3747608e | AWS         | 2020-05-11T11:34:20+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 6445add3-6039-4b56-9547-8054f4570f5b | arn:aws:kms:us-east-1:632902152528:key/6445add3-6039-4b56-9547-8054f4570f5b | AWS         | 2021-11-09T13:16:54+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
|                                      |                                                                             |             |                           |                |         |               
| 36ea95f2-a652-49fe-a3a5-bbab1bdee380 | arn:aws:kms:us-east-1:632902152528:key/36ea95f2-a652-49fe-a3a5-bbab1bdee380 | AWS         | 2021-05-31T15:29:34+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
|                                      |                                                                             |             |                           |                |         |               
| 66ce5b23-36c2-4917-8b8f-0ac8073ed7d3 | arn:aws:kms:us-east-1:632902152528:key/66ce5b23-36c2-4917-8b8f-0ac8073ed7d3 | AWS         | 2020-05-11T11:34:20+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 63606bae-c08f-4445-a71b-4f6a29eaa4f0 | arn:aws:kms:us-east-1:632902152528:key/63606bae-c08f-4445-a71b-4f6a29eaa4f0 | AWS         | 2020-05-11T11:34:20+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 566eac3a-0339-47e6-9a2b-fc0a96ad7b55 | arn:aws:kms:us-east-1:632902152528:key/566eac3a-0339-47e6-9a2b-fc0a96ad7b55 | AWS         | 2020-05-11T11:34:20+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| e69e3489-c40e-4ddb-add5-ec9d83456355 | arn:aws:kms:us-east-1:632902152528:key/e69e3489-c40e-4ddb-add5-ec9d83456355 | AWS         | 2020-05-11T11:34:20+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 5956a513-67e4-4767-8997-a4190c082b59 | arn:aws:kms:us-east-1:632902152528:key/5956a513-67e4-4767-8997-a4190c082b59 | AWS         | 2021-03-23T10:10:52+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 789b57ef-3635-41f5-816e-95c5b33c0c2e | arn:aws:kms:us-east-1:632902152528:key/789b57ef-3635-41f5-816e-95c5b33c0c2e | AWS         | 2019-12-25T18:30:05+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| d929f37f-a3b3-4b7a-bf53-0de8bd65fe14 | arn:aws:kms:us-east-1:632902152528:key/d929f37f-a3b3-4b7a-bf53-0de8bd65fe14 | AWS         | 2019-11-20T16:00:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 7868bfd9-9379-47eb-80af-fab73710ff09 | arn:aws:kms:us-east-1:632902152528:key/7868bfd9-9379-47eb-80af-fab73710ff09 | AWS         | 2021-11-10T15:04:54+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 4c033f5a-1a65-491a-af0c-23dc59cd520b | arn:aws:kms:us-east-1:632902152528:key/4c033f5a-1a65-491a-af0c-23dc59cd520b | CUSTOMER    | 2021-05-05T16:00:58+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
|                                      |                                                                             |             |                           |                |         |               
| 4d9fe3b2-450f-4a2e-9a28-1c8b5fc35459 | arn:aws:kms:us-east-1:632902152528:key/4d9fe3b2-450f-4a2e-9a28-1c8b5fc35459 | AWS         | 2020-05-11T11:34:20+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 08292c74-1b8f-4eab-bdce-1f8a94795650 | arn:aws:kms:us-east-2:632902152528:key/08292c74-1b8f-4eab-bdce-1f8a94795650 | AWS         | 2021-12-02T13:58:27+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
|                                      |                                                                             |             |                           |                |         |               
| 31ca5a5d-7798-482d-97ea-0dba66d08005 | arn:aws:kms:us-east-2:632902152528:key/31ca5a5d-7798-482d-97ea-0dba66d08005 | AWS         | 2020-05-11T11:33:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 835039e7-4699-4500-83be-a39f94ced3d3 | arn:aws:kms:us-east-2:632902152528:key/835039e7-4699-4500-83be-a39f94ced3d3 | AWS         | 2020-05-11T11:33:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 159527d1-2e29-4f45-aead-683b605a5ad6 | arn:aws:kms:us-east-2:632902152528:key/159527d1-2e29-4f45-aead-683b605a5ad6 | AWS         | 2020-05-11T11:33:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 4fc4b467-1c6a-4b07-a67c-1e23181ec4e5 | arn:aws:kms:us-east-2:632902152528:key/4fc4b467-1c6a-4b07-a67c-1e23181ec4e5 | AWS         | 2020-05-11T11:33:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 01ce81ba-9351-43e9-b263-89f2ae54781c | arn:aws:kms:us-east-2:632902152528:key/01ce81ba-9351-43e9-b263-89f2ae54781c | AWS         | 2020-05-11T11:33:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| a2e144bf-b174-4384-9f9e-97750464fe1c | arn:aws:kms:us-east-2:632902152528:key/a2e144bf-b174-4384-9f9e-97750464fe1c | AWS         | 2020-05-11T11:33:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| b6fb5854-1556-46a3-bbd9-903c12ac7c70 | arn:aws:kms:us-east-2:632902152528:key/b6fb5854-1556-46a3-bbd9-903c12ac7c70 | AWS         | 2020-05-11T11:33:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| a11298f9-5537-4cc5-b1b5-5320c2912b9e | arn:aws:kms:us-east-2:632902152528:key/a11298f9-5537-4cc5-b1b5-5320c2912b9e | AWS         | 2020-05-11T11:33:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| ff3e2033-3965-48d1-bd36-31953e52a7c8 | arn:aws:kms:us-east-2:632902152528:key/ff3e2033-3965-48d1-bd36-31953e52a7c8 | AWS         | 2020-05-11T11:33:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 2d901a4d-6c75-4cef-92a8-38ea0748e4ac | arn:aws:kms:us-east-2:632902152528:key/2d901a4d-6c75-4cef-92a8-38ea0748e4ac | AWS         | 2020-05-11T11:33:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 0ccd7ea9-ef88-4050-9c6a-23047da41d28 | arn:aws:kms:us-west-2:632902152528:key/0ccd7ea9-ef88-4050-9c6a-23047da41d28 | AWS         | 2020-05-11T11:32:23+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 32b777d4-194f-4d38-995d-3265b33f3788 | arn:aws:kms:us-east-2:632902152528:key/32b777d4-194f-4d38-995d-3265b33f3788 | AWS         | 2020-05-11T11:33:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| ab6dc8ef-11e0-4f73-b9f6-06c1370356ef | arn:aws:kms:us-west-2:632902152528:key/ab6dc8ef-11e0-4f73-b9f6-06c1370356ef | AWS         | 2020-05-11T11:32:23+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 13f032d2-97bb-4538-a3a2-8b2996d0d26a | arn:aws:kms:us-west-2:632902152528:key/13f032d2-97bb-4538-a3a2-8b2996d0d26a | AWS         | 2020-05-11T11:32:23+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| e8171b4f-00f9-460a-a7ae-6b2a64458f43 | arn:aws:kms:us-west-2:632902152528:key/e8171b4f-00f9-460a-a7ae-6b2a64458f43 | AWS         | 2020-05-11T11:32:23+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| b4a97b37-5ac4-4445-aa40-8965e9afb76d | arn:aws:kms:us-west-2:632902152528:key/b4a97b37-5ac4-4445-aa40-8965e9afb76d | AWS         | 2020-05-11T11:32:23+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 3ded21b1-6209-4ba0-a26a-9b0b7b139b70 | arn:aws:kms:us-west-2:632902152528:key/3ded21b1-6209-4ba0-a26a-9b0b7b139b70 | AWS         | 2020-05-11T11:32:23+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 9f7807f4-b2eb-4aa7-bbc5-a4646462881c | arn:aws:kms:us-east-2:632902152528:key/9f7807f4-b2eb-4aa7-bbc5-a4646462881c | AWS         | 2020-10-29T12:07:19+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| bf1f439f-7eb0-4f32-8e15-139b91aba740 | arn:aws:kms:us-west-2:632902152528:key/bf1f439f-7eb0-4f32-8e15-139b91aba740 | AWS         | 2020-05-11T11:32:23+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| ee384c91-01bd-439b-869a-8b2f879876ca | arn:aws:kms:us-west-2:632902152528:key/ee384c91-01bd-439b-869a-8b2f879876ca | AWS         | 2020-05-11T11:32:23+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 35117e97-ee0c-4089-ad8b-8d601387783b | arn:aws:kms:us-west-2:632902152528:key/35117e97-ee0c-4089-ad8b-8d601387783b | AWS         | 2020-05-11T11:32:23+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 46a3b4e7-aa2a-489d-b4c3-636c6efbf0e6 | arn:aws:kms:us-west-2:632902152528:key/46a3b4e7-aa2a-489d-b4c3-636c6efbf0e6 | AWS         | 2020-05-11T11:32:23+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 8e46b411-9f65-4723-ae43-17a78032d911 | arn:aws:kms:us-west-2:632902152528:key/8e46b411-9f65-4723-ae43-17a78032d911 | AWS         | 2020-05-11T11:32:23+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
+--------------------------------------+-----------------------------------------------------------------------------+-------------+---------------------------+----------------+---------+---------------

> select * from aws_kms_key limit 5;
+--------------------------------------+-----------------------------------------------------------------------------+-------------+---------------------------+----------------+---------+---------------
| id                                   | arn                                                                         | key_manager | creation_date             | aws_account_id | enabled | customer_maste
+--------------------------------------+-----------------------------------------------------------------------------+-------------+---------------------------+----------------+---------+---------------
| 31ae8c64-bb51-4292-bbf2-bfe04079241a | arn:aws:kms:us-east-1:632902152528:key/31ae8c64-bb51-4292-bbf2-bfe04079241a | AWS         | 2021-10-21T16:32:26+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 4c033f5a-1a65-491a-af0c-23dc59cd520b | arn:aws:kms:us-east-1:632902152528:key/4c033f5a-1a65-491a-af0c-23dc59cd520b | CUSTOMER    | 2021-05-05T16:00:58+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
|                                      |                                                                             |             |                           |                |         |               
| 0df1b095-dc6e-40d7-87ac-60f42cc3fe0c | arn:aws:kms:us-east-1:632902152528:key/0df1b095-dc6e-40d7-87ac-60f42cc3fe0c | AWS         | 2020-05-11T11:34:20+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
| 36ea95f2-a652-49fe-a3a5-bbab1bdee380 | arn:aws:kms:us-east-1:632902152528:key/36ea95f2-a652-49fe-a3a5-bbab1bdee380 | AWS         | 2021-05-31T15:29:34+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
|                                      |                                                                             |             |                           |                |         |               
| 3effca79-41e9-4bd8-9c4f-d90f3747608e | arn:aws:kms:us-east-1:632902152528:key/3effca79-41e9-4bd8-9c4f-d90f3747608e | AWS         | 2020-05-11T11:34:20+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
+--------------------------------------+-----------------------------------------------------------------------------+-------------+---------------------------+----------------+---------+---------------

> select * from aws_kms_key limit 1;
+--------------------------------------+-----------------------------------------------------------------------------+-------------+---------------------------+----------------+---------+---------------
| id                                   | arn                                                                         | key_manager | creation_date             | aws_account_id | enabled | customer_maste
+--------------------------------------+-----------------------------------------------------------------------------+-------------+---------------------------+----------------+---------+---------------
| 01ce81ba-9351-43e9-b263-89f2ae54781c | arn:aws:kms:us-east-2:632902152528:key/01ce81ba-9351-43e9-b263-89f2ae54781c | AWS         | 2020-05-11T11:33:01+05:30 | 632902152528   | true    | SYMMETRIC_DEFA
+--------------------------------------+-----------------------------------------------------------------------------+-------------+---------------------------+----------------+---------+---------------

> select * from aws_lambda_alias where function_name = 'function-test' and function_version = '1'
+----------+---------------+-----------------------------------------------------------------------+------------------+--------------------------------------+-------------+--------+------------+--------
| name     | function_name | alias_arn                                                             | function_version | revision_id                          | description | policy | policy_std | title  
+----------+---------------+-----------------------------------------------------------------------+------------------+--------------------------------------+-------------+--------+------------+--------
| test-a-3 | function-test | arn:aws:lambda:us-east-1:632902152528:function:function-test:test-a-3 | 1                | 9e26ed04-3e9a-4750-bb62-5a60bf481a0b | test        | <null> | <null>     | test-a-
+----------+---------------+-----------------------------------------------------------------------+------------------+--------------------------------------+-------------+--------+------------+--------

 select * from aws_lambda_function limit 100000;
+----------------------+---------------------------------------------------------------------+----------------------------------------------+-----------+-------------------------------+-------------+---
| name                 | arn                                                                 | code_sha_256                                 | code_size | dead_letter_config_target_arn | description | ha
+----------------------+---------------------------------------------------------------------+----------------------------------------------+-----------+-------------------------------+-------------+---
| old-func             | arn:aws:lambda:us-east-1:632902152528:function:old-func             | fI06ZlRH/KN6Ra3twvdRllUYaxv182Tjx0qNWNlKIhI= | 299       | <null>                        |             | la
| func-encrypted       | arn:aws:lambda:us-east-1:632902152528:function:func-encrypted       | uTJFxT0sQYd8f6CtxoZoBcLT6Hd0A48LniMm4gpxgDw= | 304       | <null>                        |             | in
| function-without-vpc | arn:aws:lambda:us-east-1:632902152528:function:function-without-vpc | k33TggGtygLrDDrEecfHuvfuVd+6bRxCFv7lErxWOJ0= | 304       | <null>                        |             | in
|                      |                                                                     |                                              |           |                               |             |   
| function-test        | arn:aws:lambda:us-east-1:632902152528:function:function-test        | k33TggGtygLrDDrEecfHuvfuVd+6bRxCFv7lErxWOJ0= | 304       | <null>                        |             | in
+----------------------+---------------------------------------------------------------------+----------------------------------------------+-----------+-------------------------------+-------------+---

> select * from aws_lambda_function limit 1;
+----------+---------------------------------------------------------+----------------------------------------------+-----------+-------------------------------+-------------+---------------------------
| name     | arn                                                     | code_sha_256                                 | code_size | dead_letter_config_target_arn | description | handler                   
+----------+---------------------------------------------------------+----------------------------------------------+-----------+-------------------------------+-------------+---------------------------
| old-func | arn:aws:lambda:us-east-1:632902152528:function:old-func | fI06ZlRH/KN6Ra3twvdRllUYaxv182Tjx0qNWNlKIhI= | 299       | <null>                        |             | lambda_function.lambda_han
+----------+---------------------------------------------------------+----------------------------------------------+-----------+-------------------------------+-------------+---------------------------

> select * from aws_lambda_layer limit 45
+------------+--------------------------------------------------------+------------------------------+-------------+----------------------------------------------------------+--------------+---------+--
| layer_name | layer_arn                                              | created_date                 | description | layer_version_arn                                        | license_info | version | c
+------------+--------------------------------------------------------+------------------------------+-------------+----------------------------------------------------------+--------------+---------+--
| test-layer | arn:aws:lambda:us-east-1:632902152528:layer:test-layer | 2022-01-18T09:48:50.249+0000 | test12      | arn:aws:lambda:us-east-1:632902152528:layer:test-layer:2 | <null>       | 2       | <
+------------+--------------------------------------------------------+------------------------------+-------------+----------------------------------------------------------+--------------+---------+--

 select * from aws_lambda_layer_version limit 50;
+------------+--------------------------------------------------------+----------------------------------------------------------+------------------------------+----------------------+--------------+---
| layer_name | layer_arn                                              | layer_version_arn                                        | created_date                 | description          | license_info | re
+------------+--------------------------------------------------------+----------------------------------------------------------+------------------------------+----------------------+--------------+---
| test-layer | arn:aws:lambda:us-east-1:632902152528:layer:test-layer | arn:aws:lambda:us-east-1:632902152528:layer:test-layer:2 | 2022-01-18T09:48:50.249+0000 | test12               | <null>       | <n
|            |                                                        |                                                          |                              |                      |              |   
| test-layer | arn:aws:lambda:us-east-1:632902152528:layer:test-layer | arn:aws:lambda:us-east-1:632902152528:layer:test-layer:1 | 2022-01-18T09:48:03.973+0000 | testing purpose only | <null>       | <n
|            |                                                        |                                                          |                              |                      |              |   
+------------+--------------------------------------------------------+----------------------------------------------------------+------------------------------+----------------------+--------------+---

> select * from aws_rds_db_cluster_parameter_group limit 10
+-------------------------+-----------------------------------------------------------------------+-----------------------------------------------------+---------------------------+---------------------
| name                    | arn                                                                   | description                                         | db_parameter_group_family | parameters          
+-------------------------+-----------------------------------------------------------------------+-----------------------------------------------------+---------------------------+---------------------
| default.aurora5.6       | arn:aws:rds:us-east-1:632902152528:cluster-pg:default.aurora5.6       | Default cluster parameter group for aurora5.6       | aurora5.6                 | [{"AllowedValues":"0
|                         |                                                                       |                                                     |                           | eground queries) to 
|                         |                                                                       |                                                     |                           | ":true,"MinimumEngin
|                         |                                                                       |                                                     |                           | od":"pending-reboot"
|                         |                                                                       |                                                     |                           | ortedEngineModes":["
|                         |                                                                       |                                                     |                           | taken by engine as a
|                         |                                                                       |                                                     |                           | ry instead.","IsModi
|                         |                                                                       |                                                     |                           | ataType":"boolean","
|                         |                                                                       |                                                     |                           | pplyMethod":"pending
|                         |                                                                       |                                                     |                           | MinimumEngineVersion
|                         |                                                                       |                                                     |                           | rameterName":"basedi
|                         |                                                                       |                                                     |                           | ":"Binary logging fo
|                         |                                                                       |                                                     |                           |  to the binary log. 
|                         |                                                                       |                                                     |                           | rtedEngineModes":["p

> select * from aws_rds_db_cluster_parameter_group limit 200
+-------------------------+-----------------------------------------------------------------------+-----------------------------------------------------+---------------------------+---------------------
| name                    | arn                                                                   | description                                         | db_parameter_group_family | parameters          
+-------------------------+-----------------------------------------------------------------------+-----------------------------------------------------+---------------------------+---------------------
| default.aurora5.6       | arn:aws:rds:us-east-1:632902152528:cluster-pg:default.aurora5.6       | Default cluster parameter group for aurora5.6       | aurora5.6                 | [{"AllowedValues":"0
|                         |                                                                       |                                                     |                           | eground queries) to 

> select db_cluster_identifier, arn, engine, clone_group_id from aws_rds_db_cluster where engine = 'aurora-mysql';
+-----------------------+-------------------------------------------------------+--------------+----------------+
| db_cluster_identifier | arn                                                   | engine       | clone_group_id |
+-----------------------+-------------------------------------------------------+--------------+----------------+
| database-1            | arn:aws:rds:us-east-1:632902152528:cluster:database-1 | aurora-mysql | <null>         |
+-----------------------+-------------------------------------------------------+--------------+----------------+

> select name, arn, engine_name, major_engine_version from aws_rds_db_option_group where engine_name = 'mysql' and major_engine_version = '8.0'
+-------------------+---------------------------------------------------------+-------------+----------------------+
| name              | arn                                                     | engine_name | major_engine_version |
+-------------------+---------------------------------------------------------+-------------+----------------------+
| default:mysql-8-0 | arn:aws:rds:us-east-2:632902152528:og:default:mysql-8-0 | mysql       | 8.0                  |
| default:mysql-8-0 | arn:aws:rds:us-east-1:632902152528:og:default:mysql-8-0 | mysql       | 8.0                  |
+-------------------+---------------------------------------------------------+-------------+----------------------+

> select name, arn, engine_name, major_engine_version from aws_rds_db_option_group where engine_name = 'mysql'
+-------------------+---------------------------------------------------------+-------------+----------------------+
| name              | arn                                                     | engine_name | major_engine_version |
+-------------------+---------------------------------------------------------+-------------+----------------------+
| default:mysql-8-0 | arn:aws:rds:us-east-2:632902152528:og:default:mysql-8-0 | mysql       | 8.0                  |
| default:mysql-8-0 | arn:aws:rds:us-east-1:632902152528:og:default:mysql-8-0 | mysql       | 8.0                  |
| default:mysql-5-7 | arn:aws:rds:us-east-1:632902152528:og:default:mysql-5-7 | mysql       | 5.7                  |
+-------------------+---------------------------------------------------------+-------------+----------------------+

 select name, arn, engine_name, major_engine_version from aws_rds_db_option_group where engine_name = 'mysql' limit 400
+-------------------+---------------------------------------------------------+-------------+----------------------+
| name              | arn                                                     | engine_name | major_engine_version |
+-------------------+---------------------------------------------------------+-------------+----------------------+
| default:mysql-8-0 | arn:aws:rds:us-east-2:632902152528:og:default:mysql-8-0 | mysql       | 8.0                  |
| default:mysql-5-7 | arn:aws:rds:us-east-1:632902152528:og:default:mysql-5-7 | mysql       | 5.7                  |
| default:mysql-8-0 | arn:aws:rds:us-east-1:632902152528:og:default:mysql-8-0 | mysql       | 8.0                  |
+-------------------+---------------------------------------------------------+-------------+----------------------+

> select * from aws_rds_db_parameter_group limit 10
+---------------------------+-----------------------------------------------------------------+-----------------------------------------------+---------------------------+-------------------------------
| name                      | arn                                                             | description                                   | db_parameter_group_family | parameters                    
+---------------------------+-----------------------------------------------------------------+-----------------------------------------------+---------------------------+-------------------------------
| default.sqlserver-se-15.0 | arn:aws:rds:us-east-1:632902152528:pg:default.sqlserver-se-15.0 | Default parameter group for sqlserver-se-15.0 | sqlserver-se-15.0         | [{"AllowedValues":"0,1","Apply
|                           |                                                                 |                                               |                           | urrent command affected, in an

> select * from aws_rds_db_parameter_group limit 100
+---------------------------+-----------------------------------------------------------------+-----------------------------------------------+---------------------------+-------------------------------
| name                      | arn                                                             | description                                   | db_parameter_group_family | parameters                    
+---------------------------+-----------------------------------------------------------------+-----------------------------------------------+---------------------------+-------------------------------
| default.sqlserver-se-15.0 | arn:aws:rds:us-east-1:632902152528:pg:default.sqlserver-se-15.0 | Default parameter group for sqlserver-se-15.0 | sqlserver-se-15.0         | [{"AllowedValues":"0,1","Apply
|                           |                                                                 |                                               |                           | urrent command affected, in an

select * from aws_rds_db_subnet_group limit 2000;
+-------------------------------+-------------------------------------------------------------------------+-----------------------------------------+----------+-----------------------+------------------
| name                          | arn                                                                     | description                             | status   | vpc_id                | subnets          
+-------------------------------+-------------------------------------------------------------------------+-----------------------------------------+----------+-----------------------+------------------
| default-vpc-3ac89d40          | arn:aws:rds:us-east-1:632902152528:subgrp:default-vpc-3ac89d40          | Created from the RDS Management Console | Complete | vpc-3ac89d40          | [{"SubnetAvailabi
| default-vpc-aa63a1c1          | arn:aws:rds:us-east-2:632902152528:subgrp:default-vpc-aa63a1c1          | Created from the RDS Management Console | Complete | vpc-aa63a1c1          | [{"SubnetAvailabi
| default-vpc-080a18f884224a0c3 | arn:aws:rds:us-east-1:632902152528:subgrp:default-vpc-080a18f884224a0c3 | Created from the RDS Management Console | Complete | vpc-080a18f884224a0c3 | [{"SubnetAvailabi
+-------------------------------+-------------------------------------------------------------------------+-----------------------------------------+----------+-----------------------+------------------

> select * from aws_rds_db_subnet_group limit 10;
+-------------------------------+-------------------------------------------------------------------------+-----------------------------------------+----------+-----------------------+------------------
| name                          | arn                                                                     | description                             | status   | vpc_id                | subnets          
+-------------------------------+-------------------------------------------------------------------------+-----------------------------------------+----------+-----------------------+------------------
| default-vpc-3ac89d40          | arn:aws:rds:us-east-1:632902152528:subgrp:default-vpc-3ac89d40          | Created from the RDS Management Console | Complete | vpc-3ac89d40          | [{"SubnetAvailabi
| default-vpc-aa63a1c1          | arn:aws:rds:us-east-2:632902152528:subgrp:default-vpc-aa63a1c1          | Created from the RDS Management Console | Complete | vpc-aa63a1c1          | [{"SubnetAvailabi
| default-vpc-080a18f884224a0c3 | arn:aws:rds:us-east-1:632902152528:subgrp:default-vpc-080a18f884224a0c3 | Created from the RDS Management Console | Complete | vpc-080a18f884224a0c3 | [{"SubnetAvailabi
+-------------------------------+-------------------------------------------------------------------------+-----------------------------------------+----------+-----------------------+------------------

> select * from aws_macie2_classification_job where job_type in ('SCHEDULED', 'ONE_TIME');
+----------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+-----------+----------------------------------
| name           | job_id                           | arn                                                                                       | job_status | job_type  | client_token                     
+----------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+-----------+----------------------------------
| test1          | 3fbad137a58a596041d5b3667b9b4084 | arn:aws:macie2:us-east-1:632902152528:classification-job/3fbad137a58a596041d5b3667b9b4084 | IDLE       | SCHEDULED | 09f42537-d46c-494d-a191-d082de46e
| turbottest3570 | bdaf16863e21a0ca5aad33be7eda159a | arn:aws:macie2:us-east-1:632902152528:classification-job/bdaf16863e21a0ca5aad33be7eda159a | COMPLETE   | ONE_TIME  | terraform-20220118132204762000000
+----------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+-----------+----------------------------------

> select * from aws_macie2_classification_job where job_type not in  ('SCHEDULED', 'ONE_TIME');
+------+--------+-----+------------+----------+--------------+------------+---------------+---------------------+--------------------+----------------------------+-----------------------+-----------------
| name | job_id | arn | job_status | job_type | client_token | created_at | last_run_time | sampling_percentage | bucket_definitions | custom_data_identifier_ids | last_run_error_status | s3_job_definitio
+------+--------+-----+------------+----------+--------------+------------+---------------+---------------------+--------------------+----------------------------+-----------------------+-----------------
+------+--------+-----+------------+----------+--------------+------------+---------------+---------------------+--------------------+----------------------------+-----------------------+-----------------

> select * from aws_macie2_classification_job where job_type not in  ('SCHEDULED');
+----------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-----------------------------------
| name           | job_id                           | arn                                                                                       | job_status | job_type | client_token                      
+----------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-----------------------------------
| turbottest3570 | bdaf16863e21a0ca5aad33be7eda159a | arn:aws:macie2:us-east-1:632902152528:classification-job/bdaf16863e21a0ca5aad33be7eda159a | COMPLETE   | ONE_TIME | terraform-202201181322047620000000
+----------------+----------------------------------+-------------------------------------------------------------------------------------------+------------+----------+-----------------------------------

```
</details>
