### PR TITLE
Added support to fetch dynamoDB Table class attribute in aws_dynamodb_table. Closes #935

### DIFF
--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -61,6 +61,13 @@ func tableAwsDynamoDBTable(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("CreationDateTime"),
 			},
 			{
+				Name:        "table_class",
+				Description: "The table class of the specified table. Valid values are STANDARD and STANDARD_INFREQUENT_ACCESS.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getDynamboDbTable,
+				Transform:   transform.FromField("TableClassSummary.TableClass"),
+			},
+			{
 				Name:        "table_status",
 				Description: "The current state of the table.",
 				Type:        proto.ColumnType_STRING,


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Outputs:

account_id = "533793682495"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:dynamodb:us-east-1:533793682495:table/turbottest75877"
resource_name = "turbottest75877"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:dynamodb:us-east-1:533793682495:table/turbottest75877",
    "name": "turbottest75877"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "continuous_backups_status": "ENABLED",
    "point_in_time_recovery_description": {
      "EarliestRestorableDateTime": null,
      "LatestRestorableDateTime": null,
      "PointInTimeRecoveryStatus": "DISABLED"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:dynamodb:us-east-1:533793682495:table/turbottest75877",
    "attribute_definitions": [
      {
        "AttributeName": "userId",
        "AttributeType": "S"
      }
    ],
    "key_schema": [
      {
        "AttributeName": "userId",
        "KeyType": "HASH"
      }
    ],
    "name": "turbottest75877",
    "read_capacity": 20,
    "write_capacity": 20
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "533793682495",
    "akas": [
      "arn:aws:dynamodb:us-east-1:533793682495:table/turbottest75877"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "title": "turbottest75877"
  }
]
✔ PASSED

POSTTEST: tests/aws_dynamodb_table

TEARDOWN: tests/aws_dynamodb_table

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, table_class from aws_dynamodb_table
+-------------+----------------------------+
| name        | table_class                |
+-------------+----------------------------+
| test56      | <null>                     |
| testrktable | STANDARD_INFREQUENT_ACCESS |
+-------------+----------------------------+
```
</details>
