### PR TITLE
`aws_ec2_transit_gateway_*` tables should not error in me-central-1 region

### DIFF
--- a/aws/table_aws_ec2_transit_gateway.go
+++ b/aws/table_aws_ec2_transit_gateway.go
@@ -21,7 +21,7 @@ func tableAwsEc2TransitGateway(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("transit_gateway_id"),
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidTransitGatewayID.NotFound", "InvalidTransitGatewayID.Unavailable", "InvalidTransitGatewayID.Malformed"}),
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidTransitGatewayID.NotFound", "InvalidTransitGatewayID.Unavailable", "InvalidTransitGatewayID.Malformed", "InvalidAction"}),
 			},
 			Hydrate: getEc2TransitGateway,
 		},
@@ -38,6 +38,9 @@ func tableAwsEc2TransitGateway(_ context.Context) *plugin.Table {
 				{Name: "vpn_ecmp_support", Require: plugin.Optional},
 				{Name: "owner_id", Require: plugin.Optional},
 				{Name: "state", Require: plugin.Optional},
+			},
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidAction"}),
 			},
 		},
 		GetMatrixItemFunc: BuildRegionList,

--- a/aws/table_aws_ec2_transit_gateway_route.go
+++ b/aws/table_aws_ec2_transit_gateway_route.go
@@ -25,6 +25,9 @@ func tableAwsEc2TransitGatewayRoute(_ context.Context) *plugin.Table {
 				{Name: "state", Require: plugin.Optional},
 				{Name: "type", Require: plugin.Optional},
 			},
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidAction"}),
+			},
 		},
 		GetMatrixItemFunc: BuildRegionList,
 		Columns: awsRegionalColumns([]*plugin.Column{

--- a/aws/table_aws_ec2_transit_gateway_route_table.go
+++ b/aws/table_aws_ec2_transit_gateway_route_table.go
@@ -21,7 +21,7 @@ func tableAwsEc2TransitGatewayRouteTable(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("transit_gateway_route_table_id"),
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidRouteTableID.NotFound", "InvalidRouteTableId.Unavailable", "InvalidRouteTableId.Malformed"}),
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidRouteTableID.NotFound", "InvalidRouteTableId.Unavailable", "InvalidRouteTableId.Malformed", "InvalidAction"}),
 			},
 			Hydrate: getEc2TransitGatewayRouteTable,
 		},
@@ -32,6 +32,9 @@ func tableAwsEc2TransitGatewayRouteTable(_ context.Context) *plugin.Table {
 				{Name: "state", Require: plugin.Optional},
 				{Name: "default_association_route_table", Require: plugin.Optional},
 				{Name: "default_propagation_route_table", Require: plugin.Optional},
+			},
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidAction"}),
 			},
 		},
 		GetMatrixItemFunc: BuildRegionList,

--- a/aws/table_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/aws/table_aws_ec2_transit_gateway_vpc_attachment.go
@@ -17,7 +17,7 @@ func tableAwsEc2TransitGatewayVpcAttachment(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("transit_gateway_attachment_id"),
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidTransitGatewayAttachmentID.NotFound", "InvalidTransitGatewayAttachmentID.Unavailable", "InvalidTransitGatewayAttachmentID.Malformed"}),
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidTransitGatewayAttachmentID.NotFound", "InvalidTransitGatewayAttachmentID.Unavailable", "InvalidTransitGatewayAttachmentID.Malformed", "InvalidAction"}),
 			},
 			Hydrate: getEc2TransitGatewayVpcAttachment,
 		},

--- a/aws/table_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/aws/table_aws_ec2_transit_gateway_vpc_attachment.go
@@ -33,6 +33,9 @@ func tableAwsEc2TransitGatewayVpcAttachment(_ context.Context) *plugin.Table {
 				{Name: "transit_gateway_id", Require: plugin.Optional},
 				{Name: "transit_gateway_owner_id", Require: plugin.Optional},
 			},
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: isNotFoundError([]string{"InvalidAction"}),
+			},
 		},
 		GetMatrixItemFunc: BuildRegionList,
 		Columns: awsRegionalColumns([]*plugin.Column{


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
> select transit_gateway_id from aws_ec2_transit_gateway where region = 'me-central-1'
+--------------------+
| transit_gateway_id |
+--------------------+
+--------------------+
> select transit_gateway_route_table_id from aws_ec2_transit_gateway_route where region = 'me-central-1'
+--------------------------------+
| transit_gateway_route_table_id |
+--------------------------------+
+--------------------------------+
> select transit_gateway_route_table_id from aws_ec2_transit_gateway_route_table where region = 'me-central-1'
+--------------------------------+
| transit_gateway_route_table_id |
+--------------------------------+
+--------------------------------+
> select transit_gateway_attachment_id from aws_ec2_transit_gateway_vpc_attachment where region = 'me-central-1'
+-------------------------------+
| transit_gateway_attachment_id |
+-------------------------------+
+-------------------------------+
```
</details>

