### PR TITLE
Fix MaxResults parameter issue in list API for aws_eks_identity_provider_config table. Fixes #1100

### DIFF
--- a/aws/table_aws_eks_identity_provider_config.go
+++ b/aws/table_aws_eks_identity_provider_config.go
@@ -7,7 +7,6 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin/transform"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/eks"
 )
 
@@ -148,21 +147,24 @@ func listEksIdentityProviderConfigs(ctx context.Context, d *plugin.QueryData, h 
 		return nil, err
 	}
 
+	// As per the API document input parameter MaxResults should support the value of 100.
+	// However with value of 100 API is throwing an error - InvalidParameterException: maxResults needs to be 1
+	// Raised a issue with AWS SDK - https://github.com/aws/aws-sdk-go/issues/4457
 	param := &eks.ListIdentityProviderConfigsInput{
 		ClusterName: cluster.Name,
-		MaxResults:  aws.Int64(100),
+		//MaxResults:  aws.Int64(100),
 	}
 
-	limit := d.QueryContext.Limit
-	if d.QueryContext.Limit != nil {
-		if *limit < *param.MaxResults {
-			if *limit < 1 {
-				param.MaxResults = aws.Int64(1)
-			} else {
-				param.MaxResults = limit
-			}
-		}
-	}
+	// limit := d.QueryContext.Limit
+	// if d.QueryContext.Limit != nil {
+	// 	if *limit < *param.MaxResults {
+	// 		if *limit < 1 {
+	// 			param.MaxResults = aws.Int64(1)
+	// 		} else {
+	// 			param.MaxResults = limit
+	// 		}
+	// 	}
+	// }
 
 	err = svc.ListIdentityProviderConfigsPages(
 		param,

--- a/aws/table_aws_eks_identity_provider_config.go
+++ b/aws/table_aws_eks_identity_provider_config.go
@@ -149,7 +149,7 @@ func listEksIdentityProviderConfigs(ctx context.Context, d *plugin.QueryData, h 
 
 	// As per the API document input parameter MaxResults should support the value of 100.
 	// However with value of 100, API is throwing an error - InvalidParameterException: maxResults needs to be 1.
-	// Raised a issue with AWS SDK - https://github.com/aws/aws-sdk-go/issues/4457
+	// Raised an issue with AWS SDK - https://github.com/aws/aws-sdk-go/issues/4457
 	param := &eks.ListIdentityProviderConfigsInput{
 		ClusterName: cluster.Name,
 		//MaxResults:  aws.Int64(100),

--- a/aws/table_aws_eks_identity_provider_config.go
+++ b/aws/table_aws_eks_identity_provider_config.go
@@ -148,7 +148,7 @@ func listEksIdentityProviderConfigs(ctx context.Context, d *plugin.QueryData, h 
 	}
 
 	// As per the API document input parameter MaxResults should support the value of 100.
-	// However with value of 100 API is throwing an error - InvalidParameterException: maxResults needs to be 1
+	// However with value of 100, API is throwing an error - InvalidParameterException: maxResults needs to be 1.
 	// Raised a issue with AWS SDK - https://github.com/aws/aws-sdk-go/issues/4457
 	param := &eks.ListIdentityProviderConfigsInput{
 		ClusterName: cluster.Name,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_eks_identity_provider_config []

PRETEST: tests/aws_eks_identity_provider_config

TEST: tests/aws_eks_identity_provider_config
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-west-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 1s [id=**************]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_eks_cluster.named_test_resource will be created
  + resource "aws_eks_cluster" "named_test_resource" {
      + arn                   = (known after apply)
      + certificate_authority = (known after apply)
      + created_at            = (known after apply)
      + endpoint              = (known after apply)
      + id                    = (known after apply)
      + identity              = (known after apply)
      + name                  = "turbottest92839"
      + platform_version      = (known after apply)
      + role_arn              = (known after apply)
      + status                = (known after apply)
      + tags                  = {
          + "Name" = "turbottest92839"
        }
      + tags_all              = {
          + "Name" = "turbottest92839"
        }
      + version               = (known after apply)

      + kubernetes_network_config {
          + ip_family         = (known after apply)
          + service_ipv4_cidr = (known after apply)
        }

      + vpc_config {
          + cluster_security_group_id = (known after apply)
          + endpoint_private_access   = false
          + endpoint_public_access    = true
          + public_access_cidrs       = (known after apply)
          + subnet_ids                = (known after apply)
          + vpc_id                    = (known after apply)
        }
    }

  # aws_eks_identity_provider_config.named_test_resource will be created
  + resource "aws_eks_identity_provider_config" "named_test_resource" {
      + arn          = (known after apply)
      + cluster_name = "turbottest92839"
      + id           = (known after apply)
      + status       = (known after apply)
      + tags         = {
          + "Name" = "turbottest92839"
        }
      + tags_all     = {
          + "Name" = "turbottest92839"
        }

      + oidc {
          + client_id                     = (known after apply)
          + identity_provider_config_name = "turbottest92839"
          + issuer_url                    = (known after apply)
        }

      + timeouts {
          + create = "40m"
          + delete = "40m"
        }
    }

  # aws_iam_role.named_test_resource will be created
  + resource "aws_iam_role" "named_test_resource" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "eks.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest92839"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_iam_role_policy_attachment.named_test_resource will be created
  + resource "aws_iam_role_policy_attachment" "named_test_resource" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
      + role       = "turbottest92839"
    }

  # aws_iam_role_policy_attachment.named_test_resource2 will be created
  + resource "aws_iam_role_policy_attachment" "named_test_resource2" {
      + id         = (known after apply)
      + policy_arn = "arn:aws:iam::aws:policy/AmazonEKSVPCResourceController"
      + role       = "turbottest92839"
    }

  # aws_subnet.named_test_resource1 will be created
  + resource "aws_subnet" "named_test_resource1" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-west-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "172.31.0.0/20"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_subnet.named_test_resource2 will be created
  + resource "aws_subnet" "named_test_resource2" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-west-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "172.31.32.0/20"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.named_test_resource will be created
  + resource "aws_vpc" "named_test_resource" {
      + arn                                  = (known after apply)
      + cidr_block                           = "172.31.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags_all                             = (known after apply)
    }

Plan: 8 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id                    = "**************"
  + cluster_name                  = "turbottest92839"
  + identity                      = (known after apply)
  + identity_provider_config_type = "oidc"
  + resource_aka                  = (known after apply)
  + resource_id                   = (known after apply)
  + resource_name                 = "turbottest92839"
  + role_arn                      = (known after apply)
  + status                        = (known after apply)
aws_vpc.named_test_resource: Creating...
aws_iam_role.named_test_resource: Creating...
aws_vpc.named_test_resource: Creation complete after 5s [id=vpc-01af8415609dfc430]
aws_subnet.named_test_resource2: Creating...
aws_subnet.named_test_resource1: Creating...
aws_iam_role.named_test_resource: Creation complete after 6s [id=turbottest92839]
aws_iam_role_policy_attachment.named_test_resource: Creating...
aws_iam_role_policy_attachment.named_test_resource2: Creating...
aws_subnet.named_test_resource2: Creation complete after 1s [id=subnet-0af98b93ef6e73555]
aws_subnet.named_test_resource1: Creation complete after 1s [id=subnet-013b6588329cc7e73]
aws_iam_role_policy_attachment.named_test_resource2: Creation complete after 2s [id=turbottest92839-20220629073615581500000002]
aws_iam_role_policy_attachment.named_test_resource: Creation complete after 4s [id=turbottest92839-20220629073615313500000001]
aws_eks_cluster.named_test_resource: Creating...
aws_eks_cluster.named_test_resource: Still creating... [10s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [20s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [30s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [40s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [50s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [1m0s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [1m10s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [1m20s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [1m30s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [1m40s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [1m50s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [2m0s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [2m10s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [2m20s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [2m30s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [2m40s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [2m50s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [3m0s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [3m10s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [3m20s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [3m30s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [3m40s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [3m50s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [4m0s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [4m10s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [4m20s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [4m37s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [4m47s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [4m57s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [5m7s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [5m17s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [5m27s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [5m37s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [5m47s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [5m57s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [6m7s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [6m17s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [6m27s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [6m37s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [6m47s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [6m57s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [7m7s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [7m17s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [7m27s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [7m37s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [7m47s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [7m57s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [8m7s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [8m17s elapsed]
aws_eks_cluster.named_test_resource: Still creating... [8m27s elapsed]
aws_eks_cluster.named_test_resource: Creation complete after 8m32s [id=turbottest92839]
aws_eks_identity_provider_config.named_test_resource: Creating...
aws_eks_identity_provider_config.named_test_resource: Still creating... [10s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [20s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [30s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [40s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [50s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [1m0s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [1m10s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [1m20s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [1m30s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [1m40s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [1m50s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [2m0s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [2m10s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [2m20s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [2m30s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [2m40s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [2m50s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [3m0s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [3m10s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [3m20s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [3m30s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [3m40s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [3m50s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [4m0s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [4m10s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [4m20s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [4m30s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [4m40s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [4m50s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [5m0s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [5m10s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [5m20s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [5m30s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [5m40s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [5m50s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [6m0s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [6m10s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [6m20s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [6m30s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [6m40s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [6m50s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [7m4s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [7m14s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [7m24s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [7m34s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [7m44s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [7m54s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [8m4s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [8m14s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [8m24s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [8m34s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [8m44s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [8m54s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [9m4s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [9m18s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [9m28s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [9m38s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [9m48s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [9m58s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [10m8s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [10m18s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [10m28s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [10m38s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [10m48s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [10m58s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [11m8s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [11m18s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [11m28s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [11m38s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [11m48s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [11m58s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [12m8s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [12m18s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [12m28s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [12m38s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [12m48s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [12m58s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [13m8s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [13m18s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [13m28s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [13m38s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [13m48s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [13m58s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [14m8s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [14m18s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [14m28s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [14m38s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [14m48s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [14m58s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [15m8s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [15m18s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [15m28s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [15m38s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [15m48s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [15m58s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [16m8s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [16m18s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [16m28s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [16m38s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [16m48s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [16m58s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [17m8s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [17m18s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [17m28s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [17m38s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [17m48s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [17m59s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [18m9s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [18m19s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [18m29s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [18m39s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [18m49s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [18m59s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [19m9s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [19m19s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [19m29s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [19m39s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [19m49s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [19m59s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [20m9s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [20m19s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [20m29s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [20m39s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [20m49s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [20m59s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [21m9s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [21m19s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [21m29s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [21m39s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [21m49s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [21m59s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [22m9s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [22m19s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [22m29s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [22m39s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [22m49s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [22m59s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [23m9s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [23m19s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [23m29s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [23m39s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [23m49s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [23m59s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [24m9s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [24m19s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [24m29s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [24m39s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [24m49s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [24m59s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [25m9s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [25m19s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [25m29s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [25m39s elapsed]
aws_eks_identity_provider_config.named_test_resource: Still creating... [25m49s elapsed]
aws_eks_identity_provider_config.named_test_resource: Creation complete after 25m58s [id=turbottest92839:turbottest92839]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 8 added, 0 changed, 0 destroyed.

Outputs:

account_id = "**************"
cluster_name = "turbottest92839"
identity = tolist([
  {
    "oidc" = tolist([
      {
        "issuer" = "https://oidc.eks.us-west-1.amazonaws.com/id/29CE52D4F4BF6FF410CCC5B89BB8EB57"
      },
    ])
  },
])
identity_provider_config_type = "oidc"
resource_aka = "arn:aws:eks:us-west-1:**************:identityproviderconfig/turbottest92839/oidc/turbottest92839/86c0d735-c804-8c40-a7d6-937d8868bec2"
resource_id = "turbottest92839:turbottest92839"
resource_name = "turbottest92839"
role_arn = "arn:aws:iam::**************:role/turbottest92839"
status = "ACTIVE"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:eks:us-west-1:**************:identityproviderconfig/turbottest92839/oidc/turbottest92839/86c0d735-c804-8c40-a7d6-937d8868bec2",
    "cluster_name": "turbottest92839",
    "name": "turbottest92839",
    "type": "oidc"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:eks:us-west-1:**************:identityproviderconfig/turbottest92839/oidc/turbottest92839/86c0d735-c804-8c40-a7d6-937d8868bec2",
    "name": "turbottest92839"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "**************",
    "akas": [
      "arn:aws:eks:us-west-1:**************:identityproviderconfig/turbottest92839/oidc/turbottest92839/86c0d735-c804-8c40-a7d6-937d8868bec2"
    ],
    "name": "turbottest92839",
    "tags": {
      "Name": "turbottest92839"
    },
    "title": "turbottest92839"
  }
]
✔ PASSED

POSTTEST: tests/aws_eks_identity_provider_config

TEARDOWN: tests/aws_eks_identity_provider_config

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_eks_identity_provider_config
+-----------------+------+----------------------------------+-----------------+-------------------------------------------------------------------------------------------------------------------------------------+-
| name            | type | client_id                        | cluster_name    | arn                                                                                                                                 | 
+-----------------+------+----------------------------------+-----------------+-------------------------------------------------------------------------------------------------------------------------------------+-
| turbottest80598 | oidc | 438F2F22B686661E13A2275146E69C46 | turbottest67964 | arn:aws:eks:us-west-2:****************:identityproviderconfig/turbottest67964/oidc/turbottest80598/08c0d532-2246-789f-835a-d6a7efb21342 | 
+-----------------+------+----------------------------------+-----------------+-------------------------------------------------------------------------------------------------------------------------------------+-
> select * from aws_eks_identity_provider_config where name = 'turbottest80598' and type = 'oidc' and cluster_name = 'turbottest67964'
+-----------------+------+----------------------------------+-----------------+-------------------------------------------------------------------------------------------------------------------------------------+-
| name            | type | client_id                        | cluster_name    | arn                                                                                                                                 | 
+-----------------+------+----------------------------------+-----------------+-------------------------------------------------------------------------------------------------------------------------------------+-
| turbottest80598 | oidc | 438F2F22B686661E13A2275146E69C46 | turbottest67964 | arn:aws:eks:us-west-2:****************:identityproviderconfig/turbottest67964/oidc/turbottest80598/08c0d532-2246-789f-835a-d6a7efb21342 | 
+-----------------+------+----------------------------------+-----------------+-------------------------------------------------------------------------------------------------------------------------------------+-

```
</details>
