### PR TITLE
Handle unsupported region issue in aws_backup_framework table. Fixes #1123

### DIFF
--- a/aws/table_aws_backup_framework.go
+++ b/aws/table_aws_backup_framework.go
@@ -116,7 +116,8 @@ func getNumberOfControls(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 //// LIST FUNCTION
 
 func listAwsBackupFrameworks(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
-	// AWS Backup audit manager is not supported in all regions
+	// AWS Backup service is available in all regions. However, the AWS Backup audit manager, which is newly introduced under the Backup service, is not supported in all regions.
+	// Due to this reason, we could not put a check based on the service endpoint and had to check the region code directly.
 	// https://aws.amazon.com/about-aws/whats-new/2022/05/aws-backup-audit-manager-adds-amazon-s3-storage-gateway/#:~:text=AWS%20Backup%20Audit%20Manager%20is,Middle%20East%20(Bahrain)%20Regions.
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	if region == "ap-northeast-3" {
@@ -165,7 +166,8 @@ func listAwsBackupFrameworks(ctx context.Context, d *plugin.QueryData, _ *plugin
 //// HYDRATE FUNCTIONS
 
 func getAwsBackupFramework(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	// AWS Backup audit manager is not supported in all regions
+	// AWS Backup service is available in all regions. However, the AWS Backup audit manager, which is newly introduced under the Backup service, is not supported in all regions.
+	// Due to this reason, we could not put a check based on the service endpoint and had to check the region code directly.
 	// https://aws.amazon.com/about-aws/whats-new/2022/05/aws-backup-audit-manager-adds-amazon-s3-storage-gateway/#:~:text=AWS%20Backup%20Audit%20Manager%20is,Middle%20East%20(Bahrain)%20Regions.
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	if region == "ap-northeast-3" {

--- a/aws/table_aws_backup_framework.go
+++ b/aws/table_aws_backup_framework.go
@@ -116,6 +116,13 @@ func getNumberOfControls(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 //// LIST FUNCTION
 
 func listAwsBackupFrameworks(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	// AWS Backup audit manager is not supported in all regions
+	// https://aws.amazon.com/about-aws/whats-new/2022/05/aws-backup-audit-manager-adds-amazon-s3-storage-gateway/#:~:text=AWS%20Backup%20Audit%20Manager%20is,Middle%20East%20(Bahrain)%20Regions.
+	region := d.KeyColumnQualString(matrixKeyRegion)
+	if region == "ap-northeast-3" {
+		return nil, nil
+	}
+
 	// Create session
 	svc, err := BackupService(ctx, d)
 	if err != nil {
@@ -158,6 +165,13 @@ func listAwsBackupFrameworks(ctx context.Context, d *plugin.QueryData, _ *plugin
 //// HYDRATE FUNCTIONS
 
 func getAwsBackupFramework(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	// AWS Backup audit manager is not supported in all regions
+	// https://aws.amazon.com/about-aws/whats-new/2022/05/aws-backup-audit-manager-adds-amazon-s3-storage-gateway/#:~:text=AWS%20Backup%20Audit%20Manager%20is,Middle%20East%20(Bahrain)%20Regions.
+	region := d.KeyColumnQualString(matrixKeyRegion)
+	if region == "ap-northeast-3" {
+		return nil, nil
+	}
+
 	// Create Session
 	svc, err := BackupService(ctx, d)
 	if err != nil {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_backup_framework []

PRETEST: tests/aws_backup_framework

TEST: tests/aws_backup_framework
Running terraform
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
aws_backup_framework.named_test_resource: Refreshing state... [id=turbottest51343]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 1s [id=**************]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_backup_framework.named_test_resource must be replaced
-/+ resource "aws_backup_framework" "named_test_resource" {
      ~ arn               = "arn:aws:backup:us-east-1:**************:framework:turbottest51343-ce4c7464-4826-4311-aa98-2b1a978e0039" -> (known after apply)
      ~ creation_time     = "2022-07-01T12:09:01Z" -> (known after apply)
      ~ deployment_status = "COMPLETED" -> (known after apply)
      ~ id                = "turbottest51343" -> (known after apply)
      ~ name              = "turbottest51343" -> "turbottest29153" # forces replacement
      ~ status            = "ACTIVE" -> (known after apply)
        tags              = {
            "Name" = "Steampipe test Framework"
        }
        # (2 unchanged attributes hidden)

      - control {
          - name = "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN" -> null

          - scope {
              - compliance_resource_ids   = [] -> null
              - compliance_resource_types = [
                  - "EBS",
                ] -> null
              - tags                      = {} -> null
            }
        }
      + control {
          + name = "BACKUP_RESOURCES_PROTECTED_BY_BACKUP_PLAN"

          + scope {
              + compliance_resource_ids   = []
              + compliance_resource_types = [
                  + "EBS",
                ]
            }
        }
        # (4 unchanged blocks hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.

Changes to Outputs:
  ~ id           = "turbottest51343" -> (known after apply)
  ~ resource_aka = "arn:aws:backup:us-east-1:**************:framework:turbottest51343-ce4c7464-4826-4311-aa98-2b1a978e0039" -> (known after apply)
aws_backup_framework.named_test_resource: Destroying... [id=turbottest51343]
aws_backup_framework.named_test_resource: Still destroying... [id=turbottest51343, 10s elapsed]
aws_backup_framework.named_test_resource: Destruction complete after 17s
aws_backup_framework.named_test_resource: Creating...
aws_backup_framework.named_test_resource: Still creating... [10s elapsed]
aws_backup_framework.named_test_resource: Creation complete after 11s [id=turbottest29153]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 1 destroyed.

Outputs:

id = "turbottest29153"
resource_aka = "arn:aws:backup:us-east-1:**************:framework:turbottest29153-b094cd4f-d9c1-4bc9-b62d-e3a72333f8d0"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:backup:us-east-1:**************:framework:turbottest29153-b094cd4f-d9c1-4bc9-b62d-e3a72333f8d0",
    "framework_name": "turbottest29153"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:backup:us-east-1:**************:framework:turbottest29153-b094cd4f-d9c1-4bc9-b62d-e3a72333f8d0",
    "framework_name": "turbottest29153"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:backup:us-east-1:**************:framework:turbottest29153-b094cd4f-d9c1-4bc9-b62d-e3a72333f8d0"
    ]
  }
]
✔ PASSED

POSTTEST: tests/aws_backup_framework

TEARDOWN: tests/aws_backup_framework

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_backup_framework
+-----------------+------------------------------------------------------------------------------------------------------+---------------------------------------------------------+-------------------+--------------
| framework_name  | arn                                                                                                  | framework_description                                   | deployment_status | creation_time
+-----------------+------------------------------------------------------------------------------------------------------+---------------------------------------------------------+-------------------+--------------
| turbottest51343 | arn:aws:backup:us-east-1:**************:framework:turbottest51343-ce4c7464-4826-4311-aa98-2b1a978e0039 | this is used for steampipe testing of backup frameworks | COMPLETED         | 2022-07-01T17
+-----------------+------------------------------------------------------------------------------------------------------+---------------------------------------------------------+-------------------+--------------
> .cache off
> .cache clear
> select * from aws_backup_framework where framework_name = 'turbottest51343'
+-----------------+------------------------------------------------------------------------------------------------------+---------------------------------------------------------+-------------------+--------------
| framework_name  | arn                                                                                                  | framework_description                                   | deployment_status | creation_time
+-----------------+------------------------------------------------------------------------------------------------------+---------------------------------------------------------+-------------------+--------------
| turbottest51343 | arn:aws:backup:us-east-1:**************:framework:turbottest51343-ce4c7464-4826-4311-aa98-2b1a978e0039 | this is used for steampipe testing of backup frameworks | COMPLETED         | 2022-07-01T17
+-----------------+------------------------------------------------------------------------------------------------------+---------------------------------------------------------+-------------------+--------------

```
</details>
