### PR TITLE
Allow custom endpoint url configuration. Closes #1050

### DIFF
--- a/aws/connection_config.go
+++ b/aws/connection_config.go
@@ -14,6 +14,7 @@ type awsConfig struct {
 	MaxErrorRetryAttempts *int     `cty:"max_error_retry_attempts"`
 	MinErrorRetryDelay    *int     `cty:"min_error_retry_delay"`
 	IgnoreErrorCodes      []string `cty:"ignore_error_codes"`
+	EndpointUrl           *string  `cty:"endpoint_url"`
 }
 
 var ConfigSchema = map[string]*schema.Attribute{
@@ -42,6 +43,9 @@ var ConfigSchema = map[string]*schema.Attribute{
 	},
 	"min_error_retry_delay": {
 		Type: schema.TypeInt,
+	},
+	"endpoint_url": {
+		Type: schema.TypeString,
 	},
 }
 

--- a/aws/service.go
+++ b/aws/service.go
@@ -1984,6 +1984,13 @@ func getSessionWithMaxRetries(ctx context.Context, d *plugin.QueryData, region s
 	// get aws config info
 	awsConfig := GetConfig(d.Connection)
 
+	// handle custom endpoint url, if any
+	awsEndpointUrl := os.Getenv("AWS_ENDPOINT_URL")
+
+	if awsConfig.EndpointUrl != nil {
+		awsEndpointUrl = *awsConfig.EndpointUrl
+	}
+
 	// session default configuration
 	sessionOptions := session.Options{
 		SharedConfigState: session.SharedConfigEnable,
@@ -1991,6 +1998,7 @@ func getSessionWithMaxRetries(ctx context.Context, d *plugin.QueryData, region s
 			Region:     &region,
 			MaxRetries: aws.Int(maxRetries),
 			Retryer:    NewConnectionErrRetryer(maxRetries, minRetryDelay, ctx),
+			Endpoint:   aws.String(awsEndpointUrl),
 		},
 	}
 

--- a/config/aws.spc
+++ b/config/aws.spc
@@ -28,4 +28,10 @@ connection "aws" {
   # List of additional AWS error codes to ignore for all queries.
   # By default, common not found error codes are ignored and will still be ignored even if this argument is not set.
   #ignore_error_codes = ["AccessDenied", "AccessDeniedException", "NotAuthorized", "UnauthorizedOperation", "UnrecognizedClientException", "AuthorizationError"]
+
+  # Specifies the URL to send the AWS request to. In order to make Steampipe to work with Localstack
+  # it will be required to provide custom url that Steampipe will use:
+  #  1. The `AWS_ENDPOINT_URL` environment variable
+  #  2. The endpoint url specified for the particular connection
+  #endpoint_url = "http://localhost:4566"
 }


### PR DESCRIPTION
Closes #1050.

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
