### PR TITLE
Update the column name date-created to date_created in table aws_elastic_beanstalk_environment closes #964

### DIFF
--- a/aws/table_aws_elastic_beanstalk_environment.go
+++ b/aws/table_aws_elastic_beanstalk_environment.go
@@ -51,7 +51,7 @@ func tableAwsElasticBeanstalkEnvironment(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "date-created",
+				Name:        "date_created",
 				Description: "The creation date for this environment.",
 				Type:        proto.ColumnType_TIMESTAMP,
 			},


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select environment_name, date_created from aws.aws_elastic_beanstalk_environment
+------------------+---------------------------+
| environment_name | date_created              |
+------------------+---------------------------+
| Test1-env        | 2022-04-29T11:55:18+05:30 |
+------------------+---------------------------+
```
</details>
