### PR TITLE
Fix no such host issue and complete audit manager setup issue in aws_auditmanager_* tables. Fixes#1107

### DIFF
--- a/aws-test/tests/aws_auditmanager_assessment/posttest-variables.tf
+++ b/aws-test/tests/aws_auditmanager_assessment/posttest-variables.tf
@@ -1,6 +1,6 @@
 variable "aws_profile" {
   type        = string
-  default     = "integration-tests"
+  default     = "default"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_auditmanager_assessment/variables.tf
+++ b/aws-test/tests/aws_auditmanager_assessment/variables.tf
@@ -7,7 +7,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "integration-tests"
+  default     = "default"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_auditmanager_control/test-list-expected.json
+++ b/aws-test/tests/aws_auditmanager_control/test-list-expected.json
@@ -2,7 +2,6 @@
   {
     "control_sources": "AWS CloudTrail",
     "id": "{{ output.control_id.value }}",
-    "name": "{{ resourceName }}",
-    "type": "Custom"
+    "name": "{{ resourceName }}"
   }
 ]

--- a/aws-test/tests/aws_auditmanager_control/test-list-query.sql
+++ b/aws-test/tests/aws_auditmanager_control/test-list-query.sql
@@ -1,3 +1,3 @@
-select name, id, type, control_sources
+select name, id, control_sources
 from aws.aws_auditmanager_control
 where name = '{{ output.resource_name.value }}';

