### PR TITLE
Add optional qual for list call for `aws_cost_by_service_*` and `aws_cost_by_service_usage_type_*` tables

### DIFF
--- a/aws/cost_explorer.go
+++ b/aws/cost_explorer.go
@@ -136,11 +136,8 @@ func streamCostAndUsage(ctx context.Context, d *plugin.QueryData, params *costex
 	if err != nil {
 		return nil, err
 	}
-	count := 1
-
 	// List call
 	for {
-		logger.Info("streamCostAndUsage", "COUNT", count)
 		output, err := svc.GetCostAndUsage(params)
 		if err != nil {
 			logger.Error("streamCostAndUsage", "err", err)
@@ -161,7 +158,6 @@ func streamCostAndUsage(ctx context.Context, d *plugin.QueryData, params *costex
 			break
 		}
 		params.SetNextPageToken(*output.NextPageToken)
-		count++
 	}
 
 	return nil, nil

--- a/aws/cost_explorer.go
+++ b/aws/cost_explorer.go
@@ -136,9 +136,11 @@ func streamCostAndUsage(ctx context.Context, d *plugin.QueryData, params *costex
 	if err != nil {
 		return nil, err
 	}
+	count := 1
 
 	// List call
 	for {
+		logger.Info("streamCostAndUsage", "COUNT", count)
 		output, err := svc.GetCostAndUsage(params)
 		if err != nil {
 			logger.Error("streamCostAndUsage", "err", err)
@@ -149,7 +151,7 @@ func streamCostAndUsage(ctx context.Context, d *plugin.QueryData, params *costex
 		for _, row := range buildCEMetricRows(ctx, output, d.KeyColumnQuals) {
 			d.StreamListItem(ctx, row)
 
-			if d.QueryStatus.RowsRemaining(ctx) == 0{
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
 				return nil, nil
 			}
 		}
@@ -159,6 +161,7 @@ func streamCostAndUsage(ctx context.Context, d *plugin.QueryData, params *costex
 			break
 		}
 		params.SetNextPageToken(*output.NextPageToken)
+		count++
 	}
 
 	return nil, nil

--- a/aws/table_aws_cost_by_service_daily.go
+++ b/aws/table_aws_cost_by_service_daily.go
@@ -14,6 +14,9 @@ func tableAwsCostByServiceDaily(_ context.Context) *plugin.Table {
 		Description: "AWS Cost Explorer - Cost by Service (Daily)",
 		List: &plugin.ListConfig{
 			Hydrate: listCostByServiceDaily,
+			KeyColumns: plugin.KeyColumnSlice{
+				{Name: "service", Operators: []string{"="}, Require: plugin.Optional},
+			},
 		},
 		Columns: awsColumns(
 			costExplorerColumns([]*plugin.Column{
@@ -32,6 +35,6 @@ func tableAwsCostByServiceDaily(_ context.Context) *plugin.Table {
 //// LIST FUNCTION
 
 func listCostByServiceDaily(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	params := buildCostByServiceInput("DAILY")
+	params := buildCostByServiceInput("DAILY", d)
 	return streamCostAndUsage(ctx, d, params)
 }

--- a/aws/table_aws_cost_by_service_monthly.go
+++ b/aws/table_aws_cost_by_service_monthly.go
@@ -86,5 +86,13 @@ func buildCostByServiceInput(granularity string, d *plugin.QueryData) *costexplo
 		}
 	}
 
+	if len(filters) > 1 {
+		params.Filter = &costexplorer.Expression{
+			And: filters,
+		}
+	} else if len(filters) == 1 {
+		params.Filter = filters[0]
+	}
+
 	return params
 }

--- a/aws/table_aws_cost_by_service_monthly.go
+++ b/aws/table_aws_cost_by_service_monthly.go
@@ -21,7 +21,6 @@ func tableAwsCostByServiceMonthly(_ context.Context) *plugin.Table {
 		},
 		Columns: awsColumns(
 			costExplorerColumns([]*plugin.Column{
-
 				{
 					Name:        "service",
 					Description: "The name of the AWS service.",

--- a/aws/table_aws_cost_by_service_usage_type_daily.go
+++ b/aws/table_aws_cost_by_service_usage_type_daily.go
@@ -41,6 +41,6 @@ func tableAwsCostByServiceUsageTypeDaily(_ context.Context) *plugin.Table {
 //// LIST FUNCTION
 
 func listCostByServiceAndUsageDaily(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	params := buildCostByServiceAndUsageInput(ctx, "DAILY", d.Quals, d.Table.List.KeyColumns)
+	params := buildCostByServiceAndUsageInput("DAILY", d)
 	return streamCostAndUsage(ctx, d, params)
 }

--- a/aws/table_aws_cost_by_service_usage_type_daily.go
+++ b/aws/table_aws_cost_by_service_usage_type_daily.go
@@ -37,6 +37,6 @@ func tableAwsCostByServiceUsageTypeDaily(_ context.Context) *plugin.Table {
 //// LIST FUNCTION
 
 func listCostByServiceAndUsageDaily(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	params := buildCostByServiceAndUsageInput("DAILY")
+	params := buildCostByServiceAndUsageInput(ctx, "DAILY", d.Quals, d.Table.List.KeyColumns)
 	return streamCostAndUsage(ctx, d, params)
 }

--- a/aws/table_aws_cost_by_service_usage_type_daily.go
+++ b/aws/table_aws_cost_by_service_usage_type_daily.go
@@ -14,6 +14,10 @@ func tableAwsCostByServiceUsageTypeDaily(_ context.Context) *plugin.Table {
 		Description: "AWS Cost Explorer - Cost by Service and Usage Type (Daily)",
 		List: &plugin.ListConfig{
 			Hydrate: listCostByServiceAndUsageDaily,
+			KeyColumns: plugin.KeyColumnSlice{
+				{Name: "service", Operators: []string{"="}, Require: plugin.Optional},
+				{Name: "usage_type", Operators: []string{"="}, Require: plugin.Optional},
+			},
 		},
 		Columns: awsColumns(
 			costExplorerColumns([]*plugin.Column{

--- a/aws/table_aws_cost_by_service_usage_type_monthly.go
+++ b/aws/table_aws_cost_by_service_usage_type_monthly.go
@@ -92,7 +92,7 @@ func buildCostByServiceAndUsageInput(granularity string, d *plugin.QueryData) *c
 				filter.Dimensions = &costexplorer.DimensionValues{}
 				filter.Dimensions.Key = aws.String(strings.ToUpper(keyQual.Name))
 
-				// Affected by the BUG - https://github.com/turbot/steampipe-plugin-sdk/issues/239
+				// TODO: Re-add for IN clause support once https://github.com/turbot/steampipe-plugin-sdk/issues/279 is resolved
 				//
 				// filterVal := []string{}
 				// if value.GetListValue() != nil {

--- a/aws/table_aws_cost_by_service_usage_type_monthly.go
+++ b/aws/table_aws_cost_by_service_usage_type_monthly.go
@@ -46,9 +46,7 @@ func tableAwsCostByServiceUsageTypeMonthly(_ context.Context) *plugin.Table {
 //// LIST FUNCTION
 
 func listCostByServiceAndUsageMonthly(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Info("listCostByServiceAndUsageMonthly", "ARE WE HERE", "BEFORE PARAM")
 	params := buildCostByServiceAndUsageInput("MONTHLY", d)
-	plugin.Logger(ctx).Info("listCostByServiceAndUsageMonthly", "ARE WE HERE", "AFTER PARAM")
 	return streamCostAndUsage(ctx, d, params)
 }
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from morales_aws.aws_cost_by_service_usage_type_monthly where service = 'Amazon Elastic Compute Cloud - Compute' and usage_type = 'BoxUsage:t2.micro'
+----------------------------------------+-------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+---------------------------+-------------------------+-----------------------+---------------------+---------------------------+-------------------------+-----------------------+---------------------+-------------------------+-----------------------+-----------+--------+--------------+-----------------------------------+
| service                                | usage_type        | period_start              | period_end                | estimated | blended_cost_amount | blended_cost_unit | unblended_cost_amount | unblended_cost_unit | net_unblended_cost_amount | net_unblended_cost_unit | amortized_cost_amount | amortized_cost_unit | net_amortized_cost_amount | net_amortized_cost_unit | usage_quantity_amount | usage_quantity_unit | normalized_usage_amount | normalized_usage_unit | partition | region | account_id   | _ctx                              |
+----------------------------------------+-------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+---------------------------+-------------------------+-----------------------+---------------------+---------------------------+-------------------------+-----------------------+---------------------+-------------------------+-----------------------+-----------+--------+--------------+-----------------------------------+
| Amazon Elastic Compute Cloud - Compute | BoxUsage:t2.micro | 2021-02-21T05:30:00+05:30 | 2021-03-01T05:30:00+05:30 | false     | 0.4292386628        | USD               | 0.4292386628          | USD                 | 0.4292386628              | USD                     | 0.4292386628          | USD                 | 0.4292386628              | USD                     | 37.003333             | Hrs                 | 18.5016665              | N/A                   | aws       | global | <redacted> | {"connection_name":"morales_aws"} |
| Amazon Elastic Compute Cloud - Compute | BoxUsage:t2.micro | 2021-03-01T05:30:00+05:30 | 2021-04-01T05:30:00+05:30 | false     | 0.1345213372        | USD               | 0.1345213372          | USD                 | 0.1345213372              | USD                     | 0.1345213372          | USD                 | 0.1345213372              | USD                     | 11.596667             | Hrs                 | 5.7983335               | N/A                   | aws       | global | <redacted> | {"connection_name":"morales_aws"} |
| Amazon Elastic Compute Cloud - Compute | BoxUsage:t2.micro | 2021-05-01T05:30:00+05:30 | 2021-06-01T05:30:00+05:30 | false     | 0                   | USD               | 0                     | USD                 | 0                         | USD                     | 0                     | USD                 | 0                         | USD                     | 137.880278            | Hrs                 | 68.940139               | N/A                   | aws       | global | <redacted> | {"connection_name":"morales_aws"} |
| Amazon Elastic Compute Cloud - Compute | BoxUsage:t2.micro | 2021-12-01T05:30:00+05:30 | 2022-01-01T05:30:00+05:30 | false     | 0.0108621124        | USD               | 0.0108621124          | USD                 | 0.0108621124              | USD                     | 0.0108621124          | USD                 | 0.0108621124              | USD                     | 0.936389              | Hrs                 | 0.4681945               | N/A                   | aws       | global | <redacted> | {"connection_name":"morales_aws"} |
| Amazon Elastic Compute Cloud - Compute | BoxUsage:t2.micro | 2021-08-01T05:30:00+05:30 | 2021-09-01T05:30:00+05:30 | false     | 0                   | USD               | 0                     | USD                 | 0                         | USD                     | 0                     | USD                 | 0                         | USD                     | 71.177499             | Hrs                 | 35.5887495              | N/A                   | aws       | global | <redacted> | {"connection_name":"morales_aws"} |
+----------------------------------------+-------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+---------------------------+-------------------------+-----------------------+---------------------+---------------------------+-------------------------+-----------------------+---------------------+-------------------------+-----------------------+-----------+--------+--------------+-----------------------------------+
```
</details>
