### PR TITLE
Fixed no such host exception for hydrate API calls in aws_s3_bucket table closes #926

### DIFF
--- a/aws/table_aws_s3_bucket.go
+++ b/aws/table_aws_s3_bucket.go
@@ -315,6 +315,14 @@ func getBucketLocation(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	}
 
 	if location != nil && location.LocationConstraint != nil {
+		plugin.Logger(ctx).Info("getBucketLocation", "location.LocationConstraint", *location.LocationConstraint)
+		// For few of the bucket which are available in 'eu-west-1' region we are getting the region name as 'EU' 
+		// for which the service connection throws no such host error in getBucketEncryption
+		if *location.LocationConstraint == "EU" {
+			return &s3.GetBucketLocationOutput{
+				LocationConstraint: aws.String("eu-west-1"),
+			}, nil
+		}
 		return location, nil
 	}
 


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_s3_bucket []

PRETEST: tests/aws_s3_bucket

TEST: tests/aws_s3_bucket
Running terraform
data.aws_canonical_user_id.current_user: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_region.alternate: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_kms_key.mykey: Creating...
aws_s3_bucket.named_test_resource: Creating...
aws_kms_key.mykey: Creation complete after 2s [id=345c5a84-0dba-42cf-8f6e-106ca35dded5]
aws_s3_bucket.named_test_resource: Creation complete after 7s [id=turbottest90847]
aws_s3_bucket_policy.b: Creating...
aws_s3_bucket_policy.b: Creation complete after 0s [id=turbottest90847]

Warning: Deprecated Resource

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = 632902152528
aws_partition = aws
canonical_user_id = d1a8fb36ce85e6f4a77eec13f53958565ce292fb0c7f8fce671bb0a9eb25dd40
kms_key_id = arn:aws:kms:us-east-2:632902152528:key/345c5a84-0dba-42cf-8f6e-106ca35dded5
resource_aka = arn:aws:s3:::turbottest90847
resource_name = turbottest90847

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:s3:::turbottest90847"
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "acl": {
      "Grants": [
        {
          "Grantee": {
            "DisplayName": null,
            "EmailAddress": null,
            "ID": "d1a8fb36ce85e6f4a77eec13f53958565ce292fb0c7f8fce671bb0a9eb25dd40",
            "Type": "CanonicalUser",
            "URI": null
          },
          "Permission": "FULL_CONTROL"
        }
      ],
      "Owner": {
        "DisplayName": null,
        "ID": "d1a8fb36ce85e6f4a77eec13f53958565ce292fb0c7f8fce671bb0a9eb25dd40"
      }
    },
    "bucket_policy_is_public": false,
    "lifecycle_rules": null,
    "logging": null,
    "name": "turbottest90847",
    "object_lock_configuration": {
      "ObjectLockEnabled": "Enabled",
      "Rule": null
    },
    "policy": {
      "Id": "MYBUCKETPOLICY",
      "Statement": [
        {
          "Action": "s3:*",
          "Condition": {
            "IpAddress": {
              "aws:SourceIp": "8.8.8.8/32"
            }
          },
          "Effect": "Deny",
          "Principal": "*",
          "Resource": "arn:aws:s3:::turbottest90847/*",
          "Sid": "IPAllow"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Id": "MYBUCKETPOLICY",
      "Statement": [
        {
          "Action": [
            "s3:*"
          ],
          "Condition": {
            "IpAddress": {
              "aws:sourceip": [
                "8.8.8.8/32"
              ]
            }
          },
          "Effect": "Deny",
          "Principal": {
            "AWS": [
              "*"
            ]
          },
          "Resource": [
            "arn:aws:s3:::turbottest90847/*"
          ],
          "Sid": "IPAllow"
        }
      ],
      "Version": "2012-10-17"
    },
    "replication": null,
    "server_side_encryption_configuration": null,
    "versioning_enabled": true,
    "versioning_mfa_delete": false
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:s3:::turbottest90847"
    ],
    "block_public_acls": false,
    "block_public_policy": false,
    "bucket_policy_is_public": false,
    "ignore_public_acls": false,
    "lifecycle_rules": null,
    "logging": null,
    "name": "turbottest90847",
    "partition": "aws",
    "restrict_public_buckets": false,
    "server_side_encryption_configuration": null,
    "tags": {
      "name": "turbottest90847"
    },
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest90847"
      }
    ],
    "title": "turbottest90847",
    "versioning_enabled": true,
    "versioning_mfa_delete": false
  }
]
✔ PASSED

