### PR TITLE
Add table aws_cost_by_record_type_* closes #948 #949

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -76,7 +76,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_config_rule":                                              tableAwsConfigRule(ctx),
 			"aws_cost_by_account_daily":                                    tableAwsCostByLinkedAccountDaily(ctx),
 			"aws_cost_by_account_monthly":                                  tableAwsCostByLinkedAccountMonthly(ctx),
-			"aws_cost_by_record_type_daily":                                tableAwsCostByRecordTypetDaily(ctx),
+			"aws_cost_by_record_type_daily":                                tableAwsCostByRecordTypeDaily(ctx),
 			"aws_cost_by_record_type_monthly":                              tableAwsCostByRecordTypeMonthly(ctx),
 			"aws_cost_by_service_daily":                                    tableAwsCostByServiceDaily(ctx),
 			"aws_cost_by_service_monthly":                                  tableAwsCostByServiceMonthly(ctx),

--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -76,6 +76,8 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_config_rule":                                              tableAwsConfigRule(ctx),
 			"aws_cost_by_account_daily":                                    tableAwsCostByLinkedAccountDaily(ctx),
 			"aws_cost_by_account_monthly":                                  tableAwsCostByLinkedAccountMonthly(ctx),
+			"aws_cost_by_record_type_daily":                                tableAwsCostByRecordTypetDaily(ctx),
+			"aws_cost_by_record_type_monthly":                              tableAwsCostByRecordTypeMonthly(ctx),
 			"aws_cost_by_service_daily":                                    tableAwsCostByServiceDaily(ctx),
 			"aws_cost_by_service_monthly":                                  tableAwsCostByServiceMonthly(ctx),
 			"aws_cost_by_service_usage_type_daily":                         tableAwsCostByServiceUsageTypeDaily(ctx),

--- a/aws/table_aws_cost_by_record_type_daily.go
+++ b/aws/table_aws_cost_by_record_type_daily.go
@@ -8,7 +8,7 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v2/plugin/transform"
 )
 
