### PR TITLE
Fix is_logging column of the aws_cloudtrail_trail table returns null when value is 'true' in the AWS CLI closes #957

### DIFF
--- a/aws-test/tests/aws_cloudtrail_trail/variables.tf
+++ b/aws-test/tests/aws_cloudtrail_trail/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "integration-tests"
+  default     = "default"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws/service.go
+++ b/aws/service.go
@@ -451,8 +451,8 @@ func CloudWatchLogsService(ctx context.Context, d *plugin.QueryData) (*cloudwatc
 }
 
 // CloudTrailService returns the service connection for AWS CloudTrail service
-func CloudTrailService(ctx context.Context, d *plugin.QueryData) (*cloudtrail.CloudTrail, error) {
-	region := d.KeyColumnQualString(matrixKeyRegion)
+func CloudTrailService(ctx context.Context, d *plugin.QueryData, region string) (*cloudtrail.CloudTrail, error) {
+	
 	if region == "" {
 		return nil, fmt.Errorf("region must be passed CloudTrailService")
 	}


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_cloudtrail_trail []

PRETEST: tests/aws_cloudtrail_trail

TEST: tests/aws_cloudtrail_trail
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_partition.current: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_s3_bucket.named_test_resource: Creating...
aws_s3_bucket.named_test_resource: Creation complete after 7s [id=turbottest82533]
aws_cloudtrail.named_test_resource: Creating...
aws_cloudtrail.named_test_resource: Creation complete after 5s [id=turbottest82533]

Warning: Deprecated Resource

  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Warning: Argument is deprecated

  on variables.tf line 76, in resource "aws_s3_bucket" "named_test_resource":
  76:   policy = <<POLICY
  77: {
  78:     "Version": "2012-10-17",
  79:     "Statement": [
  80:         {
  81:             "Sid": "AWSCloudTrailAclCheck",
  82:             "Effect": "Allow",
  83:             "Principal": {
  84:               "Service": "cloudtrail.amazonaws.com"
  85:             },
  86:             "Action": "s3:GetBucketAcl",
  87:             "Resource": "arn:aws:s3:::${var.resource_name}"
  88:         },
  89:         {
  90:             "Sid": "AWSCloudTrailWrite",
  91:             "Effect": "Allow",
  92:             "Principal": {
  93:               "Service": "cloudtrail.amazonaws.com"
  94:             },
  95:             "Action": "s3:PutObject",
  96:             "Resource": "arn:aws:s3:::${var.resource_name}/prefix/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
  97:             "Condition": {
  98:                 "StringEquals": {
  99:                     "s3:x-amz-acl": "bucket-owner-full-control"
 100:                 }
 101:             }
 102:         }
 103:     ]
 104: }
 105: POLICY

Use the aws_s3_bucket_policy resource instead


Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

account_id = 987902158475
aws_partition = aws
region_name = us-east-1
resource_aka = arn:aws:cloudtrail:us-east-1:987902158475:trail/turbottest82533
resource_name = turbottest82533

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:cloudtrail:us-east-1:987902158475:trail/turbottest82533",
    "has_custom_event_selectors": true,
    "has_insight_selectors": false,
    "home_region": "us-east-1",
    "include_global_service_events": false,
    "is_multi_region_trail": false,
    "is_organization_trail": false,
    "log_file_validation_enabled": false,
    "name": "turbottest82533",
    "s3_bucket_name": "turbottest82533",
    "s3_key_prefix": "prefix"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "event_selectors": [
      {
        "DataResources": [
          {
            "Type": "AWS::Lambda::Function",
            "Values": [
              "arn:aws:lambda"
            ]
          }
        ],
        "ExcludeManagementEventSources": [],
        "IncludeManagementEvents": true,
        "ReadWriteType": "All"
      }
    ],
    "is_logging": true,
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest82533"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "arn": "arn:aws:cloudtrail:us-east-1:987902158475:trail/turbottest82533",
    "name": "turbottest82533"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:cloudtrail:us-east-1:987902158475:trail/turbottest82533"
    ],
    "tags": {
      "name": "turbottest82533"
    },
    "title": "turbottest82533"
  }
]
✔ PASSED

POSTTEST: tests/aws_cloudtrail_trail

TEARDOWN: tests/aws_cloudtrail_trail

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws.aws_cloudtrail_trail where name = 'turbot-987902158475-us-east-1-trail'
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+---------
| name                                | arn                                                                                 | home_region | is_multi_region_trail | log_file_validation_enabled | is_loggi
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+---------
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+---------
> select * from aws.aws_cloudtrail_trail
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+---------
| name                                | arn                                                                                 | home_region | is_multi_region_trail | log_file_validation_enabled | is_loggi
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+---------
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
| turbot-987902158475-us-east-1-trail | arn:aws:cloudtrail:us-east-1:987902158475:trail/turbot-987902158475-us-east-1-trail | us-east-1   | true                  | true                        | true    
+-------------------------------------+-------------------------------------------------------------------------------------+-------------+-----------------------+-----------------------------+---------
> select * from aws.aws_cloudtrail_trail where name = 'turbot-2746584'
+------+-----+-------------+-----------------------+-----------------------------+------------+---------------+--------------------------+----------------------------+-----------------------+-----------
| name | arn | home_region | is_multi_region_trail | log_file_validation_enabled | is_logging | log_group_arn | cloudwatch_logs_role_arn | has_custom_event_selectors | has_insight_selectors | include_gl
+------+-----+-------------+-----------------------+-----------------------------+------------+---------------+--------------------------+----------------------------+-----------------------+-----------
+------+-----+-------------+-----------------------+-----------------------------+------------+---------------+--------------------------+----------------------------+-----------------------+-----------

```
</details>
