### PR TITLE
Add subnet_id column in table aws_ec2_network_interface #1215

### DIFF
--- a/aws/table_aws_ec2_network_interface.go
+++ b/aws/table_aws_ec2_network_interface.go
@@ -205,6 +205,11 @@ func tableAwsEc2NetworkInterface(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_BOOL,
 			},
 			{
+				Name:        "subnet_id",
+				Description: "The ID of the subnet.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "vpc_id",
 				Description: "The ID of the VPC.",
 				Type:        proto.ColumnType_STRING,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
➜  aws-test git:(ec2_eni) ✗ ./tint.js aws_ec2_network_interface              
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_network_interface []

PRETEST: tests/aws_ec2_network_interface

TEST: tests/aws_ec2_network_interface
Running terraform
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Still reading... [10s elapsed]
data.aws_caller_identity.current: Read complete after 11s [id=12345678910]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.template_file.resource_aka will be read during apply
  # (config refers to values not yet known)
 <= data "template_file" "resource_aka" {
      + id       = (known after apply)
      + rendered = (known after apply)
      + template = (known after apply)
      + vars     = {
          + "account_id" = "12345678910"
          + "partition"  = "aws"
          + "region"     = "us-east-1"
        }
    }

  # aws_network_interface.named_test_resource will be created
  + resource "aws_network_interface" "named_test_resource" {
      + arn                       = (known after apply)
      + description               = "Test Network Interface."
      + id                        = (known after apply)
      + interface_type            = (known after apply)
      + ipv4_prefix_count         = (known after apply)
      + ipv4_prefixes             = (known after apply)
      + ipv6_address_count        = (known after apply)
      + ipv6_address_list         = (known after apply)
      + ipv6_address_list_enabled = false
      + ipv6_addresses            = (known after apply)
      + ipv6_prefix_count         = (known after apply)
      + ipv6_prefixes             = (known after apply)
      + mac_address               = (known after apply)
      + outpost_arn               = (known after apply)
      + owner_id                  = (known after apply)
      + private_dns_name          = (known after apply)
      + private_ip                = (known after apply)
      + private_ip_list           = (known after apply)
      + private_ip_list_enabled   = false
      + private_ips               = (known after apply)
      + private_ips_count         = (known after apply)
      + security_groups           = (known after apply)
      + source_dest_check         = true
      + subnet_id                 = (known after apply)
      + tags                      = {
          + "Name" = "turbottest72724"
        }
      + tags_all                  = {
          + "Name" = "turbottest72724"
        }

      + attachment {
          + attachment_id = (known after apply)
          + device_index  = (known after apply)
          + instance      = (known after apply)
        }
    }

  # aws_subnet.my_subnet will be created
  + resource "aws_subnet" "my_subnet" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = (known after apply)
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.0.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "name" = "turbottest72724"
        }
      + tags_all                                       = {
          + "name" = "turbottest72724"
        }
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.my_vpc will be created
  + resource "aws_vpc" "my_vpc" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/24"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags_all                             = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "12345678910"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest72724"
  + vpc_id        = (known after apply)
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Creation complete after 4s [id=vpc-12345678910]
aws_subnet.my_subnet: Creating...
aws_subnet.my_subnet: Creation complete after 1s [id=subnet-123456789109]
aws_network_interface.named_test_resource: Creating...
aws_network_interface.named_test_resource: Creation complete after 1s [id=eni-12345678910]
data.template_file.resource_aka: Reading...
data.template_file.resource_aka: Read complete after 0s [id=12345678910c34c5ec12fbab35669235322da618f7bcb1c12345678910]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "12345678910"
resource_aka = "arn:aws:ec2:us-east-1:12345678910:network-interface/eni-12345678910"
resource_id = "eni-12345678910"
resource_name = "turbottest72724"
vpc_id = "vpc-12345678910

Running SQL query: test-get-query.sql
[
  {
    "description": "Test Network Interface.",
    "interface_type": "interface",
    "network_interface_id": "eni-12345678910d",
    "owner_id": "12345678910",
    "requester_managed": false,
    "source_dest_check": true
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:12345678910:network-interface/eni-12345678910d"
    ],
    "network_interface_id": "eni-12345678910d",
    "tags": {
      "Name": "turbottest72724"
    },
    "title": "eni-12345678910d"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "interface_type": "interface",
    "network_interface_id": "eni-12345678910d"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_network_interface

TEARDOWN: tests/aws_ec2_network_interface

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
select
  network_interface_id,
  subnet_id,
  status
  vpc_id
from
  aws_ec2_network_interface;
+-----------------------+--------------------------+-----------+
| network_interface_id  | subnet_id                | vpc_id    |
+-----------------------+--------------------------+-----------+
| eni-00d35b6c979131234 | subnet-0afdd519b9aac1234 | in-use    |
| eni-0d49a3ee4c5351234 | subnet-04ff2b77196041234 | in-use    |
| eni-0f53db6d88c831234 | subnet-0afdd519b9aac1234 | in-use    |
| eni-017dc8d4f981d1234 | subnet-0730d9c4215be1234 | available |
| eni-09b9541eae07d1234 | subnet-0e87fa92a52dc1234 | in-use    |
| eni-081dcd84d1dee1234 | subnet-04ff2b77196041234 | in-use    |
| eni-04791f6fdb2e11234 | subnet-0afdd519b9aac1234 | in-use    |
| eni-05db7d62e7c4b1234 | subnet-0fcd103a844b41234 | in-use    |
| eni-0465474d3496d1234 | subnet-0fcd103a844b41234 | in-use    |
| eni-03d7d713ef0cf1234 | subnet-04b2534f471e11234 | in-use    |
| eni-0cd623777eded1234 | subnet-0768784bf4e571234 | in-use    |
| eni-0da855e6686f91234 | subnet-0b0eefb6e2d931234 | in-use    |
| eni-08a2f280668c91234 | subnet-0b526ec3e57421234 | in-use    |
| eni-07e0dd7a7c96f1234 | subnet-0d753b25a4ca11234 | in-use    |
| eni-0e9ca2e3ec4e41234 | subnet-0c185605aefd31234 | in-use    |
| eni-038ed7b90c28b1234 | subnet-0cea4158986941234 | in-use    |
| eni-0df8d17c9e2111234 | subnet-02ad0771395f31234 | in-use    |
| eni-0bdf9b6203e711234 | subnet-0f9d9b3c2c0281234 | in-use    |
+-----------------------+--------------------------+-----------+
> 

```
</details>
