### PR TITLE
Add column pending_maintenance_actions to aws_rds_db_cluster and aws_rds_db_instance tables. Closes #1060

### DIFF
--- a/aws/table_aws_rds_db_cluster.go
+++ b/aws/table_aws_rds_db_cluster.go
@@ -296,6 +296,13 @@ func tableAwsRDSDBCluster(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
+				Name:        "pending_maintenance_actions",
+				Description: "A list that provides details about the pending maintenance actions for the resource.",
+				Hydrate:     getRDSDBClusterPendingMaintenanceAction,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromValue(),
+			},
+			{
 				Name:        "read_replica_identifiers",
 				Description: "A list of identifiers of the read replicas associated with this DB cluster.",
 				Type:        proto.ColumnType_JSON,
@@ -409,6 +416,35 @@ func getRDSDBCluster(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 
 	if op.DBClusters != nil && len(op.DBClusters) > 0 {
 		return op.DBClusters[0], nil
+	}
+	return nil, nil
+}
+
+func getRDSDBClusterPendingMaintenanceAction(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	dbClusterIdentifier := *h.Item.(*rds.DBCluster).DBClusterIdentifier
+
+	// Create service
+	svc, err := RDSService(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	filter := &rds.Filter{
+		Name:   aws.String("db-cluster-id"),
+		Values: aws.StringSlice([]string{dbClusterIdentifier}),
+	}
+	params := &rds.DescribePendingMaintenanceActionsInput{
+		Filters: []*rds.Filter{filter},
+	}
+
+	op, err := svc.DescribePendingMaintenanceActions(params)
+	if err != nil {
+		plugin.Logger(ctx).Error("getRDSDBClusterPendingMaintenanceAction", "DescribePendingMaintenanceActions", err)
+		return nil, err
+	}
+
+	if len(op.PendingMaintenanceActions) > 0 {
+		return op.PendingMaintenanceActions, nil
 	}
 	return nil, nil
 }

--- a/docs/tables/aws_rds_db_cluster.md
+++ b/docs/tables/aws_rds_db_cluster.md
@@ -17,7 +17,6 @@ where
   kms_key_id is null;
 ```
 
-
 ### List of DB clusters where backup retention period is greater than 7 days
 
 ```sql
@@ -30,7 +29,6 @@ where
   backup_retention_period > 7;
 ```
 
-
 ### Avalability zone count for each db instance
 
 ```sql
@@ -40,7 +38,6 @@ select
 from
   aws_rds_db_cluster;
 ```
-
 
 ### DB cluster Members info
 
@@ -54,4 +51,20 @@ select
 from
   aws_rds_db_cluster
   cross join jsonb_array_elements(members) as member;
+```
+
+### List DB cluster pending maintenance actions
+
+```sql
+select
+  actions ->> 'ResourceIdentifier' as db_cluster_identifier,
+  details ->> 'Action' as action,
+  details ->> 'OptInStatus' as opt_in_status,
+  details ->> 'ForcedApplyDate' as forced_apply_date,
+  details ->> 'CurrentApplyDate' as current_apply_date,
+  details ->> 'AutoAppliedAfterDate' as auto_applied_after_date
+from
+  aws_rds_db_cluster,
+  jsonb_array_elements(pending_maintenance_actions) as actions,
+  jsonb_array_elements(actions -> 'PendingMaintenanceActionDetails') as details;
 ```

--- a/docs/tables/aws_rds_db_instance.md
+++ b/docs/tables/aws_rds_db_instance.md
@@ -137,3 +137,19 @@ from
 where
   parameter_value = '0'
 ```
+
+### List DB instance pending maintenance actions
+
+```sql
+select
+  actions ->> 'ResourceIdentifier' as db_instance_identifier,
+  details ->> 'Action' as action,
+  details ->> 'OptInStatus' as opt_in_status,
+  details ->> 'ForcedApplyDate' as forced_apply_date,
+  details ->> 'CurrentApplyDate' as current_apply_date,
+  details ->> 'AutoAppliedAfterDate' as auto_applied_after_date
+from
+  aws_rds_db_instance,
+  jsonb_array_elements(pending_maintenance_actions) as actions,
+  jsonb_array_elements(actions -> 'PendingMaintenanceActionDetails') as details;
+```


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  actions ->> 'ResourceIdentifier' as db_instance_identifier,
  details ->> 'Action' as action,
  details ->> 'OptInStatus' as opt_in_status,
  details ->> 'ForcedApplyDate' as forced_apply_date,
  details ->> 'CurrentApplyDate' as current_apply_date,
  details ->> 'AutoAppliedAfterDate' as auto_applied_after_date
from
  aws_rds_db_instance,
  jsonb_array_elements(pending_maintenance_actions) as actions,
  jsonb_array_elements(actions -> 'PendingMaintenanceActionDetails') as details;
+-------------------------------------------------------+---------------+------------------+-------------------+----------------------+-------------------------+
| db_instance_identifier                                | action        | opt_in_status    | forced_apply_date | current_apply_date   | auto_applied_after_date |
+-------------------------------------------------------+---------------+------------------+-------------------+----------------------+-------------------------+
| arn:aws:rds:us-east-2:*********:db:turbot-einstein    | system-update | next-maintenance | <null>            | 2022-06-15T09:34:00Z | <null>                  |
+-------------------------------------------------------+---------------+------------------+-------------------+----------------------+-------------------------+
```
</details>
