### PR TITLE
Add column architectures to aws_lambda_function table Closes #987

### DIFF
--- a/aws/table_aws_lambda_function.go
+++ b/aws/table_aws_lambda_function.go
@@ -177,6 +177,11 @@ func tableAwsLambdaFunction(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Configuration.VpcConfig.VpcId", "VpcConfig.VpcId"),
 			},
 			{
+				Name:        "architectures",
+				Description: "The instruction set architecture that the function supports. Architecture is a string array with one of the valid values.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
 				Name:        "environment_variables",
 				Description: "The environment variables that are accessible from function code during execution.",
 				Type:        proto.ColumnType_JSON,

--- a/docs/tables/aws_lambda_function.md
+++ b/docs/tables/aws_lambda_function.md
@@ -104,3 +104,16 @@ from
 where
   dead_letter_config_target_arn is null;
 ```
+
+
+### List runtime settings for each lambda function
+
+```sql
+select 
+  name,
+  runtime, 
+  handler, 
+  architectures 
+from
+  aws_lambda_function;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select 
  name,
  runtime, 
  handler, 
  architectures 
from
  aws_lambda_function limit 5;
+---------------------------------------+------------+-------------------------+---------------+
| name                                  | runtime    | handler                 | architectures |
+---------------------------------------+------------+-------------------------+---------------+
| test1                                 | nodejs14.x | index.handler           | ["x86_64"]    |
| tets                                  | nodejs14.x | index.handler           | <null>        |
| cloud9-AppTwo-funcone-W408ZRFMCP4Q    | nodejs6.10 | funcone/index.handler   | ["x86_64"]    |
| cloud9-TestApp-lambdaone-A71A4OKVLX6D | nodejs6.10 | lambdaone/index.handler | ["x86_64"]    |
| graviton2                             | nodejs14.x | index.handler           | ["arm64"]     |
+---------------------------------------+------------+-------------------------+---------------+
```
</details>