POSTTEST: tests/aws_s3_bucket

TEARDOWN: tests/aws_s3_bucket

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,server_side_encryption_configuration, region from aws_s3_bucket
+--------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+----------------+
| name                                                   | server_side_encryption_configuration                                                                                        | region         |
+--------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+----------------+
| master-apse1-18xc8l5wtqh8h                             | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | ap-southeast-1 |
| master-apso1-1pi11ahpuw8ke                             | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | ap-south-1     |
| aws-cloudtrail-logs-936717460871-52647c0e-test-cis4.15 | <null>                                                                                                                      | us-east-1      |
| master-cace1-1mfbp0c5p6c2t                             | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | ca-central-1   |
| zzaaaacody                                             | <null>                                                                                                                      | us-east-1      |
| master-apne2-mz5j09jjixsq                              | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | ap-northeast-2 |
| master-apne1-1ne1feg2oj2an                             | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | ap-northeast-1 |
| master-apse2-1pg8vxfwfk83m                             | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | ap-southeast-2 |
| master-euwe3-17p17thz53ciq                             | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | eu-west-3      |
| master-euwe2-gsn43c9m66sk                              | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | eu-west-2      |
| master-euce1-d8e2f4p892nf                              | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | eu-central-1   |
| master-euwe1-1ibcohyed0gl8                             | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | eu-west-1      |
| master-euno1-xjwxvcox2wie                              | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | eu-north-1     |
| aws-cloudtrail-logs-936717460871-89a5adf9              | <null>                                                                                                                      | us-east-1      |
| master-uswe1-1t29y9iptd206                             | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | us-west-1      |
| master-usea1-mmwfsnv98ace                              | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | us-east-1      |
| master0021                                             | <null>                                                                                                                      | us-east-1      |
| cf-templates-1lomxhe2txxlh-us-east-1                   | <null>                                                                                                                      | us-east-1      |
| aws-logs-936717460871-us-east-1                        | <null>                                                                                                                      | us-east-1      |
| weff3f3fcody123                                        | <null>                                                                                                                      | us-east-1      |
| codyansibletesting                                     | <null>                                                                                                                      | us-east-1      |
| master002                                              | <null>                                                                                                                      | us-east-1      |
| central-cloudtrail-turbot-location                     | <null>                                                                                                                      | us-east-1      |
| turbot-936717460871                                    | <null>                                                                                                                      | us-east-1      |
| master-uswe2-16ag0s65t8jgr                             | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | us-west-2      |
| smyth-cloudtrail-test                                  | <null>                                                                                                                      | us-east-2      |
| master-usea2-1ezvoos041z72                             | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | us-east-2      |
| master-saea1-nop3bb7o828s                              | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | sa-east-1      |
+--------------------------------------------------------+-----------------------------------------------------------------------------------------------------------------------------+----------------+

> select name,server_side_encryption_configuration, region from aws_s3_bucket where name = 'master-euwe1-1ibcohyed0gl8'
+----------------------------+-----------------------------------------------------------------------------------------------------------------------------+-----------+
| name                       | server_side_encryption_configuration                                                                                        | region    |
+----------------------------+-----------------------------------------------------------------------------------------------------------------------------+-----------+
| master-euwe1-1ibcohyed0gl8 | {"Rules":[{"ApplyServerSideEncryptionByDefault":{"KMSMasterKeyID":null,"SSEAlgorithm":"AES256"},"BucketKeyEnabled":false}]} | eu-west-1 |
+----------------------------+-----------------------------------------------------------------------------------------------------------------------------+-----------+

```
</details>
