### PR TITLE
Added packagetype for lambda functions

### DIFF
--- a/aws/table_aws_lambda_function.go
+++ b/aws/table_aws_lambda_function.go
@@ -92,6 +92,12 @@ func tableAwsLambdaFunction(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Configuration.Version", "Version"),
 			},
 			{
+				Name: "packagetype",
+				Description: "The type of deployment package.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Configuration.PackageType", "PackageType"),
+			},
+			{
 				Name:        "master_arn",
 				Description: "For Lambda@Edge functions, the ARN of the master function.",
 				Type:        proto.ColumnType_STRING,


### PR DESCRIPTION
# Integration test logs
 This query works as a test:
 
 ```sql
 select
  -- Required Columns
  arn as resource,
  case
    when runtime in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then 'ok'
    else 'alarm'
  end as status,
  case
    when runtime in ('nodejs14.x', 'nodejs12.x', 'nodejs10.x', 'python3.8', 'python3.7', 'python3.6', 'ruby2.5', 'ruby2.7', 'java11', 'java8', 'go1.x', 'dotnetcore2.1', 'dotnetcore3.1') then title || ' uses latest runtime - ' || runtime || '.'
    else title || ' uses ' || runtime || ' which is not the latest version.'
  end as reason,
  -- Additional Dimensions
  region,
  account_id,
  packagetype
from
  "aws_lambda_function"
where packagetype = 'Zip';
``

