### PR TITLE
Fix title column value in aws_vpc_security_group_rule table closes #923

### DIFF
--- a/aws/table_aws_vpc_security_group_rule.go
+++ b/aws/table_aws_vpc_security_group_rule.go
@@ -391,9 +391,9 @@ func getSecurityGroupRuleTurbotData(ctx context.Context, d *plugin.QueryData, h 
 	// Create a unique AKA
 	hashCode := "_" + *sgRule.IpProtocol
 	if *sgRule.IsEgress {
-		hashCode = "ingress" + hashCode
-	} else {
 		hashCode = "egress" + hashCode
+	} else {
+		hashCode = "ingress" + hashCode
 	}
 
 	if sgRule.FromPort != nil {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
 
**Before Fix**
```
> select title, type, is_egress from aws_vpc_security_group_rule
+------------------------------------------------------------+---------+-----------+
| title                                                      | type    | is_egress |
+------------------------------------------------------------+---------+-----------+
| sgr-0177bd56f94cdd510_egress_tcp_22_22_0.0.0.0/0           | ingress | false     |
| sgr-0c364b3d2515d41c4_ingress_-1_-1_-1_0.0.0.0/0           | egress  | true      |
| sgr-0a91a6fe5233dedf4_ingress_-1_-1_-1_0.0.0.0/0           | egress  | true      |
| sgr-017d623c4abae77d7_ingress_-1_-1_-1_0.0.0.0/0           | egress  | true      |
| sgr-0d2e2bcd4c5037729_egress_tcp_80_80_0.0.0.0/0           | ingress | false     |
| sgr-0444f3ce9d7c2334a_egress_-1_-1_-1_sg-014dd385e93496c44 | ingress | false     |
| sgr-0ea2bebdd19d51ebe_ingress_-1_-1_-1_0.0.0.0/0           | egress  | true      |
| sgr-0f2f502fe8970f7fb_egress_-1_-1_-1_sg-38997275          | ingress | false     |
| sgr-03f5e2195f2b64abe_egress_-1_-1_-1_sg-6997382b          | ingress | false     |
| sgr-07c21981ecc82e84c_egress_tcp_80_80_0.0.0.0/0           | ingress | false     |
| sgr-030a46b40d9060bc3_ingress_-1_-1_-1_0.0.0.0/0           | egress  | true      |
| sgr-0f9ffd1f30224e1e0_egress_tcp_80_80_0.0.0.0/0           | ingress | false     |
```

**After Fix**
```
> select title, type, is_egress from aws_vpc_security_group_rule
+-------------------------------------------------------------+---------+-----------+
| title                                                       | type    | is_egress |
+-------------------------------------------------------------+---------+-----------+
| sgr-062d9b03147892911_egress_-1_-1_-1_0.0.0.0/0             | egress  | true      |
| sgr-02ed89be7eabc0e03_egress_-1_-1_-1_0.0.0.0/0             | egress  | true      |
| sgr-032117d42f91c6c27_egress_-1_-1_-1_0.0.0.0/0             | egress  | true      |
| sgr-0efd4b4c84516c90b_egress_-1_-1_-1_0.0.0.0/0             | egress  | true      |
| sgr-0437a3db89dd59f61_egress_-1_-1_-1_0.0.0.0/0             | egress  | true      |
| sgr-091e155cb80be452d_egress_-1_-1_-1_0.0.0.0/0             | egress  | true      |
| sgr-020ee51af0719c478_ingress_tcp_80_80_0.0.0.0/0           | ingress | false     |
| sgr-00f621e98c3de8776_ingress_tcp_80_80_0.0.0.0/0           | ingress | false     |
| sgr-028f234f0ba6f410e_egress_-1_-1_-1_0.0.0.0/0             | egress  | true      |
| sgr-08c58713ef99ffb4e_egress_-1_-1_-1_0.0.0.0/0             | egress  | true      |

```

</details>
