### PR TITLE
Fix inconsistent table names

### DIFF
--- a/aws/table_aws_ebs_volume_metric_write_ops.go
+++ b/aws/table_aws_ebs_volume_metric_write_ops.go
@@ -12,7 +12,7 @@ import (
 //// TABLE DEFINITION
 func tableAwsEbsVolumeMetricWriteOps(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "aws_ebs_volume_metric_read_ops",
+		Name:        "aws_ebs_volume_metric_write_ops",
 		Description: "AWS EBS Volume Cloudwatch Metrics - Write Ops",
 		List: &plugin.ListConfig{
 			ParentHydrate: listEBSVolume,

--- a/aws/table_aws_ebs_volume_metric_write_ops_hourly.go
+++ b/aws/table_aws_ebs_volume_metric_write_ops_hourly.go
@@ -12,7 +12,7 @@ import (
 //// TABLE DEFINITION
 func tableAwsEbsVolumeMetricWriteOpsHourly(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "aws_ebs_volume_metric_read_ops_hourly",
+		Name:        "aws_ebs_volume_metric_write_ops_hourly",
 		Description: "AWS EBS Volume Cloudwatch Metrics - Write Ops (Hourly)",
 		List: &plugin.ListConfig{
 			ParentHydrate: listEBSVolume,

--- a/aws/table_aws_vpc_flow_log.go
+++ b/aws/table_aws_vpc_flow_log.go
@@ -16,7 +16,7 @@ import (
 
 func tableAwsVpcFlowlog(_ context.Context) *plugin.Table {
 	return &plugin.Table{
-		Name:        "aws_vpc_flowlog",
+		Name:        "aws_vpc_flow_log",
 		Description: "AWS VPC Flowlog",
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("flow_log_id"),


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
