### PR TITLE
Fix column health_check_target in aws_ec2_classic_load_balancer table. Fixes #1178

### DIFF
--- a/aws/table_aws_ec2_classic_load_balancer.go
+++ b/aws/table_aws_ec2_classic_load_balancer.go
@@ -150,8 +150,8 @@ func tableAwsEc2ClassicLoadBalancer(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("HealthCheck.HealthyThreshold"),
 			},
 			{
-				Name:        "heath_check_target",
-				Description: "The instance being checked.",
+				Name:        "health_check_target",
+				Description: "The instance being checked. The protocol is either TCP, HTTP, HTTPS, or SSL. The range of valid ports is one (1) through 65535.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("HealthCheck.Target"),
 			},

--- a/docs/tables/aws_ec2_classic_load_balancer.md
+++ b/docs/tables/aws_ec2_classic_load_balancer.md
@@ -63,7 +63,7 @@ select
   name,
   healthy_threshold,
   health_check_interval,
-  heath_check_target,
+  health_check_target,
   health_check_timeout,
   unhealthy_threshold
 from


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select name, health_check_target from aws_ec2_classic_load_balancer
+------+---------------------+
| name | health_check_target |
+------+---------------------+
| test | HTTP:80/index.html  |
+------+---------------------+
```
</details>
