### PR TITLE
Fix InvalidParameterValue exception in aws_ebs_volume table closes #918

### DIFF
--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -18,7 +18,7 @@ func tableAwsEBSSnapshot(_ context.Context) *plugin.Table {
 		Description: "AWS EBS Snapshot",
 		Get: &plugin.GetConfig{
 			KeyColumns:        plugin.SingleColumn("snapshot_id"),
-			ShouldIgnoreError: isNotFoundError([]string{"InvalidSnapshot.NotFound", "InvalidSnapshotID.Malformed"}),
+			ShouldIgnoreError: isNotFoundError([]string{"InvalidSnapshot.NotFound", "InvalidSnapshotID.Malformed", "InvalidParameterValue"}),
 			Hydrate:           getAwsEBSSnapshot,
 		},
 		List: &plugin.ListConfig{

--- a/aws/table_aws_ebs_volume.go
+++ b/aws/table_aws_ebs_volume.go
@@ -372,12 +372,14 @@ func buildEbsVolumeFilter(quals plugin.KeyColumnQualMap) []*ec2.Filter {
 				filter.Values = []*string{aws.String(fmt.Sprint(value))}
 			} else {
 				value := getQualsValueByColumn(quals, columnName, "string")
-				val, ok := value.(string)
-				if ok {
-					filter.Values = []*string{aws.String(val)}
-				} else {
-					valSlice := value.([]*string)
-					filter.Values = valSlice
+				if value != nil {
+					val, ok := value.(string)
+					if ok {
+						filter.Values = []*string{aws.String(val)}
+					} else {
+						valSlice := value.([]*string)
+						filter.Values = valSlice
+					}
 				}
 			}
 			filters = append(filters, &filter)

--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -706,8 +706,12 @@ func buildEc2InstanceFilter(equalQuals plugin.KeyColumnEqualsQualMap) []*ec2.Fil
 
 func getListValues(listValue *proto.QualValueList) []*string {
 	values := make([]*string, 0)
-	for _, value := range listValue.Values {
-		values = append(values, types.String(value.GetStringValue()))
+	if listValue != nil {
+		for _, value := range listValue.Values {
+			if value.GetStringValue() != "" {
+				values = append(values, types.String(value.GetStringValue()))
+			}
+		}
 	}
 	return values
 }

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -139,7 +139,10 @@ func getQualsValueByColumn(equalQuals plugin.KeyColumnQualMap, columnName string
 			if q.Value.GetStringValue() != "" {
 				value = q.Value.GetStringValue()
 			} else {
-				value = getListValues(q.Value.GetListValue())
+				valList := getListValues(q.Value.GetListValue())
+				if len(valList) > 0 {
+					value = valList
+				}
 			}
 		}
 		if dataType == "boolean" {


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT 300

SETUP: tests/aws_ebs_volume []

PRETEST: tests/aws_ebs_volume

TEST: tests/aws_ebs_volume
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_ebs_volume.named_test_resource: Creating...
aws_ebs_volume.named_test_resource: Still creating... [10s elapsed]
aws_ebs_volume.named_test_resource: Creation complete after 14s [id=vol-06ad0e5a6ea25412b]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = 123456789012
aws_partition = aws
resource_aka = arn:aws:ec2:us-east-1:123456789012:volume/vol-06ad0e5a6ea25412b
resource_id = vol-06ad0e5a6ea25412b
resource_name = turbottest46729

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:ec2:us-east-1:123456789012:volume/vol-06ad0e5a6ea25412b",
    "attachments": null,
    "encrypted": false,
    "multi_attach_enabled": false,
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest46729"
      }
    ],
    "volume_id": "vol-06ad0e5a6ea25412b"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "auto_enable_io": false,
    "product_codes": null,
    "volume_id": "vol-06ad0e5a6ea25412b"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:123456789012:volume/vol-06ad0e5a6ea25412b"
    ],
    "tags": {
      "Name": "turbottest46729"
    },
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest46729"
      }
    ],
    "title": "turbottest46729",
    "volume_id": "vol-06ad0e5a6ea25412b"
  }
]
✔ PASSED

POSTTEST: tests/aws_ebs_volume

TEARDOWN: tests/aws_ebs_volume

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Passing empty string for snapshot_id: 
> select volume_id, volume_type, snapshot_id from aws_ebs_volume where snapshot_id = ''
+-----------+-------------+-------------+
| volume_id | volume_type | snapshot_id |
+-----------+-------------+-------------+
+-----------+-------------+-------------+
Passing null for snapshot_id: 
> select volume_id, volume_type, snapshot_id from aws_ebs_volume where snapshot_id = null
+-----------+-------------+-------------+
| volume_id | volume_type | snapshot_id |
+-----------+-------------+-------------+
+-----------+-------------+-------------+
Passing invalid value for snapshot_id:
> select volume_id, volume_type, snapshot_id from aws_ebs_volume where snapshot_id = 'snap-038b5e4'
+-----------+-------------+-------------+
| volume_id | volume_type | snapshot_id |
+-----------+-------------+-------------+
+-----------+-------------+-------------+
```

```
> with public_snapshots as (
          select
            snapshot_id
          from
            aws_ebs_snapshot
          where
            create_volume_permissions @> '[{"Group": "all"}]'
        ),
        public_volumes as (
          select
            v.title as volume
          from
            aws_ebs_volume as v,
            public_snapshots as s
          where
            v.snapshot_id = s.snapshot_id
        )
        select
          count(*) as value,
          'Publicly Accessible' as label,
          case count(*) when 0 then 'ok' else 'alert' end as type
        from
          public_volumes;
+-------+---------------------+------+
| value | label               | type |
+-------+---------------------+------+
| 0     | Publicly Accessible | ok   |
+-------+---------------------+------+
```
</details>
