### PR TITLE
Update aws_cost_* tables with optional quals closes #916

### DIFF
--- a/aws/table_aws_cost_by_service_daily.go
+++ b/aws/table_aws_cost_by_service_daily.go
@@ -15,7 +15,7 @@ func tableAwsCostByServiceDaily(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listCostByServiceDaily,
 			KeyColumns: plugin.KeyColumnSlice{
-				{Name: "service", Operators: []string{"="}, Require: plugin.Optional},
+				{Name: "service", Operators: []string{"=", "<>"}, Require: plugin.Optional},
 			},
 		},
 		Columns: awsColumns(

--- a/aws/table_aws_cost_by_service_usage_type_daily.go
+++ b/aws/table_aws_cost_by_service_usage_type_daily.go
@@ -15,8 +15,8 @@ func tableAwsCostByServiceUsageTypeDaily(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listCostByServiceAndUsageDaily,
 			KeyColumns: plugin.KeyColumnSlice{
-				{Name: "service", Operators: []string{"="}, Require: plugin.Optional},
-				{Name: "usage_type", Operators: []string{"="}, Require: plugin.Optional},
+				{Name: "service", Operators: []string{"=", "<>"}, Require: plugin.Optional},
+				{Name: "usage_type", Operators: []string{"=", "<>"}, Require: plugin.Optional},
 			},
 		},
 		Columns: awsColumns(

--- a/aws/table_aws_cost_by_service_usage_type_monthly.go
+++ b/aws/table_aws_cost_by_service_usage_type_monthly.go
@@ -107,21 +107,6 @@ func buildCostByServiceAndUsageInput(granularity string, d *plugin.QueryData) *c
 					filter.Not.Dimensions.Values = aws.StringSlice([]string{value.GetStringValue()})
 					filters = append(filters, filter)
 				}
-
-				// TODO: Re-add for IN clause support once https://github.com/turbot/steampipe-plugin-sdk/issues/279 is resolved
-				//
-				// filterVal := []string{}
-				// if value.GetListValue() != nil {
-				// 	for _, q := range value.GetListValue().Values {
-				// 		filterVal = append(filterVal, q.GetStringValue())
-				// 	}
-				// } else {
-				// 	plugin.Logger(ctx).Info("buildCostByServiceAndUsageInput", "SINGLE VALUE", "filterVal")
-				// 	plugin.Logger(ctx).Info("buildCostByServiceAndUsageInput", "value.GetStringValue()", value.GetStringValue())
-				// 	plugin.Logger(ctx).Info("buildCostByServiceAndUsageInput", "value.GetListValue()", value.GetListValue())
-				// 	filterVal = append(filterVal, value.GetStringValue())
-				// }
-				// filter.Dimensions.Values = aws.StringSlice(filterVal)
 			}
 		}
 	}

--- a/aws/table_aws_cost_by_service_usage_type_monthly.go
+++ b/aws/table_aws_cost_by_service_usage_type_monthly.go
@@ -107,6 +107,21 @@ func buildCostByServiceAndUsageInput(granularity string, d *plugin.QueryData) *c
 					filter.Not.Dimensions.Values = aws.StringSlice([]string{value.GetStringValue()})
 					filters = append(filters, filter)
 				}
+
+				// TODO: Re-add for IN clause support once https://github.com/turbot/steampipe-plugin-sdk/issues/279 is resolved
+				//
+				// filterVal := []string{}
+				// if value.GetListValue() != nil {
+				// 	for _, q := range value.GetListValue().Values {
+				// 		filterVal = append(filterVal, q.GetStringValue())
+				// 	}
+				// } else {
+				// 	plugin.Logger(ctx).Info("buildCostByServiceAndUsageInput", "SINGLE VALUE", "filterVal")
+				// 	plugin.Logger(ctx).Info("buildCostByServiceAndUsageInput", "value.GetStringValue()", value.GetStringValue())
+				// 	plugin.Logger(ctx).Info("buildCostByServiceAndUsageInput", "value.GetListValue()", value.GetListValue())
+				// 	filterVal = append(filterVal, value.GetStringValue())
+				// }
+				// filter.Dimensions.Values = aws.StringSlice(filterVal)
 			}
 		}
 	}

