### PR TITLE
Update MaxResults to default value 10 for ListServices API in aws_ecs_service table. Fixes #903

### DIFF
--- a/aws/table_aws_ecs_service.go
+++ b/aws/table_aws_ecs_service.go
@@ -215,9 +215,9 @@ func listEcsServices(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	// Get cluster details
 	cluster := h.Item.(*ecs.Cluster)
 
+	// DescribeServices API can describe up to 10 services in a single operation. Default MaxResults is 10 for ListServicesInput
 	input := &ecs.ListServicesInput{
-		Cluster:    cluster.ClusterArn,
-		MaxResults: aws.Int64(100),
+		Cluster: cluster.ClusterArn,
 	}
 
 	// If the requested number of items is less than the paging max limit


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_ecs_service []

PRETEST: tests/aws_ecs_service

TEST: tests/aws_ecs_service
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ecs_cluster.named_test_resource will be created
  + resource "aws_ecs_cluster" "named_test_resource" {
      + arn                = (known after apply)
      + capacity_providers = (known after apply)
      + id                 = (known after apply)
      + name               = "turbottest67666"
      + tags_all           = (known after apply)

      + default_capacity_provider_strategy {
          + base              = (known after apply)
          + capacity_provider = (known after apply)
          + weight            = (known after apply)
        }

      + setting {
          + name  = (known after apply)
          + value = (known after apply)
        }
    }

  # aws_ecs_service.named_test_resource will be created
  + resource "aws_ecs_service" "named_test_resource" {
      + cluster                            = (known after apply)
      + deployment_maximum_percent         = 200
      + deployment_minimum_healthy_percent = 100
      + desired_count                      = 3
      + enable_ecs_managed_tags            = false
      + enable_execute_command             = false
      + iam_role                           = (known after apply)
      + id                                 = (known after apply)
      + launch_type                        = (known after apply)
      + name                               = "turbottest67666"
      + platform_version                   = (known after apply)
      + scheduling_strategy                = "REPLICA"
      + tags                               = {
          + "name" = "turbottest67666"
        }
      + tags_all                           = {
          + "name" = "turbottest67666"
        }
      + task_definition                    = (known after apply)
      + wait_for_steady_state              = false

      + ordered_placement_strategy {
          + field = "cpu"
          + type  = "binpack"
        }

      + placement_constraints {
          + expression = "attribute:ecs.availability-zone in [us-west-2a, us-west-2b]"
          + type       = "memberOf"
        }
    }

  # aws_ecs_task_definition.named_test_resource will be created
  + resource "aws_ecs_task_definition" "named_test_resource" {
      + arn                   = (known after apply)
      + container_definitions = jsonencode(
            [
              + {
                  + cpu       = 10
                  + essential = true
                  + image     = "jenkins"
                  + memory    = 128
                  + name      = "jenkins"
                },
            ]
        )
      + family                = "turbottest67666"
      + id                    = (known after apply)
      + network_mode          = (known after apply)
      + revision              = (known after apply)
      + skip_destroy          = false
      + tags_all              = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + cluster_arn         = (known after apply)
  + resource_aka        = (known after apply)
  + resource_name       = "turbottest67666"
  + task_definition_arn = (known after apply)
aws_ecs_cluster.named_test_resource: Creating...
aws_ecs_task_definition.named_test_resource: Creating...
aws_ecs_task_definition.named_test_resource: Creation complete after 2s [id=turbottest67666]
aws_ecs_cluster.named_test_resource: Still creating... [10s elapsed]
aws_ecs_cluster.named_test_resource: Creation complete after 13s [id=arn:aws:ecs:us-east-1:533793682495:cluster/turbottest67666]
aws_ecs_service.named_test_resource: Creating...
aws_ecs_service.named_test_resource: Creation complete after 1s [id=arn:aws:ecs:us-east-1:533793682495:service/turbottest67666/turbottest67666]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

cluster_arn = "arn:aws:ecs:us-east-1:533793682495:cluster/turbottest67666"
resource_aka = "arn:aws:ecs:us-east-1:533793682495:service/turbottest67666/turbottest67666"
resource_name = "turbottest67666"
task_definition_arn = "arn:aws:ecs:us-east-1:533793682495:task-definition/turbottest67666:1"

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:ecs:us-east-1:533793682495:service/turbottest67666/turbottest67666",
    "cluster_arn": "arn:aws:ecs:us-east-1:533793682495:cluster/turbottest67666",
    "desired_count": 3,
    "enable_ecs_managed_tags": false,
    "enable_execute_command": false,
    "placement_constraints": [
      {
        "Expression": "attribute:ecs.availability-zone in [us-west-2a, us-west-2b]",
        "Type": "memberOf"
      }
    ],
    "placement_strategy": [
      {
        "Field": "CPU",
        "Type": "binpack"
      }
    ],
    "service_name": "turbottest67666",
    "task_definition": "arn:aws:ecs:us-east-1:533793682495:task-definition/turbottest67666:1"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:ecs:us-east-1:533793682495:service/turbottest67666/turbottest67666"
    ],
    "title": "turbottest67666"
  }
]
✔ PASSED

POSTTEST: tests/aws_ecs_service

TEARDOWN: tests/aws_ecs_service

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select service_name, status, desired_count  from aws_ecs_service
+--------------+--------+---------------+
| service_name | status | desired_count |
+--------------+--------+---------------+
| test4        | ACTIVE | 34            |
| test7        | ACTIVE | 4             |
| test11       | ACTIVE | 3             |
| test3        | ACTIVE | 4             |
| test6        | ACTIVE | 34            |
| test8        | ACTIVE | 3             |
| test9        | ACTIVE | 4             |
| test1        | ACTIVE | 2             |
| test10       | ACTIVE | 3             |
| test5        | ACTIVE | 3             |
| test12       | ACTIVE | 343           |
+--------------+--------+---------------+
```
</details>
