### PR TITLE
Add column vpc_endpoint_service_permissions to aws_vpc_endpoint_service table. Closes #1093

### DIFF
--- a/docs/tables/aws_vpc_endpoint_service.md
+++ b/docs/tables/aws_vpc_endpoint_service.md
@@ -53,3 +53,14 @@ from
 where
   not vpc_endpoint_policy_supported;
 ```
+
+### List allowed principals of VPC endpoint services
+
+```sql
+select
+  service_name,
+  service_id,
+  jsonb_pretty(vpc_endpoint_service_permissions) as allowed_principals
+from
+  aws_vpc_endpoint_service;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_vpc_endpoint_service []

PRETEST: tests/aws_vpc_endpoint_service

TEST: tests/aws_vpc_endpoint_service
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-west-2]
data.aws_caller_identity.current: Read complete after 2s [id=533793682495]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_internet_gateway.gw will be created
  + resource "aws_internet_gateway" "gw" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + owner_id = (known after apply)
      + tags_all = (known after apply)
      + vpc_id   = (known after apply)
    }

  # aws_lb.test will be created
  + resource "aws_lb" "test" {
      + arn                              = (known after apply)
      + arn_suffix                       = (known after apply)
      + dns_name                         = (known after apply)
      + enable_cross_zone_load_balancing = false
      + enable_deletion_protection       = false
      + id                               = (known after apply)
      + internal                         = false
      + ip_address_type                  = (known after apply)
      + load_balancer_type               = "network"
      + name                             = "turbottest21819"
      + security_groups                  = (known after apply)
      + subnets                          = (known after apply)
      + tags                             = {
          + "name" = "turbottest21819"
        }
      + tags_all                         = {
          + "name" = "turbottest21819"
        }
      + vpc_id                           = (known after apply)
      + zone_id                          = (known after apply)

      + subnet_mapping {
          + allocation_id        = (known after apply)
          + ipv6_address         = (known after apply)
          + outpost_id           = (known after apply)
          + private_ipv4_address = (known after apply)
          + subnet_id            = (known after apply)
        }
    }

  # aws_subnet.public will be created
  + resource "aws_subnet" "public" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = (known after apply)
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.1.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.main will be created
  + resource "aws_vpc" "main" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags                                 = {
          + "name" = "turbottest21819"
        }
      + tags_all                             = {
          + "name" = "turbottest21819"
        }
    }

  # aws_vpc_endpoint_service.named_test_resource will be created
  + resource "aws_vpc_endpoint_service" "named_test_resource" {
      + acceptance_required            = false
      + allowed_principals             = (known after apply)
      + arn                            = (known after apply)
      + availability_zones             = (known after apply)
      + base_endpoint_dns_names        = (known after apply)
      + id                             = (known after apply)
      + manages_vpc_endpoints          = (known after apply)
      + network_load_balancer_arns     = (known after apply)
      + private_dns_name               = (known after apply)
      + private_dns_name_configuration = (known after apply)
      + service_name                   = (known after apply)
      + service_type                   = (known after apply)
      + state                          = (known after apply)
      + supported_ip_address_types     = (known after apply)
      + tags                           = {
          + "Name" = "turbottest21819"
        }
      + tags_all                       = {
          + "Name" = "turbottest21819"
        }
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "533793682495"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest21819"
  + service_name  = (known after apply)
aws_vpc.main: Creating...
aws_vpc.main: Creation complete after 5s [id=vpc-023daef3db52cdd0e]
aws_internet_gateway.gw: Creating...
aws_subnet.public: Creating...
aws_internet_gateway.gw: Creation complete after 2s [id=igw-041a975a014dbfa9b]
aws_subnet.public: Creation complete after 2s [id=subnet-016b89d4111968314]
aws_lb.test: Creating...
aws_lb.test: Still creating... [10s elapsed]
aws_lb.test: Still creating... [20s elapsed]
aws_lb.test: Still creating... [30s elapsed]
aws_lb.test: Still creating... [40s elapsed]
aws_lb.test: Still creating... [50s elapsed]
aws_lb.test: Still creating... [1m0s elapsed]
aws_lb.test: Still creating... [1m10s elapsed]
aws_lb.test: Still creating... [1m20s elapsed]
aws_lb.test: Still creating... [1m30s elapsed]
aws_lb.test: Still creating... [1m40s elapsed]
aws_lb.test: Still creating... [1m50s elapsed]
aws_lb.test: Still creating... [2m0s elapsed]
aws_lb.test: Still creating... [2m10s elapsed]
aws_lb.test: Still creating... [2m20s elapsed]
aws_lb.test: Still creating... [2m30s elapsed]
aws_lb.test: Creation complete after 2m37s [id=arn:aws:elasticloadbalancing:us-west-2:533793682495:loadbalancer/net/turbottest21819/fc7f3d72e17e041f]
aws_vpc_endpoint_service.named_test_resource: Creating...
aws_vpc_endpoint_service.named_test_resource: Creation complete after 8s [id=vpce-svc-0f3b407b7fa6a811f]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "533793682495"
resource_aka = "arn:aws:ec2:us-west-2:533793682495:vpc-endpoint-service/vpce-svc-0f3b407b7fa6a811f"
resource_id = "vpce-svc-0f3b407b7fa6a811f"
resource_name = "turbottest21819"
service_name = "com.amazonaws.vpce.us-west-2.vpce-svc-0f3b407b7fa6a811f"

Running SQL query: test-get-query.sql
[
  {
    "acceptance_required": false,
    "manages_vpc_endpoints": false,
    "owner": "533793682495",
    "service_id": "vpce-svc-0f3b407b7fa6a811f",
    "service_name": "com.amazonaws.vpce.us-west-2.vpce-svc-0f3b407b7fa6a811f",
    "service_type": [
      {
        "ServiceType": "Interface"
      }
    ],
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest21819"
      }
    ],
    "vpc_endpoint_policy_supported": false
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-west-2:533793682495:vpc-endpoint-service/vpce-svc-0f3b407b7fa6a811f"
    ],
    "service_name": "com.amazonaws.vpce.us-west-2.vpce-svc-0f3b407b7fa6a811f",
    "tags": {
      "Name": "turbottest21819"
    },
    "title": "com.amazonaws.vpce.us-west-2.vpce-svc-0f3b407b7fa6a811f"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "service_id": "vpce-svc-0f3b407b7fa6a811f",
    "service_name": "com.amazonaws.vpce.us-west-2.vpce-svc-0f3b407b7fa6a811f"
  }
]
✔ PASSED

POSTTEST: tests/aws_vpc_endpoint_service

TEARDOWN: tests/aws_vpc_endpoint_service

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  service_name,
  service_id,
  jsonb_pretty(vpc_endpoint_service_permissions) as allowed_principals
from
  aws_vpc_endpoint_service
where
  vpc_endpoint_service_permissions is not null;
+---------------------------------------------------------+----------------------------+----------------------------------------------------------------------------------------+
| service_name                                            | service_id                 | allowed_principals                                                                     |
+---------------------------------------------------------+----------------------------+----------------------------------------------------------------------------------------+
| com.amazonaws.vpce.us-east-1.vpce-svc-02d31287a7757d250 | vpce-svc-02d31287a7757d250 | [                                                                                      |
|                                                         |                            |     {                                                                                  |
|                                                         |                            |         "Principal": "arn:aws:iam::**************:role/aws-ec2-spot-fleet-tagging-role", |
|                                                         |                            |         "PrincipalType": "Role"                                                        |
|                                                         |                            |     }                                                                                  |
|                                                         |                            | ]                                                                                      |
+---------------------------------------------------------+----------------------------+----------------------------------------------------------------------------------------+
```
</details>
