### PR TITLE
Handle BadRequestException in aws_guardduty_member table.

### DIFF
--- a/aws/table_aws_guardduty_member.go
+++ b/aws/table_aws_guardduty_member.go
@@ -21,7 +21,7 @@ func tableAwsGuardDutyMember(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.AllColumns([]string{"member_account_id", "detector_id"}),
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidInputException"}),
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidInputException", "BadRequestException"}),
 			},
 			Hydrate: getGuardDutyMember,
 		},


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_guardduty_member where member_account_id = '****************' and detector_id = '96bd2df56fc771f1619c47c0a7557f92'
+-------------------+----------------------------------+--------------+-------------------+------------+---------------------+---------------------------+--------------+-----------+------------+--------------+-----
| member_account_id | detector_id                      | master_id    | email             | invited_at | relationship_status | updated_at                | title        | partition | region     | account_id   | _ctx
+-------------------+----------------------------------+--------------+-------------------+------------+---------------------+---------------------------+--------------+-----------+------------+--------------+-----
| ****************      | 96bd2df56fc771f1619c47c0a7557f92 | 533793682495 | sourav@turbot.com | <null>     | Created             | 2022-05-18T13:45:42+05:30 | **************** | aws       | ap-south-1 | 533793682495 | {"co
+-------------------+----------------------------------+--------------+-------------------+------------+---------------------+---------------------------+--------------+-----------+------------+--------------+-----

```
</details>
