### PR TITLE
Update column name standards_control_arn to arn in aws_securityhub_standards_control table. Closes #1026

### DIFF
--- a/aws-test/tests/aws_securityhub_standards_control/test-list-expected.json
+++ b/aws-test/tests/aws_securityhub_standards_control/test-list-expected.json
@@ -1,7 +1,7 @@
 [
   {
     "account_id": "{{ output.account_id.value }}",
-    "standards_control_arn": "{{ output.standards_control_arn.value }}",
+    "arn": "{{ output.standards_control_arn.value }}",
     "title" : "{{ output.title.value }}"
   }
 ]

--- a/aws-test/tests/aws_securityhub_standards_control/test-list-query.sql
+++ b/aws-test/tests/aws_securityhub_standards_control/test-list-query.sql
@@ -1,3 +1,3 @@
-select title, account_id, standards_control_arn
+select title, account_id, arn
 from aws_securityhub_standards_control
-where standards_control_arn = '{{ output.standards_control_arn.value }}';
+where arn = '{{ output.standards_control_arn.value }}';

--- a/aws-test/tests/aws_securityhub_standards_control/test-turbot-query.sql
+++ b/aws-test/tests/aws_securityhub_standards_control/test-turbot-query.sql
@@ -1,3 +1,3 @@
 select akas, region
 from aws_securityhub_standards_control
-where standards_control_arn = '{{ output.standards_control_arn.value }}';
+where arn = '{{ output.standards_control_arn.value }}';

--- a/aws/table_aws_securityhub_standards_control.go
+++ b/aws/table_aws_securityhub_standards_control.go
@@ -30,9 +30,10 @@ func tableAwsSecurityHubStandardsControl(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "standards_control_arn",
+				Name:        "arn",
 				Description: "The ARN of the security standard control.",
 				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("StandardsControlArn"),
 			},
 			{
 				Name:        "control_status",

--- a/docs/tables/aws_securityhub_standards_control.md
+++ b/docs/tables/aws_securityhub_standards_control.md
@@ -85,7 +85,7 @@ from
   aws_securityhub_standards_control
 where
   severity_rating = 'CRITICAL'
-  and standards_control_arn like '%cis-aws-foundations-benchmark%';
+  and arn like '%cis-aws-foundations-benchmark%';
 ```
 
 ### List related requirements benchmark for S3 controls

--- a/docs/tables/aws_securityhub_standards_control.md
+++ b/docs/tables/aws_securityhub_standards_control.md
@@ -71,7 +71,7 @@ select
 from
   aws_securityhub_standards_control
 where
-  control_status_updated_at <= (now() - interval '30' day);
+  control_status_updated_at >= (now() - interval '30' day);
 ```
 
 ### List CIS AWS foundations benchmark controls with critical severity


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```

SETUP: tests/aws_securityhub_standards_control []

PRETEST: tests/aws_securityhub_standards_control

TEST: tests/aws_securityhub_standards_control
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.control will be read during apply
  # (config refers to values not yet known)
 <= data "local_file" "control"  {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/aws_securityhub_standards_control/terraform/test/control.json"
      + id             = (known after apply)
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id            = "533793682495"
  + aws_region            = "us-east-1"
  + standards_control_arn = (known after apply)
  + title                 = (known after apply)
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "      aws securityhub describe-standards-controls --standards-subscription-arn \"arn:aws:securityhub:us-east-1:533793682495:subscription/aws-foundational-security-best-practices/v/1.0.0\" > /private/var/folders/3j/6ybdbkm51c3449psm55pjsg00000gp/T/tests/aws_securityhub_standards_control/terraform/test/control.json;\n"]
null_resource.named_test_resource: Creation complete after 4s [id=3529350252505447033]
data.local_file.control: Reading...
data.local_file.control: Read complete after 0s [id=cf0d81e40ae01a46a4c2c41fc1f854f04e968092]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "533793682495"
aws_region = "us-east-1"
standards_control_arn = "arn:aws:securityhub:us-east-1:533793682495:control/aws-foundational-security-best-practices/v/1.0.0/ACM.1"
title = "ACM certificates should be renewed after a specified time period"

Running SQL query: test-list-query.sql
[
  {
    "account_id": "533793682495",
    "arn": "arn:aws:securityhub:us-east-1:533793682495:control/aws-foundational-security-best-practices/v/1.0.0/ACM.1",
    "title": "ACM certificates should be renewed after a specified time period"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:securityhub:us-east-1:533793682495:control/aws-foundational-security-best-practices/v/1.0.0/ACM.1"
    ],
    "region": "us-east-1"
  }
]
✔ PASSED

POSTTEST: tests/aws_securityhub_standards_control

TEARDOWN: tests/aws_securityhub_standards_control

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  control_id,
  control_status,
  severity_rating
from
  aws_securityhub_standards_control
where
  severity_rating = 'CRITICAL'
  and arn like '%cis-aws-foundations-benchmark%';
+------------+----------------+-----------------+
| control_id | control_status | severity_rating |
+------------+----------------+-----------------+
| CIS.1.13   | ENABLED        | CRITICAL        |
| CIS.1.14   | ENABLED        | CRITICAL        |
| CIS.2.3    | ENABLED        | CRITICAL        |
| CIS.1.12   | ENABLED        | CRITICAL        |
| CIS.1.12   | ENABLED        | CRITICAL        |
| CIS.1.13   | ENABLED        | CRITICAL        |
| CIS.2.3    | ENABLED        | CRITICAL        |
| CIS.1.14   | ENABLED        | CRITICAL        |
+------------+----------------+-----------------+
```
</details>
