### PR TITLE
Add environment_variables column to aws_lambda_function and aws_lambda_version tables.

### DIFF
--- a/aws/table_aws_lambda_function.go
+++ b/aws/table_aws_lambda_function.go
@@ -171,6 +171,12 @@ func tableAwsLambdaFunction(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Concurrency.ReservedConcurrentExecutions"),
 			},
 			{
+				Name:        "environment_variables",
+				Description: "The environment variables that are accessible from function code during execution.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Configuration.Environment.Variables", "Environment.Variables"),
+			},
+			{
 				Name:        "vpc_id",
 				Description: "The VPC ID that is attached to Lambda function.",
 				Type:        proto.ColumnType_STRING,

--- a/aws/table_aws_lambda_version.go
+++ b/aws/table_aws_lambda_version.go
@@ -119,6 +119,12 @@ func tableAwsLambdaVersion(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_INT,
 			},
 			{
+				Name:        "environment_variables",
+				Description: "The environment variables that are accessible from function code during execution.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Configuration.Environment.Variables", "Environment.Variables"),
+			},
+			{
 				Name:        "vpc_id",
 				Description: "The ID of the VPC.",
 				Type:        proto.ColumnType_STRING,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
  
```
$ steampipe query "select environment_variables from aws_lambda_function where name = 'example-hello-world'"
+---------------------------------------------------------+
| environment_variables                                   |
+---------------------------------------------------------+
| {"PG_SCHEMA":"example","SERVERLESS_REGION":"us-east-1"} |
+---------------------------------------------------------+


$ steampipe query "select environment_variables from aws_lambda_function where arn = 'arn:aws:lambda:us-east-1:000000000000:function:example-hello-world'"
+---------------------------------------------------------+
| environment_variables                                   |
+---------------------------------------------------------+
| {"PG_SCHEMA":"example","SERVERLESS_REGION":"us-east-1"} |
+---------------------------------------------------------+


$ steampipe query "select environment_variables from aws_lambda_version where arn = 'arn:aws:lambda:us-east-1:000000000000:function:example-hello-world:11'"
+---------------------------------------------------------+
| environment_variables                                   |
+---------------------------------------------------------+
| {"PG_SCHEMA":"example","SERVERLESS_REGION":"us-east-1"} |
+---------------------------------------------------------+

$ steampipe query "select version, environment_variables  from aws_lambda_version where function_name = 'example-hello-world-sbx1'"
+---------+---------------------------------------------------------+
| version | environment_variables                                   |
+---------+---------------------------------------------------------+
| 1       | {"PG_SCHEMA":"example","SERVERLESS_REGION":"us-east-1"} |
| $LATEST | {"PG_SCHEMA":"sample","SERVERLESS_REGION":"us-east-1"}  |
+---------+---------------------------------------------------------+
```