-func tableAwsCostByRecordTypetDaily(_ context.Context) *plugin.Table {
+func tableAwsCostByRecordTypeDaily(_ context.Context) *plugin.Table {
 	return &plugin.Table{
 		Name:        "aws_cost_by_record_type_daily",
 		Description: "AWS Cost Explorer - Cost by Record Type (Daily)",

--- a/aws/table_aws_cost_by_record_type_daily.go
+++ b/aws/table_aws_cost_by_record_type_daily.go
@@ -1,0 +1,43 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/turbot/steampipe-plugin-sdk/v2/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v2/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v2/plugin/transform"
+)
+
+func tableAwsCostByRecordTypetDaily(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_cost_by_record_type_daily",
+		Description: "AWS Cost Explorer - Cost by Record Type (Daily)",
+		List: &plugin.ListConfig{
+			Hydrate: listCostByRecordTypeDaily,
+		},
+		Columns: awsColumns(
+			costExplorerColumns([]*plugin.Column{
+
+				{
+					Name:        "linked_account_id",
+					Description: "The AWS Account ID.",
+					Type:        proto.ColumnType_STRING,
+					Transform:   transform.FromField("Dimension1"),
+				},
+				{
+					Name:        "record_type",
+					Description: "The different types of charges such as RI fees, usage, costs, tax refunds, and credits.",
+					Type:        proto.ColumnType_STRING,
+					Transform:   transform.FromField("Dimension2"),
+				},
+			}),
+		),
+	}
+}
+
+//// LIST FUNCTION
+
+func listCostByRecordTypeDaily(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	params := buildCostByRecordTypeInput("DAILY")
+	return streamCostAndUsage(ctx, d, params)
+}

--- a/aws/table_aws_cost_by_record_type_daily.go
+++ b/aws/table_aws_cost_by_record_type_daily.go
@@ -20,7 +20,7 @@ func tableAwsCostByRecordTypeDaily(_ context.Context) *plugin.Table {
 
 				{
 					Name:        "linked_account_id",
-					Description: "The AWS Account ID.",
+					Description: "The linked AWS Account ID.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("Dimension1"),
 				},

--- a/aws/table_aws_cost_by_record_type_monthly.go
+++ b/aws/table_aws_cost_by_record_type_monthly.go
@@ -1,0 +1,78 @@
+package aws
+
+import (
+	"context"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/costexplorer"
+
+	"github.com/turbot/steampipe-plugin-sdk/v2/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v2/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v2/plugin/transform"
+)
+
+func tableAwsCostByRecordTypeMonthly(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_cost_by_record_type_monthly",
+		Description: "AWS Cost Explorer - Cost by Record Type (Monthly)",
+		List: &plugin.ListConfig{
+			Hydrate: listCostByRecordTypeMonthly,
+		},
+		Columns: awsColumns(
+			costExplorerColumns([]*plugin.Column{
+
+				{
+					Name:        "linked_account_id",
+					Description: "The AWS Account ID.",
+					Type:        proto.ColumnType_STRING,
+					Transform:   transform.FromField("Dimension1"),
+				},
+				{
+					Name:        "record_type",
+					Description: "The different types of charges such as RI fees, usage, costs, tax refunds, and credits.",
+					Type:        proto.ColumnType_STRING,
+					Transform:   transform.FromField("Dimension2"),
+				},
+			}),
+		),
+	}
+}
+
+//// LIST FUNCTION
+
+func listCostByRecordTypeMonthly(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	params := buildCostByRecordTypeInput("MONTHLY")
+
+	return streamCostAndUsage(ctx, d, params)
+}
+
+func buildCostByRecordTypeInput(granularity string) *costexplorer.GetCostAndUsageInput {
+	timeFormat := "2006-01-02"
+	if granularity == "HOURLY" {
+		timeFormat = "2006-01-02T15:04:05Z"
+	}
+	endTime := time.Now().Format(timeFormat)
+	startTime := getCEStartDateForGranularity(granularity).Format(timeFormat)
+
+	params := &costexplorer.GetCostAndUsageInput{
+		TimePeriod: &costexplorer.DateInterval{
+			Start: aws.String(startTime),
+			End:   aws.String(endTime),
+		},
+		Granularity: aws.String(granularity),
+		Metrics:     aws.StringSlice(AllCostMetrics()),
+		GroupBy: []*costexplorer.GroupDefinition{
+			{
+				Type: aws.String("DIMENSION"),
+				Key:  aws.String("LINKED_ACCOUNT"),
+			},
+			{
+				Type: aws.String("DIMENSION"),
+				Key:  aws.String("RECORD_TYPE"),
+			},
+		},
+	}
+
+	return params
+}

--- a/aws/table_aws_cost_by_record_type_monthly.go
+++ b/aws/table_aws_cost_by_record_type_monthly.go
@@ -24,7 +24,7 @@ func tableAwsCostByRecordTypeMonthly(_ context.Context) *plugin.Table {
 
 				{
 					Name:        "linked_account_id",
-					Description: "The AWS Account ID.",
+					Description: "The linked AWS Account ID.",
 					Type:        proto.ColumnType_STRING,
 					Transform:   transform.FromField("Dimension1"),
 				},

--- a/docs/tables/aws_cost_by_record_type_daily.md
+++ b/docs/tables/aws_cost_by_record_type_daily.md
@@ -1,0 +1,60 @@
+# Table: aws_cost_by_credit_type_daily
+
+Amazon Cost Explorer helps you visualize, understand, and manage your AWS costs and usage.  The `aws_cost_by_record_type_daily` table provides a simplified view of cost for your account (or all linked accounts when run against the organization master) as per record types (fees, usage, costs, tax refunds, and credits), summarized by day, for the last year.  
+
+Note that [pricing for the Cost Explorer API](https://aws.amazon.com/aws-cost-management/pricing/) is per API request - Each request will incur a cost of $0.01.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  linked_account_id,
+  record_type,
+  period_start,
+  blended_cost_amount::numeric::money,
+  unblended_cost_amount::numeric::money,
+  amortized_cost_amount::numeric::money,
+  net_unblended_cost_amount::numeric::money,
+  net_amortized_cost_amount::numeric::money
+from 
+  aws_cost_by_record_type_daily
+order by
+  linked_account_id,
+  period_start;
+```
+
+### Min, Max, and average daily unblended_cost_amount by account and record type
+
+```sql
+select
+  linked_account_id,
+  record_type,
+  min(unblended_cost_amount)::numeric::money as min,
+  max(unblended_cost_amount)::numeric::money as max,
+  avg(unblended_cost_amount)::numeric::money as average
+from 
+  aws_cost_by_record_type_daily
+group by
+  linked_account_id,
+  record_type
+order by
+  linked_account_id;
+```
+
+### Ranked - Top 10 Most expensive days (unblended_cost_amount) by account and record type
+
+```sql
+with ranked_costs as (
+  select
+    linked_account_id,
+    record_type,
+    period_start,
+    unblended_cost_amount::numeric::money,
+    rank() over(partition by linked_account_id, record_type order by unblended_cost_amount desc)
+  from 
+    aws_cost_by_record_type_daily
+)
+select * from ranked_costs where rank <= 10
+```

--- a/docs/tables/aws_cost_by_record_type_daily.md
+++ b/docs/tables/aws_cost_by_record_type_daily.md
@@ -1,4 +1,4 @@
-# Table: aws_cost_by_credit_type_daily
+# Table: aws_cost_by_record_type_daily
 
 Amazon Cost Explorer helps you visualize, understand, and manage your AWS costs and usage.  The `aws_cost_by_record_type_daily` table provides a simplified view of cost for your account (or all linked accounts when run against the organization master) as per record types (fees, usage, costs, tax refunds, and credits), summarized by day, for the last year.  
 

--- a/docs/tables/aws_cost_by_record_type_monthly.md
+++ b/docs/tables/aws_cost_by_record_type_monthly.md
@@ -1,0 +1,59 @@
+# Table: aws_cost_by_record_type_monthly
+
+Amazon Cost Explorer helps you visualize, understand, and manage your AWS costs and usage.  The `aws_cost_by_record_type_monthly` table provides a simplified view of cost for your account (or all linked accounts when run against the organization master) as per record types (fees, usage, costs, tax refunds, and credits), summarized by month, for the last year.  
+
+Note that [pricing for the Cost Explorer API](https://aws.amazon.com/aws-cost-management/pricing/) is per API request - Each request will incur a cost of $0.01.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  linked_account_id,
+  record_type,
+  period_start,
+  blended_cost_amount::numeric::money,
+  unblended_cost_amount::numeric::money,
+  amortized_cost_amount::numeric::money,
+  net_unblended_cost_amount::numeric::money,
+  net_amortized_cost_amount::numeric::money
+from 
+  aws_cost_by_record_type_monthly
+order by
+  linked_account_id,
+  period_start;
+```
+
+
+
+### Min, Max, and average monthly unblended_cost_amount by account and record type
+
+```sql
+select
+  linked_account_id,
+  record_type,
+  min(unblended_cost_amount)::numeric::money as min,
+  max(unblended_cost_amount)::numeric::money as max,
+  avg(unblended_cost_amount)::numeric::money as average
+from 
+  aws_cost_by_record_type_monthly
+group by
+  linked_account_id,
+  record_type
+order by
+  linked_account_id;
+```
+
+### Ranked - Most expensive months (unblended_cost_amount) by account and record type
+
+```sql
+select
+  linked_account_id,
+  record_type,
+  period_start,
+  unblended_cost_amount::numeric::money,
+  rank() over(partition by linked_account_id, record_type order by unblended_cost_amount desc)
+from 
+  aws_cost_by_record_type_monthly;
+```

--- a/docs/tables/aws_cost_by_record_type_monthly.md
+++ b/docs/tables/aws_cost_by_record_type_monthly.md
@@ -25,8 +25,6 @@ order by
   period_start;
 ```
 
-
-
 ### Min, Max, and average monthly unblended_cost_amount by account and record type
 
 ```sql


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_cost_by_record_type_monthly;
+-------------------+-----------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+-------
| linked_account_id | record_type     | period_start              | period_end                | estimated | blended_cost_amount | blended_cost_unit | unblended_cost_amount | unblended_cost_unit | net_un
+-------------------+-----------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+-------
| 632902152528      | Tax             | 2021-10-01T05:30:00+05:30 | 2021-11-01T05:30:00+05:30 | false     | 0                   | USD               | 0                     | USD                 | 0     
| 632902152528      | Credit          | 2021-04-11T05:30:00+05:30 | 2021-05-01T05:30:00+05:30 | false     | -65.2310162879      | USD               | -65.2310162879        | USD                 | -65.23
| 632902152528      | Credit          | 2021-09-01T05:30:00+05:30 | 2021-10-01T05:30:00+05:30 | false     | -132.2017537239     | USD               | -132.2017537239       | USD                 | -132.2
| 632902152528      | Recurring       | 2021-10-01T05:30:00+05:30 | 2021-11-01T05:30:00+05:30 | false     | 2.4552              | USD               | 2.4552                | USD                 | 2.4552
| 632902152528      | Credit          | 2021-06-01T05:30:00+05:30 | 2021-07-01T05:30:00+05:30 | false     | -233.1242941302     | USD               | -233.1242941302       | USD                 | -233.1
| 632902152528      | Tax             | 2022-03-01T05:30:00+05:30 | 2022-04-01T05:30:00+05:30 | false     | 0                   | USD               | 0                     | USD                 | 0     
| 632902152528      | Recurring       | 2021-12-01T05:30:00+05:30 | 2022-01-01T05:30:00+05:30 | false     | 2.4552              | USD               | 2.4552                | USD                 | 2.4552
| 632902152528      | Usage           | 2021-07-01T05:30:00+05:30 | 2021-08-01T05:30:00+05:30 | false     | 67.712699748        | USD               | 67.7223757338         | USD                 | 67.722
| 632902152528      | Usage           | 2021-06-01T05:30:00+05:30 | 2021-07-01T05:30:00+05:30 | false     | 233.9356727377      | USD               | 233.1242801694        | USD                 | 233.12
| 632902152528      | Recurring       | 2021-09-01T05:30:00+05:30 | 2021-10-01T05:30:00+05:30 | false     | 2.376               | USD               | 2.376                 | USD                 | 2.376 
| 632902152528      | DiscountedUsage | 2021-08-01T05:30:00+05:30 | 2021-09-01T05:30:00+05:30 | false     | 0.0020563708        | USD               | 0                     | USD                 | 0     
| 632902152528      | Credit          | 2021-05-01T05:30:00+05:30 | 2021-06-01T05:30:00+05:30 | false     | -154.6119690964     | USD               | -154.6119690964       | USD                 | -154.6
| 632902152528      | Usage           | 2021-09-01T05:30:00+05:30 | 2021-10-01T05:30:00+05:30 | false     | 129.855599241       | USD               | 129.8257412816        | USD                 | 129.82
| 632902152528      | Tax             | 2021-12-01T05:30:00+05:30 | 2022-01-01T05:30:00+05:30 | false     | 0                   | USD               | 0                     | USD                 | 0     
| 632902152528      | Usage           | 2021-04-11T05:30:00+05:30 | 2021-05-01T05:30:00+05:30 | false     | 65.2302034644       | USD               | 65.231012722          | USD                 | 65.231
| 632902152528      | Usage           | 2022-03-01T05:30:00+05:30 | 2022-04-01T05:30:00+05:30 | false     | 499.789589576       | USD               | 498.9681674323        | USD                 | 498.96
| 632902152528      | Recurring       | 2021-08-01T05:30:00+05:30 | 2021-09-01T05:30:00+05:30 | false     | 1.054836            | USD               | 1.054836              | USD                 | 1.0548
| 632902152528      | Usage           | 2021-08-01T05:30:00+05:30 | 2021-09-01T05:30:00+05:30 | false     | 33.0810088804       | USD               | 33.0793736123         | USD                 | 33.079
| 632902152528      | Usage           | 2021-10-01T05:30:00+05:30 | 2021-11-01T05:30:00+05:30 | false     | 43.3352284116       | USD               | 43.9634397131         | USD                 | 43.963
| 632902152528      | Usage           | 2022-01-01T05:30:00+05:30 | 2022-02-01T05:30:00+05:30 | false     | 104.3985999982      | USD               | 104.4170892805        | USD                 | 104.41
| 632902152528      | Recurring       | 2022-01-01T05:30:00+05:30 | 2022-02-01T05:30:00+05:30 | false     | 2.4552              | USD               | 2.4552                | USD                 | 2.4552
| 632902152528      | Recurring       | 2022-02-01T05:30:00+05:30 | 2022-03-01T05:30:00+05:30 | false     | 2.2176              | USD               | 2.2176                | USD                 | 2.2176
| 632902152528      | Credit          | 2021-08-01T05:30:00+05:30 | 2021-09-01T05:30:00+05:30 | false     | -34.1342350526      | USD               | -34.1342350526        | USD                 | -34.13
| 632902152528      | Tax             | 2021-11-01T05:30:00+05:30 | 2021-12-01T05:30:00+05:30 | false     | 0                   | USD               | 0                     | USD                 | 0     
| 632902152528      | Usage           | 2021-12-01T05:30:00+05:30 | 2022-01-01T05:30:00+05:30 | false     | 61.5010808879       | USD               | 61.4383087671         | USD                 | 61.438
| 632902152528      | Recurring       | 2022-03-01T05:30:00+05:30 | 2022-04-01T05:30:00+05:30 | false     | 2.4552              | USD               | 2.4552                | USD                 | 2.4552
| 632902152528      | Recurring       | 2022-04-01T05:30:00+05:30 | 2022-04-11T05:30:00+05:30 | true      | 2.376               | USD               | 2.376                 | USD                 | 2.376 
| 632902152528      | Tax             | 2021-07-01T05:30:00+05:30 | 2021-08-01T05:30:00+05:30 | false     | 0                   | USD               | 0                     | USD                 | 0     
| 632902152528      | Usage           | 2021-11-01T05:30:00+05:30 | 2021-12-01T05:30:00+05:30 | false     | 58.346485477        | USD               | 58.4449703375         | USD                 | 58.444
| 632902152528      | Usage           | 2021-05-01T05:30:00+05:30 | 2021-06-01T05:30:00+05:30 | false     | 154.6299575806      | USD               | 154.6119484388        | USD                 | 154.61
| 632902152528      | Tax             | 2022-04-01T05:30:00+05:30 | 2022-04-11T05:30:00+05:30 | true      | 0                   | USD               | 0                     | USD                 | 0     
| 632902152528      | Tax             | 2022-02-01T05:30:00+05:30 | 2022-03-01T05:30:00+05:30 | false     | 0                   | USD               | 0                     | USD                 | 0     
| 632902152528      | Usage           | 2022-02-01T05:30:00+05:30 | 2022-03-01T05:30:00+05:30 | false     | 610.8454032832      | USD               | 611.177942452         | USD                 | 611.17
| 632902152528      | Tax             | 2022-01-01T05:30:00+05:30 | 2022-02-01T05:30:00+05:30 | false     | 0                   | USD               | 0                     | USD                 | 0     
| 632902152528      | Usage           | 2022-04-01T05:30:00+05:30 | 2022-04-11T05:30:00+05:30 | true      | 124.1971953516      | USD               | 124.1940915259        | USD                 | 124.19
| 632902152528      | Recurring       | 2021-11-01T05:30:00+05:30 | 2021-12-01T05:30:00+05:30 | false     | 2.376               | USD               | 2.376                 | USD                 | 2.376 
+-------------------+-----------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+-------
> select * from aws_cost_by_record_type_daily;
+-------------------+-----------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+-------
| linked_account_id | record_type     | period_start              | period_end                | estimated | blended_cost_amount | blended_cost_unit | unblended_cost_amount | unblended_cost_unit | net_un
+-------------------+-----------------+---------------------------+---------------------------+-----------+---------------------+-------------------+-----------------------+---------------------+-------
| 632902152528      | Credit          | 2021-04-11T05:30:00+05:30 | 2021-04-12T05:30:00+05:30 | false     | -4.3644353445       | USD               | -4.3644353445         | USD                 | -4.364
| 632902152528      | Usage           | 2021-04-11T05:30:00+05:30 | 2021-04-12T05:30:00+05:30 | false     | 4.3644247904        | USD               | 4.364435203           | USD                 | 4.3644
| 632902152528      | Credit          | 2021-04-24T05:30:00+05:30 | 2021-04-25T05:30:00+05:30 | false     | -2.99863062         | USD               | -2.99863062           | USD                 | -2.998
| 632902152528      | Credit          | 2021-04-14T05:30:00+05:30 | 2021-04-15T05:30:00+05:30 | false     | -3.2183264928       | USD               | -3.2183264928         | USD                 | -3.218
| 632902152528      | Credit          | 2021-04-12T05:30:00+05:30 | 2021-04-13T05:30:00+05:30 | false     | -3.1484770363       | USD               | -3.1484770363         | USD                 | -3.148
| 632902152528      | Credit          | 2021-04-20T05:30:00+05:30 | 2021-04-21T05:30:00+05:30 | false     | -2.6210957569       | USD               | -2.6210957569         | USD                 | -2.621
| 632902152528      | Usage           | 2021-04-21T05:30:00+05:30 | 2021-04-22T05:30:00+05:30 | false     | 3.4476261048        | USD               | 3.4476362608          | USD                 | 3.4476
| 632902152528      | Usage           | 2021-04-22T05:30:00+05:30 | 2021-04-23T05:30:00+05:30 | false     | 3.5682204349        | USD               | 3.5682436233          | USD                 | 3.5682
| 632902152528      | Credit          | 2021-04-23T05:30:00+05:30 | 2021-04-24T05:30:00+05:30 | false     | -2.9602061859       | USD               | -2.9602061859         | USD                 | -2.960
| 632902152528      | Usage           | 2021-04-12T05:30:00+05:30 | 2021-04-13T05:30:00+05:30 | false     | 3.1484689523        | USD               | 3.1484768836          | USD                 | 3.1484
| 632902152528      | Usage           | 2021-04-16T05:30:00+05:30 | 2021-04-17T05:30:00+05:30 | false     | 3.778169413         | USD               | 3.7787301814          | USD                 | 3.7787
| 632902152528      | Usage           | 2021-04-13T05:30:00+05:30 | 2021-04-14T05:30:00+05:30 | false     | 4.5726837369        | USD               | 4.5727071625          | USD                 | 4.5727
| 632902152528      | Credit          | 2021-04-16T05:30:00+05:30 | 2021-04-17T05:30:00+05:30 | false     | -3.7787303625       | USD               | -3.7787303625         | USD                 | -3.778
| 632902152528      | Usage           | 2021-04-23T05:30:00+05:30 | 2021-04-24T05:30:00+05:30 | false     | 2.9601993226        | USD               | 2.9602059934          | USD                 | 2.9602
| 632902152528      | Credit          | 2021-04-22T05:30:00+05:30 | 2021-04-23T05:30:00+05:30 | false     | -3.5682438156       | USD               | -3.5682438156         | USD                 | -3.568
| 632902152528      | Credit          | 2021-04-13T05:30:00+05:30 | 2021-04-14T05:30:00+05:30 | false     | -4.5727073216       | USD               | -4.5727073216         | USD                 | -4.572
| 632902152528      | Credit          | 2021-04-17T05:30:00+05:30 | 2021-04-18T05:30:00+05:30 | false     | -2.5383378933       | USD               | -2.5383378933         | USD                 | -2.538
| 632902152528      | Credit          | 2021-04-15T05:30:00+05:30 | 2021-04-16T05:30:00+05:30 | false     | -4.9492709304       | USD               | -4.9492709304         | USD                 | -4.949
| 632902152528      | Usage           | 2021-04-20T05:30:00+05:30 | 2021-04-21T05:30:00+05:30 | false     | 2.621084611         | USD               | 2.6210955768          | USD                 | 2.6210
| 632902152528      | Usage           | 2021-04-18T05:30:00+05:30 | 2021-04-19T05:30:00+05:30 | false     | 2.5353908296        | USD               | 2.535397922           | USD                 | 2.5353
| 632902152528      | Usage           | 2021-04-14T05:30:00+05:30 | 2021-04-15T05:30:00+05:30 | false     | 3.2182971637        | USD               | 3.2183263313          | USD                 | 3.2183
| 632902152528      | Credit          | 2021-04-19T05:30:00+05:30 | 2021-04-20T05:30:00+05:30 | false     | -2.5631208436       | USD               | -2.5631208436         | USD                 | -2.563
| 632902152528      | Credit          | 2021-04-21T05:30:00+05:30 | 2021-04-22T05:30:00+05:30 | false     | -3.4476364381       | USD               | -3.4476364381         | USD                 | -3.447
| 632902152528      | Usage           | 2021-04-17T05:30:00+05:30 | 2021-04-18T05:30:00+05:30 | false     | 2.5383308434        | USD               | 2.5383377114          | USD                 | 2.5383
| 632902152528      | Usage           | 2021-04-15T05:30:00+05:30 | 2021-04-16T05:30:00+05:30 | false     | 4.9492151104        | USD               | 4.9492707593          | USD                 | 4.9492
| 632902152528      | Credit          | 2021-04-18T05:30:00+05:30 | 2021-04-19T05:30:00+05:30 | false     | -2.5353981026       | USD               | -2.5353981026         | USD                 | -2.535
| 632902152528      | Credit          | 2021-05-29T05:30:00+05:30 | 2021-05-30T05:30:00+05:30 | false     | -5.7445697876       | USD               | -5.7445697876         | USD                 | -5.744
| 632902152528      | Usage           | 2021-04-19T05:30:00+05:30 | 2021-04-20T05:30:00+05:30 | false     | 2.5631134638        | USD               | 2.5631206611          | USD                 | 2.5631
| 632902152528      | Usage           | 2021-05-11T05:30:00+05:30 | 2021-05-12T05:30:00+05:30 | false     | 4.3415559954        | USD               | 4.3415569793          | USD                 | 4.3415
| 632902152528      | Credit          | 2021-06-14T05:30:00+05:30 | 2021-06-15T05:30:00+05:30 | false     | -6.2278986644       | USD               | -6.2278986644         | USD                 | -6.227
| 632902152528      | Credit          | 2021-05-12T05:30:00+05:30 | 2021-05-13T05:30:00+05:30 | false     | -3.8340909916       | USD               | -3.8340909916         | USD                 | -3.834
| 632902152528      | Credit          | 2021-06-01T05:30:00+05:30 | 2021-06-02T05:30:00+05:30 | false     | -7.539393882        | USD               | -7.539393882          | USD                 | -7.539

> select
  linked_account_id,
  record_type,
  min(unblended_cost_amount)::numeric::money as min,
  max(unblended_cost_amount)::numeric::money as max,
  avg(unblended_cost_amount)::numeric::money as average
from 
  aws_cost_by_record_type_daily
group by
  linked_account_id,
  record_type
order by
  linked_account_id;
+-------------------+-----------------+---------+--------+---------+
| linked_account_id | record_type     | min     | max    | average |
+-------------------+-----------------+---------+--------+---------+
| 632902152528      | Credit          | -$42.85 | -$0.54 | -$4.36  |
| 632902152528      | DiscountedUsage | $0.00   | $0.00  | $0.00   |
| 632902152528      | Recurring       | $1.05   | $2.46  | $2.25   |
| 632902152528      | Tax             | $0.00   | $0.00  | $0.00   |
| 632902152528      | Usage           | $0.54   | $42.85 | $5.99   |
+-------------------+-----------------+---------+--------+---------+
> with ranked_costs as (
  select
    linked_account_id,
    record_type,
    period_start,
    unblended_cost_amount::numeric::money,
    rank() over(partition by linked_account_id, record_type order by unblended_cost_amount desc)
  from 
    aws_cost_by_record_type_daily
)
select * from ranked_costs where rank <= 10
+-------------------+-----------------+---------------------------+-----------------------+------+
| linked_account_id | record_type     | period_start              | unblended_cost_amount | rank |
+-------------------+-----------------+---------------------------+-----------------------+------+
| 632902152528      | Credit          | 2021-08-02T05:30:00+05:30 | -$0.54                | 1    |
| 632902152528      | Credit          | 2021-08-01T05:30:00+05:30 | -$0.54                | 2    |
| 632902152528      | Credit          | 2021-08-14T05:30:00+05:30 | -$0.55                | 3    |
| 632902152528      | Credit          | 2021-08-15T05:30:00+05:30 | -$0.57                | 4    |
| 632902152528      | Credit          | 2021-08-17T05:30:00+05:30 | -$0.57                | 5    |
| 632902152528      | Credit          | 2021-08-16T05:30:00+05:30 | -$0.58                | 6    |
| 632902152528      | Credit          | 2021-08-12T05:30:00+05:30 | -$0.58                | 7    |
| 632902152528      | Credit          | 2021-08-13T05:30:00+05:30 | -$0.59                | 8    |
| 632902152528      | Credit          | 2021-08-11T05:30:00+05:30 | -$0.60                | 9    |
| 632902152528      | Credit          | 2021-08-03T05:30:00+05:30 | -$0.62                | 10   |
| 632902152528      | DiscountedUsage | 2021-08-20T05:30:00+05:30 | $0.00                 | 1    |
| 632902152528      | Recurring       | 2022-01-01T05:30:00+05:30 | $2.46                 | 1    |
| 632902152528      | Recurring       | 2022-03-01T05:30:00+05:30 | $2.46                 | 1    |
| 632902152528      | Recurring       | 2021-10-01T05:30:00+05:30 | $2.46                 | 1    |
| 632902152528      | Recurring       | 2021-12-01T05:30:00+05:30 | $2.46                 | 1    |
| 632902152528      | Recurring       | 2021-11-01T05:30:00+05:30 | $2.38                 | 5    |
| 632902152528      | Recurring       | 2021-09-01T05:30:00+05:30 | $2.38                 | 5    |
| 632902152528      | Recurring       | 2022-04-01T05:30:00+05:30 | $2.38                 | 5    |
| 632902152528      | Recurring       | 2022-02-01T05:30:00+05:30 | $2.22                 | 8    |
| 632902152528      | Recurring       | 2021-08-18T05:30:00+05:30 | $1.05                 | 9    |
| 632902152528      | Tax             | 2021-12-01T05:30:00+05:30 | $0.00                 | 1    |
| 632902152528      | Tax             | 2021-07-01T05:30:00+05:30 | $0.00                 | 1    |
| 632902152528      | Tax             | 2021-10-01T05:30:00+05:30 | $0.00                 | 1    |
| 632902152528      | Tax             | 2022-02-01T05:30:00+05:30 | $0.00                 | 1    |
| 632902152528      | Tax             | 2021-11-01T05:30:00+05:30 | $0.00                 | 1    |
| 632902152528      | Tax             | 2022-01-01T05:30:00+05:30 | $0.00                 | 1    |
| 632902152528      | Tax             | 2022-03-01T05:30:00+05:30 | $0.00                 | 1    |
| 632902152528      | Tax             | 2022-04-01T05:30:00+05:30 | $0.00                 | 1    |
| 632902152528      | Usage           | 2021-09-07T05:30:00+05:30 | $42.85                | 1    |
| 632902152528      | Usage           | 2022-02-11T05:30:00+05:30 | $36.55                | 2    |
| 632902152528      | Usage           | 2022-02-18T05:30:00+05:30 | $32.06                | 3    |
| 632902152528      | Usage           | 2022-02-17T05:30:00+05:30 | $29.87                | 4    |
| 632902152528      | Usage           | 2022-02-15T05:30:00+05:30 | $28.69                | 5    |
| 632902152528      | Usage           | 2022-02-21T05:30:00+05:30 | $28.13                | 6    |
| 632902152528      | Usage           | 2022-02-20T05:30:00+05:30 | $27.80                | 7    |
| 632902152528      | Usage           | 2022-02-19T05:30:00+05:30 | $27.71                | 8    |
| 632902152528      | Usage           | 2021-09-08T05:30:00+05:30 | $26.99                | 9    |
| 632902152528      | Usage           | 2022-02-14T05:30:00+05:30 | $25.48                | 10   |
+-------------------+-----------------+---------------------------+-----------------------+------+
```
</details>
