### PR TITLE
Add table aws_cloudwatch_metric closes #872

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -66,6 +66,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_cloudwatch_log_metric_filter":                             tableAwsCloudwatchLogMetricFilter(ctx),
 			"aws_cloudwatch_log_resource_policy":                           tableAwsCloudwatchLogResourcePolicy(ctx),
 			"aws_cloudwatch_log_stream":                                    tableAwsCloudwatchLogStream(ctx),
+			"aws_cloudwatch_metric":                                        tableAwsCloudWatchMetric(ctx),
 			"aws_codebuild_project":                                        tableAwsCodeBuildProject(ctx),
 			"aws_codebuild_source_credential":                              tableAwsCodeBuildSourceCredential(ctx),
 			"aws_codecommit_repository":                                    tableAwsCodeCommitRepository(ctx),

--- a/aws/table_aws_cloudwatch_metric.go
+++ b/aws/table_aws_cloudwatch_metric.go
@@ -17,7 +17,7 @@ func tableAwsCloudWatchMetric(_ context.Context) *plugin.Table {
 		Name:        "aws_cloudwatch_metric",
 		Description: "AWS CloudWatch Metric",
 		List: &plugin.ListConfig{
-			Hydrate: listCloudWatchMetric,
+			Hydrate: listCloudWatchMetrics,
 			ShouldIgnoreError: isNotFoundError([]string{"InvalidParameterValue"}),
 			KeyColumns: []*plugin.KeyColumn{
 				{
@@ -82,7 +82,7 @@ type MetricDetails struct {
 
 //// LIST FUNCTION
 
-func listCloudWatchMetric(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+func listCloudWatchMetrics(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	// Create session
 	svc, err := CloudWatchService(ctx, d)
 	if err != nil {

--- a/aws/table_aws_cloudwatch_metric.go
+++ b/aws/table_aws_cloudwatch_metric.go
@@ -51,21 +51,14 @@ func tableAwsCloudWatchMetric(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "dimensions",
-				Description: "The dimensions for the metric.",
-				Type:        proto.ColumnType_JSON,
-			},
-			{
 				Name:        "dimension_name",
 				Description: "The dimension name for the metric.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromQual("dimension_name"),
 			},
 			{
 				Name:        "dimension_value",
 				Description: "The dimension value for the metric.",
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromQual("dimension_value"),
 			},
 
 			// Steampipe standard columns
@@ -77,6 +70,13 @@ func tableAwsCloudWatchMetric(_ context.Context) *plugin.Table {
 			},
 		}),
 	}
+}
+
+type MetricDetails struct {
+	MetricName     string
+	Namespace      string
+	DimensionName  string
+	DimensionValue string
 }
 
 //// LIST FUNCTION
@@ -119,13 +119,21 @@ func listCloudWatchMetric(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 	err = svc.ListMetricsPages(
 		input,
 		func(page *cloudwatch.ListMetricsOutput, isLast bool) bool {
-			for _, metric := range page.Metrics {
-				d.StreamListItem(ctx, metric)
+			for _, metricDetail := range page.Metrics {
+				for _, dimension := range metricDetail.Dimensions {
+					d.StreamListItem(ctx, &MetricDetails{
+						MetricName:     *metricDetail.MetricName,
+						Namespace:      *metricDetail.Namespace,
+						DimensionName:  *dimension.Name,
+						DimensionValue: *dimension.Value,
+					})
 
-				// Context can be cancelled due to manual cancellation or the limit has been hit
-				if d.QueryStatus.RowsRemaining(ctx) == 0 {
-					return false
+					// Context can be cancelled due to manual cancellation or the limit has been hit
+					if d.QueryStatus.RowsRemaining(ctx) == 0 {
+						return false
+					}
 				}
+
 			}
 			return !isLast
 		},

--- a/aws/table_aws_cloudwatch_metric.go
+++ b/aws/table_aws_cloudwatch_metric.go
@@ -1,0 +1,135 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/cloudwatch"
+	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableAwsCloudWatchMetric(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_cloudwatch_metric",
+		Description: "AWS CloudWatch Metric",
+		List: &plugin.ListConfig{
+			Hydrate: listCloudWatchMetric,
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "name",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "namespace",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "dimension_name",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "dimension_value",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		GetMatrixItem: BuildRegionList,
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "name",
+				Description: "The name of the metric.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("MetricName"),
+			},
+			{
+				Name:        "namespace",
+				Description: "The namespace for the metric.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "dimensions",
+				Description: "The dimensions for the metric.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "dimension_name",
+				Description: "The dimension name for the metric.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("dimension_name"),
+			},
+			{
+				Name:        "dimension_value",
+				Description: "The dimension value for the metric.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("dimension_value"),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("MetricName"),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listCloudWatchMetric(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	// Create session
+	svc, err := CloudWatchService(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	input := &cloudwatch.ListMetricsInput{}
+
+	// Additonal Filter
+	equalQuals := d.KeyColumnQuals
+	dimensionFilters := []*cloudwatch.DimensionFilter{}
+	dimensionFilter := cloudwatch.DimensionFilter{}
+	if equalQuals["name"] != nil {
+		if equalQuals["name"].GetStringValue() != "" {
+			input.MetricName = aws.String(equalQuals["name"].GetStringValue())
+		}
+	}
+	if equalQuals["namespace"] != nil {
+		if equalQuals["namespace"].GetStringValue() != "" {
+			input.Namespace = aws.String(equalQuals["namespace"].GetStringValue())
+		}
+	}
+
+	if d.KeyColumnQualString("dimension_name") != "" && d.KeyColumnQualString("dimension_value") != "" {
+		dimensionFilter.Name = aws.String(equalQuals["dimension_name"].GetStringValue())
+		dimensionFilter.Value = aws.String(equalQuals["dimension_value"].GetStringValue())
+		dimensionFilters = append(dimensionFilters, &dimensionFilter)
+	}
+
+	if len(dimensionFilters) > 0 {
+		input.Dimensions = dimensionFilters
+	}
+
+	// List call
+	err = svc.ListMetricsPages(
+		input,
+		func(page *cloudwatch.ListMetricsOutput, isLast bool) bool {
+			for _, metric := range page.Metrics {
+				d.StreamListItem(ctx, metric)
+
+				// Context can be cancelled due to manual cancellation or the limit has been hit
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
+			}
+			return !isLast
+		},
+	)
+
+	return nil, err
+}

--- a/docs/tables/aws_cloudwatch_metric.md
+++ b/docs/tables/aws_cloudwatch_metric.md
@@ -10,7 +10,8 @@ Metrics are data about the performance of your systems. By default, many service
 select
   name,
   namespace,
-  dimensions
+  dimension_name,
+  dimension_value
 from
   aws_cloudwatch_metric;
 ```
@@ -21,7 +22,8 @@ from
 select
   name,
   namespace,
-  dimensions
+  dimension_name,
+  dimension_value
 from
   aws_cloudwatch_metric
 where
@@ -34,22 +36,20 @@ where
 select
   name,
   namespace,
-  dimensions
+  dimension_name,
+  dimension_value
 from
   aws_cloudwatch_metric
 where
   name = 'VolumeReadOps';
 ```
 
-### List metric based on single dimension name and dimension value
-
-**Note: We can not filter metric based on multiple dimension name and dimension value**
+### List metric based on dimension name and dimension value
 
 ```sql
 select
   name,
   namespace,
-  dimensions,
   dimension_name,
   dimension_value
 from

--- a/docs/tables/aws_cloudwatch_metric.md
+++ b/docs/tables/aws_cloudwatch_metric.md
@@ -16,7 +16,7 @@ from
   aws_cloudwatch_metric;
 ```
 
-### List metric by namespace
+### List metric by EBS namespace
 
 ```sql
 select
@@ -30,7 +30,7 @@ where
   namespace = 'AWS/EBS';
 ```
 
-### List metric by metric name
+### List metric details for metric name VolumeReadOps
 
 ```sql
 select
@@ -44,7 +44,7 @@ where
   name = 'VolumeReadOps';
 ```
 
-### List metric based on dimension name and dimension value
+### List metric for a redshift cluster
 
 ```sql
 select

--- a/docs/tables/aws_cloudwatch_metric.md
+++ b/docs/tables/aws_cloudwatch_metric.md
@@ -1,0 +1,59 @@
+# Table: aws_cloudwatch_metric
+
+Metrics are data about the performance of your systems. By default, many services provide free metrics for resources (such as Amazon EC2 instances, Amazon EBS volumes, and Amazon RDS DB instances).
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  namespace,
+  dimensions
+from
+  aws_cloudwatch_metric;
+```
+
+### List metric by namespace
+
+```sql
+select
+  name,
+  namespace,
+  dimensions
+from
+  aws_cloudwatch_metric
+where
+  namespace = 'AWS/EBS';
+```
+
+### List metric by metric name
+
+```sql
+select
+  name,
+  namespace,
+  dimensions
+from
+  aws_cloudwatch_metric
+where
+  name = 'VolumeReadOps';
+```
+
+### List metric based on single dimension name and dimension value
+
+**Note: We can not filter metric based on multiple dimension name and dimension value**
+
+```sql
+select
+  name,
+  namespace,
+  dimensions,
+  dimension_name,
+  dimension_value
+from
+  aws_cloudwatch_metric
+where
+  dimension_name = 'ClusterIdentifier' and dimension_value = 'redshift-cluster-1';
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  namespace,
  dimensions
from
  aws_cloudwatch_metric
where
  namespace = 'AWS/EBS' limit 5;
+-------------------+-----------+-------------------------------------------------------+
| name              | namespace | dimensions                                            |
+-------------------+-----------+-------------------------------------------------------+
| VolumeQueueLength | AWS/EBS   | [{"Name":"VolumeId","Value":"vol-0e93726d7a5ef5954"}] |
| VolumeReadOps     | AWS/EBS   | [{"Name":"VolumeId","Value":"vol-0e93726d7a5ef5954"}] |
| VolumeReadBytes   | AWS/EBS   | [{"Name":"VolumeId","Value":"vol-0e93726d7a5ef5954"}] |
| VolumeWriteOps    | AWS/EBS   | [{"Name":"VolumeId","Value":"vol-0e93726d7a5ef5954"}] |
| VolumeIdleTime    | AWS/EBS   | [{"Name":"VolumeId","Value":"vol-0e93726d7a5ef5954"}] |
+-------------------+-----------+-------------------------------------------------------+
```

```
> select
  name,
  namespace,
  dimension_name, 
  dimension_value
from
  aws_cloudwatch_metric
where
  namespace = 'AWS/EBS' limit 5;
+-------------------+-----------+----------------+-----------------------+
| name              | namespace | dimension_name | dimension_value       |
+-------------------+-----------+----------------+-----------------------+
| VolumeWriteOps    | AWS/EBS   | VolumeId       | vol-0e93726d7a5ef5954 |
| VolumeIdleTime    | AWS/EBS   | VolumeId       | vol-0e93726d7a5ef5954 |
| VolumeReadOps     | AWS/EBS   | VolumeId       | vol-0e93726d7a5ef5954 |
| VolumeReadBytes   | AWS/EBS   | VolumeId       | vol-0e93726d7a5ef5954 |
| VolumeQueueLength | AWS/EBS   | VolumeId       | vol-0e93726d7a5ef5954 |
+-------------------+-----------+----------------+-----------------------+
```

```
>  select
  name,
  namespace,
  dimension_name,
  dimension_value
from
  aws_cloudwatch_metric
where
  dimension_name = 'ClusterIdentifier' and dimension_value = 'redshift-cluster-1' limit 5 ;
+-------------------------+--------------+-------------------+--------------------+
| name                    | namespace    | dimension_name    | dimension_value    |
+-------------------------+--------------+-------------------+--------------------+
| NumExceededSchemaQuotas | AWS/Redshift | ClusterIdentifier | redshift-cluster-1 |
| QueryDuration           | AWS/Redshift | ClusterIdentifier | redshift-cluster-1 |
+-------------------------+--------------+-------------------+--------------------+
```

</details>
