### PR TITLE
Add column vpcs in table aws_route53_zone closes #1081

### DIFF
--- a/aws/table_aws_route53_zone.go
+++ b/aws/table_aws_route53_zone.go
@@ -102,6 +102,13 @@ func tableAwsRoute53Zone(_ context.Context) *plugin.Table {
 				Hydrate:     getHostedZoneTags,
 				Transform:   transform.FromField("ResourceTagSet.Tags"),
 			},
+			{
+				Name:        "vpcs",
+				Description: "The list of VPCs that are authorized to be associated with the specified hosted zone.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getHostedZone,
+				Transform:   transform.FromField("VPCs"),
+			},
 
 			// Steampipe standard columns
 			{
@@ -126,6 +133,11 @@ func tableAwsRoute53Zone(_ context.Context) *plugin.Table {
 			},
 		}),
 	}
+}
+
+type HostedZoneResult struct {
+	route53.HostedZone
+	VPCs []*route53.VPC
 }
 
 //// LIST FUNCTION
@@ -161,7 +173,7 @@ func listHostedZones(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 		input,
 		func(page *route53.ListHostedZonesOutput, isLast bool) bool {
 			for _, hostedZone := range page.HostedZones {
-				d.StreamListItem(ctx, hostedZone)
+				d.StreamListItem(ctx, &HostedZoneResult{HostedZone: *hostedZone})
 
 				// Context may get cancelled due to manual cancellation or if the limit has been reached
 				if d.QueryStatus.RowsRemaining(ctx) == 0 {
@@ -177,7 +189,7 @@ func listHostedZones(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 
 //// HYDRATE FUNCTIONS
 
-func getHostedZone(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+func getHostedZone(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getHostedZone")
 
 	// Create session
@@ -186,6 +198,11 @@ func getHostedZone(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 		return nil, err
 	}
 	id := d.KeyColumnQuals["id"].GetStringValue()
+
+	if h.Item != nil && id == "" {
+		hostedZone := h.Item.(*HostedZoneResult)
+		id = *hostedZone.Id
+	}
 
 	// Error: pq: rpc error: code = Unknown desc = InvalidParameter: 1 validation error(s) found.
 	// - minimum field size of 1, GetHostedZoneInput.Id.
@@ -203,12 +220,15 @@ func getHostedZone(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 		return nil, err
 	}
 
-	return item.HostedZone, nil
+	return &HostedZoneResult{
+		HostedZone: *item.HostedZone,
+		VPCs: item.VPCs,
+	}, nil
 }
 
 func getHostedZoneTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getHostedZone")
-	hostedZone := h.Item.(*route53.HostedZone)
+	hostedZone := h.Item.(*HostedZoneResult)
 
 	// Create session
 	svc, err := Route53Service(ctx, d)
@@ -232,7 +252,7 @@ func getHostedZoneTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 
 func getHostedZoneQueryLoggingConfigs(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getHostedZoneQueryLoggingConfigs")
-	hostedZone := h.Item.(*route53.HostedZone)
+	hostedZone := h.Item.(*HostedZoneResult)
 
 	// Create session
 	svc, err := Route53Service(ctx, d)
@@ -258,7 +278,7 @@ func getHostedZoneQueryLoggingConfigs(ctx context.Context, d *plugin.QueryData, 
 
 func getHostedZoneDNSSEC(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getHostedZoneDNSSEC")
-	hostedZone := h.Item.(*route53.HostedZone)
+	hostedZone := h.Item.(*HostedZoneResult)
 
 	// Operation is unsupported for private hosted zones.
 	if *hostedZone.Config.PrivateZone {
@@ -286,7 +306,7 @@ func getHostedZoneDNSSEC(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 
 func getRoute53HostedZoneTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getRoute53HostedZoneTurbotAkas")
-	hostedZone := h.Item.(*route53.HostedZone)
+	hostedZone := h.Item.(*HostedZoneResult)
 	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
@@ -304,7 +324,7 @@ func getRoute53HostedZoneTurbotAkas(ctx context.Context, d *plugin.QueryData, h 
 //// TRANSFORM FUNCTIONS
 
 func route53ZoneID(_ context.Context, d *transform.TransformData) (interface{}, error) {
-	hostedZone := d.HydrateItem.(*route53.HostedZone)
+	hostedZone := d.HydrateItem.(*HostedZoneResult)
 	id := strings.Split(string(*hostedZone.Id), "/")[2]
 
 	return id, nil

--- a/docs/tables/aws_route53_zone.md
+++ b/docs/tables/aws_route53_zone.md
@@ -30,7 +30,6 @@ where
   private_zone;
 ```
 
-
 ### List public zones  
 ```sql
 select
@@ -45,7 +44,6 @@ where
   not private_zone;
 ```
 
-
 ### Find zones by subdomain name
 ```sql
 select
@@ -57,4 +55,33 @@ from
   aws_route53_zone
 where
   name like '%.turbot.com.'
+```
+
+### List VPCs associated with zones
+```sql
+select 
+  name,
+  id,
+  v ->> 'VPCId'as vpc_id,
+  v ->> 'VPCRegion'as vpc_region
+from
+  aws_route53_zone,
+  jsonb_array_elements(vpcs) as v;
+```
+
+### Get VPC details associated with zones
+```sql
+select 
+  name,
+  id,
+  v.vpc_id as vpc_id,
+  v.cidr_block as cidr_block,
+  v.is_default as is_default,
+  v.dhcp_options_id as dhcp_options_id
+from
+  aws_route53_zone,
+  jsonb_array_elements(vpcs) as p,
+  aws_vpc as v
+where
+  p ->> 'VPCId' = v.vpc_id;
 ```

--- a/docs/tables/aws_route53_zone.md
+++ b/docs/tables/aws_route53_zone.md
@@ -45,6 +45,7 @@ where
 ```
 
 ### Find zones by subdomain name
+
 ```sql
 select
   name,
@@ -58,18 +59,20 @@ where
 ```
 
 ### List VPCs associated with zones
+
 ```sql
 select 
   name,
   id,
-  v ->> 'VPCId'as vpc_id,
-  v ->> 'VPCRegion'as vpc_region
+  v ->> 'VPCId' as vpc_id,
+  v ->> 'VPCRegion' as vpc_region
 from
   aws_route53_zone,
   jsonb_array_elements(vpcs) as v;
 ```
 
 ### Get VPC details associated with zones
+
 ```sql
 select 
   name,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_route53_zone []

PRETEST: tests/aws_route53_zone

TEST: tests/aws_route53_zone
Running terraform
data.aws_region.alternate: Refreshing state...
data.aws_caller_identity.current: Refreshing state...
data.aws_region.primary: Refreshing state...
data.aws_partition.current: Refreshing state...
data.aws_iam_policy_document.route53-query-logging-policy: Refreshing state...
data.null_data_source.resource: Refreshing state...
aws_route53_zone.named_test_resource: Creating...
aws_kms_key.example: Creating...
aws_cloudwatch_log_resource_policy.route53-query-logging-policy: Creating...
aws_cloudwatch_log_resource_policy.route53-query-logging-policy: Creation complete after 1s [id=route53-query-logging-policy]
aws_kms_key.example: Creation complete after 8s [id=46e939c5-847d-46e7-b684-19d812784c10]
aws_route53_zone.named_test_resource: Still creating... [10s elapsed]
aws_route53_zone.named_test_resource: Still creating... [20s elapsed]
aws_route53_zone.named_test_resource: Still creating... [30s elapsed]
aws_route53_zone.named_test_resource: Still creating... [40s elapsed]
aws_route53_zone.named_test_resource: Creation complete after 42s [id=Z09549242YPDADOJYBETI]
aws_cloudwatch_log_group.aws_route53_example_com: Creating...
aws_route53_key_signing_key.example: Creating...
aws_cloudwatch_log_group.aws_route53_example_com: Creation complete after 3s [id=/aws/route53/turbottest85200.com]
aws_route53_query_log.example_com: Creating...
aws_route53_query_log.example_com: Creation complete after 1s [id=808d0084-cb40-4432-bcb2-28e018d8f901]
aws_route53_key_signing_key.example: Still creating... [10s elapsed]
aws_route53_key_signing_key.example: Still creating... [20s elapsed]
aws_route53_key_signing_key.example: Still creating... [30s elapsed]
aws_route53_key_signing_key.example: Creation complete after 40s [id=Z09549242YPDADOJYBETI,turbottest85200]
aws_route53_hosted_zone_dnssec.example: Creating...
aws_route53_hosted_zone_dnssec.example: Still creating... [10s elapsed]
aws_route53_hosted_zone_dnssec.example: Still creating... [20s elapsed]
aws_route53_hosted_zone_dnssec.example: Creation complete after 27s [id=Z09549242YPDADOJYBETI]

Warning: Deprecated Resource

  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values to
re-use elsewhere in configuration, the same can now be achieved using locals


Apply complete! Resources: 7 added, 0 changed, 0 destroyed.

Outputs:

account_id = 746902152834
aws_region = us-east-1
cloudwatch_log_group_arn = arn:aws:logs:us-east-1:746902152834:log-group:/aws/route53/turbottest85200.com
digest_algorithm_mnemonic = SHA-256
kms_arn = arn:aws:kms:us-east-1:746902152834:key/46e939c5-847d-46e7-b684-19d812784c10
logging_configuration_id = 808d0084-cb40-4432-bcb2-28e018d8f901
resource_aka = arn:aws:route53:::hostedzone/Z09549242YPDADOJYBETI
resource_name = turbottest85200
signing_algorithm_mnemonic = ECDSAP256SHA256
zone_id = Z09549242YPDADOJYBETI

Running SQL query: test-get-query.sql
[
  {
    "comment": "Test zone",
    "id": "Z09549242YPDADOJYBETI",
    "name": "turbottest85200.com.",
    "private_zone": false,
    "resource_record_set_count": 2
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "digest_algorithm_mnemonic": "SHA-256",
    "kms_arn": "arn:aws:kms:us-east-1:746902152834:key/46e939c5-847d-46e7-b684-19d812784c10",
    "name": "turbottest85200.com.",
    "query_logging_configs": [
      {
        "CloudWatchLogsLogGroupArn": "arn:aws:logs:us-east-1:746902152834:log-group:/aws/route53/turbottest85200.com",
        "HostedZoneId": "Z09549242YPDADOJYBETI",
        "Id": "808d0084-cb40-4432-bcb2-28e018d8f901"
      }
    ],
    "signing_algorithm_mnemonic": "ECDSAP256SHA256",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest85200"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-invalid-id-query.sql
null
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "comment": "Test zone",
    "id": "Z09549242YPDADOJYBETI",
    "name": "turbottest85200.com."
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:route53:::hostedzone/Z09549242YPDADOJYBETI"
    ],
    "tags": {
      "name": "turbottest85200"
    },
    "title": "turbottest85200.com."
  }
]
✔ PASSED

POSTTEST: tests/aws_route53_zone

TEARDOWN: tests/aws_route53_zone

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, vpcs from aws_route53_zone
+----------------------+---------------------------------------------------------+
| name                 | vpcs                                                    |
+----------------------+---------------------------------------------------------+
| turbottest85200.com. | <null>                                                  |
| test.com.            | [{"VPCId":"vpc-4f8e9928","VPCRegion":"ap-southeast-1"}] |
+----------------------+---------------------------------------------------------+
```

```
+------+----+--------+------------+------------+-----------------+
> select 
  name,
  id,
  v.vpc_id as vpc_id,
  v.cidr_block as cidr_block,
  v.is_default as is_default,
  v.dhcp_options_id as dhcp_options_id
from
  aws_route53_zone,
  jsonb_array_elements(vpcs) as p,
  aws_vpc as v
where
  p ->> 'VPCId' = v.vpc_id;
+-----------+----------------------+--------------+---------------+------------+-----------------+
| name      | id                   | vpc_id       | cidr_block    | is_default | dhcp_options_id |
+-----------+----------------------+--------------+---------------+------------+-----------------+
| test.com. | Z0242537NC69PM0NDCXS | vpc-4f8e9928 | 172.31.0.0/16 | true       | dopt-faa0ae9d   |
+-----------+----------------------+--------------+---------------+------------+-----------------+
```

</details>
