### PR TITLE
Fix unsupported region issue in aws_media_store_container table. Fixes #1101

### DIFF
--- a/aws/table_aws_guardduty_member.go
+++ b/aws/table_aws_guardduty_member.go
@@ -21,7 +21,7 @@ func tableAwsGuardDutyMember(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.AllColumns([]string{"member_account_id", "detector_id"}),
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidInputException", "BadRequestException"}),
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidInputException"}),
 			},
 			Hydrate: getGuardDutyMember,
 		},

--- a/aws/table_aws_guardduty_member.go
+++ b/aws/table_aws_guardduty_member.go
@@ -21,7 +21,7 @@ func tableAwsGuardDutyMember(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.AllColumns([]string{"member_account_id", "detector_id"}),
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidInputException"}),
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidInputException", "BadRequestException"}),
 			},
 			Hydrate: getGuardDutyMember,
 		},


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_media_store_container []

PRETEST: tests/aws_media_store_container

TEST: tests/aws_media_store_container
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 2s [id=**************]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_media_store_container.named_test_resource will be created
  + resource "aws_media_store_container" "named_test_resource" {
      + arn      = (known after apply)
      + endpoint = (known after apply)
      + id       = (known after apply)
      + name     = "turbottest73723"
      + tags     = {
          + "name" = "turbottest73723"
        }
      + tags_all = {
          + "name" = "turbottest73723"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "**************"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + endpoint      = (known after apply)
  + resource_arn  = (known after apply)
  + resource_name = "turbottest73723"
aws_media_store_container.named_test_resource: Creating...
aws_media_store_container.named_test_resource: Still creating... [10s elapsed]
aws_media_store_container.named_test_resource: Creation complete after 19s [id=turbottest73723]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "**************"
aws_partition = "aws"
aws_region = "us-east-1"
endpoint = "https://lal43psoxyxah1.data.mediastore.us-east-1.amazonaws.com"
resource_arn = "arn:aws:mediastore:us-east-1:**************:container/turbottest73723"
resource_name = "turbottest73723"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:mediastore:us-east-1:**************:container/turbottest73723",
    "endpoint": "https://lal43psoxyxah1.data.mediastore.us-east-1.amazonaws.com",
    "name": "turbottest73723",
    "tags": {
      "name": "turbottest73723"
    }
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "arn": "arn:aws:mediastore:us-east-1:**************:container/turbottest73723",
    "endpoint": "https://lal43psoxyxah1.data.mediastore.us-east-1.amazonaws.com",
    "name": "turbottest73723",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest73723"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:mediastore:us-east-1:**************:container/turbottest73723",
    "endpoint": "https://lal43psoxyxah1.data.mediastore.us-east-1.amazonaws.com",
    "name": "turbottest73723",
    "tags": {
      "name": "turbottest73723"
    }
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:mediastore:us-east-1:**************:container/turbottest73723"
    ],
    "name": "turbottest73723",
    "region": "us-east-1",
    "tags": {
      "name": "turbottest73723"
    },
    "title": "turbottest73723"
  }
]
✔ PASSED

POSTTEST: tests/aws_media_store_container

TEARDOWN: tests/aws_media_store_container

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_media_store_container
+-----------------+---------------------------------------------------------------------+--------+------------------------+---------------------------+---------------------------------------------------------------
| name            | arn                                                                 | status | access_logging_enabled | creation_time             | endpoint                                                      
+-----------------+---------------------------------------------------------------------+--------+------------------------+---------------------------+---------------------------------------------------------------
| turbottest91837 | arn:aws:mediastore:us-east-1:****************:container/turbottest91837 | ACTIVE | false                  | 2022-06-21T12:31:12+05:30 | https://rjvc44tpqbdgr2.data.mediastore.us-east-1.amazonaws.com
+-----------------+---------------------------------------------------------------------+--------+------------------------+---------------------------+---------------------------------------------------------------
> .cache off
> .cache clear
> select * from aws_media_store_container where name = 'turbottest91837'
+-----------------+---------------------------------------------------------------------+--------+------------------------+---------------------------+---------------------------------------------------------------
| name            | arn                                                                 | status | access_logging_enabled | creation_time             | endpoint                                                      
+-----------------+---------------------------------------------------------------------+--------+------------------------+---------------------------+---------------------------------------------------------------
| turbottest91837 | arn:aws:mediastore:us-east-1:****************:container/turbottest91837 | ACTIVE | false                  | 2022-06-21T12:31:12+05:30 | https://rjvc44tpqbdgr2.data.mediastore.us-east-1.amazonaws.com
+-----------------+---------------------------------------------------------------------+--------+------------------------+---------------------------+---------------------------------------------------------------

```
</details>
