### PR TITLE
Fix rds cluster table to list mysql and postgres engine type clusters. Fixes #1211

### DIFF
--- a/aws/table_aws_neptune_db_cluster.go
+++ b/aws/table_aws_neptune_db_cluster.go
@@ -282,7 +282,7 @@ func listNeptuneDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 		input,
 		func(page *neptune.DescribeDBClustersOutput, isLast bool) bool {
 			for _, dbCluster := range page.DBClusters {
-				// The DescribeDBClusters API returns non-Neptune DB Clusters as well,
+				// The DescribeDBClusters API returns non-Neptune DB clusters as well,
 				// but we only want Neptune clusters here. The input has a Filter param
 				// which can help filter out non-Neptune clusters, but as of 2022/08/15,
 				// the SDK says the Filter param is not currently supported.

--- a/aws/table_aws_rds_db_cluster.go
+++ b/aws/table_aws_rds_db_cluster.go
@@ -2,8 +2,8 @@ package aws
 
 import (
 	"context"
-	"strings"
 
+	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v3/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v3/plugin/transform"
 
@@ -385,8 +385,17 @@ func listRDSDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 				// but we only want Aurora clusters here, even if the 'engine' qual
 				// isn't passed in.
 				// Current supported Aurora engine values as of 2022/08/15 are
-				// "aurora", "aurora-mysql", "aurora-postgresql".
-				if strings.Contains(*dbCluster.Engine, "aurora") {
+				// "aurora", "aurora-mysql", "aurora-postgresql", "mysql", "postgres".
+				// https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/RDS.html#createDBCluster-property
+				if helpers.StringSliceContains(
+					[]string{
+						"aurora",
+						"aurora-mysql",
+						"aurora-postgresql",
+						"mysql",
+						"postgres",
+					},
+					*dbCluster.Engine) {
 					d.StreamListItem(ctx, dbCluster)
 				}
 

--- a/aws/table_aws_rds_db_cluster.go
+++ b/aws/table_aws_rds_db_cluster.go
@@ -381,11 +381,11 @@ func listRDSDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 		input,
 		func(page *rds.DescribeDBClustersOutput, isLast bool) bool {
 			for _, dbCluster := range page.DBClusters {
-				// The DescribeDBClusters API returns non-Aurora DB Clusters as well,
-				// but we only want Aurora clusters here, even if the 'engine' qual
+				// The DescribeDBClusters API returns non-RDS DB clusters as well,
+				// but we only want RDS clusters here, even if the 'engine' qual
 				// isn't passed in.
-				// Current supported Aurora engine values as of 2022/08/15 are
-				// "aurora", "aurora-mysql", "aurora-postgresql", "mysql", "postgres".
+				// Current supported RDS engine values as of 2022/08/15 are
+				// "aurora", "aurora-mysql", "aurora-postgresql", "mysql", and "postgres".
 				// https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/RDS.html#createDBCluster-property
 				if helpers.StringSliceContains(
 					[]string{

--- a/docs/tables/aws_neptune_db_cluster.md
+++ b/docs/tables/aws_neptune_db_cluster.md
@@ -2,7 +2,7 @@
 
 An Amazon Neptune DB cluster manages access to your data through queries.
 
-**Note**: This table only returns Neptune DB clusters, not Aurora (RDS) or DocumentDB DB clusters.
+**Note**: This table only returns Neptune DB clusters, not RDS or DocumentDB DB clusters.
 
 ## Examples
 

--- a/docs/tables/aws_rds_db_cluster.md
+++ b/docs/tables/aws_rds_db_cluster.md
@@ -2,7 +2,7 @@
 
 An Amazon Aurora DB cluster consists of one or more DB instances and a cluster volume that manages the data for those DB instances.
 
-**Note**: This table only returns Aurora DB clusters, not DocumentDB or Neptune DB clusters.
+**Note**: This table only returns RDS DB clusters, e.g., Aurora, MySQL, Postgres, not DocumentDB or Neptune DB clusters.
 
 ## Examples
 


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```sql
select db_cluster_identifier, engine from aws_rds_db_cluster;
+-----------------------+--------+
| db_cluster_identifier | engine |
+-----------------------+--------+
| database-3            | mysql  |
+-----------------------+--------+
```
</details>
