### PR TITLE
Add column `vault_notification_config` to table `aws_glacier_vault` Closes #1230

### DIFF
--- a/docs/tables/aws_glacier_vault.md
+++ b/docs/tables/aws_glacier_vault.md
@@ -84,3 +84,16 @@ from
 where
   not tags :: JSONB ? 'owner';
 ```
+
+### List vaults with notifications enabled
+
+```sql
+select
+  vault_name,
+  vault_notification_config ->> 'SNSTopic' as sns_topic,
+  vault_notification_config ->> 'Events' as notification_events
+from
+  aws_glacier_vault
+where
+  vault_notification_config is not null;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Outputs:

resource_aka = "arn:aws:glacier:us-east-1:111122223333:vaults/turbottest40108"
resource_id = "turbottest40108"
resource_name = "turbottest40108"

Running SQL query: test-get-query.sql
[
  {
    "tags_src": {
      "name": "turbottest40108"
    },
    "title": "turbottest40108",
    "vault_name": "turbottest40108"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:glacier:us-east-1:111122223333:vaults/turbottest40108"
    ],
    "policy": {
      "Statement": [
        {
          "Action": [
            "glacier:InitiateJob",
            "glacier:GetJobOutput"
          ],
          "Effect": "Allow",
          "Principal": "*",
          "Resource": "arn:aws:glacier:us-east-1:111122223333:vaults/turbottest40108",
          "Sid": "__default_policy_ID"
        }
      ],
      "Version": "2012-10-17"
    },
    "tags": {
      "name": "turbottest40108"
    },
    "title": "turbottest40108",
    "vault_lock_policy_std": {
      "Statement": [
        {
          "Action": [
            "glacier:deletearchive"
          ],
          "Condition": {
            "NumericLessThan": {
              "glacier:archiveageindays": [
                "365"
              ]
            }
          },
          "Effect": "Deny",
          "Principal": {
            "AWS": [
              "*"
            ]
          },
          "Resource": [
            "arn:aws:glacier:us-east-1:111122223333:vaults/turbottest40108"
          ],
          "Sid": "deny-based-on-archive-age"
        }
      ],
      "Version": "2012-10-17"
    },
    "vault_name": "turbottest40108"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:glacier:us-east-1:111122223333:vaults/turbottest40108"
    ],
    "tags": {
      "name": "turbottest40108"
    },
    "title": "turbottest40108",
    "vault_name": "turbottest40108"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

POSTTEST: tests/aws_glacier_vault

TEARDOWN: tests/aws_glacier_vault

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
> select
  vault_name,
  vault_notification_config ->> 'SNSTopic' as sns_topic,
  vault_notification_config ->> 'Events' as notification_events
from
  aws_glacier_vault
where
  vault_notification_config is not null;
+----------------+---------------------------------------------------------------------------------------+--------------------------------------------------------------+
| vault_name     | sns_topic                                                                             | notification_events                                          |
+----------------+---------------------------------------------------------------------------------------+--------------------------------------------------------------+
| test-rel-vault | arn:aws:sns:us-east-1:111122223333:aws-relationships-trail-logs-111122223333-ef4c7fdf | ["ArchiveRetrievalCompleted", "InventoryRetrievalCompleted"] |
+----------------+---------------------------------------------------------------------------------------+--------------------------------------------------------------+
```
</details>
