### PR TITLE
Add column url_config to aws_lambda_* tables. Closes #1145

### DIFF
--- a/docs/tables/aws_lambda_alias.md
+++ b/docs/tables/aws_lambda_alias.md
@@ -36,3 +36,14 @@ select
 from
   aws_lambda_alias;
 ```
+
+### List url configuration details for each alias
+
+```sql
+select
+  name,
+  function_name,
+  jsonb_pretty(url_config) as url_config
+from
+  aws_lambda_alias;
+```

--- a/docs/tables/aws_lambda_function.md
+++ b/docs/tables/aws_lambda_function.md
@@ -130,7 +130,7 @@ from
 select
   name,
   arn,
-  jsonb_pretty(url_configs) as url_configs
+  jsonb_pretty(url_config) as url_config
 from
   aws_lambda_function;
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
SETUP: tests/aws_lambda_function []

PRETEST: tests/aws_lambda_function

TEST: tests/aws_lambda_function
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 1s [id=***************]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.archive_file.zip will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "archive_file" "zip" {
      + id                  = (known after apply)
      + output_base64sha256 = (known after apply)
      + output_md5          = (known after apply)
      + output_path         = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_lambda_function/terraform/test/../../test.zip"
      + output_sha          = (known after apply)
      + output_size         = (known after apply)
      + source_file         = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_lambda_function/terraform/test/../../test.py"
      + type                = "zip"
    }

  # aws_iam_role.aws_lambda_function will be created
  + resource "aws_iam_role" "aws_lambda_function" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "lambda.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest63979"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_lambda_function.named_test_resource will be created
  + resource "aws_lambda_function" "named_test_resource" {
      + architectures                  = (known after apply)
      + arn                            = (known after apply)
      + filename                       = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_lambda_function/terraform/test/../../test.zip"
      + function_name                  = "turbottest63979"
      + handler                        = "test.test"
      + id                             = (known after apply)
      + invoke_arn                     = (known after apply)
      + last_modified                  = (known after apply)
      + memory_size                    = 128
      + package_type                   = "Zip"
      + publish                        = false
      + qualified_arn                  = (known after apply)
      + reserved_concurrent_executions = 2
      + role                           = (known after apply)
      + runtime                        = "python3.7"
      + signing_job_arn                = (known after apply)
      + signing_profile_version_arn    = (known after apply)
      + source_code_hash               = (known after apply)
      + source_code_size               = (known after apply)
      + tags                           = {
          + "name" = "turbottest63979"
        }
      + tags_all                       = {
          + "name" = "turbottest63979"
        }
      + timeout                        = 3
      + version                        = (known after apply)

      + ephemeral_storage {
          + size = (known after apply)
        }

      + tracing_config {
          + mode = (known after apply)
        }
    }

  # aws_lambda_permission.with_sns will be created
  + resource "aws_lambda_permission" "with_sns" {
      + action              = "lambda:InvokeFunction"
      + function_name       = "turbottest63979"
      + id                  = (known after apply)
      + principal           = "sns.amazonaws.com"
      + source_arn          = (known after apply)
      + statement_id        = "AllowExecutionFromSNS"
      + statement_id_prefix = (known after apply)
    }

  # aws_sns_topic.default will be created
  + resource "aws_sns_topic" "default" {
      + arn                         = (known after apply)
      + content_based_deduplication = false
      + fifo_topic                  = false
      + id                          = (known after apply)
      + name                        = "call-lambda-maybe"
      + name_prefix                 = (known after apply)
      + owner                       = (known after apply)
      + policy                      = (known after apply)
      + tags_all                    = (known after apply)
    }

  # local_file.python_file will be created
  + resource "local_file" "python_file" {
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_lambda_function/terraform/test/../../test.py"
      + id                   = (known after apply)
      + sensitive_content    = (sensitive value)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "***************"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest63979"
  + sns_arn       = (known after apply)
local_file.python_file: Creating...
local_file.python_file: Creation complete after 0s [id=31a055a187e07d0bd8fca8ceb1f633aa4497fe53]
data.archive_file.zip: Reading...
data.archive_file.zip: Read complete after 0s [id=3d2780bc13324b697460b666c413908a395d952e]
aws_iam_role.aws_lambda_function: Creating...
aws_sns_topic.default: Creating...
aws_iam_role.aws_lambda_function: Creation complete after 2s [id=turbottest63979]
aws_lambda_function.named_test_resource: Creating...
aws_sns_topic.default: Creation complete after 2s [id=arn:aws:sns:us-east-1:***************:call-lambda-maybe]
aws_lambda_function.named_test_resource: Still creating... [10s elapsed]
aws_lambda_function.named_test_resource: Creation complete after 18s [id=turbottest63979]
aws_lambda_permission.with_sns: Creating...
aws_lambda_permission.with_sns: Creation complete after 1s [id=AllowExecutionFromSNS]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: Argument is deprecated

  with local_file.python_file,
  on variables.tf line 53, in resource "local_file" "python_file":
  53:   sensitive_content = "def test (event, context):\n\tprint ('This is a test for integration testing to check creation of a lambda function')"

Use the `local_sensitive_file` resource instead.

(and 2 more similar warnings elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "***************"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:lambda:us-east-1:***************:function:turbottest63979"
resource_name = "turbottest63979"
sns_arn = "arn:aws:sns:us-east-1:***************:call-lambda-maybe"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:lambda:us-east-1:***************:function:turbottest63979",
    "description": "",
    "name": "turbottest63979",
    "role": "arn:aws:iam::***************:role/turbottest63979",
    "version": "$LATEST"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "policy": {
      "Id": "default",
      "Statement": [
        {
          "Action": "lambda:InvokeFunction",
          "Condition": {
            "ArnLike": {
              "AWS:SourceArn": "arn:aws:sns:us-east-1:***************:call-lambda-maybe"
            }
          },
          "Effect": "Allow",
          "Principal": {
            "Service": "sns.amazonaws.com"
          },
          "Resource": "arn:aws:lambda:us-east-1:***************:function:turbottest63979",
          "Sid": "AllowExecutionFromSNS"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Id": "default",
      "Statement": [
        {
          "Action": [
            "lambda:invokefunction"
          ],
          "Condition": {
            "ArnLike": {
              "aws:sourcearn": [
                "arn:aws:sns:us-east-1:***************:call-lambda-maybe"
              ]
            }
          },
          "Effect": "Allow",
          "Principal": {
            "Service": [
              "sns.amazonaws.com"
            ]
          },
          "Resource": [
            "arn:aws:lambda:us-east-1:***************:function:turbottest63979"
          ],
          "Sid": "AllowExecutionFromSNS"
        }
      ],
      "Version": "2012-10-17"
    },
    "reserved_concurrent_executions": 2,
    "tags": {
      "name": "turbottest63979"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:lambda:us-east-1:***************:function:turbottest63979",
    "description": "",
    "name": "turbottest63979",
    "role": "arn:aws:iam::***************:role/turbottest63979",
    "version": "$LATEST"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "***************",
    "akas": [
      "arn:aws:lambda:us-east-1:***************:function:turbottest63979"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "title": "turbottest63979"
  }
]
✔ PASSED

POSTTEST: tests/aws_lambda_function

TEARDOWN: tests/aws_lambda_function

SUMMARY:

1/1 passed.


SETUP: tests/aws_lambda_alias []

PRETEST: tests/aws_lambda_alias

TEST: tests/aws_lambda_alias
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 1s [id=533793682495]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.archive_file.zip will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "archive_file" "zip" {
      + id                  = (known after apply)
      + output_base64sha256 = (known after apply)
      + output_md5          = (known after apply)
      + output_path         = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_lambda_alias/terraform/test/../../test.zip"
      + output_sha          = (known after apply)
      + output_size         = (known after apply)
      + source_file         = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_lambda_alias/terraform/test/../../test.py"
      + type                = "zip"
    }

  # aws_iam_role.aws_lambda_function will be created
  + resource "aws_iam_role" "aws_lambda_function" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "lambda.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest79856"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_lambda_alias.named_test_resource will be created
  + resource "aws_lambda_alias" "named_test_resource" {
      + arn              = (known after apply)
      + description      = "Test alias."
      + function_name    = "arn:aws:lambda:us-east-1:533793682495:function:turbottest79856"
      + function_version = "$LATEST"
      + id               = (known after apply)
      + invoke_arn       = (known after apply)
      + name             = "turbottest79856"
    }

  # aws_lambda_function.named_test_resource will be created
  + resource "aws_lambda_function" "named_test_resource" {
      + architectures                  = (known after apply)
      + arn                            = (known after apply)
      + filename                       = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_lambda_alias/terraform/test/../../test.zip"
      + function_name                  = "turbottest79856"
      + handler                        = "test.test"
      + id                             = (known after apply)
      + invoke_arn                     = (known after apply)
      + last_modified                  = (known after apply)
      + memory_size                    = 128
      + package_type                   = "Zip"
      + publish                        = false
      + qualified_arn                  = (known after apply)
      + reserved_concurrent_executions = -1
      + role                           = (known after apply)
      + runtime                        = "python3.7"
      + signing_job_arn                = (known after apply)
      + signing_profile_version_arn    = (known after apply)
      + source_code_hash               = (known after apply)
      + source_code_size               = (known after apply)
      + tags_all                       = (known after apply)
      + timeout                        = 3
      + version                        = (known after apply)

      + ephemeral_storage {
          + size = (known after apply)
        }

      + tracing_config {
          + mode = (known after apply)
        }
    }

  # local_file.python_file will be created
  + resource "local_file" "python_file" {
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_lambda_alias/terraform/test/../../test.py"
      + id                   = (known after apply)
      + sensitive_content    = (sensitive value)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "533793682495"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest79856"
local_file.python_file: Creating...
local_file.python_file: Creation complete after 0s [id=dafb34f0ced09879d73bc8baab67226f2e264bac]
data.archive_file.zip: Reading...
data.archive_file.zip: Read complete after 0s [id=152a0eabdf961fb20b337a3e73afea2d10f4a088]
aws_iam_role.aws_lambda_function: Creating...
aws_iam_role.aws_lambda_function: Creation complete after 3s [id=turbottest79856]
aws_lambda_function.named_test_resource: Creating...
aws_lambda_function.named_test_resource: Still creating... [10s elapsed]
aws_lambda_function.named_test_resource: Creation complete after 16s [id=turbottest79856]
aws_lambda_alias.named_test_resource: Creating...
aws_lambda_alias.named_test_resource: Creation complete after 1s [id=arn:aws:lambda:us-east-1:533793682495:function:turbottest79856:turbottest79856]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: Argument is deprecated

  with local_file.python_file,
  on variables.tf line 53, in resource "local_file" "python_file":
  53:   sensitive_content = "def test (event, context):\n\tprint ('This is a test for intergration testing to check creation of a lambda function')"

Use the `local_sensitive_file` resource instead.

(and 2 more similar warnings elsewhere)

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

account_id = "533793682495"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:lambda:us-east-1:533793682495:function:turbottest79856:turbottest79856"
resource_name = "turbottest79856"

Running SQL query: query.sql
[
  {
    "function_name": "turbottest79856",
    "name": "turbottest79856"
  }
]
✔ PASSED

Running SQL query: test-get-call-query.sql
[
  {
    "akas": [
      "arn:aws:lambda:us-east-1:533793682495:function:turbottest79856:turbottest79856"
    ],
    "alias_arn": "arn:aws:lambda:us-east-1:533793682495:function:turbottest79856:turbottest79856",
    "description": "Test alias.",
    "function_name": "turbottest79856",
    "function_version": "$LATEST",
    "name": "turbottest79856",
    "title": "turbottest79856"
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "akas": [
      "arn:aws:lambda:us-east-1:533793682495:function:turbottest79856:turbottest79856"
    ],
    "alias_arn": "arn:aws:lambda:us-east-1:533793682495:function:turbottest79856:turbottest79856",
    "description": "Test alias.",
    "function_name": "turbottest79856",
    "function_version": "$LATEST",
    "name": "turbottest79856",
    "title": "turbottest79856"
  }
]
✔ PASSED

POSTTEST: tests/aws_lambda_alias

TEARDOWN: tests/aws_lambda_alias

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  function_name,
  jsonb_pretty(url_config) as url_config
from
  aws_lambda_alias;
+-------+---------------+---------------------------------------------------------------------------------------------+
| name  | function_name | url_config                                                                                  |
+-------+---------------+---------------------------------------------------------------------------------------------+
| test1 | test          | {                                                                                           |
|       |               |     "Cors": null,                                                                           |
|       |               |     "AuthType": "NONE",                                                                     |
|       |               |     "FunctionArn": "arn:aws:lambda:us-east-1:***************:function:test:test1",             |
|       |               |     "FunctionUrl": "https://oaceg7iyu3cemtnrcz46bkll540axrkt.lambda-url.us-east-1.on.aws/", |
|       |               |     "CreationTime": "2022-07-07T15:19:41.225854Z",                                          |
|       |               |     "LastModifiedTime": "2022-07-07T15:19:41.225854Z"                                       |
|       |               | }                                                                                           |
+-------+---------------+---------------------------------------------------------------------------------------------+
> select
  name,
  arn,
  jsonb_pretty(url_config) as url_config
from
  aws_lambda_function;
+---------------------------------------+--------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------
| name                                  | arn                                                                                  | url_config                                                                           
+---------------------------------------+--------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------
| test1                                 | arn:aws:lambda:ap-south-1:***************:function:test1                                | <null>                                                                               
| tets                                  | arn:aws:lambda:ap-northeast-3:***************:function:tets                             | <null>                                                                               
| cloud9-TestApp-lambdaone-A71A4OKVLX6D | arn:aws:lambda:eu-west-1:***************:function:cloud9-TestApp-lambdaone-A71A4OKVLX6D | <null>                                                                               
| cloud9-AppTwo-funcone-W408ZRFMCP4Q    | arn:aws:lambda:eu-west-1:***************:function:cloud9-AppTwo-funcone-W408ZRFMCP4Q    | <null>                                                                               
| test                                  | arn:aws:lambda:us-east-1:***************:function:test                                  | {                                                                                    
|                                       |                                                                                      |     "Cors": null,                                                                    
|                                       |                                                                                      |     "AuthType": "AWS_IAM",                                                           
|                                       |                                                                                      |     "FunctionArn": "arn:aws:lambda:us-east-1:***************:function:test",            
|                                       |                                                                                      |     "FunctionUrl": "https://y4bzxnjj53oypmlltvq2cwcxwq0rsmie.lambda-url.us-east-1.on.
|                                       |                                                                                      |     "CreationTime": "2022-06-13T05:21:45.210488Z",                                   
|                                       |                                                                                      |     "LastModifiedTime": "2022-07-07T11:59:34.477923Z"                                
|                                       |                                                                                      | }                                                                                    
| graviton2                             | arn:aws:lambda:us-east-2:***************:function:graviton2                             | <null>                                                                               
| tetest0vpc                            | arn:aws:lambda:us-east-2:***************:function:tetest0vpc                            | <null>                                                                               
+---------------------------------------+--------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------

```
</details>
