### PR TITLE
Fix aws_eventbridge_rule table to list rules from the all eventbridge buses. Fixes #1212

### DIFF
--- a/aws/table_aws_eventbridge_bus.go
+++ b/aws/table_aws_eventbridge_bus.go
@@ -106,6 +106,11 @@ func listAwsEventBridgeBuses(ctx context.Context, d *plugin.QueryData, _ *plugin
 		input.NamePrefix = aws.String(equalQuals["name"].GetStringValue())
 	}
 
+	// For case when listAwsEventBridgeBuses is used as parent hydrate in aws_eventbridge_rule table
+	if equalQuals["name"] == nil && equalQuals["event_bus_name"] != nil {
+		input.NamePrefix = aws.String(equalQuals["event_bus_name"].GetStringValue())
+	}
+
 	// Reduce the basic request limit down if the user has only requested a small number of rows
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>
  
```
./tint.js tests/aws_eventbridge_rule 
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_eventbridge_rule []

PRETEST: tests/aws_eventbridge_rule

TEST: tests/aws_eventbridge_rule
Running terraform
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 1s [id=******]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_cloudwatch_event_rule.named_test_resource will be created
  + resource "aws_cloudwatch_event_rule" "named_test_resource" {
      + arn            = (known after apply)
      + event_bus_name = "default"
      + event_pattern  = jsonencode(
            {
              + detail-type = [
                  + "AWS Console Sign In via CloudTrail",
                ]
            }
        )
      + id             = (known after apply)
      + is_enabled     = true
      + name           = "turbottest78294"
      + name_prefix    = (known after apply)
      + tags           = {
          + "name" = "turbottest78294"
        }
      + tags_all       = {
          + "name" = "turbottest78294"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "******"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest78294"
aws_cloudwatch_event_rule.named_test_resource: Creating...
aws_cloudwatch_event_rule.named_test_resource: Creation complete after 2s [id=turbottest78294]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "******"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:events:us-east-1:******:rule/turbottest78294"
resource_name = "turbottest78294"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:events:us-east-1:******:rule/turbottest78294",
    "event_pattern": {
      "detail-type": [
        "AWS Console Sign In via CloudTrail"
      ]
    },
    "name": "turbottest78294",
    "tags": {
      "name": "turbottest78294"
    }
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "arn": "arn:aws:events:us-east-1:******:rule/turbottest78294",
    "name": "turbottest78294",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest78294"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:events:us-east-1:******:rule/turbottest78294",
    "event_bus_name": "default",
    "name": "turbottest78294",
    "partition": "aws",
    "region": "us-east-1",
    "state": "ENABLED",
    "tags": {
      "name": "turbottest78294"
    },
    "title": "turbottest78294"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:events:us-east-1:******:rule/turbottest78294"
    ],
    "name": "turbottest78294",
    "region": "us-east-1",
    "tags": {
      "name": "turbottest78294"
    },
    "title": "turbottest78294"
  }
]
✔ PASSED

POSTTEST: tests/aws_eventbridge_rule

TEARDOWN: tests/aws_eventbridge_rule

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
select name, event_bus_name, region from aws_eventbridge_rule order by event_bus_name;
```

```
+---------------------------------------------------+----------------+-----------+
| name                                              | event_bus_name | region    |
+---------------------------------------------------+----------------+-----------+
| turbot_aws_api_events_athena                      | default        | us-east-1 |
| aws_all_events                                    | default        | us-east-1 |
| turbot_aws_api_events                             | default        | us-east-1 |
| turbot_aws_api_events_vpc_security                | default        | us-east-1 |
| turbot_aws_api_events_ecs                         | default        | us-east-1 |
| turbot_aws_api_events_rds                         | default        | us-east-1 |
| turbot_aws_api_events_autoscaling                 | default        | us-east-1 |
| turbot_aws_api_events_elasticloadbalancing        | default        | us-east-1 |
| turbot_aws_api_events_billingconsole              | default        | us-east-1 |
| turbot_aws_api_events_glue                        | default        | us-east-1 |
| turbot_aws_api_events_cloudformation              | default        | us-east-1 |
| turbot_aws_api_events_iam                         | default        | us-east-1 |
| turbot_aws_api_events_cloudtrail                  | default        | us-east-1 |
| turbot_aws_api_events_ec2                         | default        | us-east-1 |
| turbot_aws_api_events_ssm                         | default        | us-east-1 |
| turbot_aws_api_events_ec2_ebs_volume_notification | default        | us-east-1 |
| turbot_aws_api_events_ecr                         | default        | us-east-1 |
| turbot_aws_api_events_kms                         | default        | us-east-1 |
| turbot_aws_api_events_vpc_core                    | default        | us-east-1 |
| turbot_aws_api_events_s3                          | default        | us-east-1 |
| turbot_aws_api_events_sns                         | default        | us-east-1 |
| turbot_aws_api_events_lambda                      | default        | us-east-1 |
| turbot_aws_api_events_step_functions              | default        | us-east-1 |
| turbot_aws_api_events_dynamodb                    | default        | us-east-1 |
| turbot_aws_api_events_lightsail                   | default        | us-east-1 |
| turbot_aws_api_events_codebuild                   | default        | us-east-1 |
| turbot_aws_api_events_vpc_internet                | default        | us-east-1 |
| turbot_aws_api_events_config                      | default        | us-east-1 |
| turbot_aws_api_events_vpc_connect                 | default        | us-east-1 |
| turbot_aws_api_events_logs                        | default        | us-east-1 |
| turbot_aws_api_events_eks                         | default        | us-east-1 |
| AuditManagerSecurityHubFindingsReceiver           | default        | us-east-1 |
| Schemas-events-event-bus-my-event-bus             | my-event-bus   | us-east-1 |
| test                                              | my-event-bus   | us-east-1 |
+---------------------------------------------------+----------------+-----------+
```

```sql
> select name, region from aws_eventbridge_rule where event_bus_name = 'my-event-bus'
```

```
+---------------------------------------+-----------+
| name                                  | region    |
+---------------------------------------+-----------+
| Schemas-events-event-bus-my-event-bus | us-east-1 |
| test                                  | us-east-1 |
+---------------------------------------+-----------+

Time: 1.5s. Rows fetched: 2. Hydrate calls: 2.
```
</details>
