### PR TITLE
Add better engine filtering in `aws_neptune_db_cluster` and `aws_rds_db_cluster` tables

### DIFF
--- a/aws/table_aws_neptune_db_cluster.go
+++ b/aws/table_aws_neptune_db_cluster.go
@@ -260,7 +260,6 @@ func listNeptuneDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 		return nil, err
 	}
 
-	// Filter parameter is not supported yet in this SDK version so optional quals can not be implemented
 	input := &neptune.DescribeDBClustersInput{
 		MaxRecords: aws.Int64(100),
 	}
@@ -282,14 +281,18 @@ func listNeptuneDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 		input,
 		func(page *neptune.DescribeDBClustersOutput, isLast bool) bool {
 			for _, dbCluster := range page.DBClusters {
+				// The DescribeDBClusters API returns non-Neptune DB Clusters as well,
+				// but we only want Neptune clusters here. The input has a Filter param
+				// which can help filter out non-Neptune clusters, but as of 2022/08/15,
+				// the SDK says the Filter param is not currently supported.
+				// Related issue: https://github.com/aws/aws-sdk-go/issues/4515
 				if *dbCluster.Engine == "neptune" {
-
 					d.StreamListItem(ctx, dbCluster)
+				}
 
-					// Context may get cancelled due to manual cancellation or if the limit has been reached
-					if d.QueryStatus.RowsRemaining(ctx) == 0 {
-						return false
-					}
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return false
 				}
 			}
 			return !isLast

--- a/aws/table_aws_neptune_db_cluster.go
+++ b/aws/table_aws_neptune_db_cluster.go
@@ -260,6 +260,7 @@ func listNeptuneDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 		return nil, err
 	}
 
+	// Filter parameter is not supported yet in this SDK version so optional quals can not be implemented
 	input := &neptune.DescribeDBClustersInput{
 		MaxRecords: aws.Int64(100),
 	}

--- a/aws/table_aws_neptune_db_cluster.go
+++ b/aws/table_aws_neptune_db_cluster.go
@@ -263,12 +263,6 @@ func listNeptuneDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	// Filter parameter is not supported yet in this SDK version so optional quals can not be implemented
 	input := &neptune.DescribeDBClustersInput{
 		MaxRecords: aws.Int64(100),
-		Filters: []*neptune.Filter{
-			{
-				Name:   aws.String("engine"),
-				Values: []*string{aws.String("neptune")},
-			},
-		},
 	}
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows
@@ -288,11 +282,14 @@ func listNeptuneDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 		input,
 		func(page *neptune.DescribeDBClustersOutput, isLast bool) bool {
 			for _, dbCluster := range page.DBClusters {
-				d.StreamListItem(ctx, dbCluster)
+				if *dbCluster.Engine == "neptune" {
 
-				// Context may get cancelled due to manual cancellation or if the limit has been reached
-				if d.QueryStatus.RowsRemaining(ctx) == 0 {
-					return false
+					d.StreamListItem(ctx, dbCluster)
+
+					// Context may get cancelled due to manual cancellation or if the limit has been reached
+					if d.QueryStatus.RowsRemaining(ctx) == 0 {
+						return false
+					}
 				}
 			}
 			return !isLast

--- a/aws/table_aws_neptune_db_cluster.go
+++ b/aws/table_aws_neptune_db_cluster.go
@@ -263,6 +263,12 @@ func listNeptuneDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	// Filter parameter is not supported yet in this SDK version so optional quals can not be implemented
 	input := &neptune.DescribeDBClustersInput{
 		MaxRecords: aws.Int64(100),
+		Filters: []*neptune.Filter{
+			{
+				Name:   aws.String("engine"),
+				Values: []*string{aws.String("neptune")},
+			},
+		},
 	}
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows

--- a/aws/table_aws_rds_db_cluster.go
+++ b/aws/table_aws_rds_db_cluster.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"strings"
 
 	"github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin/transform"
@@ -380,7 +381,12 @@ func listRDSDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 		input,
 		func(page *rds.DescribeDBClustersOutput, isLast bool) bool {
 			for _, dbCluster := range page.DBClusters {
-				d.StreamListItem(ctx, dbCluster)
+				// The DescribeDBClusters API returns non-Aurora DB Clusters as well,
+				// but we only want Aurora clusters here, even if the 'engine' qual
+				// isn't passed in.
+				if strings.Contains(*dbCluster.Engine, "aurora") {
+					d.StreamListItem(ctx, dbCluster)
+				}
 
 				// Check if context has been cancelled or if the limit has been reached (if specified)
 				// if there is a limit, it will return the number of rows required to reach this limit

--- a/aws/table_aws_rds_db_cluster.go
+++ b/aws/table_aws_rds_db_cluster.go
@@ -384,6 +384,8 @@ func listRDSDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 				// The DescribeDBClusters API returns non-Aurora DB Clusters as well,
 				// but we only want Aurora clusters here, even if the 'engine' qual
 				// isn't passed in.
+				// Current supported engine values as of 2022/08/15 are "aurora",
+				// "aurora-mysql", "aurora-postgresql".
 				if strings.Contains(*dbCluster.Engine, "aurora") {
 					d.StreamListItem(ctx, dbCluster)
 				}

--- a/aws/table_aws_rds_db_cluster.go
+++ b/aws/table_aws_rds_db_cluster.go
@@ -384,8 +384,8 @@ func listRDSDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 				// The DescribeDBClusters API returns non-Aurora DB Clusters as well,
 				// but we only want Aurora clusters here, even if the 'engine' qual
 				// isn't passed in.
-				// Current supported engine values as of 2022/08/15 are "aurora",
-				// "aurora-mysql", "aurora-postgresql".
+				// Current supported Aurora engine values as of 2022/08/15 are
+				// "aurora", "aurora-mysql", "aurora-postgresql".
 				if strings.Contains(*dbCluster.Engine, "aurora") {
 					d.StreamListItem(ctx, dbCluster)
 				}

--- a/docs/tables/aws_neptune_db_cluster.md
+++ b/docs/tables/aws_neptune_db_cluster.md
@@ -2,6 +2,8 @@
 
 An Amazon Neptune DB cluster manages access to your data through queries.
 
+**Note**: This table only returns Neptune DB clusters, not Aurora (RDS) or DocumentDB DB clusters.
+
 ## Examples
 
 ### List of DB clusters which are not encrypted

--- a/docs/tables/aws_rds_db_cluster.md
+++ b/docs/tables/aws_rds_db_cluster.md
@@ -2,6 +2,8 @@
 
 An Amazon Aurora DB cluster consists of one or more DB instances and a cluster volume that manages the data for those DB instances.
 
+**Note**: This table only returns Aurora DB clusters, not DocumentDB or Neptune DB clusters.
+
 ## Examples
 
 ### List of DB clusters which are not encrypted


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select db_cluster_identifier, engine from aws_neptune_db_cluster
+-----------------------+---------+
| db_cluster_identifier | engine  |
+-----------------------+---------+
| database-1            | neptune |
+-----------------------+---------+
```
</details>
