### PR TITLE
feat: add ecr image finding table

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -164,6 +164,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_ec2_transit_gateway_route_table":                          tableAwsEc2TransitGatewayRouteTable(ctx),
 			"aws_ec2_transit_gateway_vpc_attachment":                       tableAwsEc2TransitGatewayVpcAttachment(ctx),
 			"aws_ecr_image":                                                tableAwsEcrImage(ctx),
+			"aws_ecr_image_scan_finding":                                   tableAwsEcrImageScanFinding(ctx),
 			"aws_ecr_repository":                                           tableAwsEcrRepository(ctx),
 			"aws_ecrpublic_repository":                                     tableAwsEcrpublicRepository(ctx),
 			"aws_ecs_cluster":                                              tableAwsEcsCluster(ctx),

--- a/docs/tables/aws_ecr_image_scan_finding.md
+++ b/docs/tables/aws_ecr_image_scan_finding.md
@@ -1,0 +1,77 @@
+# Table: aws_ecr_image_finding
+
+Amazon Elastic Container Registry (Amazon ECR) stores Docker images and allows you to scan them on push, or periodically.
+The corresponding CVE findings are available in this table for an image tag, in a repository.
+
+## Examples
+
+### Get CVEs count from an image tag scan, group by severity
+
+```sql
+select
+  repository_name,
+  image_tag,
+  image_digest,
+  image_scan_status,
+  image_scan_completed_at,
+  vulnerability_source_updated_at,
+  severity,
+  count(*) as nb 
+from
+  aws_ecr_image_scan_finding 
+where
+  repository_name = 'my-repo' 
+  and image_tag = 'my-image-tag' 
+group by
+  1,
+  2,
+  3,
+  4,
+  5,
+  6,
+  7
+```
+
+### Get details from an image tag scan
+
+```sql
+select
+  repository_name,
+  image_tag,
+  image_digest,
+  image_scan_status,
+  image_scan_completed_at,
+  vulnerability_source_updated_at,
+  severity,
+  name,
+  description,
+  attributes,
+  uri 
+from
+  aws_ecr_image_scan_finding 
+where
+  repository_name = 'my-repo' 
+  and image_tag = 'my-image-tag'
+```
+
+### Get CVEs for all images pushed in the last 24 hours
+
+```sql
+select
+  findings.* 
+from
+  (
+    select
+      repository_name,
+      jsonb_array_elements_text(image_tags) as image_tag 
+    from
+      aws_ecr_image i 
+    where
+      i.image_pushed_at > now() - interval '24' hour 
+  )
+  images 
+  left outer join
+    aws_ecr_image_scan_finding findings 
+    on images.repository_name = findings.repository_name 
+    and images.image_tag = findings.image_tag
+```


### PR DESCRIPTION
This table is used to get findings on a specific tag, in a specific repository allowing joins with others data sources

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example ecr image tag findings

``` sql
select 
    repository_name
    ,image_tag
    ,image_scan_completed_at
    ,vulnerability_source_updated_at
    ,finding
    ,partition
    ,repository_name
    ,account_id
from services.aws_ecr_image_findings where repository_name = 'my-ecr-repository-name' and image_tag = 'v1.0.0'
```

# Get findings on images tags pushed in the last 24 hours

```sql
select
    finding.*
from (
    select
        repository_name
        ,jsonb_array_elements_text(image_tags) as image_tag
    from services.aws_ecr_image i
    where
        i.image_pushed_at > now() - interval '24' hour
) images
left outer join services.aws_ecr_image_findings finding
on images.repository_name = finding.repository_name and images.image_tag = finding.image_tag
```