### PR TITLE
Removes error check for missing regions

### DIFF
--- a/aws/connection_config.go
+++ b/aws/connection_config.go
@@ -1,8 +1,6 @@
 package aws
 
 import (
-	"fmt"
-
 	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v4/plugin/schema"
 )
@@ -65,12 +63,5 @@ func GetConfig(connection *plugin.Connection) awsConfig {
 		return awsConfig{}
 	}
 	config, _ := connection.Config.(awsConfig)
-
-	// Setting "regions = []" in the connection config is not valid
-	if len(config.Regions) == 0 {
-		errorMessage := fmt.Sprintf("\nconnection %s has invalid value for \"regions\", it must contain at least 1 region.", connection.Name)
-		panic(errorMessage)
-	}
-
 	return config
 }


### PR DESCRIPTION
This PR reverts commit 08d619d0b4e35d8e5e4ab832ec2d01d2ccbf3730 which added a check for empty AWS regions list. Unfortunately, this broke the fallback options for defining regions elsewhere, such as the profiles and `AWS_REGION` env var, and made `regions` a required option.

