### PR TITLE
Add column associated_resources in aws_wafv2_web_acl table. Closes #1157

### DIFF
--- a/aws/table_aws_wafv2_web_acl.go
+++ b/aws/table_aws_wafv2_web_acl.go
@@ -75,7 +75,7 @@ func tableAwsWafv2WebAcl(_ context.Context) *plugin.Table {
 				Hydrate:     getAwsWafv2WebAcl,
 			},
 			{
-				Name:        "associated_resources_arns",
+				Name:        "associated_resources",
 				Description: "The array of Amazon Resource Names (ARNs) of the associated resources.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listAssociatedResources,

--- a/docs/tables/aws_wafv2_web_acl.md
+++ b/docs/tables/aws_wafv2_web_acl.md
@@ -100,14 +100,19 @@ where
   logging_configuration is null;
 ```
 
-### List associated resources ARNs of the web ACLs
+### List associated ALBs of the web ACLs
 
 ```sql
 select
-  name,
-  id,
-  jsonb_pretty(associated_resources_arns) as associated_resources_arns,
-  region
+  lb.name as application_load_balancer_name,
+  w.name as web_acl_name,
+  w.id as web_acl_id,
+  w.scope as web_acl_scope,
+  lb.type as application_load_balancer_type
 from
-  aws_wafv2_web_acl;
+  aws_ec2_application_load_balancer as lb,
+  aws_wafv2_web_acl as w,
+  jsonb_array_elements_text(associated_resources_arns) as arns
+where
+  lb.arn = arns;
 ```

--- a/docs/tables/aws_wafv2_web_acl.md
+++ b/docs/tables/aws_wafv2_web_acl.md
@@ -99,3 +99,15 @@ from
 where
   logging_configuration is null;
 ```
+
+### List associated resources ARNs of the web ACLs
+
+```sql
+select
+  name,
+  id,
+  jsonb_pretty(associated_resources_arns) as associated_resources_arns,
+  region
+from
+  aws_wafv2_web_acl;
+```

--- a/docs/tables/aws_wafv2_web_acl.md
+++ b/docs/tables/aws_wafv2_web_acl.md
@@ -100,7 +100,7 @@ where
   logging_configuration is null;
 ```
 
-### List associated ALBs of the web ACLs
+### Get details for ALBs associated with each web ACL
 
 ```sql
 select
@@ -112,7 +112,7 @@ select
 from
   aws_ec2_application_load_balancer as lb,
   aws_wafv2_web_acl as w,
-  jsonb_array_elements_text(associated_resources_arns) as arns
+  jsonb_array_elements_text(associated_resources) as arns
 where
   lb.arn = arns;
 ```


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select
  name,
  id,
  jsonb_pretty(associated_resources) as associated_resources,
  region
from
  aws_wafv2_web_acl;
+-------+--------------------------------------+--------------------------------------------------------------------------------------------------+-----------+
| name  | id                                   | associated_resources                                                                             | region    |
+-------+--------------------------------------+--------------------------------------------------------------------------------------------------+-----------+
| test  | 0f0d9a1e-1fa7-4dc6-9127-6fc9a1389c36 | [                                                                                                | us-east-1 |
|       |                                      |     "arn:aws:elasticloadbalancing:us-east-1:***************:loadbalancer/app/test/29ec3215936052b0" |           |
|       |                                      | ]                                                                                                |           |
| test2 | 9e2d92ec-4837-4f01-935a-4c9dcf1bf96f | <null>                                                                                           | us-east-1 |
+-------+--------------------------------------+--------------------------------------------------------------------------------------------------+-----------+
```
</details>
