### PR TITLE
Add missing limit, context cancel logic in tables closes #895

### DIFF
--- a/aws/cloudwatch_metric.go
+++ b/aws/cloudwatch_metric.go
@@ -188,6 +188,10 @@ func listCWMetricStatistics(ctx context.Context, d *plugin.QueryData, granularit
 			Sum:            datapoint.Sum,
 			Unit:           datapoint.Unit,
 		})
+
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 
 	return nil, nil

--- a/aws/cost_explorer.go
+++ b/aws/cost_explorer.go
@@ -148,6 +148,10 @@ func streamCostAndUsage(ctx context.Context, d *plugin.QueryData, params *costex
 		// stream the results...
 		for _, row := range buildCEMetricRows(ctx, output, d.KeyColumnQuals) {
 			d.StreamListItem(ctx, row)
+
+			if d.QueryStatus.RowsRemaining(ctx) == 0{
+				return nil, nil
+			}
 		}
 
 		// get more pages if there are any...

--- a/aws/table_aws_api_gateway_api_authorizer.go
+++ b/aws/table_aws_api_gateway_api_authorizer.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/apigateway"
+	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/plugin/transform"
@@ -116,7 +117,20 @@ func listRestAPIAuthorizers(ctx context.Context, d *plugin.QueryData, h *plugin.
 	}
 
 	params := &apigateway.GetAuthorizersInput{
+		Limit:     aws.Int64(500),
 		RestApiId: restAPI.Id,
+	}
+
+	// Limiting the results
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *params.Limit {
+			if *limit < 1 {
+				params.Limit = types.Int64(1)
+			} else {
+				params.Limit = limit
+			}
+		}
 	}
 
 	op, err := svc.GetAuthorizers(params)

