### PR TITLE
Update `aws_kms_key` table `title` column to use the first alias if available Closes #1245

### DIFF
--- a/aws-test/tests/aws_kms_key/test-turbot-expected.json
+++ b/aws-test/tests/aws_kms_key/test-turbot-expected.json
@@ -6,6 +6,6 @@
     "tags": {
       "Name": "{{ resourceName }}"
     },
-    "title": "{{ output.resource_id.value }}"
+    "title": "{{ output.key_title.value }}"
   }
 ]

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -383,10 +383,17 @@ func kmsKeyTitle(ctx context.Context, d *transform.TransformData) (interface{}, 
 	plugin.Logger(ctx).Trace("kmsKeyTitle")
 	key := d.HydrateItem.([]*kms.AliasListEntry)
 
+	var keyID string
+	if d.HydrateResults["listKmsKeys"] != nil {
+		keyID = *(d.HydrateResults["listKmsKeys"]).(*kms.KeyListEntry).KeyId
+	} else if d.HydrateResults["getKmsKey"] != nil {
+		keyID = *(d.HydrateResults["getKmsKey"]).(*kms.KeyListEntry).KeyId
+	}
+
 	if len(key) > 0 {
 		return key[0].AliasName, nil
 	}
-	return nil, nil
+	return keyID, nil
 }
 
 func getAwsKmsKeyPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -380,8 +380,8 @@ func getAwsKmsKeyAliases(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 }
 
 func kmsKeyTitle(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	// Use the first alias if one is set, else fallback to the key ID
 	key := d.HydrateItem.([]*kms.AliasListEntry)
-	
 	if len(key) > 0 {
 		return key[0].AliasName, nil
 	}

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -380,8 +380,11 @@ func getAwsKmsKeyAliases(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 }
 
 func kmsKeyTitle(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("kmsKeyTitle")
 	key := d.HydrateItem.([]*kms.AliasListEntry)
+	
+	if len(key) > 0 {
+		return key[0].AliasName, nil
+	}
 
 	var keyID string
 	if d.HydrateResults["listKmsKeys"] != nil {
@@ -390,9 +393,6 @@ func kmsKeyTitle(ctx context.Context, d *transform.TransformData) (interface{}, 
 		keyID = *(d.HydrateResults["getKmsKey"]).(*kms.KeyListEntry).KeyId
 	}
 
-	if len(key) > 0 {
-		return key[0].AliasName, nil
-	}
 	return keyID, nil
 }
 

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -160,7 +160,7 @@ func tableAwsKmsKey(ctx context.Context) *plugin.Table {
 				Description: resourceInterfaceDescription("title"),
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getAwsKmsKeyAliases,
-				Transform:   transform.From(getAwsKmsKeyTitle),
+				Transform:   transform.From(kmsKeyTitle),
 			},
 			{
 				Name:        "tags",
@@ -379,8 +379,8 @@ func getAwsKmsKeyAliases(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	return keyData, nil
 }
 
-func getAwsKmsKeyTitle(ctx context.Context, d *transform.TransformData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getAwsKmsKeyTitle")
+func kmsKeyTitle(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("kmsKeyTitle")
 	key := d.HydrateItem.([]*kms.AliasListEntry)
 
 	if len(key) > 0 {

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -159,7 +159,8 @@ func tableAwsKmsKey(ctx context.Context) *plugin.Table {
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("KeyId"),
+				Hydrate:     getAwsKmsKeyAliases,
+				Transform:   transform.From(getAwsKmsKeyTitle),
 			},
 			{
 				Name:        "tags",
@@ -376,6 +377,16 @@ func getAwsKmsKeyAliases(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	}
 
 	return keyData, nil
+}
+
+func getAwsKmsKeyTitle(ctx context.Context, d *transform.TransformData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getAwsKmsKeyTitle")
+	key := d.HydrateItem.([]*kms.AliasListEntry)
+
+	if len(key) > 0 {
+		return key[0].AliasName, nil
+	}
+	return nil, nil
 }
 
 func getAwsKmsKeyPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/docs/tables/aws_kms_key.md
+++ b/docs/tables/aws_kms_key.md
@@ -4,6 +4,19 @@ AWS Key Management Service (KMS) is an Amazon Web Services product that allows a
 
 ## Examples
 
+### Basic info
+
+```sql
+select
+  id,
+  title,
+  arn,
+  key_manager,
+  creation_date
+from
+  aws_kms_key;
+```
+
 ### List of KMS keys where key rotation is not enabled
 
 ```sql


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Outputs:

account_id = "111122223333"
alias_arn = "arn:aws:kms:us-east-1:111122223333:alias/my-key-alias_turbottest40147"
aws_partition = "aws"
key_title = "alias/my-key-alias_turbottest40147"
resource_aka = "arn:aws:kms:us-east-1:111122223333:key/99e97abd-3222-4082-b7d7-400db3bb21b6"
resource_id = "99e97abd-3222-4082-b7d7-400db3bb21b6"
resource_name = "turbottest40147"

Running SQL query: test-get-query.sql
[
  {
    "id": "99e97abd-3222-4082-b7d7-400db3bb21b6"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "alias_arn": "arn:aws:kms:us-east-1:111122223333:alias/my-key-alias_turbottest40147",
    "alias_name": "alias/my-key-alias_turbottest40147",
    "alias_target_key_id": "99e97abd-3222-4082-b7d7-400db3bb21b6",
    "key_manager": "CUSTOMER",
    "key_rotation_enabled": false,
    "policy": {
      "Id": "key-default-1",
      "Statement": [
        {
          "Action": "kms:*",
          "Effect": "Allow",
          "Principal": {
            "AWS": "arn:aws:iam::111122223333:root"
          },
          "Resource": "*",
          "Sid": "Enable IAM User Permissions"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Id": "key-default-1",
      "Statement": [
        {
          "Action": [
            "kms:*"
          ],
          "Effect": "Allow",
          "Principal": {
            "AWS": [
              "arn:aws:iam::111122223333:root"
            ]
          },
          "Resource": [
            "*"
          ],
          "Sid": "Enable IAM User Permissions"
        }
      ],
      "Version": "2012-10-17"
    },
    "tags_src": [
      {
        "TagKey": "Name",
        "TagValue": "turbottest40147"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "id": "99e97abd-3222-4082-b7d7-400db3bb21b6"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:kms:us-east-1:111122223333:key/99e97abd-3222-4082-b7d7-400db3bb21b6"
    ],
    "tags": {
      "Name": "turbottest40147"
    },
    "title": "alias/my-key-alias_turbottest40147"
  }
]
✔ PASSED

POSTTEST: tests/aws_kms_key

TEARDOWN: tests/aws_kms_key

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```sql
> select
  id,
  title,
  arn,
  key_manager,
  creation_date
from
  aws_kms_key limit 5;
+--------------------------------------+--------------------------------------+------------------------------------------------------------------------------+-------------+---------------------------+
| id                                   | title                                | arn                                                                          | key_manager | creation_date             |
+--------------------------------------+--------------------------------------+------------------------------------------------------------------------------+-------------+---------------------------+
| 72a62fad-e141-438f-9e05-72efc4c3ee21 | alias/aws/elasticfilesystem          | arn:aws:kms:ap-south-1:533793682495:key/72a62fad-e141-438f-9e05-72efc4c3ee21 | AWS         | 2020-12-04T23:07:22+05:30 |
| e38e406e-3c8a-4fa4-8edb-cb5c3f7520cc | alias/aws/codecommit                 | arn:aws:kms:ap-south-1:533793682495:key/e38e406e-3c8a-4fa4-8edb-cb5c3f7520cc | AWS         | 2021-06-25T15:51:09+05:30 |
| 9c909e47-4143-4e47-8323-66d8c30ff7cd | alias/aws/codeartifact               | arn:aws:kms:ap-south-1:533793682495:key/9c909e47-4143-4e47-8323-66d8c30ff7cd | AWS         | 2022-07-25T21:34:14+05:30 |
| 6d1e81de-49f2-4ab0-a4fb-d63cbbfe0e9e | alias/aws/glue                       | arn:aws:kms:ap-south-1:533793682495:key/6d1e81de-49f2-4ab0-a4fb-d63cbbfe0e9e | AWS         | 2020-12-04T23:07:22+05:30 |
| 8583ba5e-6272-45b2-9995-5d9ebd656751 | 8583ba5e-6272-45b2-9995-5d9ebd656751 | arn:aws:kms:ap-south-1:533793682495:key/8583ba5e-6272-45b2-9995-5d9ebd656751 | AWS         | 2019-02-11T17:32:57+05:30 |
+--------------------------------------+--------------------------------------+------------------------------------------------------------------------------+-------------+---------------------------+
```
</details>
