### PR TITLE
Add table aws_securityhub_finding closes #999

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -259,6 +259,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_sagemaker_notebook_instance":                              tableAwsSageMakerNotebookInstance(ctx),
 			"aws_sagemaker_training_job":                                   tableAwsSageMakerTrainingJob(ctx),
 			"aws_secretsmanager_secret":                                    tableAwsSecretsManagerSecret(ctx),
+			"aws_securityhub_finding":                                      tableAwsSecurityHubFinding(ctx),
 			"aws_securityhub_hub":                                          tableAwsSecurityHub(ctx),
 			"aws_securityhub_product":                                      tableAwsSecurityhubProduct(ctx),
 			"aws_securityhub_standards_subscription":                       tableAwsSecurityHubStandardsSubscription(ctx),

--- a/docs/tables/aws_securityhub_finding.md
+++ b/docs/tables/aws_securityhub_finding.md
@@ -1,0 +1,48 @@
+# Table: aws_securityhub_finding
+
+AWS Security Hub eliminates the complexity of addressing large volumes of findings from multiple providers. It reduces the effort required to manage and improve the security of all of your AWS accounts, resources, and workloads.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  name,
+  id,
+  company_name,
+  created_at,
+  criticality,
+  confidence
+from
+  aws_securityhub_finding;
+```
+
+### List findings with high severity
+
+```sql
+select
+  name,
+  product_arn,
+  product_name,
+  severity ->> 'Original' as severity_original
+from
+  aws_securityhub_finding
+where
+  severity ->> 'Original' = 'HIGH'
+```
+
+### List findings with failed compliance
+
+```sql
+select
+  name,
+  product_arn,
+  product_name,
+  compliance ->> 'Status' as compliance_status,
+  compliance ->> 'StatusReasons'as compliance_status_reason
+from
+  aws_securityhub_finding
+where
+  compliance ->> 'Status' = 'FAILED'
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_redhood.aws_securityhub_finding where company_name = 'AWS'
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+------------+-------------
| id                                                                                                                                                              | company_name | confidence | created_at  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+------------+-------------
| arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2.0/2.5/finding/dc783beb-1613-4af4-9830-eb10236c695c                 | AWS          | <null>     | 2022-01-06T2
| arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2.0/3.10/finding/9e8e0261-3974-4fc3-9e37-0ef81acf6f80                | AWS          | <null>     | 2022-01-06T2
| arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2.0/3.9/finding/d8cf8ee8-f0eb-4ce0-8466-9b3f80fe517f                 | AWS          | <null>     | 2022-01-06T2
| arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2.0/3.12/finding/acb1a6e1-82fd-4491-9bf0-b79d5e0d9956                | AWS          | <null>     | 2022-01-06T2
| arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2.0/3.8/finding/15421cf5-0282-48af-b883-4531540fa3e1                 | AWS          | <null>     | 2022-01-06T2

> select * from aws_redhood.aws_securityhub_finding where compliance_status = 'FAILED'
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+------------+-------------
| id                                                                                                                                                              | company_name | confidence | created_at  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------+------------+-------------
| arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2.0/3.7/finding/47f801b7-0aa8-4af8-a4e1-a3f14a48b7d9                 | AWS          | <null>     | 2022-01-06T2
| arn:aws:securityhub:ap-south-1:453319552164:subscription/aws-foundational-security-best-practices/v/1.0.0/Config.1/finding/15a7414c-ce7f-4639-ab9d-9acdbfd5fce8 | AWS          | <null>     | 2022-01-07T1
| arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2.0/3.12/finding/acb1a6e1-82fd-4491-9bf0-b79d5e0d9956                | AWS          | <null>     | 2022-01-06T2
| arn:aws:securityhub:ap-south-1:533793682495:subscription/aws-foundational-security-best-practices/v/1.0.0/Config.1/finding/7aca3fd7-e6d7-4706-82ff-851de6d482c5 | AWS          | <null>     | 2021-09-11T2

