### PR TITLE
Getting gateway load balancer information in aws_ec2_application_load_balancer table closes #1269

### DIFF
--- a/aws/table_aws_ec2_application_load_balancer.go
+++ b/aws/table_aws_ec2_application_load_balancer.go
@@ -207,11 +207,13 @@ func listEc2ApplicationLoadBalancers(ctx context.Context, d *plugin.QueryData, _
 		}
 
 		for _, items := range output.LoadBalancers {
-			d.StreamListItem(ctx, items)
+			if items.Type == types.LoadBalancerTypeEnumApplication {
+				d.StreamListItem(ctx, items)
 
-			// Context can be cancelled due to manual cancellation or the limit has been hit
-			if d.QueryStatus.RowsRemaining(ctx) == 0 {
-				return nil, nil
+				// Context can be cancelled due to manual cancellation or the limit has been hit
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return nil, nil
+				}
 			}
 		}
 


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>
  
```
No env file present for the current environment:  staging
 Falling back to .env config
No env file present for the current environment:  staging

customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_application_load_balancer []
PRETEST: tests/aws_ec2_application_load_balancer

TEST: tests/aws_ec2_application_load_balancer
Running terraform
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-west-2]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 1s [id=857902152385]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_internet_gateway.igw will be created
  + resource "aws_internet_gateway" "igw" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + owner_id = (known after apply)
      + tags_all = (known after apply)
      + vpc_id   = (known after apply)
    }

  # aws_lb.named_test_resource will be created
  + resource "aws_lb" "named_test_resource" {
      + arn                        = (known after apply)
      + arn_suffix                 = (known after apply)
      + desync_mitigation_mode     = "defensive"
      + dns_name                   = (known after apply)
      + drop_invalid_header_fields = false
      + enable_deletion_protection = false
      + enable_http2               = true
      + enable_waf_fail_open       = false
      + id                         = (known after apply)
      + idle_timeout               = 60
      + internal                   = false
      + ip_address_type            = (known after apply)
      + load_balancer_type         = "application"
      + name                       = "turbottest86665"
      + preserve_host_header       = false
      + security_groups            = (known after apply)
      + subnets                    = (known after apply)
      + tags                       = {
          + "name" = "turbottest86665"
        }
      + tags_all                   = {
          + "name" = "turbottest86665"
        }
      + vpc_id                     = (known after apply)
      + zone_id                    = (known after apply)

      + subnet_mapping {
          + allocation_id        = (known after apply)
          + ipv6_address         = (known after apply)
          + outpost_id           = (known after apply)
          + private_ipv4_address = (known after apply)
          + subnet_id            = (known after apply)
        }
    }

  # aws_subnet.my_subnet1 will be created
  + resource "aws_subnet" "my_subnet1" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-west-2a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.0.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_subnet.my_subnet2 will be created
  + resource "aws_subnet" "my_subnet2" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-west-2b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.1.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.my_vpc will be created
  + resource "aws_vpc" "my_vpc" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags_all                             = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "857902152385"
  + aws_partition = "aws"
  + region_name   = "us-west-2"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest86665"
  + vpc_id        = (known after apply)
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Creation complete after 4s [id=vpc-0accbaed61bc696c4]
aws_internet_gateway.igw: Creating...
aws_internet_gateway.igw: Creation complete after 2s [id=igw-0674af45483ab81c8]
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet2: Creation complete after 2s [id=subnet-030149ed56872c6d5]
aws_subnet.my_subnet1: Creation complete after 2s [id=subnet-038db5b389f17a84f]
aws_lb.named_test_resource: Creating...
aws_lb.named_test_resource: Still creating... [10s elapsed]
aws_lb.named_test_resource: Still creating... [20s elapsed]
aws_lb.named_test_resource: Still creating... [30s elapsed]
aws_lb.named_test_resource: Still creating... [40s elapsed]
aws_lb.named_test_resource: Still creating... [50s elapsed]
aws_lb.named_test_resource: Still creating... [1m0s elapsed]
aws_lb.named_test_resource: Still creating... [1m10s elapsed]
aws_lb.named_test_resource: Still creating... [1m20s elapsed]
aws_lb.named_test_resource: Still creating... [1m30s elapsed]
aws_lb.named_test_resource: Still creating... [1m40s elapsed]
aws_lb.named_test_resource: Still creating... [1m50s elapsed]
aws_lb.named_test_resource: Still creating... [2m0s elapsed]
aws_lb.named_test_resource: Still creating... [2m10s elapsed]
aws_lb.named_test_resource: Still creating... [2m20s elapsed]
aws_lb.named_test_resource: Creation complete after 2m30s [id=arn:aws:elasticloadbalancing:us-west-2:857902152385:loadbalancer/app/turbottest86665/bcf6519fde1bd214]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "857902152385"
aws_partition = "aws"
region_name = "us-west-2"
resource_aka = "arn:aws:elasticloadbalancing:us-west-2:857902152385:loadbalancer/app/turbottest86665/bcf6519fde1bd214"
resource_id = "arn:aws:elasticloadbalancing:us-west-2:857902152385:loadbalancer/app/turbottest86665/bcf6519fde1bd214"
resource_name = "turbottest86665"
vpc_id = "vpc-0accbaed61bc696c4"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-west-2:857902152385:loadbalancer/app/turbottest86665/bcf6519fde1bd214",
    "ip_address_type": "ipv4",
    "name": "turbottest86665",
    "scheme": "internet-facing",
    "state_code": "active",
    "type": "application",
    "vpc_id": "vpc-0accbaed61bc696c4"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:elasticloadbalancing:us-west-2:857902152385:loadbalancer/app/turbottest86665/bcf6519fde1bd214",
    "name": "turbottest86665"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:elasticloadbalancing:us-west-2:857902152385:loadbalancer/app/turbottest86665/bcf6519fde1bd214"
    ],
    "tags": {
      "name": "turbottest86665"
    },
    "title": "turbottest86665"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_application_load_balancer

TEARDOWN: tests/aws_ec2_application_load_balancer

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select * from aws_ec2_application_load_balancer
+-----------------------+--------------------------------------------------------------------------------------------------------------+-------------+-----------------+--------------------------+-------
| name                  | arn                                                                                                          | type        | scheme          | canonical_hosted_zone_id | vpc_id
+-----------------------+--------------------------------------------------------------------------------------------------------------+-------------+-----------------+--------------------------+-------
| test-app-loadbalancer | arn:aws:elasticloadbalancing:ap-south-1:857902152385:loadbalancer/app/test-app-loadbalancer/f9a598adb3bc3d34 | application | internet-facing | ZP97RAFLXTNZK            | vpc-03
+-----------------------+--------------------------------------------------------------------------------------------------------------+-------------+-----------------+--------------------------+-------
> select * from aws_ec2_gateway_load_balancer
+---------------------------+------------------------------------------------------------------------------------------------------------------+---------+------------+--------+----------+--------------+
| name                      | arn                                                                                                              | type    | state_code | scheme | dns_name | vpc_id       |
+---------------------------+------------------------------------------------------------------------------------------------------------------+---------+------------+--------+----------+--------------+
| test-gateway-loadbalancer | arn:aws:elasticloadbalancing:ap-south-1:857902152385:loadbalancer/gwy/test-gateway-loadbalancer/e981fcb1340e1359 | gateway | active     |        | <null>   | vpc-0308016b |
+---------------------------+------------------------------------------------------------------------------------------------------------------+---------+------------+--------+----------+--------------+

```
</details>
