### PR TITLE
Add Code column in the aws_lambda_function table. Closes #1292

### DIFF
--- a/aws/table_aws_lambda_function.go
+++ b/aws/table_aws_lambda_function.go
@@ -183,6 +183,12 @@ func tableAwsLambdaFunction(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
+				Name:        "code",
+				Description: "The deployment package of the function or version.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsLambdaFunction,
+			},
+			{
 				Name:        "environment_variables",
 				Description: "The environment variables that are accessible from function code during execution.",
 				Type:        proto.ColumnType_JSON,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```

SETUP: tests/aws_lambda_function []

PRETEST: tests/aws_lambda_function

TEST: tests/aws_lambda_function
Running terraform
data.aws_region.alternate: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 1s [id=***********]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.archive_file.zip will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "archive_file" "zip" {
      + id                  = (known after apply)
      + output_base64sha256 = (known after apply)
      + output_md5          = (known after apply)
      + output_path         = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_lambda_function/terraform/test/../../test.zip"
      + output_sha          = (known after apply)
      + output_size         = (known after apply)
      + source_file         = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_lambda_function/terraform/test/../../test.py"
      + type                = "zip"
    }

  # aws_iam_role.aws_lambda_function will be created
  + resource "aws_iam_role" "aws_lambda_function" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "lambda.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest55419"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_lambda_function.named_test_resource will be created
  + resource "aws_lambda_function" "named_test_resource" {
      + architectures                  = (known after apply)
      + arn                            = (known after apply)
      + filename                       = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_lambda_function/terraform/test/../../test.zip"
      + function_name                  = "turbottest55419"
      + handler                        = "test.test"
      + id                             = (known after apply)
      + invoke_arn                     = (known after apply)
      + last_modified                  = (known after apply)
      + memory_size                    = 128
      + package_type                   = "Zip"
      + publish                        = false
      + qualified_arn                  = (known after apply)
      + reserved_concurrent_executions = 2
      + role                           = (known after apply)
      + runtime                        = "python3.7"
      + signing_job_arn                = (known after apply)
      + signing_profile_version_arn    = (known after apply)
      + source_code_hash               = (known after apply)
      + source_code_size               = (known after apply)
      + tags                           = {
          + "name" = "turbottest55419"
        }
      + tags_all                       = {
          + "name" = "turbottest55419"
        }
      + timeout                        = 3
      + version                        = (known after apply)

      + ephemeral_storage {
          + size = (known after apply)
        }

      + tracing_config {
          + mode = (known after apply)
        }
    }

  # aws_lambda_permission.with_sns will be created
  + resource "aws_lambda_permission" "with_sns" {
      + action              = "lambda:InvokeFunction"
      + function_name       = "turbottest55419"
      + id                  = (known after apply)
      + principal           = "sns.amazonaws.com"
      + source_arn          = (known after apply)
      + statement_id        = "AllowExecutionFromSNS"
      + statement_id_prefix = (known after apply)
    }

  # aws_sns_topic.default will be created
  + resource "aws_sns_topic" "default" {
      + arn                         = (known after apply)
      + content_based_deduplication = false
      + fifo_topic                  = false
      + id                          = (known after apply)
      + name                        = "call-lambda-maybe"
      + name_prefix                 = (known after apply)
      + owner                       = (known after apply)
      + policy                      = (known after apply)
      + tags_all                    = (known after apply)
    }

  # local_file.python_file will be created
  + resource "local_file" "python_file" {
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "/private/var/folders/mn/z714twf97531zdzc267pw73h0000gn/T/tests/aws_lambda_function/terraform/test/../../test.py"
      + id                   = (known after apply)
      + sensitive_content    = (sensitive value)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "***********"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest55419"
  + sns_arn       = (known after apply)
local_file.python_file: Creating...
local_file.python_file: Creation complete after 0s [id=31a055a187e07d0bd8fca8ceb1f633aa4497fe53]
data.archive_file.zip: Reading...
data.archive_file.zip: Read complete after 0s [id=3d2780bc13324b697460b666c413908a395d952e]
aws_sns_topic.default: Creating...
aws_iam_role.aws_lambda_function: Creating...
aws_iam_role.aws_lambda_function: Creation complete after 3s [id=turbottest55419]
aws_lambda_function.named_test_resource: Creating...
aws_sns_topic.default: Creation complete after 3s [id=arn:aws:sns:us-east-1:***********:call-lambda-maybe]
aws_lambda_function.named_test_resource: Still creating... [10s elapsed]
aws_lambda_function.named_test_resource: Creation complete after 16s [id=turbottest55419]
aws_lambda_permission.with_sns: Creating...
aws_lambda_permission.with_sns: Creation complete after 1s [id=AllowExecutionFromSNS]

Warning: Deprecated Resource

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: Argument is deprecated

  with local_file.python_file,
  on variables.tf line 53, in resource "local_file" "python_file":
  53:   sensitive_content = "def test (event, context):\n\tprint ('This is a test for integration testing to check creation of a lambda function')"

Use the `local_sensitive_file` resource instead.

(and 2 more similar warnings elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "***********"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:lambda:us-east-1:***********:function:turbottest55419"
resource_name = "turbottest55419"
sns_arn = "arn:aws:sns:us-east-1:***********:call-lambda-maybe"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:lambda:us-east-1:***********:function:turbottest55419",
    "description": "",
    "name": "turbottest55419",
    "role": "arn:aws:iam::***********:role/turbottest55419",
    "version": "$LATEST"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "policy": {
      "Id": "default",
      "Statement": [
        {
          "Action": "lambda:InvokeFunction",
          "Condition": {
            "ArnLike": {
              "AWS:SourceArn": "arn:aws:sns:us-east-1:***********:call-lambda-maybe"
            }
          },
          "Effect": "Allow",
          "Principal": {
            "Service": "sns.amazonaws.com"
          },
          "Resource": "arn:aws:lambda:us-east-1:***********:function:turbottest55419",
          "Sid": "AllowExecutionFromSNS"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Id": "default",
      "Statement": [
        {
          "Action": [
            "lambda:invokefunction"
          ],
          "Condition": {
            "ArnLike": {
              "aws:sourcearn": [
                "arn:aws:sns:us-east-1:***********:call-lambda-maybe"
              ]
            }
          },
          "Effect": "Allow",
          "Principal": {
            "Service": [
              "sns.amazonaws.com"
            ]
          },
          "Resource": [
            "arn:aws:lambda:us-east-1:***********:function:turbottest55419"
          ],
          "Sid": "AllowExecutionFromSNS"
        }
      ],
      "Version": "2012-10-17"
    },
    "reserved_concurrent_executions": 2,
    "tags": {
      "name": "turbottest55419"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:lambda:us-east-1:***********:function:turbottest55419",
    "description": "",
    "name": "turbottest55419",
    "role": "arn:aws:iam::***********:role/turbottest55419",
    "version": "$LATEST"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "***********",
    "akas": [
      "arn:aws:lambda:us-east-1:***********:function:turbottest55419"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "title": "turbottest55419"
  }
]
✔ PASSED

POSTTEST: tests/aws_lambda_function

TEARDOWN: tests/aws_lambda_function

SUMMARY:

1/1 passed.


```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> select jsonb_pretty(code) from aws_lambda_function
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| jsonb_pretty                                                                                                                                                                                                        
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| {                                                                                                                                                                                                                   
|     "ImageUri": null,                                                                                                                                                                                               
|     "Location": "https://prod-04-2014-tasks.s3.us-east-1.amazonaws.com/snapshots/533793682495/test-delete-57ba0b83-2247-4227-abd3-fd2547312966?versionId=9AwCseksMkk17qs5drOj4IQuh_gMmJ0B&X-Amz-Security-Token=IQoJb
| V%2BCh4JuSWh9arTk3%2BktUu3qpgQKtpzsuvdZmoAFQb45pX76%2FPwNUzrVxXCw67nzYbHy7sPRro86FfQaRj4%2FqmAeP7I9RNLDvbb6FkBAA3aj6OitAWAJ4lr%2BFt2QZDXwCtHxC94PykrZF1k6NARGGEIFn9g0oWJ2lL23IiZem5Ywys3bmAY6qQG3oRoykpMxiy4hHNugp1W
|     "RepositoryType": "S3",                                                                                                                                                                                         
|     "ResolvedImageUri": null                                                                                                                                                                                        
| }                                                                                                                                                                                                                   
| {                                                                                                                                                                                                                   
|     "ImageUri": null,                                                                                                                                                                                               
|     "Location": "https://prod-04-2014-tasks.s3.us-east-1.amazonaws.com/snapshots/533793682495/tets-65606a2d-f94f-43d9-87c2-0559565718a3?versionId=WRNTBVPOsl2usSyXlOBrW_obAjfZcxhy&X-Amz-Security-Token=IQoJb3JpZ2lu
| e7msaoQqqazaaUW8bKXi9ckpOps%2B8Ys0CzYna0lN2UcYEryhahkHFrMdY6zNGbva36C3JxzIT3u0lak8MGTMA4DmsElUS3zwRyJ91EdaSbKydV%2FGqGVZha6TF6ClpcFsAOyAz8Qgxu%2BL8a3kWbnn0ei7m8rTqcQnodjPHxCunzDf29uYBjqqAeW9ScaqegrEjR0CByafO0eRwq
|     "RepositoryType": "S3",                                                                                                                                                                                         
|     "ResolvedImageUri": null                                                                                                                                                                                        
| }                                                                                                                                                                                                                   
| {                                                                                                                                                                                                                   
|     "ImageUri": null,                                                                                                                                                                                               
|     "Location": "https://prod-04-2014-tasks.s3.us-east-1.amazonaws.com/snapshots/533793682495/LogsToElasticsearch_tets-41608860-2700-4a7f-beb9-ba302497cdac?versionId=JdcgZ6ohtoKjKuNn14ME9DzVFaip2njA&X-Amz-Securit
| uGAvA5bKjqy1LbUOMCL7bU8uC8GfZKP9KjESdsRujwUmpjUGwUV9nJUAE9ie4IfrM57Ho5l%2FkeoAA0OtwtDqisCcPVe4RZzbChiMVDf2IwvqTEwKXnaKkq3Jn3uX%2BFCI1bT1q2qbfOXPF7s%2FfHQzpyNiaPBAMqio6ZEoFkxjhsKXb%2BReuMaDbBUe6hqQ9L5WZYGCegQ3PAHZ
|     "RepositoryType": "S3",                                                                                                                                                                                         
|     "ResolvedImageUri": null                                                                                                                                                                                        
| }                                                                                                                                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
</details>
