### PR TITLE
Add column `disable_execute_api_endpoint` to table `aws_api_gatewayv2_api` Closes #1241

### DIFF
--- a/aws/table_aws_api_gatewayv2_api.go
+++ b/aws/table_aws_api_gatewayv2_api.go
@@ -56,6 +56,11 @@ func tableAwsAPIGatewayV2Api(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "disable_execute_api_endpoint",
+				Description: "Specifies whether clients can invoke your API by using the default execute-api endpoint",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
 				Name:        "route_selection_expression",
 				Description: "The route selection expression for the API. For HTTP APIs, the routeSelectionExpression must be ${request.method} ${request.path}. If not provided, this will be the default for HTTP APIs",
 				Type:        proto.ColumnType_STRING,

--- a/aws/table_aws_api_gatewayv2_api.go
+++ b/aws/table_aws_api_gatewayv2_api.go
@@ -57,7 +57,7 @@ func tableAwsAPIGatewayV2Api(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "disable_execute_api_endpoint",
-				Description: "Specifies whether clients can invoke your API by using the default execute-api endpoint",
+				Description: "Specifies whether clients can invoke your API by using the default execute-api endpoint.",
 				Type:        proto.ColumnType_BOOL,
 			},
 			{

--- a/docs/tables/aws_api_gatewayv2_api.md
+++ b/docs/tables/aws_api_gatewayv2_api.md
@@ -31,3 +31,16 @@ from
 where
   protocol_type = 'WEBSOCKET';
 ```
+
+### List of API gateway v2 API where default endpoint is enabled
+
+```sql
+select
+  name,
+  api_id,
+  api_endpoint
+from
+  aws_api_gatewayv2_api
+where
+  not disable_execute_api_endpoint
+```

--- a/docs/tables/aws_api_gatewayv2_api.md
+++ b/docs/tables/aws_api_gatewayv2_api.md
@@ -42,5 +42,5 @@ select
 from
   aws_api_gatewayv2_api
 where
-  not disable_execute_api_endpoint
+  not disable_execute_api_endpoint;
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Outputs:

api_endpoint = "https://t36iak6iz0.execute-api.us-east-1.amazonaws.com"
resource_aka = "arn:aws:apigateway:us-east-1::/apis/t36iak6iz0"
resource_id = "t36iak6iz0"
resource_name = "turbottest55990"

Running SQL query: query.sql
[
  {
    "name": "turbottest55990"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:apigateway:us-east-1::/apis/t36iak6iz0"
    ],
    "tags": {
      "name": "turbottest55990"
    },
    "title": "turbottest55990"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:apigateway:us-east-1::/apis/t36iak6iz0"
    ],
    "api_endpoint": "https://t36iak6iz0.execute-api.us-east-1.amazonaws.com",
    "api_id": "t36iak6iz0",
    "name": "turbottest55990",
    "tags": {
      "name": "turbottest55990"
    },
    "title": "turbottest55990"
  }
]
✔ PASSED

POSTTEST: tests/aws_api_gatewayv2_api

TEARDOWN: tests/aws_api_gatewayv2_api

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
> select
  name,
  api_id,
  api_endpoint
from
  aws_api_gatewayv2_api
where
  disable_execute_api_endpoint
+---------------+------------+--------------------------------------------------------+
| name          | api_id     | api_endpoint                                           |
+---------------+------------+--------------------------------------------------------+
| test-rel-api1 | tm4n83mso1 | https://tm4n83mso1.execute-api.us-east-1.amazonaws.com |
+---------------+------------+--------------------------------------------------------+
```
</details>
