### PR TITLE
Add table aws_cost_usage_by_category. Closes #1075

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -101,6 +101,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_cost_forecast_daily":                                      tableAwsCostForecastDaily(ctx),
 			"aws_cost_forecast_monthly":                                    tableAwsCostForecastMonthly(ctx),
 			"aws_cost_usage":                                               tableAwsCostAndUsage(ctx),
+			"aws_cost_usage_by_category":                                   tableAwsCostAndUsageByCategory(ctx),
 			"aws_dax_cluster":                                              tableAwsDaxCluster(ctx),
 			"aws_directory_service_directory":                              tableAwsDirectoryServiceDirectory(ctx),
 			"aws_dlm_lifecycle_policy":                                     tableAwsDLMLifecyclePolicy(ctx),

--- a/aws/table_aws_cost_usage_by_category.go
+++ b/aws/table_aws_cost_usage_by_category.go
@@ -113,7 +113,6 @@ func buildInputParamAndStreamCostAndUsageByCategory(ctx context.Context, d *plug
 	}
 	costCategoryDefinitions := c.([]*costexplorer.CostCategoryReference)
 
-	// setCategoryKey := false
 	for _, definition := range costCategoryDefinitions {
 
 		if categoryKey != "" {
@@ -135,7 +134,7 @@ func buildInputParamAndStreamCostAndUsageByCategory(ctx context.Context, d *plug
 			Metrics:     aws.StringSlice(AllCostMetrics()),
 		}
 
-		// Get cost category value based of optional quals "category_value"
+		// Get cost category value based on optional quals "category_value"
 		values := getCategoryValuesForFilterParam(definition.Values, categoryValue, categoryValueOperator)
 
 		if categoryKey != "" && len(values) <= 0 {
@@ -153,7 +152,7 @@ func buildInputParamAndStreamCostAndUsageByCategory(ctx context.Context, d *plug
 			filter := &costexplorer.Expression{
 				CostCategories: &costexplorer.CostCategoryValues{
 					Key:          definition.Name,
-					MatchOptions: []*string{aws.String("EQUALS")}, // The value will be EQUALS always because we are manipulating the data based on optional quals operator
+					MatchOptions: []*string{aws.String("EQUALS")}, // The value will be EQUALS always because we are manipulating the category key and category value based on optional quals value and operator
 					Values:       []*string{value},
 				},
 			}

--- a/aws/table_aws_cost_usage_by_category.go
+++ b/aws/table_aws_cost_usage_by_category.go
@@ -102,7 +102,6 @@ func buildInputParamAndStreamCostAndUsageByCategory(ctx context.Context, d *plug
 
 			}
 		}
-
 	}
 
 	// List all cost category definitions
@@ -142,8 +141,8 @@ func buildInputParamAndStreamCostAndUsageByCategory(ctx context.Context, d *plug
 		if categoryKey != "" && len(values) <= 0 {
 			return nil, nil
 		}
-		
-		// Empty check for the category value 
+
+		// Empty check for the category value
 		if len(values) <= 0 {
 			categoryKey = ""
 			continue
@@ -154,13 +153,16 @@ func buildInputParamAndStreamCostAndUsageByCategory(ctx context.Context, d *plug
 			filter := &costexplorer.Expression{
 				CostCategories: &costexplorer.CostCategoryValues{
 					Key:          definition.Name,
-					MatchOptions: []*string{aws.String("EQUALS")}, // The value will be EQUALS always because we are manipulating the data based on optional quals operator 
+					MatchOptions: []*string{aws.String("EQUALS")}, // The value will be EQUALS always because we are manipulating the data based on optional quals operator
 					Values:       []*string{value},
 				},
 			}
 			params.SetFilter(filter)
 
-			streamCostAndUsageByCategory(ctx, d, h, params, *definition.Name, *value)
+			_, err := streamCostAndUsageByCategory(ctx, d, h, params, *definition.Name, *value)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -240,7 +242,7 @@ func listCostCategoryDefinitions(ctx context.Context, d *plugin.QueryData, _ *pl
 func getCategoryValuesForFilterParam(values []*string, categoryValue string, categoryValueOperator string) []*string {
 	var filteredValues []*string
 	for _, value := range values {
-		if categoryValue == *value && categoryValueOperator == "=" { // List out cost and usage for given category value 
+		if categoryValue == *value && categoryValueOperator == "=" { // List out cost and usage for given category value
 			filteredValues = append(filteredValues, value)
 			return filteredValues
 		} else if categoryValue != *value && categoryValueOperator == "<>" { // List out cost and usage not for given category value

--- a/aws/table_aws_cost_usage_by_category.go
+++ b/aws/table_aws_cost_usage_by_category.go
@@ -1,0 +1,262 @@
+package aws
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/service/costexplorer"
+
+	"github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
+)
+
+func tableAwsCostAndUsageByCategory(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_cost_usage_by_category",
+		Description: "AWS Cost Explorer - Cost and Usage By Category",
+		List: &plugin.ListConfig{
+			KeyColumns: plugin.KeyColumnSlice{
+				{Name: "granularity", Require: plugin.Required},
+				{Name: "category_key", Require: plugin.Optional, Operators: []string{"=", "<>"}},
+				{Name: "category_value", Require: plugin.Optional, Operators: []string{"=", "<>"}},
+			},
+			Hydrate: listCostAndUsageByCategory,
+		},
+		Columns: awsColumns(
+			costExplorerColumns([]*plugin.Column{
+				{
+					Name:        "category_key",
+					Description: "The unique name of the Cost Category.",
+					Type:        proto.ColumnType_STRING,
+				},
+				{
+					Name:        "category_value",
+					Description: "The specific value of the Cost Category.",
+					Type:        proto.ColumnType_STRING,
+				},
+
+				// Quals columns - to filter the lookups
+				{
+					Name:        "granularity",
+					Description: "",
+					Type:        proto.ColumnType_STRING,
+					Hydrate:     hydrateCostAndUsageQuals,
+				},
+				{
+					Name:        "search_start_time", // Optional quals for future implementation
+					Description: "",
+					Type:        proto.ColumnType_TIMESTAMP,
+					Hydrate:     hydrateCostAndUsageQuals,
+				},
+				{
+					Name:        "search_end_time", // Optional quals for future implementation
+					Description: "",
+					Type:        proto.ColumnType_TIMESTAMP,
+					Hydrate:     hydrateCostAndUsageQuals,
+				},
+			}),
+		),
+	}
+}
+
+//// LIST FUNCTION
+
+func listCostAndUsageByCategory(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	return buildInputParamAndStreamCostAndUsageByCategory(ctx, d, h)
+}
+
+type CostByCategory struct {
+	CategoryKey   *string
+	CategoryValue *string
+	CEMetricRow
+}
+
+func buildInputParamAndStreamCostAndUsageByCategory(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("buildInputParamAndStreamCostAndUsageByCategory")
+	granularity := strings.ToUpper(getQualsValueByColumn(d.Quals, "granularity", "string").(string))
+	timeFormat := "2006-01-02"
+	if granularity == "HOURLY" {
+		timeFormat = "2006-01-02T15:04:05Z"
+	}
+	endTime := time.Now().Format(timeFormat)
+	startTime := getCEStartDateForGranularity(granularity).Format(timeFormat)
+
+	var categoryKey, categoryValue, categoryKeyOperator, categoryValueOperator string = "", "", "", ""
+
+	optionalColumns := []string{"category_key", "category_value"}
+
+	// Get Optional quals value and given operator
+	for _, column := range optionalColumns {
+		if d.Quals[column] != nil {
+			for _, q := range d.Quals[column].Quals {
+				switch column {
+				case "category_key":
+					categoryKey = q.Value.GetStringValue()
+					categoryKeyOperator = q.Operator
+				case "category_value":
+					categoryValue = q.Value.GetStringValue()
+					categoryValueOperator = q.Operator
+				}
+
+			}
+		}
+
+	}
+
+	// List all cost category definitions
+	getCostCategoryDeFinitionsCached := plugin.HydrateFunc(listCostCategoryDefinitions).WithCache()
+	c, err := getCostCategoryDeFinitionsCached(ctx, d, h)
+	if err != nil {
+		plugin.Logger(ctx).Error("getCostCategoryDeFinitionsCached", "api_error", err)
+		return nil, err
+	}
+	costCategoryDefinitions := c.([]*costexplorer.CostCategoryReference)
+
+	setCategoryKey := false
+	for _, definition := range costCategoryDefinitions {
+
+		if categoryKey != "" {
+			if categoryKey != *definition.Name && categoryKeyOperator == "=" {
+				continue
+			}
+			if categoryKey == *definition.Name && categoryKeyOperator == "<>" {
+				continue
+			}
+		}
+
+		// If category_key has not been provided in optional qulas, then we need to get cost and usage for all cost category
+		if categoryKey == "" {
+			categoryKey = *definition.Name
+			categoryKeyOperator = "="
+			setCategoryKey = true
+		}
+
+		// Build the common param without filter
+		params := &costexplorer.GetCostAndUsageInput{
+			TimePeriod: &costexplorer.DateInterval{
+				Start: aws.String(startTime),
+				End:   aws.String(endTime),
+			},
+			Granularity: aws.String(granularity),
+			Metrics:     aws.StringSlice(AllCostMetrics()),
+		}
+
+		// Get cost category value based of optional quals "category_value"
+		values := getCategoryValuesForFilterParam(definition.Values, categoryValue, categoryValueOperator)
+
+		// Empty check for the category value 
+		if len(values) <= 0 {
+			categoryKey = ""
+			continue
+		}
+
+		// Add filter in param with given optional qulals cost category value
+		for _, value := range values {
+			filter := &costexplorer.Expression{
+				CostCategories: &costexplorer.CostCategoryValues{
+					Key:          definition.Name,
+					MatchOptions: []*string{aws.String("EQUALS")}, // The value will be EQUALS always because we are manipulating the data based on optional quals operator 
+					Values:       []*string{value},
+				},
+			}
+			params.SetFilter(filter)
+
+			// If we wants to get cost by category for all category key 
+			if setCategoryKey {
+				categoryKey = ""
+			}
+
+			streamCostAndUsageByCategory(ctx, d, h, params, *definition.Name, *value)
+		}
+	}
+
+	return nil, err
+}
+
+func streamCostAndUsageByCategory(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData, params *costexplorer.GetCostAndUsageInput, categoryKey string, categoryValue string) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("streamCostAndUsageByCategory")
+
+	// Create session
+	svc, err := CostExplorerService(ctx, d)
+	if err != nil {
+		logger.Error("streamCostAndUsageByCategory", "connection_error", err)
+		return nil, err
+	}
+
+	// List call
+	for {
+		output, err := svc.GetCostAndUsage(params)
+		if err != nil {
+			logger.Error("streamCostAndUsageByCategory", "err", err)
+			return nil, err
+		}
+
+		// stream the results...
+		for _, row := range buildCEMetricRows(ctx, output, d.KeyColumnQuals) {
+			d.StreamListItem(ctx, &CostByCategory{
+				CategoryKey:   &categoryKey,
+				CategoryValue: &categoryValue,
+				CEMetricRow:   row,
+			})
+
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+
+		// get more pages if there are any...
+		if output.NextPageToken == nil {
+			break
+		}
+		params.SetNextPageToken(*output.NextPageToken)
+	}
+
+	return nil, nil
+}
+
+func listCostCategoryDefinitions(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	logger.Trace("listCostCategoryDefinitions")
+
+	// Create session
+	svc, err := CostExplorerService(ctx, d)
+	if err != nil {
+		logger.Error("listCostCategoryDefinitions", "connection_error", err)
+		return nil, err
+	}
+	var definitions []*costexplorer.CostCategoryReference
+	input := &costexplorer.ListCostCategoryDefinitionsInput{}
+	err = svc.ListCostCategoryDefinitionsPages(input,
+		func(page *costexplorer.ListCostCategoryDefinitionsOutput, isLast bool) bool {
+			definitions = append(definitions, page.CostCategoryReferences...)
+			return !isLast
+		},
+	)
+
+	if err != nil {
+		logger.Error("listCostCategoryDefinitions", "api_error", err)
+		return nil, err
+	}
+
+	return definitions, nil
+}
+
+//// UTILITY FUNCTION
+func getCategoryValuesForFilterParam(values []*string, categoryValue string, categoryValueOperator string) []*string {
+	var filteredValues []*string
+	for _, value := range values {
+		if categoryValue == *value && categoryValueOperator == "=" { // List out cost and usage for given category value 
+			filteredValues = append(filteredValues, value)
+			return filteredValues
+		} else if categoryValue != *value && categoryValueOperator == "<>" { // List out cost and usage not for given category value
+			filteredValues = append(filteredValues, value)
+		} else if categoryValue == "" { // List out cost and usage for all category value
+			filteredValues = append(filteredValues, value)
+		}
+	}
+
+	return filteredValues
+}

--- a/aws/table_aws_cost_usage_by_category.go
+++ b/aws/table_aws_cost_usage_by_category.go
@@ -114,7 +114,7 @@ func buildInputParamAndStreamCostAndUsageByCategory(ctx context.Context, d *plug
 	}
 	costCategoryDefinitions := c.([]*costexplorer.CostCategoryReference)
 
-	setCategoryKey := false
+	// setCategoryKey := false
 	for _, definition := range costCategoryDefinitions {
 
 		if categoryKey != "" {
@@ -124,13 +124,6 @@ func buildInputParamAndStreamCostAndUsageByCategory(ctx context.Context, d *plug
 			if categoryKey == *definition.Name && categoryKeyOperator == "<>" {
 				continue
 			}
-		}
-
-		// If category_key has not been provided in optional qulas, then we need to get cost and usage for all cost category
-		if categoryKey == "" {
-			categoryKey = *definition.Name
-			categoryKeyOperator = "="
-			setCategoryKey = true
 		}
 
 		// Build the common param without filter
@@ -146,6 +139,10 @@ func buildInputParamAndStreamCostAndUsageByCategory(ctx context.Context, d *plug
 		// Get cost category value based of optional quals "category_value"
 		values := getCategoryValuesForFilterParam(definition.Values, categoryValue, categoryValueOperator)
 
+		if categoryKey != "" && len(values) <= 0 {
+			return nil, nil
+		}
+		
 		// Empty check for the category value 
 		if len(values) <= 0 {
 			categoryKey = ""
@@ -162,11 +159,6 @@ func buildInputParamAndStreamCostAndUsageByCategory(ctx context.Context, d *plug
 				},
 			}
 			params.SetFilter(filter)
-
-			// If we wants to get cost by category for all category key 
-			if setCategoryKey {
-				categoryKey = ""
-			}
 
 			streamCostAndUsageByCategory(ctx, d, h, params, *definition.Name, *value)
 		}

--- a/docs/tables/aws_cost_usage_by_category.md
+++ b/docs/tables/aws_cost_usage_by_category.md
@@ -1,0 +1,87 @@
+# Table: aws_cost_usage_by_category
+
+Amazon Cost Explorer helps you visualize, understand, and manage your AWS costs and usage.  The `aws_cost_usage_by_category` table provides a simplified yet flexible view of cost for your account by cost category against the organization master account.  You must specify a granularity (`MONTHLY`, `DAILY`), and you may pass category key or category value for filter out the cost for usage by category otherwise it will show all the cost by usage for all available category.
+
+This tables requires an '=' qualifier for columns: granularity and "=" or "<>" qualifier for category_key and category_value columns.
+
+Note that [pricing for the Cost Explorer API](https://aws.amazon.com/aws-cost-management/pricing/) is per API request - Each request will incur a cost of $0.01.
+
+## Examples
+
+### Monthly net unblended cost by account and service
+```sql
+select 
+  period_start,
+  category_key,
+  category_value,
+  net_unblended_cost_amount::numeric::money
+from 
+  aws_nagraj_master_acc.aws_cost_usage_by_category
+where 
+  granularity = 'MONTHLY'
+and
+  category_key = 'Test_Cost_Category'
+order by
+  category_key,
+  period_start;
+```
+
+### Top 5 most expensive (net unblended cost) in each cost by category
+```sql
+with ranked_costs as (
+  select 
+    category_key,
+    category_value,
+    sum(net_unblended_cost_amount)::numeric::money as net_unblended_cost,
+    rank() over(partition by category_key order by sum(net_unblended_cost_amount) desc)
+  from 
+    aws_nagraj_master_acc.aws_cost_usage_by_category
+  where 
+    granularity = 'MONTHLY'
+  group by
+    category_key,
+    category_value
+  order by
+    category_key,
+    net_unblended_cost desc
+)
+select * from ranked_costs where rank <= 5;
+```
+
+### Monthly net unblended cost by category
+
+```sql
+select 
+  period_start,
+  category_key,
+  category_value,
+  net_unblended_cost_amount::numeric::money
+from 
+  aws_nagraj_master_acc.aws_cost_usage_by_category
+where 
+  granularity = 'MONTHLY'
+and
+  category_key = 'nagaraj_category'
+order by
+  category_key,
+  period_start;
+```
+
+### List monthly cost and usage by cost category value
+
+```sql
+select 
+  period_start,
+  category_key,
+  category_value,
+  net_unblended_cost_amount::numeric::money
+from 
+  aws_nagraj_master_acc.aws_cost_usage_by_category
+where 
+  granularity = 'MONTHLY'
+and
+  category_value = '49'
+order by
+  category_key,
+  period_start;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select 
  period_start,
  category_key,
  category_value,
  net_unblended_cost_amount::numeric::money
from 
  aws_nagraj_master_acc.aws_cost_usage_by_category
where 
  granularity = 'MONTHLY'
and
  category_key = 'Test_Cost_Category'
order by
  category_key,
  period_start;
+---------------------------+--------------------+----------------+---------------------------+
| period_start              | category_key       | category_value | net_unblended_cost_amount |
+---------------------------+--------------------+----------------+---------------------------+
| 2021-06-13T05:30:00+05:30 | Test_Cost_Category | 50             | $0.00                     |
| 2021-07-01T05:30:00+05:30 | Test_Cost_Category | 50             | $0.00                     |
| 2021-08-01T05:30:00+05:30 | Test_Cost_Category | 50             | $0.00                     |
| 2021-09-01T05:30:00+05:30 | Test_Cost_Category | 50             | $0.00                     |
| 2021-10-01T05:30:00+05:30 | Test_Cost_Category | 50             | $0.00                     |
| 2021-11-01T05:30:00+05:30 | Test_Cost_Category | 50             | $0.00                     |
| 2021-12-01T05:30:00+05:30 | Test_Cost_Category | 50             | $0.00                     |
| 2022-01-01T05:30:00+05:30 | Test_Cost_Category | 50             | $0.00                     |
| 2022-02-01T05:30:00+05:30 | Test_Cost_Category | 50             | $0.00                     |
| 2022-03-01T05:30:00+05:30 | Test_Cost_Category | 50             | $0.00                     |
| 2022-04-01T05:30:00+05:30 | Test_Cost_Category | 50             | $0.00                     |
| 2022-05-01T05:30:00+05:30 | Test_Cost_Category | 50             | $0.00                     |
| 2022-06-01T05:30:00+05:30 | Test_Cost_Category | 50             | $32.54                    |
+---------------------------+--------------------+----------------+---------------------------+

 with ranked_costs as (
  select 
    category_key,
    category_value,
    sum(net_unblended_cost_amount)::numeric::money as net_unblended_cost,
    rank() over(partition by category_key order by sum(net_unblended_cost_amount) desc)

  from 
    aws_nagraj_master_acc.aws_cost_usage_by_category
  where 
    granularity = 'MONTHLY'
  group by
    category_key,
    category_value
  order by
    category_key,
    net_unblended_cost desc
)
select * from ranked_costs where rank <= 5;
+--------------------+----------------+--------------------+------+
| category_key       | category_value | net_unblended_cost | rank |
+--------------------+----------------+--------------------+------+
| Test_Cost_Category | 50             | $32.54             | 1    |
| nagaraj_category   | 49             | $33.04             | 1    |
+--------------------+----------------+--------------------+------+

> select 
  period_start,
  category_key,
  category_value,
  net_unblended_cost_amount::numeric::money
from 
  aws_nagraj_master_acc.aws_cost_usage_by_category
where 
  granularity = 'MONTHLY'
and
  category_key = 'nagaraj_category'
order by
  category_key,
  period_start;
+---------------------------+------------------+----------------+---------------------------+
| period_start              | category_key     | category_value | net_unblended_cost_amount |
+---------------------------+------------------+----------------+---------------------------+
| 2021-06-13T05:30:00+05:30 | nagaraj_category | 49             | $0.00                     |
| 2021-07-01T05:30:00+05:30 | nagaraj_category | 49             | $0.00                     |
| 2021-08-01T05:30:00+05:30 | nagaraj_category | 49             | $0.00                     |
| 2021-09-01T05:30:00+05:30 | nagaraj_category | 49             | $0.00                     |
| 2021-10-01T05:30:00+05:30 | nagaraj_category | 49             | $0.00                     |
| 2021-11-01T05:30:00+05:30 | nagaraj_category | 49             | $0.00                     |
| 2021-12-01T05:30:00+05:30 | nagaraj_category | 49             | $0.00                     |
| 2022-01-01T05:30:00+05:30 | nagaraj_category | 49             | $0.00                     |
| 2022-02-01T05:30:00+05:30 | nagaraj_category | 49             | $0.00                     |
| 2022-03-01T05:30:00+05:30 | nagaraj_category | 49             | $0.00                     |
| 2022-04-01T05:30:00+05:30 | nagaraj_category | 49             | $0.00                     |
| 2022-05-01T05:30:00+05:30 | nagaraj_category | 49             | $0.00                     |
| 2022-06-01T05:30:00+05:30 | nagaraj_category | 49             | $33.04                    |
+---------------------------+------------------+----------------+---------------------------+


```
</details>
