### PR TITLE
Fix the integration tests issues

### DIFF
--- a/aws-test/tests/aws_auditmanager_assessment/variables.tf
+++ b/aws-test/tests/aws_auditmanager_assessment/variables.tf
@@ -50,7 +50,6 @@ data "null_data_source" "resource" {
 // Create S3 bucket to store assessment reports
 resource "aws_s3_bucket" "named_test_resource" {
   bucket        = var.resource_name
-  acl           = "private"
   force_destroy = true
 }
 

--- a/aws-test/tests/aws_cloudfront_distribution/variables.tf
+++ b/aws-test/tests/aws_cloudfront_distribution/variables.tf
@@ -48,7 +48,6 @@ data "null_data_source" "resource" {
 
 resource "aws_s3_bucket" "test_bucket" {
   bucket = var.resource_name
-  acl    = "private"
   force_destroy = true
 }
 

--- a/aws-test/tests/aws_codebuild_project/variables.tf
+++ b/aws-test/tests/aws_codebuild_project/variables.tf
@@ -63,7 +63,6 @@ resource "aws_subnet" "my_subnet2" {
 
 resource "aws_s3_bucket" "test_bucket" {
   bucket        = var.resource_name
-  acl           = "private"
   force_destroy = true
 }
 

--- a/aws-test/tests/aws_codepipeline_pipeline/vatiable.tf
+++ b/aws-test/tests/aws_codepipeline_pipeline/vatiable.tf
@@ -126,8 +126,7 @@ resource "aws_codestarconnections_connection" "example" {
 }
 
 resource "aws_s3_bucket" "codepipeline_bucket" {
-  bucket = var.resource_name
-  acl    = "private"
+  bucket = var.resource_name  
 }
 
 resource "aws_iam_role" "codepipeline_role" {

--- a/aws-test/tests/aws_dax_cluster/variables.tf
+++ b/aws-test/tests/aws_dax_cluster/variables.tf
@@ -71,11 +71,13 @@ resource "aws_vpc" "my_vpc" {
 
 resource "aws_subnet" "my_subnet1" {
   cidr_block = "10.1.1.0/24"
+  availability_zone = "${var.aws_region}a"
   vpc_id     = aws_vpc.my_vpc.id
 }
 
 resource "aws_subnet" "my_subnet2" {
   cidr_block = "10.1.2.0/24"
+  availability_zone = "${var.aws_region}b"
   vpc_id     = aws_vpc.my_vpc.id
 }
 

--- a/aws-test/tests/aws_directory_service_directory/variables.tf
+++ b/aws-test/tests/aws_directory_service_directory/variables.tf
@@ -71,11 +71,13 @@ resource "aws_vpc" "my_vpc" {
 
 resource "aws_subnet" "my_subnet1" {
   cidr_block = "10.1.1.0/24"
+  availability_zone = "${var.aws_region}a"
   vpc_id     = aws_vpc.my_vpc.id
 }
 
 resource "aws_subnet" "my_subnet2" {
   cidr_block = "10.1.2.0/24"
+  availability_zone = "${var.aws_region}b"
   vpc_id     = aws_vpc.my_vpc.id
 }
 

--- a/aws-test/tests/aws_dms_replication_instance/test-get-expected.json
+++ b/aws-test/tests/aws_dms_replication_instance/test-get-expected.json
@@ -23,6 +23,7 @@
     "tags_src": [
       {
         "Key": "foo",
+        "ResourceArn": null,
         "Value": "bar"
       }
     ],

--- a/aws-test/tests/aws_dms_replication_instance/test-hydrate-expected.json
+++ b/aws-test/tests/aws_dms_replication_instance/test-hydrate-expected.json
@@ -9,6 +9,7 @@
     "tags_src": [
       {
         "Key": "foo",
+        "ResourceArn": null,
         "Value": "bar"
       }
     ],

--- a/aws-test/tests/aws_ec2_ami/test-hydrate-expected.json
+++ b/aws-test/tests/aws_ec2_ami/test-hydrate-expected.json
@@ -7,10 +7,14 @@
     "launch_permissions": [
       {
         "Group":null,
+        "OrganizationArn": null,
+        "OrganizationalUnitArn": null,
         "UserId":"388460667113"
       },
       {
         "Group":null,
+        "OrganizationArn": null,
+        "OrganizationalUnitArn": null,
         "UserId":"013122550996"
       }
     ],

--- a/aws-test/tests/aws_ecs_cluster/test-list-expected.json
+++ b/aws-test/tests/aws_ecs_cluster/test-list-expected.json
@@ -10,12 +10,7 @@
     "pending_tasks_count": 0,
     "registered_container_instances_count": 0,
     "running_tasks_count": 0,
-    "settings": [
-      {
-        "Name": "containerInsights",
-        "Value": "disabled"
-      }
-    ],
+    "settings": [],
     "statistics": [],
     "status": "ACTIVE"
   }

--- a/aws-test/tests/aws_emr_instance_group/variables.tf
+++ b/aws-test/tests/aws_emr_instance_group/variables.tf
@@ -154,7 +154,7 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "emr_profile" {
-  name = "var.resource_name"
+  name = "${var.resource_name}"
   role = aws_iam_role.iam_emr_profile_role.name
 }
 
@@ -233,7 +233,7 @@ resource "aws_main_route_table_association" "test_association" {
 }
 
 resource "aws_key_pair" "deployer" {
-  key_name   = "deployer-key"
+  key_name   = "${var.resource_name}"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC6B60dQX19dOO0wmNnPf27NJBXQhuVAsFcshY7YqTmNA1dfl0lXvJFSF0nVTvaxtE2854gmvygm/yafopG33zJeH+k2ZrblivkEuH0NNajKMp2mBumkk8RiTVvU1ET4m6Z1jZaK0dTSeV2k6gUk7Wmvo4+6RIu+wdAtwGGGcSq4HJ4M0G1CGHruBywMdOs5CklqRn7BRMh2aexowDachlabUKRFwTf7OCjDcoCWHo+o4kHV7NDEdhFzrE2fxXttt054kd5CMZOEOB9p01pAqSPrxFv3S/BpiXuhmjwsUsIdfHIgFrFhNY/M4+KhTa3pI69NqsigReotTEzk2QwHyHSjsRwfzeJNRgI8iqGIdYr3+t6zCKswyzgV0hqalZhXtpVUEBbumJAKWy+VzTnOXUQ5zEVvabTxi3dsW9zMGofjwhiC75x97RE7U/ZEanRM+0Avr8e3c3ob4NLf9JOwbvB/jYvS6j/nuwJ5H6igT3Oj0oDiknh2WtOgH/BKKaCq5Nyl15Df65i0PNgKRcLy+x0fubYUtsCOMPpQTfztSYGjbvAhAOrH2LJF0i2dTD3PcVw6R6uDpJSw9QkzdD+2ofxnqjGPUeKR3mraGOXt2hZe9F9bvvdZScDfdAoyBUYTO2/sxsQFobRtdiEk2up+mNIx9QXMXO2dOgtNUYZKc1DdQ== clara@turbot.com"
 }
 

--- a/aws-test/tests/aws_emr_instance_group/variables.tf
+++ b/aws-test/tests/aws_emr_instance_group/variables.tf
@@ -154,7 +154,7 @@ EOF
 }
 
 resource "aws_iam_instance_profile" "emr_profile" {
-  name = "${var.resource_name}"
+  name = "var.resource_name"
   role = aws_iam_role.iam_emr_profile_role.name
 }
 
@@ -233,7 +233,7 @@ resource "aws_main_route_table_association" "test_association" {
 }
 
 resource "aws_key_pair" "deployer" {
-  key_name   = "${var.resource_name}"
+  key_name   = "deployer-key"
   public_key = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAACAQC6B60dQX19dOO0wmNnPf27NJBXQhuVAsFcshY7YqTmNA1dfl0lXvJFSF0nVTvaxtE2854gmvygm/yafopG33zJeH+k2ZrblivkEuH0NNajKMp2mBumkk8RiTVvU1ET4m6Z1jZaK0dTSeV2k6gUk7Wmvo4+6RIu+wdAtwGGGcSq4HJ4M0G1CGHruBywMdOs5CklqRn7BRMh2aexowDachlabUKRFwTf7OCjDcoCWHo+o4kHV7NDEdhFzrE2fxXttt054kd5CMZOEOB9p01pAqSPrxFv3S/BpiXuhmjwsUsIdfHIgFrFhNY/M4+KhTa3pI69NqsigReotTEzk2QwHyHSjsRwfzeJNRgI8iqGIdYr3+t6zCKswyzgV0hqalZhXtpVUEBbumJAKWy+VzTnOXUQ5zEVvabTxi3dsW9zMGofjwhiC75x97RE7U/ZEanRM+0Avr8e3c3ob4NLf9JOwbvB/jYvS6j/nuwJ5H6igT3Oj0oDiknh2WtOgH/BKKaCq5Nyl15Df65i0PNgKRcLy+x0fubYUtsCOMPpQTfztSYGjbvAhAOrH2LJF0i2dTD3PcVw6R6uDpJSw9QkzdD+2ofxnqjGPUeKR3mraGOXt2hZe9F9bvvdZScDfdAoyBUYTO2/sxsQFobRtdiEk2up+mNIx9QXMXO2dOgtNUYZKc1DdQ== clara@turbot.com"
 }
 

--- a/aws-test/tests/aws_iam_access_advisor/test-list-expected.json
+++ b/aws-test/tests/aws_iam_access_advisor/test-list-expected.json
@@ -1,7 +1,6 @@
 [
 	{
 		"last_authenticated_entity": "{{ output.user_arn.value }}",
-		"last_authenticated_region": "{{ output.aws_region.value }}",
 		"partition": "{{ output.aws_partition.value }}",
 		"principal_arn": "{{ output.user_arn.value }}",
 		"region": "global",

--- a/aws-test/tests/aws_iam_access_advisor/test-list-query.sql
+++ b/aws-test/tests/aws_iam_access_advisor/test-list-query.sql
@@ -4,7 +4,6 @@ select
   service_namespace,
   last_authenticated_entity,
   partition,
-  region,
-  last_authenticated_region
+  region
 from aws.aws_iam_access_advisor
 where principal_arn = '{{ output.user_arn.value }}' and service_namespace = 'sts';

--- a/aws-test/tests/aws_kinesis_firehose_delivery_stream/variables.tf
+++ b/aws-test/tests/aws_kinesis_firehose_delivery_stream/variables.tf
@@ -48,7 +48,6 @@ data "null_data_source" "resource" {
 
 resource "aws_s3_bucket" "firehose_bucket" {
   bucket = var.resource_name
-  acl    = "private"
 }
 
 resource "aws_iam_role" "firehose_role" {

--- a/aws-test/tests/aws_macie2_classification_job/variables.tf
+++ b/aws-test/tests/aws_macie2_classification_job/variables.tf
@@ -47,8 +47,7 @@ data "null_data_source" "resource" {
 }
 
 resource "aws_s3_bucket" "test" {
-  bucket = var.resource_name
-  acl    = "private"
+  bucket = var.resource_name  
 }
 
 resource "aws_macie2_account" "test" {

--- a/aws-test/tests/aws_rds_db_instance/test-get-expected.json
+++ b/aws-test/tests/aws_rds_db_instance/test-get-expected.json
@@ -11,7 +11,7 @@
     "deletion_protection": false,
     "endpoint_port": 3306,
     "engine": "mysql",
-    "engine_version": "8.0.23",
+    "engine_version": "8.0.27",
     "iam_database_authentication_enabled": false,
     "master_user_name": "master",
     "multi_az": false,

--- a/aws-test/tests/aws_rds_db_instance/test-hydrate-expected.json
+++ b/aws-test/tests/aws_rds_db_instance/test-hydrate-expected.json
@@ -11,7 +11,7 @@
     "deletion_protection": false,
     "endpoint_port": 3306,
     "engine": "mysql",
-    "engine_version": "8.0.23",
+    "engine_version": "8.0.27",
     "iam_database_authentication_enabled": false,
     "master_user_name": "master",
     "multi_az": false,

--- a/aws-test/tests/aws_s3_bucket/variables.tf
+++ b/aws-test/tests/aws_s3_bucket/variables.tf
@@ -107,15 +107,6 @@ resource "aws_s3_bucket" "named_test_resource" {
     }
   }
 
-  server_side_encryption_configuration {
-    rule {
-      apply_server_side_encryption_by_default {
-        kms_master_key_id = aws_kms_key.mykey.arn
-        sse_algorithm     = "aws:kms"
-      }
-    }
-  }
-
   grant {
     id          = data.aws_canonical_user_id.current_user.id
     type        = "CanonicalUser"

--- a/aws-test/tests/aws_wafv2_web_acl/variables.tf
+++ b/aws-test/tests/aws_wafv2_web_acl/variables.tf
@@ -98,7 +98,6 @@ resource "aws_wafv2_web_acl" "named_test_resource" {
 
 resource "aws_s3_bucket" "firehose_bucket" {
   bucket = var.resource_name
-  acl    = "private"
 }
 
 resource "aws_iam_role" "firehose_role" {

--- a/aws/table_aws_ec2_load_balancer_listener.go
+++ b/aws/table_aws_ec2_load_balancer_listener.go
@@ -20,7 +20,7 @@ func tableAwsEc2ApplicationLoadBalancerListener(_ context.Context) *plugin.Table
 		Description: "AWS EC2 Load Balancer Listener",
 		Get: &plugin.GetConfig{
 			KeyColumns:        plugin.SingleColumn("arn"),
-			ShouldIgnoreError: isNotFoundError([]string{"ListenerNotFound", "LoadBalancerNotFound"}),
+			ShouldIgnoreError: isNotFoundError([]string{"ListenerNotFound", "LoadBalancerNotFound", "ValidationError"}),
 			Hydrate:           getEc2LoadBalancerListener,
 		},
 		List: &plugin.ListConfig{

--- a/aws/table_aws_ec2_network_load_balancer.go
+++ b/aws/table_aws_ec2_network_load_balancer.go
@@ -20,12 +20,12 @@ func tableAwsEc2NetworkLoadBalancer(_ context.Context) *plugin.Table {
 		Description: "AWS EC2 Network Load Balancer",
 		Get: &plugin.GetConfig{
 			KeyColumns:        plugin.SingleColumn("arn"),
-			ShouldIgnoreError: isNotFoundError([]string{"LoadBalancerNotFound"}),
+			ShouldIgnoreError: isNotFoundError([]string{"LoadBalancerNotFound", "ValidationError"}),
 			Hydrate:           getEc2NetworkLoadBalancer,
 		},
 		List: &plugin.ListConfig{
 			Hydrate:           listEc2NetworkLoadBalancers,
-			ShouldIgnoreError: isNotFoundError([]string{"LoadBalancerNotFound"}),
+			ShouldIgnoreError: isNotFoundError([]string{"LoadBalancerNotFound", "ValidationError"}),
 			KeyColumns: []*plugin.KeyColumn{
 				{
 					Name:    "name",


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_gateway_load_balancer []

PRETEST: tests/aws_ec2_gateway_load_balancer

TEST: tests/aws_ec2_gateway_load_balancer
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Creation complete after 4s [id=vpc-0dbf1458d5e0f5be7]
aws_internet_gateway.igw: Creating...
aws_internet_gateway.igw: Creation complete after 1s [id=igw-059a5736a4f764871]
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet1: Creation complete after 2s [id=subnet-08269196f2de3e09a]
aws_subnet.my_subnet2: Creation complete after 2s [id=subnet-0f27ae64123e0991f]
aws_lb.named_test_resource: Creating...
aws_lb.named_test_resource: Still creating... [10s elapsed]
aws_lb.named_test_resource: Still creating... [20s elapsed]
aws_lb.named_test_resource: Still creating... [30s elapsed]
aws_lb.named_test_resource: Still creating... [40s elapsed]
aws_lb.named_test_resource: Still creating... [50s elapsed]
aws_lb.named_test_resource: Still creating... [1m0s elapsed]
aws_lb.named_test_resource: Creation complete after 1m4s [id=arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/gwy/turbottest55939/6c1529102111f672]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = 632902152528
aws_partition = aws
region_name = us-east-1
resource_aka = arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/gwy/turbottest55939/6c1529102111f672
resource_id = arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/gwy/turbottest55939/6c1529102111f672
resource_name = turbottest55939
vpc_id = vpc-0dbf1458d5e0f5be7

Running SQL query: test-get-query.sql
[
  {
    "account_id": "632902152528",
    "arn": "arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/gwy/turbottest55939/6c1529102111f672",
    "name": "turbottest55939",
    "region": "us-east-1",
    "state_code": "active",
    "type": "gateway",
    "vpc_id": "vpc-0dbf1458d5e0f5be7"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/gwy/turbottest55939/6c1529102111f672",
    "load_balancer_attributes": [
      {
        "Key": "deletion_protection.enabled",
        "Value": "false"
      },
      {
        "Key": "load_balancing.cross_zone.enabled",
        "Value": "false"
      }
    ],
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest55939"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/gwy/turbottest55939/6c1529102111f672",
    "name": "turbottest55939"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/gwy/turbottest55939/6c1529102111f672"
    ],
    "tags": {
      "name": "turbottest55939"
    },
    "title": "turbottest55939"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_gateway_load_balancer

TEARDOWN: tests/aws_ec2_gateway_load_balancer


Error: Unrecognized remote plugin message: 

This usually means that the plugin is either invalid or simply
needs to be recompiled to support the latest protocol.


SUMMARY:

1/1 passed.


================================================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_directory_service_directory []

PRETEST: tests/aws_directory_service_directory

TEST: tests/aws_directory_service_directory
Running terraform
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_region.alternate: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_iam_role.my_role: Creating...
aws_vpc.my_vpc: Creating...
aws_iam_role.my_role: Creation complete after 2s [id=turbottest96535]
aws_vpc.my_vpc: Creation complete after 3s [id=vpc-004ff71758f5fbfc3]
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet1: Creation complete after 2s [id=subnet-0086d518871013a6b]
aws_subnet.my_subnet2: Creation complete after 2s [id=subnet-0d48aa481f6934c87]
aws_directory_service_directory.named_test_resource: Creating...
aws_directory_service_directory.named_test_resource: Still creating... [10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m10s elapsed]
aws_directory_service_directory.named_test_resource: Creation complete after 6m17s [id=d-90675e6551]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = 632902152528
aws_partition = aws
aws_region = us-east-1
resource_aka = arn:aws:ds:us-east-1:632902152528:directory/d-90675e6551
resource_id = d-90675e6551
resource_name = turbottest96535

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:ds:us-east-1:632902152528:directory/d-90675e6551",
    "directory_id": "d-90675e6551",
    "name": "turbottest96535.com"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ds:us-east-1:632902152528:directory/d-90675e6551"
    ],
    "name": "turbottest96535.com",
    "tags": {
      "Name": "turbottest96535"
    },
    "title": "turbottest96535.com"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:ds:us-east-1:632902152528:directory/d-90675e6551"
    ],
    "name": "turbottest96535.com",
    "title": "turbottest96535.com"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

POSTTEST: tests/aws_directory_service_directory

TEARDOWN: tests/aws_directory_service_directory


Error: rpc error: code = Unavailable desc = transport is closing


SUMMARY:

1/1 passed.

===========================================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_dms_replication_instance []

PRETEST: tests/aws_dms_replication_instance

TEST: tests/aws_dms_replication_instance
Running terraform
data.aws_caller_identity.current: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_region.alternate: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_dms_replication_instance.named_test_resource: Creating...
aws_dms_replication_instance.named_test_resource: Still creating... [10s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [20s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [30s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [40s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [50s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [1m0s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [1m10s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [1m20s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [1m30s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [1m40s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [1m50s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [2m0s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [2m10s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [2m20s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [2m30s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [2m40s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [2m50s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [3m0s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [3m10s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [3m20s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [3m30s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [3m40s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [3m50s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [4m0s elapsed]
aws_dms_replication_instance.named_test_resource: Still creating... [4m10s elapsed]
aws_dms_replication_instance.named_test_resource: Creation complete after 4m16s [id=turbottest58148]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = 632902152528
aws_partition = aws
aws_region = us-east-2
resource_aka = arn:aws:dms:us-east-2:632902152528:rep:6U3OCWQG354ISA6OUINUUUOSWMGR72N3HZHJFZY
resource_name = turbottest58148

Running SQL query: test-get-query.sql
[
  {
    "account_id": "632902152528",
    "akas": [
      "arn:aws:dms:us-east-2:632902152528:rep:6U3OCWQG354ISA6OUINUUUOSWMGR72N3HZHJFZY"
    ],
    "allocated_storage": 5,
    "arn": "arn:aws:dms:us-east-2:632902152528:rep:6U3OCWQG354ISA6OUINUUUOSWMGR72N3HZHJFZY",
    "auto_minor_version_upgrade": true,
    "availability_zone": "us-east-2a",
    "dns_name_servers": null,
    "free_until": null,
    "multi_az": false,
    "partition": "aws",
    "preferred_maintenance_window": "sun:10:30-sun:14:30",
    "publicly_accessible": false,
    "region": "us-east-2",
    "replication_instance_class": "dms.t2.micro",
    "replication_instance_identifier": "turbottest58148",
    "replication_instance_status": "available",
    "secondary_availability_zone": null,
    "tags": {
      "foo": "bar"
    },
    "tags_src": [
      {
        "Key": "foo",
        "ResourceArn": null,
        "Value": "bar"
      }
    ],
    "title": "turbottest58148"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "arn": "arn:aws:dms:us-east-2:632902152528:rep:6U3OCWQG354ISA6OUINUUUOSWMGR72N3HZHJFZY",
    "region": "us-east-2",
    "replication_instance_identifier": "turbottest58148",
    "tags": {
      "foo": "bar"
    },
    "tags_src": [
      {
        "Key": "foo",
        "ResourceArn": null,
        "Value": "bar"
      }
    ],
    "title": "turbottest58148"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:dms:us-east-2:632902152528:rep:6U3OCWQG354ISA6OUINUUUOSWMGR72N3HZHJFZY",
    "publicly_accessible": false,
    "region": "us-east-2",
    "replication_instance_class": "dms.t2.micro",
    "replication_instance_identifier": "turbottest58148",
    "title": "turbottest58148"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:dms:us-east-2:632902152528:rep:6U3OCWQG354ISA6OUINUUUOSWMGR72N3HZHJFZY"
    ],
    "tags": {
      "foo": "bar"
    },
    "title": "turbottest58148"
  }
]
✔ PASSED

TEARDOWN: tests/aws_dms_replication_instance

SUMMARY:

✔ tests/aws_dms_replication_instance failed.

1/1 passed.


=================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_dax_cluster []

PRETEST: tests/aws_dax_cluster

TEST: tests/aws_dax_cluster
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.my_vpc: Creating...
aws_iam_role.my_role: Creating...
aws_iam_role.my_role: Creation complete after 2s [id=turbottest48018]
aws_vpc.my_vpc: Creation complete after 3s [id=vpc-030e699eadba319ab]
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet2: Creation complete after 1s [id=subnet-032489228daff65ce]
aws_subnet.my_subnet1: Creation complete after 2s [id=subnet-0c69e2711f9e72936]
aws_dax_subnet_group.my_subnet_group: Creating...
aws_dax_subnet_group.my_subnet_group: Creation complete after 2s [id=turbottest48018]
aws_dax_cluster.named_test_resource: Creating...
aws_dax_cluster.named_test_resource: Still creating... [10s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [20s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [30s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [40s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [50s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [1m0s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [1m10s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [1m20s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [1m30s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [1m40s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [1m50s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [2m0s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [2m10s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [2m20s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [2m30s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [2m40s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [2m50s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [3m0s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [3m10s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [3m20s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [3m30s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [3m40s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [3m50s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [4m0s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [4m10s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [4m20s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [4m30s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [4m40s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [4m50s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [5m0s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [5m10s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [5m20s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [5m30s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [5m40s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [5m50s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [6m0s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [6m10s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [6m20s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [6m30s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [6m40s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [6m50s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [7m0s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [7m10s elapsed]
aws_dax_cluster.named_test_resource: Still creating... [7m20s elapsed]
aws_dax_cluster.named_test_resource: Creation complete after 7m25s [id=turbottest48018]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Outputs:

account_id = 632902152528
aws_partition = aws
aws_region = us-east-1
resource_aka = arn:aws:dax:us-east-1:632902152528:cache/turbottest48018
resource_id = turbottest48018
resource_name = turbottest48018

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:dax:us-east-1:632902152528:cache/turbottest48018",
    "cluster_name": "turbottest48018",
    "description": "A test cluster",
    "node_type": "dax.r4.large",
    "tags": {
      "name": "turbottest48018"
    }
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:dax:us-east-1:632902152528:cache/turbottest48018"
    ],
    "cluster_name": "turbottest48018",
    "tags": {
      "name": "turbottest48018"
    },
    "title": "turbottest48018"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:dax:us-east-1:632902152528:cache/turbottest48018"
    ],
    "cluster_name": "turbottest48018",
    "title": "turbottest48018"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

POSTTEST: tests/aws_dax_cluster

TEARDOWN: tests/aws_dax_cluster

SUMMARY:

1/1 passed.


=====================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_ami []

PRETEST: tests/aws_ec2_ami

TEST: tests/aws_ec2_ami
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_ebs_volume.my_volume: Creating...
aws_ebs_volume.my_volume: Still creating... [10s elapsed]
aws_ebs_volume.my_volume: Creation complete after 11s [id=vol-098a8c7c8127dc905]
aws_ebs_snapshot.my_snapshot: Creating...
aws_ebs_snapshot.my_snapshot: Still creating... [10s elapsed]
aws_ebs_snapshot.my_snapshot: Creation complete after 16s [id=snap-0737f705d603819a4]
aws_ami.named_test_resource: Creating...
aws_ami.named_test_resource: Creation complete after 7s [id=ami-01a1089544d4a2ace]
aws_ami_launch_permission.deny_access: Creating...
data.template_file.resource_aka: Refreshing state...
aws_ami_launch_permission.allow_access: Creating...
aws_ami_launch_permission.allow_access: Creation complete after 1s [id=ami-01a1089544d4a2ace-388460667113]
aws_ami_launch_permission.deny_access: Creation complete after 1s [id=ami-01a1089544d4a2ace-013122550996]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = 632902152528
aws_partition = aws
region_name = us-east-1
resource_aka = arn:aws:ec2:us-east-1:632902152528:image/ami-01a1089544d4a2ace
resource_id = ami-01a1089544d4a2ace
resource_name = turbottest27372
snapshot_id = snap-0737f705d603819a4

Running SQL query: query.sql
[
  {
    "image_id": "ami-01a1089544d4a2ace",
    "name": "turbottest27372"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "architecture": "x86_64",
    "block_device_mappings": [
      {
        "DeviceName": "/dev/sda1",
        "Ebs": {
          "DeleteOnTermination": true,
          "Encrypted": false,
          "Iops": null,
          "KmsKeyId": null,
          "OutpostArn": null,
          "SnapshotId": "snap-0737f705d603819a4",
          "Throughput": null,
          "VolumeSize": 8,
          "VolumeType": "standard"
        },
        "NoDevice": null,
        "VirtualName": null
      }
    ],
    "description": "This is a test image.",
    "ena_support": false,
    "hypervisor": "xen",
    "image_id": "ami-01a1089544d4a2ace",
    "image_location": "632902152528/turbottest27372",
    "image_type": "machine",
    "name": "turbottest27372",
    "owner_id": "632902152528",
    "platform_details": "Linux/UNIX",
    "public": false,
    "root_device_name": "/dev/sda1",
    "root_device_type": "ebs",
    "sriov_net_support": "simple",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest27372"
      }
    ],
    "usage_operation": "RunInstances",
    "virtualization_type": "hvm"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:632902152528:image/ami-01a1089544d4a2ace"
    ],
    "image_id": "ami-01a1089544d4a2ace",
    "launch_permissions": [
      {
        "Group": null,
        "OrganizationArn": null,
        "OrganizationalUnitArn": null,
        "UserId": "388460667113"
      },
      {
        "Group": null,
        "OrganizationArn": null,
        "OrganizationalUnitArn": null,
        "UserId": "013122550996"
      }
    ],
    "tags": {
      "Name": "turbottest27372"
    },
    "title": "turbottest27372"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "image_id": "ami-01a1089544d4a2ace",
    "name": "turbottest27372"
  }
]
✔ PASSED

TEARDOWN: tests/aws_ec2_ami

SUMMARY:

✔ tests/aws_ec2_ami failed.

1/1 passed.

===========================================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_application_load_balancer []

PRETEST: tests/aws_ec2_application_load_balancer

TEST: tests/aws_ec2_application_load_balancer
Running terraform
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.alternate: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Creation complete after 4s [id=vpc-09110fe00301628f6]
aws_internet_gateway.igw: Creating...
aws_internet_gateway.igw: Still creating... [10s elapsed]
aws_internet_gateway.igw: Still creating... [20s elapsed]
aws_internet_gateway.igw: Still creating... [30s elapsed]
aws_internet_gateway.igw: Still creating... [40s elapsed]
aws_internet_gateway.igw: Still creating... [50s elapsed]
aws_internet_gateway.igw: Still creating... [1m0s elapsed]
aws_internet_gateway.igw: Still creating... [1m10s elapsed]
aws_internet_gateway.igw: Still creating... [1m20s elapsed]
aws_internet_gateway.igw: Still creating... [1m30s elapsed]
aws_internet_gateway.igw: Still creating... [1m40s elapsed]
aws_internet_gateway.igw: Still creating... [1m50s elapsed]
aws_internet_gateway.igw: Still creating... [2m0s elapsed]
aws_internet_gateway.igw: Still creating... [2m10s elapsed]
aws_internet_gateway.igw: Still creating... [2m20s elapsed]
aws_internet_gateway.igw: Still creating... [2m30s elapsed]
aws_internet_gateway.igw: Creation complete after 2m40s [id=igw-00c1c700e33744a47]
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet2: Creation complete after 2s [id=subnet-06e6b78f8f3454191]
aws_subnet.my_subnet1: Creation complete after 2s [id=subnet-0f5d5ff355cf3cf82]
aws_lb.named_test_resource: Creating...
aws_lb.named_test_resource: Still creating... [10s elapsed]
aws_lb.named_test_resource: Still creating... [20s elapsed]
aws_lb.named_test_resource: Still creating... [30s elapsed]
aws_lb.named_test_resource: Still creating... [40s elapsed]
aws_lb.named_test_resource: Still creating... [50s elapsed]
aws_lb.named_test_resource: Still creating... [1m0s elapsed]
aws_lb.named_test_resource: Still creating... [1m10s elapsed]
aws_lb.named_test_resource: Still creating... [1m20s elapsed]
aws_lb.named_test_resource: Still creating... [1m30s elapsed]
aws_lb.named_test_resource: Still creating... [1m40s elapsed]
aws_lb.named_test_resource: Still creating... [1m50s elapsed]
aws_lb.named_test_resource: Still creating... [2m0s elapsed]
aws_lb.named_test_resource: Creation complete after 2m6s [id=arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/app/turbottest13458/0f456581f27dbe32]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = 632902152528
aws_partition = aws
region_name = us-east-1
resource_aka = arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/app/turbottest13458/0f456581f27dbe32
resource_id = arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/app/turbottest13458/0f456581f27dbe32
resource_name = turbottest13458
vpc_id = vpc-09110fe00301628f6

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/app/turbottest13458/0f456581f27dbe32",
    "ip_address_type": "ipv4",
    "name": "turbottest13458",
    "scheme": "internet-facing",
    "state_code": "active",
    "type": "application",
    "vpc_id": "vpc-09110fe00301628f6"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/app/turbottest13458/0f456581f27dbe32",
    "load_balancer_attributes": [
      {
        "Key": "access_logs.s3.enabled",
        "Value": "false"
      },
      {
        "Key": "access_logs.s3.bucket",
        "Value": ""
      },
      {
        "Key": "access_logs.s3.prefix",
        "Value": ""
      },
      {
        "Key": "idle_timeout.timeout_seconds",
        "Value": "60"
      },
      {
        "Key": "deletion_protection.enabled",
        "Value": "false"
      },
      {
        "Key": "routing.http2.enabled",
        "Value": "true"
      },
      {
        "Key": "routing.http.drop_invalid_header_fields.enabled",
        "Value": "false"
      },
      {
        "Key": "routing.http.xff_client_port.enabled",
        "Value": "false"
      },
      {
        "Key": "routing.http.desync_mitigation_mode",
        "Value": "defensive"
      },
      {
        "Key": "waf.fail_open.enabled",
        "Value": "false"
      },
      {
        "Key": "routing.http.x_amzn_tls_version_and_cipher_suite.enabled",
        "Value": "false"
      }
    ],
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest13458"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/app/turbottest13458/0f456581f27dbe32",
    "name": "turbottest13458"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/app/turbottest13458/0f456581f27dbe32"
    ],
    "tags": {
      "name": "turbottest13458"
    },
    "title": "turbottest13458"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_application_load_balancer

TEARDOWN: tests/aws_ec2_application_load_balancer

SUMMARY:

1/1 passed.

========================================================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_emr_cluster []

PRETEST: tests/aws_emr_cluster

TEST: tests/aws_emr_cluster
Running terraform
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.alternate: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.my_vpc: Creating...
aws_iam_role.iam_emr_profile_role: Creating...
aws_key_pair.deployer: Creating...
aws_iam_role.iam_emr_service_role: Creating...
aws_key_pair.deployer: Creation complete after 1s [id=deployer-key]
aws_iam_role.iam_emr_service_role: Creation complete after 2s [id=turbottest18151_1]
aws_iam_role.iam_emr_profile_role: Creation complete after 2s [id=turbottest18151_2]
aws_iam_role_policy.iam_emr_profile_policy: Creating...
aws_iam_instance_profile.emr_profile: Creating...
aws_iam_role_policy.iam_emr_service_policy: Creating...
aws_iam_instance_profile.emr_profile: Creation complete after 1s [id=var.resource_name]
aws_iam_role_policy.iam_emr_profile_policy: Creation complete after 1s [id=turbottest18151_2:turbottest18151_2]
aws_iam_role_policy.iam_emr_service_policy: Creation complete after 1s [id=turbottest18151_1:turbottest18151_1]
aws_vpc.my_vpc: Creation complete after 4s [id=vpc-0d027668fb22dedd0]
aws_internet_gateway.gw: Creating...
aws_subnet.my_subnet: Creating...
aws_subnet.my_subnet: Creation complete after 1s [id=subnet-0eb321af3db65fca7]
aws_security_group.emr_master: Creating...
aws_internet_gateway.gw: Creation complete after 1s [id=igw-025e5c964d0be4a39]
aws_route_table.test_route_table: Creating...
aws_route_table.test_route_table: Creation complete after 3s [id=rtb-00557ba0ed6310d7e]
aws_main_route_table_association.test_association: Creating...
aws_security_group.emr_master: Creation complete after 4s [id=sg-0fb0f4f5564b36839]
aws_emr_cluster.named_test_resource: Creating...
aws_main_route_table_association.test_association: Creation complete after 2s [id=rtbassoc-06dc14a4fe05b22f6]
aws_emr_cluster.named_test_resource: Still creating... [10s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [20s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [30s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [40s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [50s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [1m0s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [1m10s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [1m20s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [1m30s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [1m40s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [1m50s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [2m0s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [2m10s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [2m20s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [2m30s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [2m40s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [2m50s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [3m0s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [3m10s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [3m20s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [3m30s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [3m40s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [3m50s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [4m0s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [4m10s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [4m20s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [4m30s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [4m40s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [4m50s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [5m0s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [5m10s elapsed]
aws_emr_cluster.named_test_resource: Still creating... [5m20s elapsed]
aws_emr_cluster.named_test_resource: Creation complete after 5m25s [id=j-BAW99CYSDHZH]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: Quoted references are deprecated

  on variables.tf line 201, in resource "aws_security_group" "emr_master":
 201:   depends_on = ["aws_subnet.my_subnet"]

In this context, references are expected literally rather than in quotes.
Terraform 0.11 and earlier required quotes, but quoted references are now
deprecated and will be removed in a future version of Terraform. Remove the
quotes surrounding this reference to silence this warning.

(and 2 more similar warnings elsewhere)


Apply complete! Resources: 13 added, 0 changed, 0 destroyed.

Outputs:

account_id = 632902152528
region_name = us-east-1
resource_aka = arn:aws:elasticmapreduce:us-east-1:632902152528:cluster/j-BAW99CYSDHZH
resource_id = j-BAW99CYSDHZH
resource_name = turbottest18151
transit_gateway_id = j-BAW99CYSDHZH
vpc_id = vpc-0d027668fb22dedd0

Running SQL query: test-get-query.sql
[
  {
    "auto_terminate": false,
    "cluster_arn": "arn:aws:elasticmapreduce:us-east-1:632902152528:cluster/j-BAW99CYSDHZH",
    "ebs_root_volume_size": null,
    "id": "j-BAW99CYSDHZH",
    "name": "turbottest18151",
    "tags": {
      "name": "turbottest18151"
    }
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "account_id": "632902152528",
    "akas": [
      "arn:aws:elasticmapreduce:us-east-1:632902152528:cluster/j-BAW99CYSDHZH"
    ],
    "auto_terminate": false,
    "cluster_arn": "arn:aws:elasticmapreduce:us-east-1:632902152528:cluster/j-BAW99CYSDHZH",
    "id": "j-BAW99CYSDHZH",
    "name": "turbottest18151",
    "region": "us-east-1",
    "tags": {
      "name": "turbottest18151"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "auto_terminate": false,
    "cluster_arn": "arn:aws:elasticmapreduce:us-east-1:632902152528:cluster/j-BAW99CYSDHZH",
    "id": "j-BAW99CYSDHZH",
    "name": "turbottest18151"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:elasticmapreduce:us-east-1:632902152528:cluster/j-BAW99CYSDHZH"
    ],
    "tags": {
      "name": "turbottest18151"
    },
    "title": "turbottest18151"
  }
]
✔ PASSED

POSTTEST: tests/aws_emr_cluster

TEARDOWN: tests/aws_emr_cluster

SUMMARY:

1/1 passed.

===============================================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_fsx_file_system []

PRETEST: tests/aws_fsx_file_system

TEST: tests/aws_fsx_file_system
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Creation complete after 4s [id=vpc-07007c8fe647786e7]
aws_subnet.my_subnet: Creating...
aws_subnet.my_subnet: Creation complete after 1s [id=subnet-07f24404634521814]
aws_fsx_lustre_file_system.named_test_resource: Creating...
aws_fsx_lustre_file_system.named_test_resource: Still creating... [10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [30s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [40s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [50s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [1m0s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [1m10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [1m20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [1m30s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [1m40s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [1m50s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [2m0s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [2m10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [2m20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [2m30s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [2m40s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [2m50s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [3m0s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [3m10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [3m20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [3m30s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [3m40s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [3m50s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [4m0s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [4m10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [4m20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [4m30s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [4m40s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [4m50s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [5m0s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [5m10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [5m20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [5m30s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [5m40s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [5m50s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [6m0s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Creation complete after 6m1s [id=fs-030cd72b5c1ed0688]
data.template_file.resource_aka: Refreshing state...

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: Interpolation-only expressions are deprecated

  on variables.tf line 53, in resource "aws_subnet" "my_subnet":
  53:   vpc_id     = "${aws_vpc.my_vpc.id}"

Terraform 0.11 and earlier required all non-constant expressions to be
provided via interpolation syntax, but this pattern is now deprecated. To
silence this warning, remove the "${ sequence from the start and the }"
sequence from the end of this expression, leaving just the inner expression.

Template interpolation syntax is still used to construct strings from
expressions when the template includes multiple interpolation sequences or a
mixture of literal strings and interpolations. This deprecation applies only
to templates that consist entirely of a single interpolation sequence.


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = arn:aws:fsx:us-east-1:632902152528:file-system/fs-030cd72b5c1ed0688
resource_id = fs-030cd72b5c1ed0688
resource_name = turbottest28583

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:fsx:us-east-1:632902152528:file-system/fs-030cd72b5c1ed0688",
    "file_system_id": "fs-030cd72b5c1ed0688"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:fsx:us-east-1:632902152528:file-system/fs-030cd72b5c1ed0688"
    ],
    "file_system_id": "fs-030cd72b5c1ed0688",
    "title": "fs-030cd72b5c1ed0688"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "file_system_id": "fs-030cd72b5c1ed0688",
    "title": "fs-030cd72b5c1ed0688"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

POSTTEST: tests/aws_fsx_file_system

TEARDOWN: tests/aws_fsx_file_system

SUMMARY:

1/1 passed.

====================================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_network_load_balancer []

PRETEST: tests/aws_ec2_network_load_balancer

TEST: tests/aws_ec2_network_load_balancer
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Creation complete after 4s [id=vpc-01e1b5adb478cfb99]
aws_internet_gateway.igw: Creating...
aws_internet_gateway.igw: Creation complete after 1s [id=igw-09ed4f4eac4e177ad]
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet2: Creation complete after 2s [id=subnet-03088f9de53ab86b2]
aws_subnet.my_subnet1: Creation complete after 2s [id=subnet-014e5676ebf726d0d]
aws_lb.named_test_resource: Creating...
aws_lb.named_test_resource: Still creating... [10s elapsed]
aws_lb.named_test_resource: Still creating... [20s elapsed]
aws_lb.named_test_resource: Still creating... [30s elapsed]
aws_lb.named_test_resource: Still creating... [40s elapsed]
aws_lb.named_test_resource: Still creating... [50s elapsed]
aws_lb.named_test_resource: Still creating... [1m0s elapsed]
aws_lb.named_test_resource: Still creating... [1m10s elapsed]
aws_lb.named_test_resource: Still creating... [1m20s elapsed]
aws_lb.named_test_resource: Still creating... [1m30s elapsed]
aws_lb.named_test_resource: Still creating... [1m40s elapsed]
aws_lb.named_test_resource: Still creating... [1m50s elapsed]
aws_lb.named_test_resource: Still creating... [2m0s elapsed]
aws_lb.named_test_resource: Still creating... [2m10s elapsed]
aws_lb.named_test_resource: Still creating... [2m20s elapsed]
aws_lb.named_test_resource: Still creating... [2m30s elapsed]
aws_lb.named_test_resource: Creation complete after 2m36s [id=arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/net/turbottest65636/ff6dda50770908ca]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = 632902152528
aws_partition = aws
region_name = us-east-1
resource_aka = arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/net/turbottest65636/ff6dda50770908ca
resource_id = arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/net/turbottest65636/ff6dda50770908ca
resource_name = turbottest65636
vpc_id = vpc-01e1b5adb478cfb99

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/net/turbottest65636/ff6dda50770908ca",
    "ip_address_type": "ipv4",
    "name": "turbottest65636",
    "scheme": "internet-facing",
    "state_code": "active",
    "type": "network",
    "vpc_id": "vpc-01e1b5adb478cfb99"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/net/turbottest65636/ff6dda50770908ca",
    "load_balancer_attributes": [
      {
        "Key": "access_logs.s3.enabled",
        "Value": "false"
      },
      {
        "Key": "access_logs.s3.prefix",
        "Value": ""
      },
      {
        "Key": "deletion_protection.enabled",
        "Value": "false"
      },
      {
        "Key": "access_logs.s3.bucket",
        "Value": ""
      },
      {
        "Key": "load_balancing.cross_zone.enabled",
        "Value": "false"
      }
    ],
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest65636"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/net/turbottest65636/ff6dda50770908ca",
    "name": "turbottest65636"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:elasticloadbalancing:us-east-1:632902152528:loadbalancer/net/turbottest65636/ff6dda50770908ca"
    ],
    "tags": {
      "name": "turbottest65636"
    },
    "title": "turbottest65636"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_network_load_balancer

TEARDOWN: tests/aws_ec2_network_load_balancer


Error: Unrecognized remote plugin message: 

This usually means that the plugin is either invalid or simply
needs to be recompiled to support the latest protocol.


SUMMARY:

1/1 passed.

=========================================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_reserved_instance []

PRETEST: tests/aws_ec2_reserved_instance

TEST: tests/aws_ec2_reserved_instance
Running terraform
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.alternate: Refreshing state...
data.null_data_source.resource: Refreshing state...
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "aws ec2 describe-reserved-instances --output json > /private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/aws_ec2_reserved_instance/terraform/test/output.json"]
null_resource.named_test_resource: Creation complete after 2s [id=7710477984151366849]
data.local_file.input: Refreshing state...

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

currency_code = USD
fixed_price = 0
instance_type = t3.nano
offering_class = standard
resource_aka = arn:aws:ec2:us-east-1:632902152528:reserved-instances/0bdff5fd-4b22-470c-8e1d-3eaff8a4ec3b
resource_name = 0bdff5fd-4b22-470c-8e1d-3eaff8a4ec3b
scope = Region
state = active
usage_price = 0

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:ec2:us-east-1:632902152528:reserved-instances/0bdff5fd-4b22-470c-8e1d-3eaff8a4ec3b",
    "currency_code": "USD",
    "fixed_price": "0",
    "instance_state": "active",
    "instance_type": "t3.nano",
    "offering_class": "standard",
    "reserved_instance_id": "0bdff5fd-4b22-470c-8e1d-3eaff8a4ec3b",
    "scope": "Region",
    "usage_price": "0"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:ec2:us-east-1:632902152528:reserved-instances/0bdff5fd-4b22-470c-8e1d-3eaff8a4ec3b",
    "instance_type": "t3.nano",
    "reserved_instance_id": "0bdff5fd-4b22-470c-8e1d-3eaff8a4ec3b"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:632902152528:reserved-instances/0bdff5fd-4b22-470c-8e1d-3eaff8a4ec3b"
    ],
    "title": "0bdff5fd-4b22-470c-8e1d-3eaff8a4ec3b"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_reserved_instance

TEARDOWN: tests/aws_ec2_reserved_instance


Error: Unrecognized remote plugin message: 

This usually means that the plugin is either invalid or simply
needs to be recompiled to support the latest protocol.


SUMMARY:

1/1 passed.

========================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_iam_access_advisor []

PRETEST: tests/aws_iam_access_advisor

TEST: tests/aws_iam_access_advisor
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "aws sts get-caller-identity --profile default"]
null_resource.named_test_resource (local-exec): {
null_resource.named_test_resource (local-exec):     "UserId": "AIDAZGW7IOFICBCZ2E6UW",
null_resource.named_test_resource (local-exec):     "Account": "632902152528",
null_resource.named_test_resource (local-exec):     "Arn": "arn:aws:iam::632902152528:user/partha"
null_resource.named_test_resource (local-exec): }
null_resource.named_test_resource: Creation complete after 2s [id=7494518205912833964]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

aws_account = 632902152528
aws_partition = aws
aws_region = us-east-1
user_arn = arn:aws:iam::632902152528:user/partha

Running SQL query: test-list-query.sql
[
  {
    "last_authenticated_entity": "arn:aws:iam::632902152528:user/partha",
    "partition": "aws",
    "principal_arn": "arn:aws:iam::632902152528:user/partha",
    "region": "global",
    "service_name": "AWS Security Token Service",
    "service_namespace": "sts"
  }
]
✔ PASSED

TEARDOWN: tests/aws_iam_access_advisor

SUMMARY:

✔ tests/aws_iam_access_advisor failed.

1/1 passed.


===============================================


No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_iam_account_password_policy []

PRETEST: tests/aws_iam_account_password_policy

TEST: tests/aws_iam_account_password_policy
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_partition.current: Refreshing state...
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "aws iam get-account-password-policy --output json --profile default --region us-east-1 > /private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/aws_iam_account_password_policy/terraform/test/output.json"]
null_resource.named_test_resource: Creation complete after 2s [id=2544029387410581220]
data.local_file.input: Refreshing state...

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

allow_users_to_change_password = false
aws_account = 632902152528
aws_partition = aws
aws_region = us-east-1
expire_passwords = false
minimum_password_length = 6
require_lowercase_characters = false
require_numbers = false
require_symbols = false
require_uppercase_characters = false

Running SQL query: test-get-query.sql
[
  {
    "account_id": "632902152528",
    "allow_users_to_change_password": false,
    "expire_passwords": false,
    "minimum_password_length": 6,
    "partition": "aws",
    "region": "global",
    "require_lowercase_characters": false,
    "require_numbers": false,
    "require_symbols": false,
    "require_uppercase_characters": false
  }
]
✔ PASSED

POSTTEST: tests/aws_iam_account_password_policy

TEARDOWN: tests/aws_iam_account_password_policy

SUMMARY:

1/1 passed.

==============================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_kinesis_consumer []

PRETEST: tests/aws_kinesis_consumer

TEST: tests/aws_kinesis_consumer
Running terraform
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.alternate: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_kinesis_stream.named_test_resource: Creating...
aws_kinesis_stream.named_test_resource: Still creating... [10s elapsed]
aws_kinesis_stream.named_test_resource: Still creating... [20s elapsed]
aws_kinesis_stream.named_test_resource: Creation complete after 24s [id=arn:aws:kinesis:us-east-1:632902152528:stream/turbottest83684]
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "aws kinesis register-stream-consumer --stream-arn arn:aws:kinesis:us-east-1:632902152528:stream/turbottest83684 --consumer-name turbottest83684 --profile default --region  us-east-1"]
null_resource.named_test_resource (local-exec): {
null_resource.named_test_resource (local-exec):     "Consumer": {
null_resource.named_test_resource (local-exec):         "ConsumerName": "turbottest83684",
null_resource.named_test_resource (local-exec):         "ConsumerARN": "arn:aws:kinesis:us-east-1:632902152528:stream/turbottest83684/consumer/turbottest83684:1645109722",
null_resource.named_test_resource (local-exec):         "ConsumerStatus": "CREATING",
null_resource.named_test_resource (local-exec):         "ConsumerCreationTimestamp": "2022-02-17T20:25:22+05:30"
null_resource.named_test_resource (local-exec):     }
null_resource.named_test_resource (local-exec): }
null_resource.named_test_resource: Creation complete after 1s [id=7500375223257471465]
null_resource.output_test_resource: Creating...
null_resource.output_test_resource: Provisioning with 'local-exec'...
null_resource.output_test_resource (local-exec): Executing: ["/bin/sh" "-c" "aws kinesis list-stream-consumers --stream-arn arn:aws:kinesis:us-east-1:632902152528:stream/turbottest83684 --output json --profile default --region us-east-1 > /private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/aws_kinesis_consumer/terraform/test/kinesis_stream.json"]
null_resource.output_test_resource: Creation complete after 2s [id=3424756593033391346]
data.local_file.input: Refreshing state...

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = 632902152528
aws_region = us-east-1
resource_aka = arn:aws:kinesis:us-east-1:632902152528:stream/turbottest83684/consumer/turbottest83684:1645109722
resource_name = turbottest83684
stream_aka = arn:aws:kinesis:us-east-1:632902152528:stream/turbottest83684

Running SQL query: test-get-query.sql
[
  {
    "consumer_arn": "arn:aws:kinesis:us-east-1:632902152528:stream/turbottest83684/consumer/turbottest83684:1645109722",
    "consumer_name": "turbottest83684",
    "consumer_status": "ACTIVE"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "stream_arn": "arn:aws:kinesis:us-east-1:632902152528:stream/turbottest83684"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "consumer_arn": "arn:aws:kinesis:us-east-1:632902152528:stream/turbottest83684/consumer/turbottest83684:1645109722",
    "consumer_name": "turbottest83684"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "632902152528",
    "akas": [
      "arn:aws:kinesis:us-east-1:632902152528:stream/turbottest83684/consumer/turbottest83684:1645109722"
    ],
    "region": "us-east-1",
    "title": "turbottest83684"
  }
]
✔ PASSED

POSTTEST: tests/aws_kinesis_consumer

TEARDOWN: tests/aws_kinesis_consumer

SUMMARY:

1/1 passed

=================================================================================

SETUP: tests/aws_rds_db_snapshot []

PRETEST: tests/aws_rds_db_snapshot

TEST: tests/aws_rds_db_snapshot
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_db_instance.my_instance will be created
  + resource "aws_db_instance" "my_instance" {
      + address                               = (known after apply)
      + allocated_storage                     = 20
      + apply_immediately                     = (known after apply)
      + arn                                   = (known after apply)
      + auto_minor_version_upgrade            = true
      + availability_zone                     = (known after apply)
      + backup_retention_period               = (known after apply)
      + backup_window                         = (known after apply)
      + ca_cert_identifier                    = (known after apply)
      + character_set_name                    = (known after apply)
      + copy_tags_to_snapshot                 = false
      + db_name                               = (known after apply)
      + db_subnet_group_name                  = "turbottest4991"
      + delete_automated_backups              = true
      + endpoint                              = (known after apply)
      + engine                                = "mysql"
      + engine_version                        = (known after apply)
      + engine_version_actual                 = (known after apply)
      + hosted_zone_id                        = (known after apply)
      + id                                    = (known after apply)
      + identifier                            = (known after apply)
      + identifier_prefix                     = (known after apply)
      + instance_class                        = "db.t2.micro"
      + kms_key_id                            = (known after apply)
      + latest_restorable_time                = (known after apply)
      + license_model                         = (known after apply)
      + maintenance_window                    = (known after apply)
      + monitoring_interval                   = 0
      + monitoring_role_arn                   = (known after apply)
      + multi_az                              = (known after apply)
      + name                                  = "turbottest4991"
      + nchar_character_set_name              = (known after apply)
      + option_group_name                     = (known after apply)
      + parameter_group_name                  = (known after apply)
      + password                              = (sensitive value)
      + performance_insights_enabled          = false
      + performance_insights_kms_key_id       = (known after apply)
      + performance_insights_retention_period = (known after apply)
      + port                                  = (known after apply)
      + publicly_accessible                   = false
      + replica_mode                          = (known after apply)
      + replicas                              = (known after apply)
      + resource_id                           = (known after apply)
      + skip_final_snapshot                   = true
      + snapshot_identifier                   = (known after apply)
      + status                                = (known after apply)
      + storage_type                          = (known after apply)
      + tags_all                              = (known after apply)
      + timezone                              = (known after apply)
      + username                              = "turbottest"
      + vpc_security_group_ids                = (known after apply)
    }

  # aws_db_snapshot.named_test_resource will be created
  + resource "aws_db_snapshot" "named_test_resource" {
      + allocated_storage             = (known after apply)
      + availability_zone             = (known after apply)
      + db_instance_identifier        = (known after apply)
      + db_snapshot_arn               = (known after apply)
      + db_snapshot_identifier        = "turbottest4991"
      + encrypted                     = (known after apply)
      + engine                        = (known after apply)
      + engine_version                = (known after apply)
      + id                            = (known after apply)
      + iops                          = (known after apply)
      + kms_key_id                    = (known after apply)
      + license_model                 = (known after apply)
      + option_group_name             = (known after apply)
      + port                          = (known after apply)
      + snapshot_type                 = (known after apply)
      + source_db_snapshot_identifier = (known after apply)
      + source_region                 = (known after apply)
      + status                        = (known after apply)
      + storage_type                  = (known after apply)
      + tags                          = {
          + "name" = "turbottest4991"
        }
      + tags_all                      = {
          + "name" = "turbottest4991"
        }
      + vpc_id                        = (known after apply)
    }

  # aws_db_subnet_group.default will be created
  + resource "aws_db_subnet_group" "default" {
      + arn         = (known after apply)
      + description = "Managed by Terraform"
      + id          = (known after apply)
      + name        = "turbottest4991"
      + name_prefix = (known after apply)
      + subnet_ids  = (known after apply)
      + tags_all    = (known after apply)
    }

  # aws_subnet.backend will be created
  + resource "aws_subnet" "backend" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "175.0.128.0/17"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "turbottest4991"
        }
      + tags_all                                       = {
          + "Name" = "turbottest4991"
        }
      + vpc_id                                         = (known after apply)
    }

  # aws_subnet.frontend will be created
  + resource "aws_subnet" "frontend" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "175.0.0.0/17"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "Name" = "turbottest4991"
        }
      + tags_all                                       = {
          + "Name" = "turbottest4991"
        }
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.my_vpc will be created
  + resource "aws_vpc" "my_vpc" {
      + arn                                  = (known after apply)
      + cidr_block                           = "175.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags                                 = {
          + "Name" = "turbottest4991"
        }
      + tags_all                             = {
          + "Name" = "turbottest4991"
        }
    }

Plan: 6 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id             = "828685001623"
  + aws_partition          = "aws"
  + db_instance_identifier = (known after apply)
  + region_name            = "us-east-1"
  + resource_aka           = (known after apply)
  + resource_name          = "turbottest4991"
  + vpc_id                 = (known after apply)
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Creation complete after 4s [id=vpc-0b93c8eb07d16e4c4]
aws_subnet.frontend: Creating...
aws_subnet.backend: Creating...
aws_subnet.frontend: Creation complete after 1s [id=subnet-0282a64f865578b68]
aws_subnet.backend: Creation complete after 1s [id=subnet-07c7db5d6dfa38e4b]
aws_db_subnet_group.default: Creating...
aws_db_subnet_group.default: Creation complete after 2s [id=turbottest4991]
aws_db_instance.my_instance: Creating...
aws_db_instance.my_instance: Still creating... [10s elapsed]
aws_db_instance.my_instance: Still creating... [20s elapsed]
aws_db_instance.my_instance: Still creating... [30s elapsed]
aws_db_instance.my_instance: Still creating... [40s elapsed]
aws_db_instance.my_instance: Still creating... [50s elapsed]
aws_db_instance.my_instance: Still creating... [1m0s elapsed]
aws_db_instance.my_instance: Still creating... [1m10s elapsed]
aws_db_instance.my_instance: Still creating... [1m20s elapsed]
aws_db_instance.my_instance: Still creating... [1m30s elapsed]
aws_db_instance.my_instance: Still creating... [1m40s elapsed]
aws_db_instance.my_instance: Still creating... [1m50s elapsed]
aws_db_instance.my_instance: Still creating... [2m0s elapsed]
aws_db_instance.my_instance: Still creating... [2m10s elapsed]
aws_db_instance.my_instance: Still creating... [2m20s elapsed]
aws_db_instance.my_instance: Still creating... [2m30s elapsed]
aws_db_instance.my_instance: Still creating... [2m40s elapsed]
aws_db_instance.my_instance: Still creating... [2m50s elapsed]
aws_db_instance.my_instance: Still creating... [3m0s elapsed]
aws_db_instance.my_instance: Still creating... [3m10s elapsed]
aws_db_instance.my_instance: Still creating... [3m20s elapsed]
aws_db_instance.my_instance: Still creating... [3m30s elapsed]
aws_db_instance.my_instance: Still creating... [3m40s elapsed]
aws_db_instance.my_instance: Still creating... [3m50s elapsed]
aws_db_instance.my_instance: Still creating... [4m0s elapsed]
aws_db_instance.my_instance: Creation complete after 4m10s [id=terraform-20220217112931384000000001]
aws_db_snapshot.named_test_resource: Creating...
aws_db_snapshot.named_test_resource: Still creating... [10s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [20s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [30s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [40s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [50s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [1m0s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [1m10s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [1m20s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [1m30s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [1m40s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [1m50s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [2m0s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [2m10s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [2m20s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [2m30s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [2m40s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [2m50s elapsed]
aws_db_snapshot.named_test_resource: Still creating... [3m0s elapsed]
aws_db_snapshot.named_test_resource: Creation complete after 3m5s [id=turbottest4991]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: Argument is deprecated

  with aws_db_instance.my_instance,
  on variables.tf line 84, in resource "aws_db_instance" "my_instance":
  84:   name                 = var.resource_name

Use db_name instead

(and 2 more similar warnings elsewhere)

Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Outputs:

account_id = "828685001623"
aws_partition = "aws"
db_instance_identifier = "terraform-20220217112931384000000001"
region_name = "us-east-1"
resource_aka = "arn:aws:rds:us-east-1:828685001623:snapshot:turbottest4991"
resource_name = "turbottest4991"
vpc_id = "vpc-0b93c8eb07d16e4c4"

Running SQL query: test-get-query.sql
[
  {
    "allocated_storage": 20,
    "arn": "arn:aws:rds:us-east-1:828685001623:snapshot:turbottest4991",
    "db_instance_identifier": "terraform-20220217112931384000000001",
    "db_snapshot_identifier": "turbottest4991",
    "encrypted": false,
    "engine": "mysql",
    "engine_version": "8.0.27",
    "iam_database_authentication_enabled": false,
    "license_model": "general-public-license",
    "master_user_name": "turbottest",
    "port": 3306,
    "storage_type": "gp2",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest4991"
      }
    ],
    "type": "manual",
    "vpc_id": "vpc-0b93c8eb07d16e4c4"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "db_snapshot_attributes": [
      {
        "AttributeName": "restore",
        "AttributeValues": null
      }
    ],
    "db_snapshot_identifier": "turbottest4991"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:rds:us-east-1:828685001623:snapshot:turbottest4991",
    "db_snapshot_identifier": "turbottest4991"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:rds:us-east-1:828685001623:snapshot:turbottest4991"
    ],
    "db_snapshot_identifier": "turbottest4991",
    "tags": {
      "name": "turbottest4991"
    },
    "title": "turbottest4991"
  }
]
✔ PASSED

TEARDOWN: tests/aws_rds_db_snapshot

SUMMARY:

✔ tests/aws_rds_db_snapshot.

1/1 passed.

===================================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_rds_db_instance []

PRETEST: tests/aws_rds_db_instance

TEST: tests/aws_rds_db_instance
Running terraform
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.alternate: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Creation complete after 5s [id=vpc-04420d232623285da]
aws_internet_gateway.igw: Creating...
aws_internet_gateway.igw: Creation complete after 2s [id=igw-0c5ef2547de0adf8c]
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet2: Creation complete after 1s [id=subnet-0cd88b88b45b0fc90]
aws_subnet.my_subnet1: Creation complete after 2s [id=subnet-0c03377eddd0ff212]
aws_db_subnet_group.my_subnetgroup: Creating...
aws_db_subnet_group.my_subnetgroup: Creation complete after 2s [id=turbottest28377]
aws_db_instance.named_test_resource: Creating...
aws_db_instance.named_test_resource: Still creating... [10s elapsed]
aws_db_instance.named_test_resource: Still creating... [20s elapsed]
aws_db_instance.named_test_resource: Still creating... [30s elapsed]
aws_db_instance.named_test_resource: Still creating... [40s elapsed]
aws_db_instance.named_test_resource: Still creating... [50s elapsed]
aws_db_instance.named_test_resource: Still creating... [1m0s elapsed]
aws_db_instance.named_test_resource: Still creating... [1m10s elapsed]
aws_db_instance.named_test_resource: Still creating... [1m20s elapsed]
aws_db_instance.named_test_resource: Still creating... [1m30s elapsed]
aws_db_instance.named_test_resource: Still creating... [1m40s elapsed]
aws_db_instance.named_test_resource: Still creating... [1m50s elapsed]
aws_db_instance.named_test_resource: Still creating... [2m0s elapsed]
aws_db_instance.named_test_resource: Still creating... [2m10s elapsed]
aws_db_instance.named_test_resource: Still creating... [2m20s elapsed]
aws_db_instance.named_test_resource: Still creating... [2m30s elapsed]
aws_db_instance.named_test_resource: Still creating... [2m40s elapsed]
aws_db_instance.named_test_resource: Creation complete after 2m46s [id=turbottest28377]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 6 added, 0 changed, 0 destroyed.

Outputs:

account_id = 632902152528
aws_partition = aws
region_name = us-east-2
resource_aka = arn:aws:rds:us-east-2:632902152528:db:turbottest28377
resource_id = db-VAONIRCULCLETDSYNZNCOFGFZI
resource_name = turbottest28377

Running SQL query: test-get-query.sql
[
  {
    "allocated_storage": 5,
    "arn": "arn:aws:rds:us-east-2:632902152528:db:turbottest28377",
    "auto_minor_version_upgrade": true,
    "class": "db.m5.large",
    "copy_tags_to_snapshot": false,
    "customer_owned_ip_enabled": false,
    "db_instance_identifier": "turbottest28377",
    "db_subnet_group_name": "turbottest28377",
    "deletion_protection": false,
    "endpoint_port": 3306,
    "engine": "mysql",
    "engine_version": "8.0.27",
    "engine_version": "8.0.23",
    "iam_database_authentication_enabled": false,
    "master_user_name": "master",
    "multi_az": false,
    "performance_insights_enabled": false,
    "port": 0,
    "publicly_accessible": false,
    "resource_id": "db-VAONIRCULCLETDSYNZNCOFGFZI",
    "storage_encrypted": true,
    "storage_type": "gp2",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest28377"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "allocated_storage": 5,
    "arn": "arn:aws:rds:us-east-2:632902152528:db:turbottest28377",
    "auto_minor_version_upgrade": true,
    "class": "db.m5.large",
    "copy_tags_to_snapshot": false,
    "customer_owned_ip_enabled": false,
    "db_instance_identifier": "turbottest28377",
    "db_subnet_group_name": "turbottest28377",
    "deletion_protection": false,
    "endpoint_port": 3306,
    "engine": "mysql",
    "engine_version": "8.0.27",
    "iam_database_authentication_enabled": false,
    "master_user_name": "master",
    "multi_az": false,
    "performance_insights_enabled": false,
    "port": 0,
    "publicly_accessible": false,
    "resource_id": "db-VAONIRCULCLETDSYNZNCOFGFZI",
    "storage_encrypted": true,
    "storage_type": "gp2",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest28377"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:rds:us-east-2:632902152528:db:turbottest28377",
    "db_instance_identifier": "turbottest28377",
    "resource_id": "db-VAONIRCULCLETDSYNZNCOFGFZI"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:rds:us-east-2:632902152528:db:turbottest28377"
    ],
    "db_instance_identifier": "turbottest28377",
    "tags": {
      "name": "turbottest28377"
    },
    "title": "turbottest28377"
  }
]
✔ PASSED

TEARDOWN: tests/aws_rds_db_instance

SUMMARY:

1/1 passed.

=========================================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_sfn_state_machine_execution []

PRETEST: tests/aws_sfn_state_machine_execution

TEST: tests/aws_sfn_state_machine_execution
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_partition.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_iam_role.sfn_role: Creating...
aws_iam_role.sfn_role: Creation complete after 2s [id=turbottest97525]
aws_sfn_state_machine.named_test_resource: Creating...
aws_sfn_state_machine.named_test_resource: Creation complete after 2s [id=arn:aws:states:us-east-1:632902152528:stateMachine:turbottest97525]
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "aws stepfunctions start-execution --state-machine-arn arn:aws:states:us-east-1:632902152528:stateMachine:turbottest97525  --output json > /private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/aws_sfn_state_machine_execution/terraform/test/output.json"]
null_resource.named_test_resource: Creation complete after 2s [id=7033621158157264938]
data.local_file.input: Refreshing state...

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

execution_arn = arn:aws:states:us-east-1:632902152528:execution:turbottest97525:4af58abb-e061-4174-9424-989fadf5d3a7
state_machine_arn = arn:aws:states:us-east-1:632902152528:stateMachine:turbottest97525

Running SQL query: test-get-call-query.sql
[
  {
    "akas": [
      "arn:aws:states:us-east-1:632902152528:execution:turbottest97525:4af58abb-e061-4174-9424-989fadf5d3a7"
    ],
    "execution_arn": "arn:aws:states:us-east-1:632902152528:execution:turbottest97525:4af58abb-e061-4174-9424-989fadf5d3a7",
    "state_machine_arn": "arn:aws:states:us-east-1:632902152528:stateMachine:turbottest97525"
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "akas": [
      "arn:aws:states:us-east-1:632902152528:execution:turbottest97525:4af58abb-e061-4174-9424-989fadf5d3a7"
    ],
    "execution_arn": "arn:aws:states:us-east-1:632902152528:execution:turbottest97525:4af58abb-e061-4174-9424-989fadf5d3a7",
    "state_machine_arn": "arn:aws:states:us-east-1:632902152528:stateMachine:turbottest97525"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:states:us-east-1:632902152528:execution:turbottest97525:4af58abb-e061-4174-9424-989fadf5d3a7"
    ]
  }
]
✔ PASSED

POSTTEST: tests/aws_sfn_state_machine_execution

TEARDOWN: tests/aws_sfn_state_machine_execution

SUMMARY:

1/1 passed.

====================================================================

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_codebuild_project []

PRETEST: tests/aws_codebuild_project

TEST: tests/aws_codebuild_project
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_iam_role.test_role: Creating...
aws_vpc.my_vpc: Creating...
aws_s3_bucket.test_bucket: Creating...
aws_iam_role.test_role: Creation complete after 2s [id=turbottest54578]
aws_vpc.my_vpc: Creation complete after 3s [id=vpc-0395cb3fc8cd82cbc]
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet1: Creation complete after 1s [id=subnet-09007a31c72bb869a]
aws_subnet.my_subnet2: Creation complete after 2s [id=subnet-0211e93f86c91aa6c]
aws_s3_bucket.test_bucket: Creation complete after 5s [id=turbottest54578]
aws_iam_role_policy.test_role_policy: Creating...
aws_codebuild_project.named_test_resource: Creating...
aws_iam_role_policy.test_role_policy: Creation complete after 0s [id=turbottest54578:terraform-20220217093943863400000001]
aws_codebuild_project.named_test_resource: Creation complete after 5s [id=arn:aws:codebuild:us-east-1:632902152528:project/turbottest54578]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 7 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = arn:aws:codebuild:us-east-1:632902152528:project/turbottest54578
resource_id = arn:aws:codebuild:us-east-1:632902152528:project/turbottest54578
resource_name = turbottest54578

Running SQL query: test-get-query.sql
[
  {
    "artifacts": {
      "ArtifactIdentifier": null,
      "BucketOwnerAccess": null,
      "EncryptionDisabled": null,
      "Location": null,
      "Name": null,
      "NamespaceType": null,
      "OverrideArtifactName": false,
      "Packaging": null,
      "Path": null,
      "Type": "NO_ARTIFACTS"
    },
    "cache": {
      "Location": "turbottest54578",
      "Modes": null,
      "Type": "S3"
    },
    "description": "Resource for testing",
    "name": "turbottest54578",
    "source": {
      "Auth": null,
      "BuildStatusConfig": null,
      "Buildspec": "",
      "GitCloneDepth": 0,
      "GitSubmodulesConfig": null,
      "InsecureSsl": false,
      "Location": "https://github.com/mitchellh/packer.git",
      "ReportBuildStatus": false,
      "SourceIdentifier": null,
      "Type": "GITHUB"
    },
    "title": "turbottest54578"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:codebuild:us-east-1:632902152528:project/turbottest54578"
    ],
    "description": "Resource for testing",
    "name": "turbottest54578",
    "tags": {
      "foo": "bar"
    },
    "title": "turbottest54578"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "artifacts": {
      "ArtifactIdentifier": null,
      "BucketOwnerAccess": null,
      "EncryptionDisabled": null,
      "Location": null,
      "Name": null,
      "NamespaceType": null,
      "OverrideArtifactName": false,
      "Packaging": null,
      "Path": null,
      "Type": "NO_ARTIFACTS"
    },
    "description": "Resource for testing",
    "name": "turbottest54578",
    "tags": {
      "foo": "bar"
    },
    "title": "turbottest54578"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

POSTTEST: tests/aws_codebuild_project

TEARDOWN: tests/aws_codebuild_project

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
