### PR TITLE
Add column shared_directories in table aws_directory_service_directory Closes #1020

### DIFF
--- a/aws/table_aws_directory_service_directory.go
+++ b/aws/table_aws_directory_service_directory.go
@@ -161,6 +161,13 @@ func tableAwsDirectoryServiceDirectory(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
+				Name:        "shared_directories",
+				Description: "Details about the shared directory in the directory owner account for which the share request in the directory consumer account has been accepted.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getDirectoryServiceSharedDirectory,
+				Transform:   transform.FromValue(),
+			},
+			{
 				Name:        "vpc_settings",
 				Description: "A DirectoryVpcSettingsDescription object that contains additional information about a directory.",
 				Type:        proto.ColumnType_JSON,
@@ -281,6 +288,42 @@ func getDirectoryServiceDirectory(ctx context.Context, d *plugin.QueryData, _ *p
 
 	if op.DirectoryDescriptions != nil && len(op.DirectoryDescriptions) > 0 {
 		return op.DirectoryDescriptions[0], nil
+	}
+	return nil, nil
+}
+
+func getDirectoryServiceSharedDirectory(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getDirectoryServiceSharedDirectory")
+
+	// Create service
+	svc, err := DirectoryService(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+	directory := h.Item.(*directoryservice.DirectoryDescription)
+
+	params := &directoryservice.DescribeSharedDirectoriesInput{
+		OwnerDirectoryId: directory.DirectoryId,
+	}
+
+	directories := make([]*directoryservice.SharedDirectory, 0)
+
+	for {
+		response, err := svc.DescribeSharedDirectories(params)
+		if err != nil {
+			return nil, err
+		}
+		if response.SharedDirectories != nil {
+			directories = append(directories, response.SharedDirectories...)
+		}
+		if response.NextToken == nil {
+			break
+		}
+		params.NextToken = response.NextToken
+	}
+
+	if len(directories) > 0 {
+		return directories, nil
 	}
 	return nil, nil
 }

--- a/docs/tables/aws_directory_service_directory.md
+++ b/docs/tables/aws_directory_service_directory.md
@@ -28,3 +28,18 @@ from
 where 
   type = 'MicrosoftAD';
 ```
+
+### Get details about the shared directories
+
+```sql
+select
+  name,
+  directory_id,
+  sd ->> 'ShareMethod' share_method,
+  sd ->> 'ShareStatus' share_status,
+  sd ->> 'SharedAccountId' shared_account_id,
+  sd ->> 'SharedDirectoryId' shared_directory_id
+from
+  aws_directory_service_directory,
+  jsonb_array_elements(shared_directories) sd;
+```


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  directory_id,
  sd ->> 'ShareMethod' share_method,
  sd ->> 'ShareStatus' share_status,
  sd ->> 'SharedAccountId' shared_account_id,
  sd ->> 'SharedDirectoryId' shared_directory_id
from
  aws_directory_service_directory,
  jsonb_array_elements(shared_directories) sd;

+----------------------+--------------+--------------+--------------+-------------------+---------------------+
| name                 | directory_id | share_method | share_status | shared_account_id | shared_directory_id |
+----------------------+--------------+--------------+--------------+-------------------+---------------------+
| turbot.steampipe.com | d-90674d92a6 | HANDSHAKE    | Deleted      | 986325076436      | d-90674d9d00        |
+----------------------+--------------+--------------+--------------+-------------------+---------------------+
```
</details>