> select * from aws_redhood.aws_securityhub_finding where generator_id = 'arn:aws:securityhub:::ruleset/cis-aws-foundations-benchmark/v/1.2.0/rule/3.5'
+-------------------------------------------------------------------------------------------------------------------------------------------------+--------------+------------+---------------------------+-
| id                                                                                                                                              | company_name | confidence | created_at                | 
+-------------------------------------------------------------------------------------------------------------------------------------------------+--------------+------------+---------------------------+-
| arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2.0/3.5/finding/994c9258-e8a4-4b75-8ff5-a19e82cd32a4 | AWS          | <null>     | 2022-01-06T21:40:11+05:30 | 
+-------------------------------------------------------------------------------------------------------------------------------------------------+--------------+------------+---------------------------+-

> select * from aws_redhood.aws_securityhub_finding where name = '2.5 Ensure AWS Config is enabled'
+----------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+--------------+-------
| name                             | id                                                                                                                                              | company_name | confid
+----------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+--------------+-------
| 2.5 Ensure AWS Config is enabled | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2.0/2.5/finding/dc783beb-1613-4af4-9830-eb10236c695c | AWS          | <null>
+----------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+--------------+-------

> select * from aws_redhood.aws_securityhub_finding where product_arn = 'arn:aws:securityhub:ap-south-1::product/aws/securityhub'
+-------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------
| name                                                                                                        | id                                                                                          
+-------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------
| Config.1 AWS Config should be enabled                                                                       | arn:aws:securityhub:ap-south-1:453319552164:subscription/aws-foundational-security-best-prac
| 3.10 Ensure a log metric filter and alarm exist for security group changes                                  | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| 3.1 Ensure a log metric filter and alarm exist for unauthorized API calls                                   | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| 3.11 Ensure a log metric filter and alarm exist for changes to Network Access Control Lists (NACL)          | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| 3.9 Ensure a log metric filter and alarm exist for AWS Config configuration changes                         | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| 2.5 Ensure AWS Config is enabled                                                                            | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| 3.7 Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| 3.13 Ensure a log metric filter and alarm exist for route table changes                                     | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2

> select * from aws_redhood.aws_securityhub_finding where product_name = 'Security Hub'
+-------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------
| name                                                                                                        | id                                                                                          
+-------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------
| 2.5 Ensure AWS Config is enabled                                                                            | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| 3.7 Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| Config.1 AWS Config should be enabled                                                                       | arn:aws:securityhub:ap-south-1:453319552164:subscription/aws-foundational-security-best-prac
| 3.8 Ensure a log metric filter and alarm exist for S3 bucket policy changes                                 | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2

> select * from aws_redhood.aws_securityhub_finding where record_state = 'ACTIVE'
+-------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------
| name                                                                                                        | id                                                                                          
+-------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------
| 3.5 Ensure a log metric filter and alarm exist for CloudTrail configuration changes                         | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| Config.1 AWS Config should be enabled                                                                       | arn:aws:securityhub:ap-south-1:453319552164:subscription/aws-foundational-security-best-prac
| 3.7 Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2

> select * from aws_redhood.aws_securityhub_finding where workflow_state = 'NEW'
+-------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------
| name                                                                                                        | id                                                                                          
+-------------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------
| 2.5 Ensure AWS Config is enabled                                                                            | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| 3.5 Ensure a log metric filter and alarm exist for CloudTrail configuration changes                         | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| Config.1 AWS Config should be enabled                                                                       | arn:aws:securityhub:ap-south-1:453319552164:subscription/aws-foundational-security-best-prac
| 3.4 Ensure a log metric filter and alarm exist for IAM policy changes                                       | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| 3.8 Ensure a log metric filter and alarm exist for S3 bucket policy changes                                 | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| Config.1 AWS Config should be enabled                                                                       | arn:aws:securityhub:ap-south-1:533793682495:subscription/aws-foundational-security-best-prac
| 3.6 Ensure a log metric filter and alarm exist for AWS Management Console authentication failures           | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2
| 3.7 Ensure a log metric filter and alarm exist for disabling or scheduled deletion of customer created CMKs | arn:aws:securityhub:ap-south-1:453319552164:subscription/cis-aws-foundations-benchmark/v/1.2


```
</details>
