### PR TITLE
Add column administrator_account to table aws_securityhub_hub Closes #1037

### DIFF
--- a/aws/table_aws_securityhub_hub.go
+++ b/aws/table_aws_securityhub_hub.go
@@ -33,6 +33,13 @@ func tableAwsSecurityHub(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "administrator_account",
+				Description: "Provides the details for the Security Hub administrator account for the current member account.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getSecurityHubAdministratorAccount,
+				Transform:   transform.FromValue(),
+			},
+			{
 				Name:        "auto_enable_controls",
 				Description: "Whether to automatically enable new controls when they are added to standards that are enabled.",
 				Type:        proto.ColumnType_BOOL,
@@ -114,6 +121,26 @@ func getSecurityHub(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 		return nil, err
 	}
 	return op, nil
+}
+
+func getSecurityHubAdministratorAccount(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	// get service
+	svc, err := SecurityHubService(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_securityhub_hub.getSecurityHubAdministratorAccount", "service_creation_error", err)
+		return nil, err
+	}
+
+	// Build the params
+	params := &securityhub.GetAdministratorAccountInput{}
+
+	// Get call
+	op, err := svc.GetAdministratorAccount(params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_securityhub_hub.getSecurityHubAdministratorAccount", "api_error", err)
+		return nil, err
+	}
+	return op.Administrator, nil
 }
 
 func getSecurityHubTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/docs/tables/aws_securityhub_hub.md
+++ b/docs/tables/aws_securityhub_hub.md
@@ -28,3 +28,19 @@ from
 where
   not auto_enable_controls;
 ```
+
+### List administrator account details for the hub 
+
+```sql
+select
+  hub_arn,
+  auto_enable_controls,
+  administrator_account ->> 'AccountId' as administrator_account_id,
+  administrator_account ->> 'InvitationId' as administrator_invitation_id,
+  administrator_account ->> 'InvitedAt' as administrator_invitation_time,
+  administrator_account ->> 'MemberStatus' as administrator_status
+from
+  aws_securityhub_hub
+where
+ administrator_account is not null;
+```

--- a/docs/tables/aws_securityhub_hub.md
+++ b/docs/tables/aws_securityhub_hub.md
@@ -42,5 +42,5 @@ select
 from
   aws_securityhub_hub
 where
- administrator_account is not null;
+  administrator_account is not null;
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
> select
  hub_arn,
  auto_enable_controls,
  administrator_account ->> 'AccountId' as administrator_account_id,
  administrator_account ->> 'InvitationId' as administrator_invitation_id,
  administrator_account ->> 'InvitedAt' as administrator_invitation_time,
  administrator_account ->> 'MemberStatus' as administrator_status
from
  aws_securityhub_hub
where
  administrator_account is not null;
+--------------------------------------------------------+----------------------+--------------------------+----------------------------------+-------------------------------+----------------------+
| hub_arn                                                | auto_enable_controls | administrator_account_id | administrator_invitation_id      | administrator_invitation_time | administrator_status |
+--------------------------------------------------------+----------------------+--------------------------+----------------------------------+-------------------------------+----------------------+
| arn:aws:securityhub:us-east-1:533793682495:hub/default | true                 | 013122550996             | b0c06de4797a2c7eedf26a627255caf1 | 2022-05-19T10:07:01.364Z      | Enabled              |
+--------------------------------------------------------+----------------------+--------------------------+----------------------------------+-------------------------------+----------------------+
```
</details>