--- a/aws/table_aws_cost_forecast_daily.go
+++ b/aws/table_aws_cost_forecast_daily.go
@@ -66,6 +66,10 @@ func listCostForecastDaily(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	// stream the results...
 	for _, r := range output.ForecastResultsByTime {
 		d.StreamListItem(ctx, r)
+
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 
 	return nil, nil
@@ -75,6 +79,11 @@ func buildCostForecastInput(_ map[string]*proto.QualValue, granularity string) *
 
 	// TO DO - specify metric as qual?   get all cost metrics in parallel?
 	//metric := strings.ToUpper(keyQuals["metric"].GetStringValue())
+	
+	// As the response of the api call doesn't return metric value so we do not have a column for it,
+	// If we will have a column for it, then we need to get the value from quals only(we may get the null value if it has not been passed), so we have not added it as optional quals.
+	// We can add it as required param, but there is a bug with "in" clause so we cann't iterate the value properly in param. 
+
 	metric := "UNBLENDED_COST"
 
 	timeFormat := "2006-01-02"

--- a/aws/table_aws_cost_forecast_monthly.go
+++ b/aws/table_aws_cost_forecast_monthly.go
@@ -62,6 +62,10 @@ func listCostForecastMonthly(ctx context.Context, d *plugin.QueryData, _ *plugin
 	// stream the results...
 	for _, r := range output.ForecastResultsByTime {
 		d.StreamListItem(ctx, r)
+
+		if d.QueryStatus.RowsRemaining(ctx) == 0 {
+			return nil, nil
+		}
 	}
 
 	return nil, nil


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  service,
  period_start,
  blended_cost_amount::numeric::money,
  unblended_cost_amount::numeric::money,
  amortized_cost_amount::numeric::money,
  net_unblended_cost_amount::numeric::money,
  net_amortized_cost_amount::numeric::money
from 
  aws_cost_by_service_daily
order by
  service,
  period_start limit 10;
+----------------+---------------------------+---------------------+-----------------------+-----------------------+---------------------------+---------------------------+
| service        | period_start              | blended_cost_amount | unblended_cost_amount | amortized_cost_amount | net_unblended_cost_amount | net_amortized_cost_amount |
+----------------+---------------------------+---------------------+-----------------------+-----------------------+---------------------------+---------------------------+
| AWS CloudShell | 2021-07-13T05:30:00+05:30 | $0.00               | $0.00                 | $0.00                 | $0.00                     | $0.00                     |
| AWS CloudTrail | 2021-02-24T05:30:00+05:30 | $0.00               | $0.00                 | $0.00                 | $0.00                     | $0.00                     |
| AWS CloudTrail | 2021-02-25T05:30:00+05:30 | $0.00               | $0.00                 | $0.00                 | $0.00                     | $0.00                     |
| AWS CloudTrail | 2021-02-26T05:30:00+05:30 | $0.00               | $0.00                 | $0.00                 | $0.00                     | $0.00                     |
| AWS CloudTrail | 2021-02-27T05:30:00+05:30 | $0.00               | $0.00                 | $0.00                 | $0.00                     | $0.00                     |
| AWS CloudTrail | 2021-02-28T05:30:00+05:30 | $0.00               | $0.00                 | $0.00                 | $0.00                     | $0.00                     |
| AWS CloudTrail | 2021-03-01T05:30:00+05:30 | $0.00               | $0.00                 | $0.00                 | $0.00                     | $0.00                     |
| AWS CloudTrail | 2021-03-02T05:30:00+05:30 | $0.00               | $0.00                 | $0.00                 | $0.00                     | $0.00                     |
| AWS CloudTrail | 2021-03-03T05:30:00+05:30 | $0.00               | $0.00                 | $0.00                 | $0.00                     | $0.00                     |
| AWS CloudTrail | 2021-03-04T05:30:00+05:30 | $0.00               | $0.00                 | $0.00                 | $0.00                     | $0.00                     |
+----------------+---------------------------+---------------------+-----------------------+-----------------------+---------------------------+---------------------------+

===================================================================

> select * from aws_cost_by_service_daily where service = 'AWS CloudShell'
+----------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+---------------------------+
| service        | period_start              | period_end                | estimated | blended_cost_amount | blended_cost_unit | unblended_cost_amount | unblended_cost_unit | net_unblended_cost_amount |
+----------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+---------------------------+
| AWS CloudShell | 2021-07-13T05:30:00+05:30 | 2021-07-14T05:30:00+05:30 | false     | 0.0000081688        | USD               | 0.0000081688          | USD                 | 0.0000081688              |
+----------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+---------------------------+

=====================================================================

> select * from aws_cost_by_service_monthly limit 4;
+------------------------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+--------
| service                            | period_start              | period_end                | estimated | blended_cost_amount | blended_cost_unit | unblended_cost_amount | unblended_cost_unit | net_unb
+------------------------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+--------
| AWS Cost Explorer                  | 2021-02-24T05:30:00+05:30 | 2021-03-01T05:30:00+05:30 | false     | 0.36                | USD               | 0.36                  | USD                 | 0.36   
| EC2 - Other                        | 2021-02-24T05:30:00+05:30 | 2021-03-01T05:30:00+05:30 | false     | 0.217840232         | USD               | 0.217840232           | USD                 | 0.21784
| AWS CloudTrail                     | 2021-02-24T05:30:00+05:30 | 2021-03-01T05:30:00+05:30 | false     | 0                   | USD               | 0                     | USD                 | 0      
| Amazon Simple Notification Service | 2021-02-24T05:30:00+05:30 | 2021-03-01T05:30:00+05:30 | false     | 0.0000019456        | USD               | 0.000002132           | USD                 | 0.00000
+------------------------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+--------

======================================================================

> select * from aws_cost_by_service_monthly where service = 'AWS Cost Explorer';
+-------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+-------------------------
| service           | period_start              | period_end                | estimated | blended_cost_amount | blended_cost_unit | unblended_cost_amount | unblended_cost_unit | net_unblended_cost_amoun
+-------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+-------------------------
| AWS Cost Explorer | 2021-02-24T05:30:00+05:30 | 2021-03-01T05:30:00+05:30 | false     | 0.36                | USD               | 0.36                  | USD                 | 0.36                    
| AWS Cost Explorer | 2021-11-01T05:30:00+05:30 | 2021-12-01T05:30:00+05:30 | false     | 3.44                | USD               | 3.44                  | USD                 | 3.44                    
| AWS Cost Explorer | 2021-08-01T05:30:00+05:30 | 2021-09-01T05:30:00+05:30 | false     | 0                   | USD               | 0                     | USD                 | 0                       
| AWS Cost Explorer | 2021-09-01T05:30:00+05:30 | 2021-10-01T05:30:00+05:30 | false     | -0                  | USD               | -0                    | USD                 | -0                      
| AWS Cost Explorer | 2021-07-01T05:30:00+05:30 | 2021-08-01T05:30:00+05:30 | false     | 2.42                | USD               | 2.42                  | USD                 | 2.42                    
| AWS Cost Explorer | 2021-03-01T05:30:00+05:30 | 2021-04-01T05:30:00+05:30 | false     | 2.4                 | USD               | 2.4                   | USD                 | 2.4                     
| AWS Cost Explorer | 2021-12-01T05:30:00+05:30 | 2022-01-01T05:30:00+05:30 | false     | 2.6                 | USD               | 2.6                   | USD                 | 2.6                     
| AWS Cost Explorer | 2021-10-01T05:30:00+05:30 | 2021-11-01T05:30:00+05:30 | false     | 2.42                | USD               | 2.42                  | USD                 | 2.42                    
| AWS Cost Explorer | 2022-01-01T05:30:00+05:30 | 2022-02-01T05:30:00+05:30 | false     | 2.42                | USD               | 2.42                  | USD                 | 2.42                    
| AWS Cost Explorer | 2021-06-01T05:30:00+05:30 | 2021-07-01T05:30:00+05:30 | false     | -0                  | USD               | -0                    | USD                 | -0                      
| AWS Cost Explorer | 2022-02-01T05:30:00+05:30 | 2022-02-24T05:30:00+05:30 | true      | 56.39               | USD               | 56.39                 | USD                 | 56.39                   
| AWS Cost Explorer | 2021-04-01T05:30:00+05:30 | 2021-05-01T05:30:00+05:30 | false     | -0                  | USD               | -0                    | USD                 | -0                      
| AWS Cost Explorer | 2021-05-01T05:30:00+05:30 | 2021-06-01T05:30:00+05:30 | false     | 0                   | USD               | 0                     | USD                 | 0                       
+-------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+-------------------------

=====================================================================

> select * from aws_cost_by_service_usage_type_daily where service <> 'AWS Cost Explorer'
+-------------------------------------------------+---------------------------------------------------+---------------------------+---------------------------+-----------+---------------------+---------
| service                                         | usage_type                                        | period_start              | period_end                | estimated | blended_cost_amount | blended_
+-------------------------------------------------+---------------------------------------------------+---------------------------+---------------------------+-----------+---------------------+---------
| AWS CloudTrail                                  | APN2-FreeEventsRecorded                           | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| AWS CloudTrail                                  | APN1-FreeEventsRecorded                           | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| AWS CloudTrail                                  | APS3-FreeEventsRecorded                           | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| AWS CloudTrail                                  | USW1-FreeEventsRecorded                           | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| AWS CloudTrail                                  | APS1-FreeEventsRecorded                           | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| AWS CloudTrail                                  | EUN1-FreeEventsRecorded                           | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| AWS CloudTrail                                  | EUW3-FreeEventsRecorded                           | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| AWS CloudTrail                                  | SAE1-FreeEventsRecorded                           | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| AWS CloudTrail                                  | APS2-FreeEventsRecorded                           | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| AWS CloudTrail                                  | USE1-FreeEventsRecorded                           | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| AWS CloudTrail                                  | EUC1-FreeEventsRecorded                           | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| Amazon Simple Notification Service              | DeliveryAttempts-HTTP                             | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| Amazon Simple Notification Service              | DataTransfer-Out-Bytes                            | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0.0000009731        | USD     
| AWS CloudTrail                                  | EUW2-FreeEventsRecorded                           | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     
| Amazon Simple Storage Service                   | Requests-Tier1                                    | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0.021475            | USD     
| Amazon Simple Storage Service                   | USE1-APN1-AWS-In-Bytes                            | 2021-02-24T05:30:00+05:30 | 2021-02-25T05:30:00+05:30 | false     | 0                   | USD     

============================================

> select * from aws_cost_by_service_usage_type_daily where service = 'AWS Data Transfer' and usage_type = 'DataTransfer-Out-Bytes'
+-------------------+------------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+
| service           | usage_type             | period_start              | period_end                | estimated | blended_cost_amount | blended_cost_unit | unblended_cost_amount | unblended_cost_unit |
+-------------------+------------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+
| AWS Data Transfer | DataTransfer-Out-Bytes | 2021-04-30T05:30:00+05:30 | 2021-05-01T05:30:00+05:30 | false     | -0.0000010665       | USD               | -0.0000010665         | USD                 |
| AWS Data Transfer | DataTransfer-Out-Bytes | 2021-05-03T05:30:00+05:30 | 2021-05-04T05:30:00+05:30 | false     | -0.0000066933       | USD               | -0.0000066933         | USD                 |
| AWS Data Transfer | DataTransfer-Out-Bytes | 2021-04-11T05:30:00+05:30 | 2021-04-12T05:30:00+05:30 | false     | -0.0000010665       | USD               | -0.0000010665         | USD                 |

============================================================

> select * from aws_cost_by_service_usage_type_daily where service = 'AWS Data Transfer' and usage_type <> 'DataTransfer-Out-Bytes'
+-------------------+----------------------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+------------
| service           | usage_type                       | period_start              | period_end                | estimated | blended_cost_amount | blended_cost_unit | unblended_cost_amount | unblended_c
+-------------------+----------------------------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+------------
| AWS Data Transfer | APS3-DataTransfer-Regional-Bytes | 2021-04-14T05:30:00+05:30 | 2021-04-15T05:30:00+05:30 | false     | -0.0000004091       | USD               | -0.0000004091         | USD        
| AWS Data Transfer | APS3-USE1-AWS-Out-Bytes          | 2021-04-07T05:30:00+05:30 | 2021-04-08T05:30:00+05:30 | false     | -0.0000000697       | USD               | -0.0000000697         | USD        
| AWS Data Transfer | USE1-APS3-AWS-Out-Bytes          | 2021-04-01T05:30:00+05:30 | 2021-04-02T05:30:00+05:30 | false     | -0.000000053        | USD               | -0.000000053          | USD        

=============================================================

> select * from aws_cost_forecast_monthly;
+---------------------------+---------------------------+-------------------+-----------+--------+--------------+---------------------------+
| period_start              | period_end                | mean_value        | partition | region | account_id   | _ctx                      |
+---------------------------+---------------------------+-------------------+-----------+--------+--------------+---------------------------+
| 2022-03-01T05:30:00+05:30 | 2022-04-01T05:30:00+05:30 | 617.0017365954296 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-11-01T05:30:00+05:30 | 2022-12-01T05:30:00+05:30 | 597.2549373751547 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-10-01T05:30:00+05:30 | 2022-11-01T05:30:00+05:30 | 617.0896663313529 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-08-01T05:30:00+05:30 | 2022-09-01T05:30:00+05:30 | 617.0896663276898 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-07-01T05:30:00+05:30 | 2022-08-01T05:30:00+05:30 | 617.0896662575535 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-02-01T05:30:00+05:30 | 2022-03-01T05:30:00+05:30 | 619.5702505252548 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-06-01T05:30:00+05:30 | 2022-07-01T05:30:00+05:30 | 597.2549360238893 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-04-01T05:30:00+05:30 | 2022-05-01T05:30:00+05:30 | 597.2546197280823 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-12-01T05:30:00+05:30 | 2023-01-01T05:30:00+05:30 | 617.0896663313631 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-09-01T05:30:00+05:30 | 2022-10-01T05:30:00+05:30 | 597.2549373749731 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2023-01-01T05:30:00+05:30 | 2023-02-01T05:30:00+05:30 | 617.0896663313631 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-05-01T05:30:00+05:30 | 2022-06-01T05:30:00+05:30 | 617.0896356414187 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2023-02-01T05:30:00+05:30 | 2023-03-01T05:30:00+05:30 | 557.5854794627392 | aws       | global | 632902152528 | {"connection_name":"aws"} |
+---------------------------+---------------------------+-------------------+-----------+--------+--------------+---------------------------+

==================================================================

> select * from aws_cost_forecast_daily;
+---------------------------+---------------------------+--------------------+-----------+--------+--------------+---------------------------+
| period_start              | period_end                | mean_value         | partition | region | account_id   | _ctx                      |
+---------------------------+---------------------------+--------------------+-----------+--------+--------------+---------------------------+
| 2022-02-26T05:30:00+05:30 | 2022-02-27T05:30:00+05:30 | 19.46553099299386  | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-03-01T05:30:00+05:30 | 2022-03-02T05:30:00+05:30 | 21.800996693762343 | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-02-25T05:30:00+05:30 | 2022-02-26T05:30:00+05:30 | 19.61260760876393  | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-02-28T05:30:00+05:30 | 2022-03-01T05:30:00+05:30 | 19.75533218266129  | aws       | global | 632902152528 | {"connection_name":"aws"} |
| 2022-02-27T05:30:00+05:30 | 2022-02-28T05:30:00+05:30 | 20.269950308655744 | aws       | global | 632902152528 | {"connection_name":"aws"} |


```
</details>