--- a/aws/table_aws_api_gatewayv2_stage.go
+++ b/aws/table_aws_api_gatewayv2_stage.go
@@ -186,6 +186,11 @@ func listAPIGatewayV2Stages(ctx context.Context, d *plugin.QueryData, h *plugin.
 
 	for _, stage := range stages {
 		d.StreamLeafListItem(ctx, &v2StageRowData{stage, apiGatewayv2API.ApiId})
+
+		// Context can be cancelled due to manual cancellation or the limit has been hit
+		if d.QueryStatus.RowsRemaining(ctx) == 0{
+			return nil, nil
+		}
 	}
 
 	return nil, err

--- a/aws/table_aws_auditmanager_control.go
+++ b/aws/table_aws_auditmanager_control.go
@@ -144,7 +144,6 @@ func listAuditManagerControls(ctx context.Context, d *plugin.QueryData, _ *plugi
 	err = svc.ListControlsPages(
 		&auditmanager.ListControlsInput{
 			ControlType: aws.String("Standard"),
-			MaxResults: aws.Int64(1000),
 		},
 		func(page *auditmanager.ListControlsOutput, lastPage bool) bool {
 			for _, items := range page.ControlMetadataList {

--- a/aws/table_aws_auditmanager_control.go
+++ b/aws/table_aws_auditmanager_control.go
@@ -140,27 +140,12 @@ func listAuditManagerControls(ctx context.Context, d *plugin.QueryData, _ *plugi
 		return nil, err
 	}
 
-	input := &auditmanager.ListControlsInput{
-		ControlType: aws.String("Standard"),
-		MaxResults: aws.Int64(1000),
-	}
-
-	// If the requested number of items is less than the paging max limit
-	// set the limit to that instead
-	limit := d.QueryContext.Limit
-	if d.QueryContext.Limit != nil {
-		if *limit < *input.MaxResults {
-			if *limit < 1 {
-				input.MaxResults = aws.Int64(1)
-			} else {
-				input.MaxResults = limit
-			}
-		}
-	}
-
 	// List all standard controls
 	err = svc.ListControlsPages(
-		input,
+		&auditmanager.ListControlsInput{
+			ControlType: aws.String("Standard"),
+			MaxResults: aws.Int64(1000),
+		},
 		func(page *auditmanager.ListControlsOutput, lastPage bool) bool {
 			for _, items := range page.ControlMetadataList {
 				d.StreamListItem(ctx, items)

--- a/aws/table_aws_auditmanager_control.go
+++ b/aws/table_aws_auditmanager_control.go
@@ -140,14 +140,35 @@ func listAuditManagerControls(ctx context.Context, d *plugin.QueryData, _ *plugi
 		return nil, err
 	}
 
+	input := &auditmanager.ListControlsInput{
+		ControlType: aws.String("Standard"),
+		MaxResults: aws.Int64(1000),
+	}
+
+	// If the requested number of items is less than the paging max limit
+	// set the limit to that instead
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *input.MaxResults {
+			if *limit < 1 {
+				input.MaxResults = aws.Int64(1)
+			} else {
+				input.MaxResults = limit
+			}
+		}
+	}
+
 	// List all standard controls
 	err = svc.ListControlsPages(
-		&auditmanager.ListControlsInput{
-			ControlType: aws.String("Standard"),
-		},
+		input,
 		func(page *auditmanager.ListControlsOutput, lastPage bool) bool {
 			for _, items := range page.ControlMetadataList {
 				d.StreamListItem(ctx, items)
+
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !lastPage
 		},

--- a/aws/table_aws_auditmanager_framework.go
+++ b/aws/table_aws_auditmanager_framework.go
@@ -147,6 +147,11 @@ func listAuditManagerFrameworks(ctx context.Context, d *plugin.QueryData, _ *plu
 		func(page *auditmanager.ListAssessmentFrameworksOutput, lastPage bool) bool {
 			for _, framework := range page.FrameworkMetadataList {
 				d.StreamListItem(ctx, framework)
+
+				// Context can be cancelled due to manual cancellation or the limit has been hit
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !lastPage
 		},

--- a/aws/table_aws_backup_recovery_point.go
+++ b/aws/table_aws_backup_recovery_point.go
@@ -196,12 +196,12 @@ func listAwsBackupRecoveryPoints(ctx context.Context, d *plugin.QueryData, h *pl
 		input,
 		func(page *backup.ListRecoveryPointsByBackupVaultOutput, lastPage bool) bool {
 			for _, point := range page.RecoveryPoints {
+				d.StreamListItem(ctx, point)
 
 				// Context can be cancelled due to manual cancellation or the limit has been hit
 				if d.QueryStatus.RowsRemaining(ctx) == 0 {
 					return false
 				}
-				d.StreamListItem(ctx, point)
 			}
 			return !lastPage
 		},

--- a/aws/table_aws_backup_vault.go
+++ b/aws/table_aws_backup_vault.go
@@ -134,6 +134,11 @@ func listAwsBackupVaults(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 		func(page *backup.ListBackupVaultsOutput, lastPage bool) bool {
 			for _, vault := range page.BackupVaultList {
 				d.StreamListItem(ctx, vault)
+
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !lastPage
 		},

--- a/aws/table_aws_cloudfront_cache_policy.go
+++ b/aws/table_aws_cloudfront_cache_policy.go
@@ -140,6 +140,11 @@ func listCloudFrontCachePolicies(ctx context.Context, d *plugin.QueryData, _ *pl
 		}
 		for _, policy := range result.CachePolicyList.Items {
 			d.StreamListItem(ctx, policy)
+
+			// Context may get cancelled due to manual cancellation or if the limit has been reached
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
 		}
 		if result.CachePolicyList.NextMarker != nil {
 			input.Marker = result.CachePolicyList.NextMarker

--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -244,6 +244,11 @@ func listCloudtrailTrails(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 
 	for _, trail := range resp.TrailList {
 		d.StreamListItem(ctx, trail)
+
+		// Context may get cancelled due to manual cancellation or if the limit has been reached
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 
 	return nil, err

--- a/aws/table_aws_cloudtrail_trail_event.go
+++ b/aws/table_aws_cloudtrail_trail_event.go
@@ -290,6 +290,11 @@ func listCloudwatchLogTrailEvents(ctx context.Context, d *plugin.QueryData, _ *p
 		func(page *cloudwatchlogs.FilterLogEventsOutput, _ bool) bool {
 			for _, logEvent := range page.Events {
 				d.StreamListItem(ctx, logEvent)
+
+				// Context can be cancelled due to manual cancellation or the limit has been hit
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			// Abort if we've been cancelled, which probably means we've reached the requested limit
 			select {

--- a/aws/table_aws_cloudwatch_log_event.go
+++ b/aws/table_aws_cloudwatch_log_event.go
@@ -121,6 +121,11 @@ func listCloudwatchLogEvents(ctx context.Context, d *plugin.QueryData, _ *plugin
 		func(page *cloudwatchlogs.FilterLogEventsOutput, _ bool) bool {
 			for _, logEvent := range page.Events {
 				d.StreamListItem(ctx, logEvent)
+
+				// Context can be cancelled due to manual cancellation or the limit has been hit
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			// Abort if we've been cancelled, which probably means we've reached the requested limit
 			select {

--- a/aws/table_aws_cloudwatch_log_resource_policy.go
+++ b/aws/table_aws_cloudwatch_log_resource_policy.go
@@ -90,6 +90,11 @@ func listCloudwatchLogResourcePolicies(ctx context.Context, d *plugin.QueryData,
 		// Stream results
 		for _, policy := range resp.ResourcePolicies {
 			d.StreamListItem(ctx, policy)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
 		}
 
 		if resp.NextToken == nil {

--- a/aws/table_aws_config_conformance_pack.go
+++ b/aws/table_aws_config_conformance_pack.go
@@ -100,7 +100,18 @@ func listConfigConformancePacks(ctx context.Context, d *plugin.QueryData, _ *plu
 		return nil, err
 	}
 
-	input := &configservice.DescribeConformancePacksInput{}
+	input := &configservice.DescribeConformancePacksInput{
+		Limit: aws.Int64(20),
+	}
+
+	// If the requested number of items is less than the paging max limit
+	// set the limit to that instead
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *input.Limit {
+			input.Limit = limit
+		}
+	}
 
 	// Additonal Filter
 	equalQuals := d.KeyColumnQuals

--- a/aws/table_aws_directory_service_directory.go
+++ b/aws/table_aws_directory_service_directory.go
@@ -208,7 +208,18 @@ func listDirectoryServiceDirectories(ctx context.Context, d *plugin.QueryData, _
 	}
 
 	// Build the params
-	input := &directoryservice.DescribeDirectoriesInput{}
+	input := &directoryservice.DescribeDirectoriesInput{
+		Limit: aws.Int64(1000),
+	}
+
+	// If the requested number of items is less than the paging max limit
+	// set the limit to that instead
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < *input.Limit {
+			input.Limit = limit
+		}
+	}
 
 	// Additonal Filter
 	equalQuals := d.KeyColumnQuals

--- a/aws/table_aws_ec2_reserved_instance.go
+++ b/aws/table_aws_ec2_reserved_instance.go
@@ -26,7 +26,6 @@ func tableAwsEc2ReservedInstance(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listEc2ReservedInstances,
-
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "availability_zone", Require: plugin.Optional},
 				{Name: "duration", Require: plugin.Optional},

--- a/aws/table_aws_guardduty_finding.go
+++ b/aws/table_aws_guardduty_finding.go
@@ -193,6 +193,11 @@ func listGuardDutyFindings(ctx context.Context, d *plugin.QueryData, h *plugin.H
 
 		for _, finding := range result.Findings {
 			d.StreamListItem(ctx, FindingInfo{*finding, detectorId})
+
+			// Context may get cancelled due to manual cancellation or if the limit has been reached
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
 		}
 	}
 

--- a/aws/table_aws_iam_action.go
+++ b/aws/table_aws_iam_action.go
@@ -82,6 +82,11 @@ func listIamActions(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 				Prefix:      service.Prefix,
 				Privilege:   privilege.Privilege,
 			})
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
 		}
 	}
 	return nil, nil

--- a/aws/table_aws_kinesis_video_stream.go
+++ b/aws/table_aws_kinesis_video_stream.go
@@ -129,6 +129,11 @@ func listKinesisVideoStreams(ctx context.Context, d *plugin.QueryData, _ *plugin
 		func(page *kinesisvideo.ListStreamsOutput, isLast bool) bool {
 			for _, stream := range page.StreamInfoList {
 				d.StreamListItem(ctx, stream)
+
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !isLast
 		},

--- a/aws/table_aws_lambda_alias.go
+++ b/aws/table_aws_lambda_alias.go
@@ -156,6 +156,11 @@ func listLambdaAliases(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 		func(page *lambda.ListAliasesOutput, lastPage bool) bool {
 			for _, alias := range page.Aliases {
 				d.StreamLeafListItem(ctx, &aliasRowData{alias, function.FunctionName})
+
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !lastPage
 		},

--- a/aws/table_aws_lambda_function.go
+++ b/aws/table_aws_lambda_function.go
@@ -253,6 +253,11 @@ func listAwsLambdaFunctions(ctx context.Context, d *plugin.QueryData, _ *plugin.
 		func(page *lambda.ListFunctionsOutput, lastPage bool) bool {
 			for _, function := range page.Functions {
 				d.StreamListItem(ctx, function)
+
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !lastPage
 		},

--- a/aws/table_aws_serverlessapplicationrepository_application.go
+++ b/aws/table_aws_serverlessapplicationrepository_application.go
@@ -158,6 +158,11 @@ func listServerlessApplicationRepositoryApplications(ctx context.Context, d *plu
 		func(page *serverlessapplicationrepository.ListApplicationsOutput, lastPage bool) bool {
 			for _, application := range page.Applications {
 				d.StreamListItem(ctx, application)
+
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !lastPage
 		},

--- a/aws/table_aws_ssm_patch_baseline.go
+++ b/aws/table_aws_ssm_patch_baseline.go
@@ -214,6 +214,10 @@ func describePatchBaselines(ctx context.Context, d *plugin.QueryData, _ *plugin.
 				}
 				d.StreamListItem(ctx, rowData)
 
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !isLast
 		},

--- a/aws/table_aws_vpc_security_group_rule.go
+++ b/aws/table_aws_vpc_security_group_rule.go
@@ -247,6 +247,11 @@ func listSecurityGroupRules(ctx context.Context, d *plugin.QueryData, h *plugin.
 		func(page *ec2.DescribeSecurityGroupRulesOutput, isLast bool) bool {
 			for _, securityGroupRule := range page.SecurityGroupRules {
 				d.StreamListItem(ctx, securityGroupRule)
+
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
+				}
 			}
 			return !isLast
 		},


### PR DESCRIPTION
**Table affected by the changes**
- aws_api_gateway_api_authorizer
- aws_api_gatewayv2_stage
- aws_auditmanager_control
- aws_auditmanager_framework
- aws_backup_recovery_point
- aws_backup_vault
- aws_cloudfront_cache_policy
- aws_cloudtrail_trail
- aws_cloudtrail_trail_event
- aws_cloudwatch_log_event
- aws_cloudwatch_log_resource_policy
- aws_config_conformance_pack
- aws_directory_service_directory
- aws_ec2_reserved_instance
- aws_ecs_container_instance
- aws_ecs_service
- aws_guardduty_finding
- aws_iam_action
- aws_kinesis_video_stream
- aws_lambda_alias
- aws_lambda_function
- aws_serverlessapplicationrepository_application
- aws_ssm_patch_baseline
- aws_vpc_security_group_rule

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_backup_vault
+--------------------------------+------------------------------------------------------------------------------------+---------------------------+--------------------------------------------------+------
| name                           | arn                                                                                | creation_date             | creator_request_id                               | encry
+--------------------------------+------------------------------------------------------------------------------------+---------------------------+--------------------------------------------------+------
| Default                        | arn:aws:backup:us-east-1:632902152528:backup-vault:Default                         | 2021-10-26T12:28:12+05:30 | Default                                          | arn:a
| Default                        | arn:aws:backup:ap-south-1:632902152528:backup-vault:Default                        | 2021-05-27T16:11:00+05:30 | Default                                          | arn:a
| aws/efs/automatic-backup-vault | arn:aws:backup:us-east-1:632902152528:backup-vault:aws/efs/automatic-backup-vault  | 2022-01-10T18:50:39+05:30 | aws/efs/automatic-backup-632902152528-us-east-1  | arn:a
| aws/efs/automatic-backup-vault | arn:aws:backup:ap-south-1:632902152528:backup-vault:aws/efs/automatic-backup-vault | 2021-04-08T17:30:52+05:30 | aws/efs/automatic-backup-632902152528-ap-south-1 | arn:a
+--------------------------------+------------------------------------------------------------------------------------+---------------------------+--------------------------------------------------+------

> select * from aws_backup_vault limit 1
+---------+-------------------------------------------------------------+---------------------------+--------------------+------------------------------------------------------------------------------+---
| name    | arn                                                         | creation_date             | creator_request_id | encryption_key_arn                                                           | nu
+---------+-------------------------------------------------------------+---------------------------+--------------------+------------------------------------------------------------------------------+---
| Default | arn:aws:backup:ap-south-1:632902152528:backup-vault:Default | 2021-05-27T16:11:00+05:30 | Default            | arn:aws:kms:ap-south-1:632902152528:key/c5c6dbb8-d6d7-46e4-8b18-30cd70f22f5d | 0 
+---------+-------------------------------------------------------------+---------------------------+--------------------+------------------------------------------------------------------------------+---

> select * from aws_cloudfront_cache_policy
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
| name                                           | id                                   | comment                                       | default_ttl | etag           | max_ttl  | min_ttl | last_modified_
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
| Managed-Elemental-MediaPackage                 | 08627262-05a9-4f76-9ded-b50ca2e3a84f | Policy for Elemental MediaPackage Origin      | 86400       | E23ZP02F085DFQ | 31536000 | 0       | 1970-01-01T05:
| Managed-Amplify                                | 2e54312d-136d-493c-8eb9-b001f22f67d2 | Policy for Amplify Origin                     | 2           | E23ZP02F085DFQ | 600      | 2       | 1970-01-01T05:
| Managed-CachingOptimizedForUncompressedObjects | b2884449-e4de-46a7-ac36-70bc7f1ddd6d | Default policy when compression is disabled   | 86400       | E23ZP02F085DFQ | 31536000 | 1       | 1970-01-01T05:
| Managed-CachingDisabled                        | 4135ea2d-6df8-44a3-9df3-4b5a84be39ad | Policy with caching disabled                  | 0           | E23ZP02F085DFQ | 0        | 0       | 1970-01-01T05:
| Managed-CachingOptimized                       | 658327ea-f89d-4fab-a63d-7e88639e58f6 | Default policy when CF compression is enabled | 86400       | E23ZP02F085DFQ | 31536000 | 1       | 1970-01-01T05:
+------------------------------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------
> select * from aws_cloudfront_cache_policy limit 1
+--------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------------------+---------
| name                     | id                                   | comment                                       | default_ttl | etag           | max_ttl  | min_ttl | last_modified_time        | paramete
+--------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------------------+---------
| Managed-CachingOptimized | 658327ea-f89d-4fab-a63d-7e88639e58f6 | Default policy when CF compression is enabled | 86400       | E23ZP02F085DFQ | 31536000 | 1       | 1970-01-01T05:30:00+05:30 | {"Cookie
+--------------------------+--------------------------------------+-----------------------------------------------+-------------+----------------+----------+---------+---------------------------+---------

> select * from aws_cloudtrail_trail
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+-----------
| name                                | arn                                                                                 | home_region | is_multi_region_trail | log_file_validation_enabled | is_logging
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+-----------
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | true      
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+-----------
> select * from aws_cloudtrail_trail limit 2
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+-----------
| name                                | arn                                                                                 | home_region | is_multi_region_trail | log_file_validation_enabled | is_logging
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+-----------
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
| turbot-632902152528-us-east-1-trail | arn:aws:cloudtrail:us-east-1:632902152528:trail/turbot-632902152528-us-east-1-trail | us-east-1   | true                  | true                        | <null>    
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+-----------

```
</details>
