### PR TITLE
Fix aws_codecommit_repository table list call failing for regions with more than 25 repos due to API limitations. Fixes #891

### DIFF
--- a/aws/table_aws_codecommit_repository.go
+++ b/aws/table_aws_codecommit_repository.go
@@ -116,22 +116,39 @@ func listCodeCommitRepositories(ctx context.Context, d *plugin.QueryData, _ *plu
 		return nil, err
 	}
 
-	// Build params
-	params := &codecommit.BatchGetRepositoriesInput{
-		RepositoryNames: repositoryNames,
-	}
+	passedRepositoryNames := 0
+	nameLeft := true
+	for nameLeft {
+		// BatchGetRepositories api can take maximum 25 number of repository name at a time.
+		var names []*string
+		if len(repositoryNames) > passedRepositoryNames {
+			if (len(repositoryNames) - passedRepositoryNames) >= 25 {
+				names = repositoryNames[passedRepositoryNames : passedRepositoryNames+25]
+				passedRepositoryNames += 25
+			} else {
+				names = repositoryNames[passedRepositoryNames:]
+				passedRepositoryNames = len(repositoryNames)
+				nameLeft = false
+			}
+		}
 
-	// Get details for all available repositories
-	result, err := svc.BatchGetRepositories(params)
-	if err != nil {
-		return nil, err
-	}
-	for _, repository := range result.Repositories {
-		d.StreamListItem(ctx, repository)
+		// Build params
+		params := &codecommit.BatchGetRepositoriesInput{
+			RepositoryNames: names,
+		}
 
-		// Context can be cancelled due to manual cancellation or the limit has been hit
-		if d.QueryStatus.RowsRemaining(ctx) == 0 {
-			return nil, nil
+		// Get details for all available repositories
+		result, err := svc.BatchGetRepositories(params)
+		if err != nil {
+			return nil, err
+		}
+		for _, repository := range result.Repositories {
+			d.StreamListItem(ctx, repository)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
 		}
 	}
 

--- a/aws/table_aws_codecommit_repository.go
+++ b/aws/table_aws_codecommit_repository.go
@@ -127,7 +127,6 @@ func listCodeCommitRepositories(ctx context.Context, d *plugin.QueryData, _ *plu
 				passedRepositoryNames += 25
 			} else {
 				names = repositoryNames[passedRepositoryNames:]
-				passedRepositoryNames = len(repositoryNames)
 				nameLeft = false
 			}
 		}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_codecommit_repository []

PRETEST: tests/aws_codecommit_repository

TEST: tests/aws_codecommit_repository
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_codecommit_repository.named_test_resource: Creating...
aws_codecommit_repository.named_test_resource: Creation complete after 4s [id=turbottest53880]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = arn:aws:codecommit:us-east-1:632902152528:turbottest53880
resource_id = 492250fe-1464-4612-906a-5414ac49ea6a
resource_name = turbottest53880

Running SQL query: test-hydrate-query.sql
[
  {
    "repository_name": "turbottest53880",
    "tags": {
      "name": "turbottest53880"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:codecommit:us-east-1:632902152528:turbottest53880",
    "description": "This is the Sample App Repository",
    "repository_id": "492250fe-1464-4612-906a-5414ac49ea6a",
    "repository_name": "turbottest53880"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:codecommit:us-east-1:632902152528:turbottest53880"
    ],
    "title": "turbottest53880"
  }
]
✔ PASSED

POSTTEST: tests/aws_codecommit_repository

TEARDOWN: tests/aws_codecommit_repository

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_codecommit_repository;
+-----------------+--------------------------------------+---------------------------------------------------+-------------+---------------------------+--------------------------------------------------
| repository_name | repository_id                        | arn                                               | description | creation_date             | clone_url_http                                   
+-----------------+--------------------------------------+---------------------------------------------------+-------------+---------------------------+--------------------------------------------------
| test26          | 4ec71e06-ff79-4de2-b102-9ccd9bfdc043 | arn:aws:codecommit:ap-south-1:632902152528:test26 | test26      | 2022-02-10T12:11:37+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test3           | 95b7c81b-3b64-46c3-812c-7b7fb708322a | arn:aws:codecommit:ap-south-1:632902152528:test3  | test3       | 2022-02-10T12:06:07+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test22          | f4bba8a0-cee7-499d-b102-32e9a205c6d6 | arn:aws:codecommit:ap-south-1:632902152528:test22 | test22      | 2022-02-10T12:10:53+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test28          | deec6ba4-d83d-46a8-bb34-984090a851e6 | arn:aws:codecommit:ap-south-1:632902152528:test28 | test28      | 2022-02-10T12:11:59+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test12          | 9a0968e0-944c-4a42-94f8-d80f65787085 | arn:aws:codecommit:ap-south-1:632902152528:test12 | test12      | 2022-02-10T12:09:06+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test16          | eeea3d61-b0e7-488b-a929-edde86faacf8 | arn:aws:codecommit:ap-south-1:632902152528:test16 | test16      | 2022-02-10T12:09:51+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test23          | 963dddff-0b04-4349-b76d-2ef3ee4ce964 | arn:aws:codecommit:ap-south-1:632902152528:test23 | test23      | 2022-02-10T12:11:04+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test6           | ed99f7d0-f6eb-49ac-98af-38fc8770569d | arn:aws:codecommit:ap-south-1:632902152528:test6  | test6       | 2022-02-10T12:06:48+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test21          | ef48690a-2d4c-4a31-ac8f-68b311dfe011 | arn:aws:codecommit:ap-south-1:632902152528:test21 | test21      | 2022-02-10T12:10:43+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test10          | 23ac3f19-a0ca-4233-be1d-eb8af1094087 | arn:aws:codecommit:ap-south-1:632902152528:test10 | test10      | 2022-02-10T12:08:41+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test7           | b7e75fd5-7705-4131-b601-68db3e57a0a3 | arn:aws:codecommit:ap-south-1:632902152528:test7  | test7       | 2022-02-10T12:07:09+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test9           | a47a39d9-8ecc-4a12-86ac-11169b006125 | arn:aws:codecommit:ap-south-1:632902152528:test9  | test9       | 2022-02-10T12:07:31+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test24          | 027bfe26-5d6a-416a-8d86-3c58c794ffa8 | arn:aws:codecommit:ap-south-1:632902152528:test24 | test24      | 2022-02-10T12:11:15+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test13          | 11eda08e-d6c8-4025-893f-12ada2fb4351 | arn:aws:codecommit:ap-south-1:632902152528:test13 | test13      | 2022-02-10T12:09:16+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test8           | b5bef82b-7f42-42f8-b3b9-77fe5d11fc15 | arn:aws:codecommit:ap-south-1:632902152528:test8  | test8       | 2022-02-10T12:07:19+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test20          | 0384994d-5ab4-4c0a-8dfe-5e85bc91b112 | arn:aws:codecommit:ap-south-1:632902152528:test20 | test20      | 2022-02-10T12:10:34+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test17          | 84f20fc5-f5e6-4e4c-b3ad-a1b6320ca656 | arn:aws:codecommit:ap-south-1:632902152528:test17 | test17      | 2022-02-10T12:10:01+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test18          | 8a3fb6d7-d241-4048-a4c3-af47c38dd1ea | arn:aws:codecommit:ap-south-1:632902152528:test18 | test18      | 2022-02-10T12:10:10+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test4           | 630f2f84-845d-4916-b8a9-8f3fd337a6be | arn:aws:codecommit:ap-south-1:632902152528:test4  | test4       | 2022-02-10T12:06:18+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test14          | 88c1d259-2186-40f9-b529-9ece07674abb | arn:aws:codecommit:ap-south-1:632902152528:test14 | test14      | 2022-02-10T12:09:25+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test1           | 4a19732b-3fde-4304-8b02-c65b5e1db74a | arn:aws:codecommit:ap-south-1:632902152528:test1  | test1       | 2022-02-10T12:05:46+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test2           | 7c55df81-aa8c-40ff-9cc5-9e56c0685807 | arn:aws:codecommit:ap-south-1:632902152528:test2  | test2       | 2022-02-10T12:05:56+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test19          | 415cc82f-117d-4f5c-a4a7-bf12175b5440 | arn:aws:codecommit:ap-south-1:632902152528:test19 | test19      | 2022-02-10T12:10:20+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test27          | 275963e3-25b6-49cf-8c31-7de5fed798b3 | arn:aws:codecommit:ap-south-1:632902152528:test27 | test27      | 2022-02-10T12:11:50+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test15          | 3d9dcd55-d706-45d8-9ec9-312f9035f698 | arn:aws:codecommit:ap-south-1:632902152528:test15 | test15      | 2022-02-10T12:09:39+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test25          | ba1064e6-6299-4944-931f-d68bf50615a4 | arn:aws:codecommit:ap-south-1:632902152528:test25 | test25      | 2022-02-10T12:11:26+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test11          | e23fb450-f594-411e-b98a-d0737691b0ea | arn:aws:codecommit:ap-south-1:632902152528:test11 | test11      | 2022-02-10T12:08:54+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
| test5           | 94e5c6f7-9297-42e4-bfcf-dc54964fb375 | arn:aws:codecommit:ap-south-1:632902152528:test5  | test5       | 2022-02-10T12:06:33+05:30 | https://git-codecommit.ap-south-1.amazonaws.com/v
+-----------------+--------------------------------------+---------------------------------------------------+-------------+---------------------------+--------------------------------------------------
> select count(*) from aws_codecommit_repository
+-------+
| count |
+-------+
| 28    |
+-------+

```
</details>