--- a/aws-test/tests/aws_auditmanager_control/variables.tf
+++ b/aws-test/tests/aws_auditmanager_control/variables.tf
@@ -6,7 +6,7 @@ variable "resource_name" {
 
 variable "aws_profile" {
   type        = string
-  default     = "integration-tests"
+  default     = "default"
   description = "AWS credentials profile used for the test. Default is to use the default profile."
 }
 

--- a/aws-test/tests/aws_auditmanager_framework/test-turbot-query.sql
+++ b/aws-test/tests/aws_auditmanager_framework/test-turbot-query.sql
@@ -1,3 +1,3 @@
 select title, akas
 from aws.aws_auditmanager_framework
-where id = '{{ output.id.value }}';
+where arn = '{{ output.arn.value }}';

--- a/aws/table_aws_auditmanager_assessment.go
+++ b/aws/table_aws_auditmanager_assessment.go
@@ -249,8 +249,14 @@ func getAwsAuditManagerAssessment(ctx context.Context, d *plugin.QueryData, h *p
 
 	// Get call
 	data, err := svc.GetAssessment(params)
+
+	// User with Admin access gets the error as ‘AccessDeniedException: Please complete AWS Audit Manager setup from home page to enable this action in this account’
+	// for the regions where the  Audit Manager setup is not complete, this suppresses the value from the regions where the setup is completed.
 	if err != nil {
-		plugin.Logger(ctx).Error("getAwsAuditManagerAssessment", "ERROR", err)
+		if strings.Contains(err.Error(), "Please complete AWS Audit Manager setup") {
+			return nil, nil
+		}
+		plugin.Logger(ctx).Error("getAwsAuditManagerAssessment", "err", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_auditmanager_assessment.go
+++ b/aws/table_aws_auditmanager_assessment.go
@@ -2,9 +2,11 @@ package aws
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/auditmanager"
+	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
@@ -154,6 +156,14 @@ func listAwsAuditManagerAssessments(ctx context.Context, d *plugin.QueryData, _ 
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	plugin.Logger(ctx).Trace("listAwsAuditManagerAssessments", "AWS_REGION", region)
 
+	// AWS Audit Manager is not supported in all regions. For unsupported regions the API throws an error, e.g.,
+	// Get "https://auditmanager.eu-west-3.amazonaws.com/assessments?maxResults=1000": dial tcp: lookup auditmanager.eu-west-3.amazonaws.com: no such host
+	serviceId := auditmanager.EndpointsID
+	validRegions := SupportedRegionsForService(ctx, d, serviceId)
+	if !helpers.StringSliceContains(validRegions, region) {
+		return nil, nil
+	}
+
 	// Create session
 	svc, err := AuditManagerService(ctx, d, region)
 	if err != nil {
@@ -190,7 +200,18 @@ func listAwsAuditManagerAssessments(ctx context.Context, d *plugin.QueryData, _ 
 			return !isLast
 		},
 	)
-	return nil, err
+
+	// User with Admin access gets the error as ‘AccessDeniedException: Please complete AWS Audit Manager setup from home page to enable this action in this account’
+	// for the regions where the  Audit Manager setup is not complete, this suppresses the value from the regions where the setup is completed.
+	if err != nil {
+		if strings.Contains(err.Error(), "Please complete AWS Audit Manager setup") {
+			return nil, nil
+		}
+		plugin.Logger(ctx).Error("listAwsAuditManagerAssessments", "err", err)
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 //// HYDRATE FUNCTIONS
@@ -199,6 +220,14 @@ func getAwsAuditManagerAssessment(ctx context.Context, d *plugin.QueryData, h *p
 	plugin.Logger(ctx).Trace("getAwsAuditManagerAssessment")
 
 	region := d.KeyColumnQualString(matrixKeyRegion)
+
+	// AWS Audit Manager is not supported in all regions. For unsupported regions the API throws an error, e.g.,
+	// Get "https://auditmanager.eu-west-3.amazonaws.com/assessments?maxResults=1000": dial tcp: lookup auditmanager.eu-west-3.amazonaws.com: no such host
+	serviceId := auditmanager.EndpointsID
+	validRegions := SupportedRegionsForService(ctx, d, serviceId)
+	if !helpers.StringSliceContains(validRegions, region) {
+		return nil, nil
+	}
 
 	var id string
 	if h.Item != nil {
@@ -221,7 +250,7 @@ func getAwsAuditManagerAssessment(ctx context.Context, d *plugin.QueryData, h *p
 	// Get call
 	data, err := svc.GetAssessment(params)
 	if err != nil {
-		plugin.Logger(ctx).Debug("getAwsAuditManagerAssessment", "ERROR", err)
+		plugin.Logger(ctx).Error("getAwsAuditManagerAssessment", "ERROR", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_auditmanager_control.go
+++ b/aws/table_aws_auditmanager_control.go
@@ -239,8 +239,14 @@ func getAuditManagerControl(ctx context.Context, d *plugin.QueryData, h *plugin.
 	}
 
 	op, err := svc.GetControl(params)
+
+	// User with Admin access gets the error as ‘AccessDeniedException: Please complete AWS Audit Manager setup from home page to enable this action in this account’
+	// for the regions where the  Audit Manager setup is not complete, this suppresses the value from the regions where the setup is completed.
 	if err != nil {
-		plugin.Logger(ctx).Error("getAuditManagerControl", "ERROR", err)
+		if strings.Contains(err.Error(), "Please complete AWS Audit Manager setup") {
+			return nil, nil
+		}
+		plugin.Logger(ctx).Error("getAuditManagerControl", "err", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_auditmanager_evidence.go
+++ b/aws/table_aws_auditmanager_evidence.go
@@ -2,10 +2,12 @@ package aws
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/auditmanager"
+	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
@@ -171,6 +173,14 @@ func listAuditManagerEvidences(ctx context.Context, d *plugin.QueryData, h *plug
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	plugin.Logger(ctx).Trace("listAuditManagerEvidences", "AWS_REGION", region)
 
+	// AWS Audit Manager is not supported in all regions. For unsupported regions the API throws an error, e.g.,
+	// Get "https://auditmanager.sa-east-1.amazonaws.com/": dial tcp: lookup auditmanager.sa-east-1.amazonaws.com: no such host
+	serviceId := auditmanager.EndpointsID
+	validRegions := SupportedRegionsForService(ctx, d, serviceId)
+	if !helpers.StringSliceContains(validRegions, region) {
+		return nil, nil
+	}
+
 	// Get assessment details
 	assessmentID := *h.Item.(*auditmanager.AssessmentMetadataItem).Id
 
@@ -268,14 +278,22 @@ func getRowDataForEvidence(ctx context.Context, d *plugin.QueryData, item auditm
 	var items []evidenceInfo
 
 	listEvidence, err := svc.GetEvidenceByEvidenceFolder(params)
+
+	// User with Admin access gets the error as ‘AccessDeniedException: Please complete AWS Audit Manager setup from home page to enable this action in this account’
+	// for the regions where the Audit Manager setup is not complete, this suppresses the value from the regions where the setup is completed.
 	if err != nil {
+		if strings.Contains(err.Error(), "Please complete AWS Audit Manager setup") {
+			return nil, nil
+		}
+		plugin.Logger(ctx).Error("getRowDataForEvidence", "err", err)
 		return nil, err
 	}
 
 	for _, evidence := range listEvidence.Evidence {
 		items = append(items, evidenceInfo{evidence, item.AssessmentId, item.ControlSetId})
 	}
-	return items, err
+
+	return items, nil
 }
 
 //// HYDRATE FUNCTIONS
@@ -283,6 +301,14 @@ func getRowDataForEvidence(ctx context.Context, d *plugin.QueryData, item auditm
 func getAuditManagerEvidence(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	plugin.Logger(ctx).Trace("getAuditManagerEvidence")
 	region := d.KeyColumnQualString(matrixKeyRegion)
+
+	// AWS Audit Manager is not supported in all regions. For unsupported regions the API throws an error, e.g.,
+	// Get "https://auditmanager.sa-east-1.amazonaws.com/": dial tcp: lookup auditmanager.sa-east-1.amazonaws.com: no such host
+	serviceId := auditmanager.EndpointsID
+	validRegions := SupportedRegionsForService(ctx, d, serviceId)
+	if !helpers.StringSliceContains(validRegions, region) {
+		return nil, nil
+	}
 
 	// Create Session
 	svc, err := AuditManagerService(ctx, d, region)
@@ -306,7 +332,7 @@ func getAuditManagerEvidence(ctx context.Context, d *plugin.QueryData, _ *plugin
 	// Get call
 	data, err := svc.GetEvidence(params)
 	if err != nil {
-		plugin.Logger(ctx).Debug("getAuditManagerEvidence", "ERROR", err)
+		plugin.Logger(ctx).Error("getAuditManagerEvidence", "ERROR", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_auditmanager_evidence.go
+++ b/aws/table_aws_auditmanager_evidence.go
@@ -331,8 +331,14 @@ func getAuditManagerEvidence(ctx context.Context, d *plugin.QueryData, _ *plugin
 
 	// Get call
 	data, err := svc.GetEvidence(params)
+
+	// User with Admin access gets the error as ‘AccessDeniedException: Please complete AWS Audit Manager setup from home page to enable this action in this account’
+	// for the regions where the Audit Manager setup is not complete, this suppresses the value from the regions where the setup is completed.
 	if err != nil {
-		plugin.Logger(ctx).Error("getAuditManagerEvidence", "ERROR", err)
+		if strings.Contains(err.Error(), "Please complete AWS Audit Manager setup") {
+			return nil, nil
+		}
+		plugin.Logger(ctx).Error("getAuditManagerEvidence", "err", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_auditmanager_evidence_folder.go
+++ b/aws/table_aws_auditmanager_evidence_folder.go
@@ -251,8 +251,14 @@ func getAuditManagerEvidenceFolder(ctx context.Context, d *plugin.QueryData, _ *
 
 	// Get call
 	data, err := svc.GetEvidenceFolder(params)
+
+	// User with Admin access gets the error as ‘AccessDeniedException: Please complete AWS Audit Manager setup from home page to enable this action in this account’
+	// for the regions where the Audit Manager setup is not complete, this suppresses the value from the regions where the setup is completed.
 	if err != nil {
-		plugin.Logger(ctx).Error("getAuditManagerEvidenceFolder", "ERROR", err)
+		if strings.Contains(err.Error(), "Please complete AWS Audit Manager setup") {
+			return nil, nil
+		}
+		plugin.Logger(ctx).Error("getAuditManagerEvidenceFolder", "err", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_auditmanager_framework.go
+++ b/aws/table_aws_auditmanager_framework.go
@@ -239,7 +239,13 @@ func getAuditManagerFramework(ctx context.Context, d *plugin.QueryData, h *plugi
 	}
 
 	op, err := svc.GetAssessmentFramework(params)
+
+	// User with Admin access gets the error as ‘AccessDeniedException: Please complete AWS Audit Manager setup from home page to enable this action in this account’
+	// for the regions where the Audit Manager setup is not complete, this suppresses the value from the regions where the setup is completed.
 	if err != nil {
+		if strings.Contains(err.Error(), "Please complete AWS Audit Manager setup") {
+			return nil, nil
+		}
 		plugin.Logger(ctx).Error("getAuditManagerFramework", "err", err)
 		return nil, err
 	}

--- a/aws/table_aws_auditmanager_framework.go
+++ b/aws/table_aws_auditmanager_framework.go
@@ -2,10 +2,12 @@ package aws
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/auditmanager"
 
+	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin/transform"
@@ -138,6 +140,14 @@ func listAuditManagerFrameworks(ctx context.Context, d *plugin.QueryData, _ *plu
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	plugin.Logger(ctx).Debug("listAuditManagerFrameworks", "REGION", region)
 
+	// AWS Audit Manager is not supported in all regions. For unsupported regions the API throws an error, e.g.,
+	// Get "https://auditmanager.ap-northeast-3.amazonaws.com/assessmentFrameworks?frameworkType=Standard": dial tcp: lookup auditmanager.ap-northeast-3.amazonaws.com: no such host
+	serviceId := auditmanager.EndpointsID
+	validRegions := SupportedRegionsForService(ctx, d, serviceId)
+	if !helpers.StringSliceContains(validRegions, region) {
+		return nil, nil
+	}
+
 	svc, err := AuditManagerService(ctx, d, region)
 	if err != nil {
 		return nil, err
@@ -159,7 +169,13 @@ func listAuditManagerFrameworks(ctx context.Context, d *plugin.QueryData, _ *plu
 		},
 	)
 
+	// User with Admin access gets the error as ‘AccessDeniedException: Please complete AWS Audit Manager setup from home page to enable this action in this account’
+	// for the regions where the Audit Manager setup is not complete, this suppresses the value from the regions where the setup is completed.
 	if err != nil {
+		if strings.Contains(err.Error(), "Please complete AWS Audit Manager setup") {
+			return nil, nil
+		}
+		plugin.Logger(ctx).Error("listAuditManagerFrameworks_standard", "err", err)
 		return nil, err
 	}
 
@@ -174,7 +190,17 @@ func listAuditManagerFrameworks(ctx context.Context, d *plugin.QueryData, _ *plu
 		},
 	)
 
-	return nil, err
+	// User with Admin access gets the error as ‘AccessDeniedException: Please complete AWS Audit Manager setup from home page to enable this action in this account’
+	// for the regions where the Audit Manager setup is not complete, this suppresses the value from the regions where the setup is completed.
+	if err != nil {
+		if strings.Contains(err.Error(), "Please complete AWS Audit Manager setup") {
+			return nil, nil
+		}
+		plugin.Logger(ctx).Error("listAuditManagerFrameworks_custom", "err", err)
+		return nil, err
+	}
+
+	return nil, nil
 }
 
 //// HYDRATE FUNCTIONS
@@ -182,6 +208,14 @@ func listAuditManagerFrameworks(ctx context.Context, d *plugin.QueryData, _ *plu
 func getAuditManagerFramework(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	plugin.Logger(ctx).Debug("getAuditManagerFramework", "REGION", region)
+
+	// AWS Audit Manager is not supported in all regions. For unsupported regions the API throws an error, e.g.,
+	// Get "https://auditmanager.ap-northeast-3.amazonaws.com/assessmentFrameworks?frameworkType=Standard": dial tcp: lookup auditmanager.ap-northeast-3.amazonaws.com: no such host
+	serviceId := auditmanager.EndpointsID
+	validRegions := SupportedRegionsForService(ctx, d, serviceId)
+	if !helpers.StringSliceContains(validRegions, region) {
+		return nil, nil
+	}
 
 	// Create Session
 	svc, err := AuditManagerService(ctx, d, region)
@@ -206,6 +240,7 @@ func getAuditManagerFramework(ctx context.Context, d *plugin.QueryData, h *plugi
 
 	op, err := svc.GetAssessmentFramework(params)
 	if err != nil {
+		plugin.Logger(ctx).Error("getAuditManagerFramework", "err", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_auditmanager_assessment []

PRETEST: tests/aws_auditmanager_assessment

TEST: tests/aws_auditmanager_assessment
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 1s [id=533793682495]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.assessment will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "local_file" "assessment" {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_auditmanager_assessment/terraform/test/assessment.json"
      + id             = (known after apply)
    }

  # data.local_file.framework will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "local_file" "framework" {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_auditmanager_assessment/terraform/test/list-framework.json"
      + id             = (known after apply)
    }

  # aws_s3_bucket.named_test_resource will be created
  + resource "aws_s3_bucket" "named_test_resource" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "turbottest52018"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = true
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = (known after apply)
          + allowed_methods = (known after apply)
          + allowed_origins = (known after apply)
          + expose_headers  = (known after apply)
          + max_age_seconds = (known after apply)
        }

      + grant {
          + id          = (known after apply)
          + permissions = (known after apply)
          + type        = (known after apply)
          + uri         = (known after apply)
        }

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = (known after apply)
          + enabled                                = (known after apply)
          + id                                     = (known after apply)
          + prefix                                 = (known after apply)
          + tags                                   = (known after apply)

          + expiration {
              + date                         = (known after apply)
              + days                         = (known after apply)
              + expired_object_delete_marker = (known after apply)
            }

          + noncurrent_version_expiration {
              + days = (known after apply)
            }

          + noncurrent_version_transition {
              + days          = (known after apply)
              + storage_class = (known after apply)
            }

          + transition {
              + date          = (known after apply)
              + days          = (known after apply)
              + storage_class = (known after apply)
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = (known after apply)
        }

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

  # null_resource.list_frameworks will be created
  + resource "null_resource" "list_frameworks" {
      + id = (known after apply)
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

  # null_resource.tag_assessment will be created
  + resource "null_resource" "tag_assessment" {
      + id = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id     = "533793682495"
  + assessment_arn = (known after apply)
  + assessment_id  = (known after apply)
  + aws_partition  = "aws"
  + aws_region     = "us-east-1"
  + resource_name  = "turbottest52018"
null_resource.list_frameworks: Creating...
null_resource.list_frameworks: Provisioning with 'local-exec'...
null_resource.list_frameworks (local-exec): Executing: ["/bin/sh" "-c" "aws auditmanager list-assessment-frameworks --framework-type Standard --output json --profile default --region us-east-1 > /private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_auditmanager_assessment/terraform/test/list-framework.json"]
aws_s3_bucket.named_test_resource: Creating...
null_resource.list_frameworks: Creation complete after 2s [id=7054954944087803499]
data.local_file.framework: Reading...
data.local_file.framework: Read complete after 0s [id=f92f8d662cd477a470b5ce2451e412aa3ed8a26f]
aws_s3_bucket.named_test_resource: Creation complete after 5s [id=turbottest52018]
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "aws auditmanager create-assessment --name turbottest52018 --description 'Test assessment to validate table outcomes.' --scope 'awsAccounts=[{id=\"533793682495\"}],awsServices=[{serviceName=\"ec2\"}]' --roles 'roleArn=\"arn:aws:iam::533793682495:user/turbot/account/federated/sourav\",roleType=\"PROCESS_OWNER\"' --assessment-reports-destination 'destinationType=\"S3\",destination=\"s3://turbottest52018\"' --framework-id 'f7cdaffa-69c5-367a-8c58-c9a4bc5704e1' --profile default --region  us-east-1 > /private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_auditmanager_assessment/terraform/test/assessment.json"]
null_resource.named_test_resource: Creation complete after 2s [id=162213761390593194]
data.local_file.assessment: Reading...
data.local_file.assessment: Read complete after 0s [id=8ee54b9519e4298e54da0f57174cffa7d9d9783c]
null_resource.tag_assessment: Creating...
null_resource.tag_assessment: Provisioning with 'local-exec'...
null_resource.tag_assessment (local-exec): Executing: ["/bin/sh" "-c" "aws auditmanager tag-resource --resource-arn 'arn:aws:auditmanager:us-east-1:533793682495:assessment/b74b22e0-e471-4af6-8d11-d2a96806bf58' --tags name=turbottest52018 --profile default --region us-east-1"]
null_resource.tag_assessment: Creation complete after 1s [id=1386699117924437998]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

account_id = "533793682495"
assessment_arn = "arn:aws:auditmanager:us-east-1:533793682495:assessment/b74b22e0-e471-4af6-8d11-d2a96806bf58"
assessment_id = "b74b22e0-e471-4af6-8d11-d2a96806bf58"
aws_partition = "aws"
aws_region = "us-east-1"
resource_name = "turbottest52018"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:auditmanager:us-east-1:533793682495:assessment/b74b22e0-e471-4af6-8d11-d2a96806bf58",
    "assessment_report_destination": "s3://turbottest52018",
    "assessment_report_destination_type": "S3",
    "aws_account": {
      "EmailAddress": null,
      "Id": "533793682495",
      "Name": null
    },
    "description": "Test assessment to validate table outcomes.",
    "id": "b74b22e0-e471-4af6-8d11-d2a96806bf58",
    "name": "turbottest52018",
    "scope": {
      "AwsAccounts": [
        {
          "EmailAddress": null,
          "Id": "533793682495",
          "Name": null
        }
      ],
      "AwsServices": [
        {
          "ServiceName": "ec2"
        }
      ]
    },
    "status": "ACTIVE"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:auditmanager:us-east-1:533793682495:assessment/b74b22e0-e471-4af6-8d11-d2a96806bf58",
    "id": "b74b22e0-e471-4af6-8d11-d2a96806bf58",
    "name": "turbottest52018"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:auditmanager:us-east-1:533793682495:assessment/b74b22e0-e471-4af6-8d11-d2a96806bf58"
    ],
    "name": "turbottest52018",
    "tags": {
      "name": "turbottest52018"
    },
    "title": "turbottest52018"
  }
]
✔ PASSED

POSTTEST: tests/aws_auditmanager_assessment
Running terraform
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 1s [id=533793682495]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "aws auditmanager delete-assessment --assessment-id b74b22e0-e471-4af6-8d11-d2a96806bf58 --profile default"]
null_resource.named_test_resource: Creation complete after 2s [id=5790964208039355628]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on posttest-variables.tf line 37, in data "null_data_source" "resource":
  37: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

TEARDOWN: tests/aws_auditmanager_assessment


SUMMARY:

1/1 passed.

SETUP: tests/aws_auditmanager_framework []

PRETEST: tests/aws_auditmanager_framework

TEST: tests/aws_auditmanager_framework
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 2s [id=533793682495]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.input will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "local_file" "input" {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_auditmanager_framework/terraform/test/output.json"
      + id             = (known after apply)
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + arn           = (known after apply)
  + aws_account   = "533793682495"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + id            = (known after apply)
  + name          = (known after apply)
  + type          = (known after apply)
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "aws auditmanager list-assessment-frameworks --framework-type Standard --output json --profile default --region us-east-1 > /private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_auditmanager_framework/terraform/test/output.json"]
null_resource.named_test_resource: Creation complete after 7s [id=4465983460411433508]
data.local_file.input: Reading...
data.local_file.input: Read complete after 0s [id=f92f8d662cd477a470b5ce2451e412aa3ed8a26f]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

arn = "arn:aws:auditmanager:us-east-1::assessmentFramework/f7cdaffa-69c5-367a-8c58-c9a4bc5704e1"
aws_account = "533793682495"
aws_partition = "aws"
aws_region = "us-east-1"
id = "f7cdaffa-69c5-367a-8c58-c9a4bc5704e1"
name = "HIPAA"
type = "Standard"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:auditmanager:us-east-1::assessmentFramework/f7cdaffa-69c5-367a-8c58-c9a4bc5704e1",
    "id": "f7cdaffa-69c5-367a-8c58-c9a4bc5704e1",
    "name": "HIPAA",
    "partition": "aws",
    "type": "Standard"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:auditmanager:us-east-1::assessmentFramework/f7cdaffa-69c5-367a-8c58-c9a4bc5704e1",
    "id": "f7cdaffa-69c5-367a-8c58-c9a4bc5704e1",
    "name": "HIPAA",
    "partition": "aws",
    "type": "Standard"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:auditmanager:us-east-1::assessmentFramework/f7cdaffa-69c5-367a-8c58-c9a4bc5704e1"
    ],
    "title": "HIPAA"
  }
]
✔ PASSED

POSTTEST: tests/aws_auditmanager_framework

TEARDOWN: tests/aws_auditmanager_framework

SUMMARY:

1/1 passed.

SETUP: tests/aws_auditmanager_control []

PRETEST: tests/aws_auditmanager_control

TEST: tests/aws_auditmanager_control
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 1s [id=aws]
data.aws_caller_identity.current: Read complete after 1s [id=533793682495]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.local_file.control will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "local_file" "control" {
      + content        = (known after apply)
      + content_base64 = (known after apply)
      + filename       = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_auditmanager_control/terraform/test/control.json"
      + id             = (known after apply)
    }

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "533793682495"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + control_id    = (known after apply)
  + resource_aka  = (known after apply)
  + resource_name = "turbottest79294"
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "      aws auditmanager create-control --name turbottest79294 --control-mapping-sources \"sourceName\"=turbottest79294,\"sourceType\"=\"AWS_Cloudtrail\",\"sourceSetUpOption\"=\"System_Controls_Mapping\",sourceKeyword=\"{keywordInputType=\"SELECT_FROM_LIST\",keywordValue=\"a4b_ApproveSkill\"}\" --tags name=turbottest79294 --profile default > /private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_auditmanager_control/terraform/test/control.json;\n"]
null_resource.named_test_resource: Creation complete after 2s [id=4633925452216038888]
data.local_file.control: Reading...
data.local_file.control: Read complete after 0s [id=ca1f249932dde7e0e0edd9ea4970329886476aa2]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "533793682495"
aws_partition = "aws"
aws_region = "us-east-1"
control_id = "f2457387-c1a9-4b72-9d38-33ed702052b8"
resource_aka = "arn:aws:auditmanager:us-east-1:533793682495:control/f2457387-c1a9-4b72-9d38-33ed702052b8"
resource_name = "turbottest79294"

Running SQL query: test-get-query.sql
[
  {
    "control_sources": "AWS CloudTrail",
    "id": "f2457387-c1a9-4b72-9d38-33ed702052b8",
    "name": "turbottest79294",
    "type": "Custom"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "control_sources": "AWS CloudTrail",
    "id": "f2457387-c1a9-4b72-9d38-33ed702052b8",
    "name": "turbottest79294"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:auditmanager:us-east-1:533793682495:control/f2457387-c1a9-4b72-9d38-33ed702052b8"
    ],
    "tags": {
      "name": "turbottest79294"
    },
    "title": "turbottest79294"
  }
]
✔ PASSED

POSTTEST: tests/aws_auditmanager_control
Running terraform
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 1s [id=533793682495]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # null_resource.named_test_resource will be created
  + resource "null_resource" "named_test_resource" {
      + id = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.
null_resource.named_test_resource: Creating...
null_resource.named_test_resource: Provisioning with 'local-exec'...
null_resource.named_test_resource (local-exec): Executing: ["/bin/sh" "-c" "aws auditmanager delete-control --control-id f2457387-c1a9-4b72-9d38-33ed702052b8 --profile default"]
null_resource.named_test_resource: Creation complete after 2s [id=8733195168719168494]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on posttest-variables.tf line 37, in data "null_data_source" "resource":
  37: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

TEARDOWN: tests/aws_auditmanager_control


SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select name,id,status from aws_auditmanager_assessment where id = 'e7e8a890-7cd2-40c6-bba1-d64117e7510e'
+------+--------------------------------------+--------+
| name | id                                   | status |
+------+--------------------------------------+--------+
| test | e7e8a890-7cd2-40c6-bba1-d64117e7510e | ACTIVE |
+------+--------------------------------------+--------+
> select name,id,status from aws_auditmanager_assessment
+------+--------------------------------------+--------+
| name | id                                   | status |
+------+--------------------------------------+--------+
| test | e7e8a890-7cd2-40c6-bba1-d64117e7510e | ACTIVE |
+------+--------------------------------------+--------+

> select name,id,type from aws_auditmanager_control limit 1
+-------------------+--------------------------------------+----------+
| name              | id                                   | type     |
+-------------------+--------------------------------------+----------+
| 164.314(a)(2)(ii) | ee0739cc-698c-4035-90e4-05edd2f85965 | Standard |
+-------------------+--------------------------------------+----------+
> select name,id,type from aws_auditmanager_control where id = 'ee0739cc-698c-4035-90e4-05edd2f85965' limit 1
+-------------------+--------------------------------------+----------+
| name              | id                                   | type     |
+-------------------+--------------------------------------+----------+
| 164.314(a)(2)(ii) | ee0739cc-698c-4035-90e4-05edd2f85965 | Standard |
+-------------------+--------------------------------------+----------+

> select name,id,type from aws_auditmanager_framework limit 1
+-------+--------------------------------------+----------+
| name  | id                                   | type     |
+-------+--------------------------------------+----------+
| HIPAA | f7cdaffa-69c5-367a-8c58-c9a4bc5704e1 | Standard |
+-------+--------------------------------------+----------+
> select name,id,type from aws_auditmanager_framework where id = 'f7cdaffa-69c5-367a-8c58-c9a4bc5704e1' and region = 'us-east-1'
+-------+--------------------------------------+----------+
| name  | id                                   | type     |
+-------+--------------------------------------+----------+
| HIPAA | f7cdaffa-69c5-367a-8c58-c9a4bc5704e1 | Standard |
+-------+--------------------------------------+----------+
```
</details>
