### PR TITLE
Add support for Amazon SQS key (SSE-SQS) in aws_sqs_queue table closes #921

### DIFF
--- a/aws/table_aws_sqs_queue.go
+++ b/aws/table_aws_sqs_queue.go
@@ -79,7 +79,7 @@ func tableAwsSqsQueue(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "sqs_managed_sse_enabled",
-				Description: "Returns true if the queue is using SSE-SQS encryption using SQS owned encryption keys",
+				Description: "Returns true if the queue is using SSE-SQS encryption with SQS-owned encryption keys.",
 				Type:        proto.ColumnType_BOOL,
 				Hydrate:     getQueueAttributes,
 				Transform:   transform.FromField("Attributes.SqsManagedSseEnabled"),

--- a/aws/table_aws_sqs_queue.go
+++ b/aws/table_aws_sqs_queue.go
@@ -78,6 +78,13 @@ func tableAwsSqsQueue(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Attributes.ReceiveMessageWaitTimeSeconds"),
 			},
 			{
+				Name:        "sqs_managed_sse_enabled",
+				Description: "Returns true if the queue is using SSE-SQS encryption using SQS owned encryption keys",
+				Type:        proto.ColumnType_BOOL,
+				Hydrate:     getQueueAttributes,
+				Transform:   transform.FromField("Attributes.SqsManagedSseEnabled"),
+			},
+			{
 				Name:        "visibility_timeout_seconds",
 				Description: "The visibility timeout for the queue in seconds.",
 				Type:        proto.ColumnType_STRING,
@@ -115,7 +122,7 @@ func tableAwsSqsQueue(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "kms_master_key_id",
-				Description: "the ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK.",
+				Description: "The ID of an AWS-managed customer master key (CMK) for Amazon SQS or a custom CMK.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getQueueAttributes,
 				Transform:   transform.FromField("Attributes.KmsMasterKeyId"),

--- a/docs/tables/aws_sqs_queue.md
+++ b/docs/tables/aws_sqs_queue.md
@@ -4,47 +4,7 @@ Amazon Simple Queue Service (SQS) is a fully managed message queuing service tha
 
 ## Examples
 
-### List of SQS queues which are not encrypted
-
-```sql
-select
-  title,
-  kms_master_key_id,
-  sqs_managed_sse_enabled
-from
-  aws_sqs_queue
-where
-  kms_master_key_id is null and not sqs_managed_sse_enabled;
-```
-
-### List of SQS queues which are encrypted by CMK
-
-```sql
-select
-  title,
-  kms_master_key_id,
-  sqs_managed_sse_enabled
-from
-  aws_sqs_queue
-where
-  kms_master_key_id is not null;
-```
-
-### List of SQS queues which are encrypted by queue managed key
-
-```sql
-select
-  title,
-  kms_master_key_id,
-  sqs_managed_sse_enabled
-from
-  aws_sqs_queue
-where
-  sqs_managed_sse_enabled;
-```
-
-
-### SQS queue message configuration info
+### Basic info
 
 ```sql
 select
@@ -58,8 +18,47 @@ from
   aws_sqs_queue;
 ```
 
+### List unencrypted queues
 
-### List of SQS queues where message retention period is less than 7 days
+```sql
+select
+  title,
+  kms_master_key_id,
+  sqs_managed_sse_enabled
+from
+  aws_sqs_queue
+where
+  kms_master_key_id is null
+  and not sqs_managed_sse_enabled;
+```
+
+### List queues encrypted with a CMK
+
+```sql
+select
+  title,
+  kms_master_key_id,
+  sqs_managed_sse_enabled
+from
+  aws_sqs_queue
+where
+  kms_master_key_id is not null;
+```
+
+### List queues encrypted with an SQS-owned encryption key
+
+```sql
+select
+  title,
+  kms_master_key_id,
+  sqs_managed_sse_enabled
+from
+  aws_sqs_queue
+where
+  sqs_managed_sse_enabled;
+```
+
+### List queues with a message retention period less than 7 days
 
 ```sql
 select
@@ -71,8 +70,7 @@ where
   message_retention_seconds < '604800';
 ```
 
-
-### List of queues which are not configured with DLQ(Dead Letter Queue)
+### List queues which are not configured with a dead-letter queue (DLQ)
 
 ```sql
 select
@@ -84,8 +82,7 @@ where
   redrive_policy is null;
 ```
 
-
-### List of FIFO queues
+### List FIFO queues
 
 ```sql
 select
@@ -97,7 +94,7 @@ where
   fifo_queue;
 ```
 
-### List of queues policy statements that grant external access
+### List queues with policy statements that grant cross-account access
 
 ```sql
 select
@@ -120,8 +117,7 @@ where
   );
 ```
 
-
-### Queue policy statements that grant anonymous access
+### List queues with policy statements that grant anoymous access
 
 ```sql
 select
@@ -140,8 +136,7 @@ where
   and s ->> 'Effect' = 'Allow';
 ```
 
-
-### Queue policy statements that grant full access (sqs:*)
+### List queues with policy statements that grant full access (sqs:*)
 
 ```sql
 select

--- a/docs/tables/aws_sqs_queue.md
+++ b/docs/tables/aws_sqs_queue.md
@@ -14,7 +14,7 @@ select
 from
   aws_sqs_queue
 where
-  kms_master_key_id is null or not sqs_managed_sse_enabled;
+  kms_master_key_id is null and not sqs_managed_sse_enabled;
 ```
 
 ### List of SQS queues which are encrypted by CMK

--- a/docs/tables/aws_sqs_queue.md
+++ b/docs/tables/aws_sqs_queue.md
@@ -9,11 +9,38 @@ Amazon Simple Queue Service (SQS) is a fully managed message queuing service tha
 ```sql
 select
   title,
-  kms_master_key_id
+  kms_master_key_id,
+  sqs_managed_sse_enabled
 from
   aws_sqs_queue
 where
-  kms_master_key_id is null;
+  kms_master_key_id is null or not sqs_managed_sse_enabled;
+```
+
+### List of SQS queues which are encrypted by CMK
+
+```sql
+select
+  title,
+  kms_master_key_id,
+  sqs_managed_sse_enabled
+from
+  aws_sqs_queue
+where
+  kms_master_key_id is not null;
+```
+
+### List of SQS queues which are encrypted by queue managed key
+
+```sql
+select
+  title,
+  kms_master_key_id,
+  sqs_managed_sse_enabled
+from
+  aws_sqs_queue
+where
+  sqs_managed_sse_enabled;
 ```
 
 


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_sqs_queue []

PRETEST: tests/aws_sqs_queue

TEST: tests/aws_sqs_queue
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_sqs_queue.named_test_resource: Creating...
aws_sns_topic.named_test_resource: Creating...
aws_sns_topic.named_test_resource: Creation complete after 3s [id=arn:aws:sns:us-east-1:632902152528:turbottest92319]
aws_sqs_queue.named_test_resource: Still creating... [10s elapsed]
aws_sqs_queue.named_test_resource: Still creating... [20s elapsed]
aws_sqs_queue.named_test_resource: Creation complete after 28s [id=https://sqs.us-east-1.amazonaws.com/632902152528/turbottest92319]
aws_sqs_queue_policy.test: Creating...
aws_sqs_queue_policy.test: Still creating... [10s elapsed]
aws_sqs_queue_policy.test: Still creating... [20s elapsed]
aws_sqs_queue_policy.test: Creation complete after 27s [id=https://sqs.us-east-1.amazonaws.com/632902152528/turbottest92319]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = 632902152528
aws_region = us-east-1
queue_url = https://sqs.us-east-1.amazonaws.com/632902152528/turbottest92319
resource_aka = arn:aws:sqs:us-east-1:632902152528:turbottest92319
resource_name = turbottest92319
sns_topic_arn = arn:aws:sns:us-east-1:632902152528:turbottest92319

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:sqs:us-east-1:632902152528:turbottest92319"
    ],
    "tags": {
      "name": "turbottest92319"
    },
    "title": "turbottest92319"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "delay_seconds": "0",
    "max_message_size": "262144",
    "message_retention_seconds": "345600",
    "partition": "aws",
    "policy": {
      "Id": "sqspolicy",
      "Statement": [
        {
          "Action": "sqs:SendMessage",
          "Condition": {
            "ArnEquals": {
              "aws:SourceArn": "arn:aws:sns:us-east-1:632902152528:turbottest92319"
            }
          },
          "Effect": "Allow",
          "Principal": "*",
          "Resource": "arn:aws:sqs:us-east-1:632902152528:turbottest92319",
          "Sid": "First"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Id": "sqspolicy",
      "Statement": [
        {
          "Action": [
            "sqs:sendmessage"
          ],
          "Condition": {
            "ArnEquals": {
              "aws:sourcearn": [
                "arn:aws:sns:us-east-1:632902152528:turbottest92319"
              ]
            }
          },
          "Effect": "Allow",
          "Principal": {
            "AWS": [
              "*"
            ]
          },
          "Resource": [
            "arn:aws:sqs:us-east-1:632902152528:turbottest92319"
          ],
          "Sid": "First"
        }
      ],
      "Version": "2012-10-17"
    },
    "queue_arn": "arn:aws:sqs:us-east-1:632902152528:turbottest92319",
    "queue_url": "https://sqs.us-east-1.amazonaws.com/632902152528/turbottest92319",
    "receive_wait_time_seconds": "0",
    "tags": {
      "name": "turbottest92319"
    }
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "632902152528",
    "akas": [
      "arn:aws:sqs:us-east-1:632902152528:turbottest92319"
    ],
    "region": "us-east-1",
    "tags": {
      "name": "turbottest92319"
    },
    "title": "turbottest92319"
  }
]
✔ PASSED

POSTTEST: tests/aws_sqs_queue

TEARDOWN: tests/aws_sqs_queue

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  

```sql
 select queue_arn, sqs_managed_sse_enabled from aws_sqs_queue
```

```
+-------------------------------------------------+-------------------------+
| queue_arn                                       | sqs_managed_sse_enabled |
+-------------------------------------------------+-------------------------+
| arn:aws:sqs:ap-south-1:533793682495:testq       | false                   |
| arn:aws:sqs:ap-south-1:533793682495:deletemeq   | true                    |
| arn:aws:sqs:ap-south-1:533793682495:deletemecmk | false                   |
+-------------------------------------------------+-------------------------+
```

```sql
select
  title,
  kms_master_key_id,
  sqs_managed_sse_enabled
from
  aws_sqs_queue
where
  kms_master_key_id is null or not sqs_managed_sse_enabled;
```

```
+-------------+----------------------+-------------------------+
| title       | kms_master_key_id    | sqs_managed_sse_enabled |
+-------------+----------------------+-------------------------+
| deletemeq   | <null>               | true                    |
| testq       | <null>               | false                   |
| deletemecmk | alias/turbot/default | false                   |
+-------------+----------------------+-------------------------+
```

```sql
 select
  title,
  kms_master_key_id,
  sqs_managed_sse_enabled
from
  aws_sqs_queue
where
  sqs_managed_sse_enabled;
```

```
+-----------+-------------------+-------------------------+
| title     | kms_master_key_id | sqs_managed_sse_enabled |
+-----------+-------------------+-------------------------+
| deletemeq | <null>            | true                    |
+-----------+-------------------+-------------------------+
```

```sql 
select
  title,
  kms_master_key_id,
  sqs_managed_sse_enabled
from
  aws_sqs_queue
where
  kms_master_key_id is not null;

```
```
+-------------+----------------------+-------------------------+
| title       | kms_master_key_id    | sqs_managed_sse_enabled |
+-------------+----------------------+-------------------------+
| deletemecmk | alias/turbot/default | false                   |
+-------------+----------------------+-------------------------+
```
</details>
