### PR TITLE
Add column vpc_id to aws_ec2_network_interface table Closes #988

### DIFF
--- a/aws/table_aws_ec2_network_interface.go
+++ b/aws/table_aws_ec2_network_interface.go
@@ -203,6 +203,11 @@ func tableAwsEc2NetworkInterface(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_BOOL,
 			},
 			{
+				Name:        "vpc_id",
+				Description: "The ID of the VPC.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "groups",
 				Description: "Any security groups for the network interface.",
 				Type:        proto.ColumnType_JSON,

--- a/docs/tables/aws_ec2_network_interface.md
+++ b/docs/tables/aws_ec2_network_interface.md
@@ -69,16 +69,16 @@ order by
 
 ```sql
 select
-  eni.network_interface_id,
-  vpc.vpc_id,
-  vpc.is_default,
-  vpc.cidr_block,
-  vpc.state,
-  vpc.account_id,
-  vpc.region
+  e.network_interface_id,
+  v.vpc_id,
+  v.is_default,
+  v.cidr_block,
+  v.state,
+  v.account_id,
+  v.region
 from
-  aws_ec2_network_interface eni,
-  aws_vpc vpc
+  aws_ec2_network_interface e,
+  aws_vpc v
 where 
-  eni.vpc_id = vpc.vpc_id;
+  e.vpc_id = v.vpc_id;
 ```

--- a/docs/tables/aws_ec2_network_interface.md
+++ b/docs/tables/aws_ec2_network_interface.md
@@ -18,7 +18,6 @@ from
   aws_ec2_network_interface;
 ```
 
-
 ### Find all ENIs with private IPs that are in a given subnet (10.66.0.0/16)
 
 ```sql
@@ -35,7 +34,6 @@ where
   private_ip_address :: cidr < <= '10.66.0.0/16';
 ```
 
-
 ### Count of ENIs by interface type
 
 ```sql
@@ -50,7 +48,6 @@ order by
   count desc;
 ```
 
-
 ### Security groups attached to each ENI
 
 ```sql
@@ -64,7 +61,6 @@ from
 order by
   eni;
 ```
-
 
 ### Get network details for each ENI
 

--- a/docs/tables/aws_ec2_network_interface.md
+++ b/docs/tables/aws_ec2_network_interface.md
@@ -65,6 +65,7 @@ order by
   eni;
 ```
 
+
 ### Get network details for each ENI
 
 ```sql

--- a/docs/tables/aws_ec2_network_interface.md
+++ b/docs/tables/aws_ec2_network_interface.md
@@ -64,3 +64,21 @@ from
 order by
   eni;
 ```
+
+### Get network details for each ENI
+
+```sql
+select
+  eni.network_interface_id,
+  vpc.vpc_id,
+  vpc.is_default,
+  vpc.cidr_block,
+  vpc.state,
+  vpc.account_id,
+  vpc.region
+from
+  aws_ec2_network_interface eni,
+  aws_vpc vpc
+where 
+  eni.vpc_id = vpc.vpc_id;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  eni.network_interface_id,
  vpc.vpc_id,
  vpc.is_default,
  vpc.cidr_block,
  vpc.state,
  vpc.region
from
  aws_ec2_network_interface eni,
  aws_vpc vpc
where 
  eni.vpc_id = vpc.vpc_id limit 5;
+-----------------------+-----------------------+------------+-----------------+-----------+-----------+
| network_interface_id  | vpc_id                | is_default | cidr_block      | state     | region    |
+-----------------------+-----------------------+------------+-----------------+-----------+-----------+
| eni-0e9ca2e3ec4e4b090 | vpc-02067788fa317042e | false      | 10.114.190.0/26 | available | us-east-2 |
| eni-0ad70e5067b71ba87 | vpc-02067788fa317042e | false      | 10.114.190.0/26 | available | us-east-2 |
| eni-038ed7b90c28b15ab | vpc-0e37ac97135a24f2e | false      | 10.5.0.0/16     | available | us-east-2 |
| eni-06ee5f4e72114483c | vpc-0a93262e0a9f10dda | false      | 10.11.14.0/24   | available | us-east-2 |
| eni-07e0dd7a7c96fdde5 | vpc-0afd81a0cb70bee91 | false      | 10.84.77.0/24   | available | eu-west-1 |
+-----------------------+-----------------------+------------+-----------------+-----------+-----------+
```
</details>
