### PR TITLE
Fix query failure for any new regions released by AWS when the config uses `wilcards` for regions in steampipe connection config 

### DIFF
--- a/aws/multi_region.go
+++ b/aws/multi_region.go
@@ -43,7 +43,7 @@ func getAllAwsRegions() []string {
 }
 
 // BuildRegionList :: return a list of matrix items, one per region specified in the connection config.
-// Plugin supports wildcards "*" and "?" in the connection config for thr regions.
+// Plugin supports wildcards "*" and "?" in the connection config for the regions.
 //
 // This function will build the regions list dynamically based the activated region in the AWS account.
 // For this it uses https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
@@ -59,7 +59,7 @@ func getAllAwsRegions() []string {
 // regions="af-south-1, eu-north-1, ap-south-1, eu-west-3, eu-west-2, eu-south-1, eu-west-1, ap-northeast-3, ap-northeast-2, me-south-1, ap-northeast-1, sa-east-1, ca-central-1, ap-southeast-1, ap-southeast-2, eu-central-1, us-east-1, us-east-2, us-west-1, us-west-2"
 //
 // regions = ["me-*", "ap-*", "us-*"]
-// BuildRegionList: connection_name=aws regions="me-south-1, ap-south-1, ap-northeast-3, ap-northeast-2, ap-northeast-1, ap-southeast-1, ap-southeast-2, us-east-1, us-east-2, us-west-1, us-west-2"
+// regions="me-south-1, ap-south-1, ap-northeast-3, ap-northeast-2, ap-northeast-1, ap-southeast-1, ap-southeast-2, us-east-1, us-east-2, us-west-1, us-west-2"
 func BuildRegionList(ctx context.Context, d *plugin.QueryData) []map[string]interface{} {
 
 	// Cache region list matrix

--- a/aws/multi_region.go
+++ b/aws/multi_region.go
@@ -17,53 +17,67 @@ import (
 const matrixKeyRegion = "region"
 const matrixKeyServiceCode = "serviceCode"
 
-//var d *plugin.QueryData
+type RegionsData struct {
+	AllRegions      []string
+	ActiveRegions   []string
+	NotOptedRegions []string
+	APIRetrivedList bool
+}
 
-//func init() {
-//	d = &plugin.QueryData{
-//		ConnectionManager: connection.NewManager(nil),
-//	}
-//}
+var (
+	awsCommercialRegions = []string{
+		"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2"}
 
-// BuildRegionList :: return a list of matrix items, one per region specified in the connection config
+	awsUsGovRegions  = []string{"us-gov-east-1", "us-gov-west-1"}
+	awsChinaRegions  = []string{"cn-north-1", "cn-northwest-1"}
+	awsUsIsoRegions  = []string{"us-iso-east-1", "us-iso-west-1"}
+	awsUsIsobRegions = []string{"us-isob-east-1"}
+)
+
+func getAllAwsRegions() []string {
+	awsRegions := append(awsCommercialRegions, awsUsGovRegions...)
+	awsRegions = append(awsRegions, awsChinaRegions...)
+	awsRegions = append(awsRegions, awsUsIsoRegions...)
+	awsRegions = append(awsRegions, awsUsIsobRegions...)
+	return awsRegions
+}
+
+// BuildRegionList :: return a list of matrix items, one per region specified in the connection config.
+// Plugin supports wildcards "*" and "?" in the connection config for thr regions.
+//
+// This function will build the regions list dynamically based the activated region in the AWS account.
+// For this it uses https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRegions.html
+//
+// Some scenarios
+// When no regions mentioned in connection config
+// region = "us-east-1"
+//
+// When no regions mentioned in connection config and started steampipe as AWS_REGION=ap-south-1 steampipe query
+// region = "ap-south-1"
+//
+// regions = ["*"]
+// regions="af-south-1, eu-north-1, ap-south-1, eu-west-3, eu-west-2, eu-south-1, eu-west-1, ap-northeast-3, ap-northeast-2, me-south-1, ap-northeast-1, sa-east-1, ca-central-1, ap-southeast-1, ap-southeast-2, eu-central-1, us-east-1, us-east-2, us-west-1, us-west-2"
+//
+// regions = ["me-*", "ap-*", "us-*"]
+// BuildRegionList: connection_name=aws regions="me-south-1, ap-south-1, ap-northeast-3, ap-northeast-2, ap-northeast-1, ap-southeast-1, ap-southeast-2, us-east-1, us-east-2, us-west-1, us-west-2"
 func BuildRegionList(ctx context.Context, d *plugin.QueryData) []map[string]interface{} {
 
-	// cache matrix
+	// Cache region list matrix
 	cacheKey := "RegionListMatrix"
 	if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
 		return cachedData.([]map[string]interface{})
 	}
 
-	defaultAwsRegion := GetDefaultAwsRegion(d)
-	regionData, _ := listRegions(ctx, d)
-	var allRegions []string
-
-	// retrieve regions from connection config
+	// Retrieve regions list from the AWS plugin steampipe connection config
 	awsConfig := GetConfig(d.Connection)
-	// Get only the regions as required by config file
-	if awsConfig.Regions != nil {
-		for _, pattern := range awsConfig.Regions {
-			for _, validRegion := range regionData["AllRegions"] {
-				if ok, _ := path.Match(pattern, validRegion); ok {
-					allRegions = append(allRegions, validRegion)
-				}
-			}
-		}
-	}
+	defaultAwsRegion := GetDefaultAwsRegion(d)
 
-	if len(allRegions) > 0 {
-		uniqueRegions := unique(allRegions)
-
-		if len(getInvalidRegions(uniqueRegions, d)) > 0 {
-			panic("\n\nConnection config has invalid regions: " + strings.Join(getInvalidRegions(uniqueRegions, nil), ", "))
-		}
-
-		// Remove inactive regions from the list
-		finalRegions := helpers.StringSliceDiff(uniqueRegions, regionData["NotOptedRegions"])
-
-		matrix := make([]map[string]interface{}, len(finalRegions))
-		for i, region := range finalRegions {
-			matrix[i] = map[string]interface{}{matrixKeyRegion: region}
+	// If regions are not mentioned in the plugin steampipe connection config
+	// get the default aws region and prepare the matrix
+	if awsConfig.Regions == nil {
+		plugin.Logger(ctx).Info("BuildRegionList", "connection_name", d.Connection.Name, "region", defaultAwsRegion)
+		matrix := []map[string]interface{}{
+			{matrixKeyRegion: defaultAwsRegion},
 		}
 
 		// set cache
@@ -71,8 +85,38 @@ func BuildRegionList(ctx context.Context, d *plugin.QueryData) []map[string]inte
 		return matrix
 	}
 
-	matrix := []map[string]interface{}{
-		{matrixKeyRegion: defaultAwsRegion},
+	// If regions are mentioned in the connection config
+	// Get the list of AWS region from EC2 DescribeRegions API
+	regionData, _ := listRegions(ctx, d)
+	var finalRegions []string
+
+	// If the list was retrived from AWS API - just looks for Active Regions
+	if regionData.APIRetrivedList {
+		for _, pattern := range awsConfig.Regions {
+			for _, validRegion := range regionData.ActiveRegions {
+				if ok, _ := path.Match(pattern, validRegion); ok {
+					finalRegions = append(finalRegions, validRegion)
+				}
+			}
+			finalRegions = helpers.StringSliceDistinct(finalRegions)
+		}
+	} else {
+		// If the list was not retrived from AWS API
+		// match for regions from all regions list
+		for _, pattern := range awsConfig.Regions {
+			for _, validRegion := range regionData.AllRegions {
+				if ok, _ := path.Match(pattern, validRegion); ok {
+					finalRegions = append(finalRegions, validRegion)
+				}
+			}
+		}
+		finalRegions = helpers.StringSliceDistinct(finalRegions)
+	}
+
+	plugin.Logger(ctx).Info("BuildRegionList", "connection_name", d.Connection.Name, "regions", strings.Join(finalRegions, ", "))
+	matrix := make([]map[string]interface{}, len(finalRegions))
+	for i, region := range finalRegions {
+		matrix[i] = map[string]interface{}{matrixKeyRegion: region}
 	}
 
 	// set cache
@@ -81,8 +125,7 @@ func BuildRegionList(ctx context.Context, d *plugin.QueryData) []map[string]inte
 }
 
 func getInvalidRegions(regions []string, d *plugin.QueryData) []string {
-	awsRegions := []string{
-		"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "us-gov-east-1", "us-gov-west-1", "cn-north-1", "cn-northwest-1", "us-iso-east-1", "us-iso-west-1", "us-isob-east-1"}
+	awsRegions := getAllAwsRegions()
 
 	invalidRegions := []string{}
 	for _, region := range regions {
@@ -109,20 +152,14 @@ func BuildWafRegionList(ctx context.Context, d *plugin.QueryData) []map[string]i
 	return matrix
 }
 
-func listRegions(ctx context.Context, d *plugin.QueryData) (map[string][]string, error) {
+func listRegions(ctx context.Context, d *plugin.QueryData) (RegionsData, error) {
 	cacheKey := "listRegions"
 
 	// if found in cache, return the result
 	if cachedData, ok := d.ConnectionManager.Cache.Get(cacheKey); ok {
-		return cachedData.(map[string][]string), nil
+		return cachedData.(RegionsData), nil
 	}
 
-	awsCommercialRegions := []string{
-		"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2"}
-	awsUsGovRegions := []string{"us-gov-east-1", "us-gov-west-1"}
-	awsChinaRegions := []string{"cn-north-1", "cn-northwest-1"}
-	awsUsIsoRegions := []string{"us-iso-east-1", "us-iso-west-1"}
-	awsUsIsobRegions := []string{"us-isob-east-1"}
 	defaultRegions := awsCommercialRegions
 
 	defaultRegion := GetDefaultAwsRegion(d)
@@ -136,9 +173,10 @@ func listRegions(ctx context.Context, d *plugin.QueryData) (map[string][]string,
 		defaultRegions = awsUsIsoRegions
 	}
 
-	data := map[string][]string{
-		"AllRegions":    defaultRegions,
-		"ActiveRegions": defaultRegions,
+	data := RegionsData{
+		AllRegions:      defaultRegions,
+		ActiveRegions:   defaultRegions,
+		APIRetrivedList: false,
 	}
 
 	// We can query EC2 for the list of supported regions. If credentials
@@ -165,11 +203,13 @@ func listRegions(ctx context.Context, d *plugin.QueryData) (map[string][]string,
 		return data, nil
 	}
 
-	var activeRegions []string
-	var notOptedRegions []string
-	var allRegions []string
+	var activeRegions []string   // All enabled regions in the account.
+	var notOptedRegions []string // All not enabled regions in the account.
+	var allRegions []string      // All regions listed by the API DescribeRegions.
+
 	for _, region := range resp.Regions {
 		allRegions = append(allRegions, *region.RegionName)
+
 		if *region.OptInStatus != "not-opted-in" {
 			activeRegions = append(activeRegions, *region.RegionName)
 		} else {
@@ -177,9 +217,12 @@ func listRegions(ctx context.Context, d *plugin.QueryData) (map[string][]string,
 		}
 	}
 
-	data["AllRegions"] = allRegions
-	data["ActiveRegions"] = activeRegions
-	data["NotOptedRegions"] = notOptedRegions
+	data = RegionsData{
+		AllRegions:      allRegions,
+		ActiveRegions:   activeRegions,
+		NotOptedRegions: notOptedRegions,
+		APIRetrivedList: true,
+	}
 
 	// save to extension cache
 	d.ConnectionManager.Cache.Set(cacheKey, data)
@@ -241,7 +284,7 @@ func BuildServiceQuotasServicesRegionList(ctx context.Context, d *plugin.QueryDa
 	// Get only the regions as required by config file
 	if awsConfig.Regions != nil {
 		for _, pattern := range awsConfig.Regions {
-			for _, validRegion := range regionData["AllRegions"] {
+			for _, validRegion := range regionData.AllRegions {
 				if ok, _ := path.Match(pattern, validRegion); ok {
 					allRegions = append(allRegions, validRegion)
 				}
@@ -257,7 +300,7 @@ func BuildServiceQuotasServicesRegionList(ctx context.Context, d *plugin.QueryDa
 		}
 
 		// Remove inactive regions from the list
-		finalRegions := helpers.StringSliceDiff(uniqueRegions, regionData["NotOptedRegions"])
+		finalRegions := helpers.StringSliceDiff(uniqueRegions, regionData.NotOptedRegions)
 
 		matrix := make([]map[string]interface{}, len(finalRegions)*len(services))
 		for i, region := range finalRegions {

--- a/aws/service.go
+++ b/aws/service.go
@@ -1012,8 +1012,7 @@ func getSessionForRegion(ctx context.Context, d *plugin.QueryData, region string
 // GetDefaultAwsRegion returns the default region for AWS partiton
 // if not set by Env variable or in aws profile
 func GetDefaultAwsRegion(d *plugin.QueryData) string {
-	allAwsRegions := []string{
-		"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "us-gov-east-1", "us-gov-west-1", "cn-north-1", "cn-northwest-1", "us-iso-east-1", "us-iso-west-1", "us-isob-east-1"}
+	allAwsRegions := getAllAwsRegions()
 
 	// have we already created and cached the service?
 	serviceCacheKey := "GetDefaultAwsRegion"


### PR DESCRIPTION
Tested for below scenarios and it is working fine.
```
connection "aws" {
  plugin = "aws"

  # Same for With AWS EC2 API working and Not Working
  # When no region mentioned
  #  BuildRegionList: connection_name=aws region=us-east-1

  # aws-config-region-check⚡ ⇒  AWS_REGION=ap-south-1 steampipe query
  # BuildRegionList: connection_name=aws region=ap-south-1

  # regions = ["*"]
  # BuildRegionList: connection_name=aws regions="af-south-1, eu-north-1, ap-south-1, eu-west-3, eu-west-2, eu-south-1, eu-west-1, ap-northeast-3, ap-northeast-2, me-south-1, ap-northeast-1, sa-east-1, ca-central-1, ap-southeast-1, ap-southeast-2, eu-central-1, us-east-1, us-east-2, us-west-1, us-west-2"

  # When EC2 Describe Regions failed
  # "af-south-1, ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1, ap-southeast-2, ap-southeast-3, ca-central-1, eu-central-1, eu-north-1, eu-south-1, eu-west-1, eu-west-2, eu-west-3, me-south-1, sa-east-1, us-east-1, us-east-2, us-west-1, us-west-2"

  # regions = ["me-*"]
  # BuildRegionList: connection_name=aws regions=me-south-1

  # When EC2 Describe Regions failed
  # BuildRegionList: connection_name=aws regions=me-south-1

  # regions = ["me-*", "ap-*", "us-*"]
  # BuildRegionList: connection_name=aws regions="me-south-1, ap-south-1, ap-northeast-3, ap-northeast-2, ap-northeast-1, ap-southeast-1, ap-southeast-2, us-east-1, us-east-2, us-west-1, us-west-2"

  # When EC2 Describe Regions failed
  # BuildRegionList: connection_name=aws regions=me-south-1
  #  BuildRegionList: connection_name=aws regions="me-south-1, ap-east-1, ap-northeast-1, ap-northeast-2, ap-northeast-3, ap-south-1, ap-southeast-1, ap-southeast-2, ap-southeast-3, us-east-1, us-east-2, us-west-1, us-west-2"

  regions = ["us-east-1"]
  # In both case
  #  BuildRegionList: connection_name=aws region="us-east-1"

  # regions = ["us-east-1", "ap-south-1"]
  # In both case
  #  BuildRegionList: connection_name=aws regions="us-east-1, ap-south-1"
}
```