### PR TITLE
Handle NotFound error for InvalidGroup in getSecurityGroupDetails Hydrate call for aws_vpc_security_group_rule table. Fixes #874

### DIFF
--- a/aws/table_aws_vpc_security_group_rule.go
+++ b/aws/table_aws_vpc_security_group_rule.go
@@ -201,12 +201,6 @@ func tableAwsVpcSecurityGroupRule(_ context.Context) *plugin.Table {
 	}
 }
 
-type groupDetail struct {
-	GroupName     string
-	PairGroupName string
-	VpcId         string
-}
-
 //// LIST FUNCTION
 
 func listSecurityGroupRules(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/aws/table_aws_vpc_security_group_rule.go
+++ b/aws/table_aws_vpc_security_group_rule.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -324,6 +325,10 @@ func getSecurityGroupDetails(ctx context.Context, d *plugin.QueryData, h *plugin
 
 	op, err := svc.DescribeSecurityGroups(params)
 	if err != nil {
+		// Handle NotFound error for InvalidGroup
+		if strings.Contains(err.Error(), "InvalidGroup.NotFound") {
+			return nil, nil
+		}
 		plugin.Logger(ctx).Error("getSecurityGroupDetails", "ERROR", err)
 		return nil, err
 	}


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select group_id, group_name from aws_vpc_security_group_rule where security_group_rule_id = 'sgr-04c0d1145bd2ac638'
+----------------------+------------+
| group_id             | group_name |
+----------------------+------------+
| sg-0a6ab4a4ec00dda70 | <null>     |
+----------------------+------------+

> select group_id, group_name from aws_vpc_security_group_rule
+----------------------+------------------------------------------------------------------------------------------------------+
| group_id             | group_name                                                                                           |
+----------------------+------------------------------------------------------------------------------------------------------+
| sg-0b4fb35d91879e88d | launch-wizard-2                                                                                      |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-0281a516a2d38d5df | app_private                                                                                          |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-0b4fb35d91879e88d | launch-wizard-2                                                                                      |
| sg-0281a516a2d38d5df | app_private                                                                                          |
| sg-0c201995bfca44eb5 | OutboundHttpSG                                                                                       |
| sg-0c22fe61b2a55b223 | db_private                                                                                           |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-0281a516a2d38d5df | app_private                                                                                          |
| sg-08a4f6c8f2b0f4b06 | default                                                                                              |
| sg-077a0c06b5b5373a0 | launch-wizard-1                                                                                      |
```
</details>
