### PR TITLE
Fix FSx, Inspector, KMS and Lambda tables to return null for unsupported regions

### DIFF
--- a/aws/service_v2.go
+++ b/aws/service_v2.go
@@ -74,9 +74,9 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
 
 	fsxEndpoint "github.com/aws/aws-sdk-go/service/fsx"
-	lambdaEndpoint "github.com/aws/aws-sdk-go/service/lambda"
-	kmsEndpoint "github.com/aws/aws-sdk-go/service/kms"
 	inspectorEndpoint "github.com/aws/aws-sdk-go/service/inspector"
+	kmsEndpoint "github.com/aws/aws-sdk-go/service/kms"
+	lambdaEndpoint "github.com/aws/aws-sdk-go/service/lambda"
 )
 
 // https://github.com/aws/aws-sdk-go-v2/issues/543
@@ -467,7 +467,7 @@ func IAMClient(ctx context.Context, d *plugin.QueryData) (*iam.Client, error) {
 }
 
 func InspectorClient(ctx context.Context, d *plugin.QueryData) (*inspector.Client, error) {
-	cfg, err := getClientForQuerySupportedRegion(ctx, d, inspector.EndpointsID)
+	cfg, err := getClientForQuerySupportedRegion(ctx, d, inspectorEndpoint.EndpointsID)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/service_v2.go
+++ b/aws/service_v2.go
@@ -471,6 +471,9 @@ func InspectorClient(ctx context.Context, d *plugin.QueryData) (*inspector.Clien
 	if err != nil {
 		return nil, err
 	}
+	if cfg == nil {
+		return nil, nil
+	}
 	return inspector.NewFromConfig(*cfg), nil
 }
 

--- a/aws/service_v2.go
+++ b/aws/service_v2.go
@@ -75,6 +75,8 @@ import (
 
 	fsxEndpoint "github.com/aws/aws-sdk-go/service/fsx"
 	lambdaEndpoint "github.com/aws/aws-sdk-go/service/lambda"
+	kmsEndpoint "github.com/aws/aws-sdk-go/service/kms"
+	inspectorEndpoint "github.com/aws/aws-sdk-go/service/inspector"
 )
 
 // https://github.com/aws/aws-sdk-go-v2/issues/543
@@ -465,7 +467,7 @@ func IAMClient(ctx context.Context, d *plugin.QueryData) (*iam.Client, error) {
 }
 
 func InspectorClient(ctx context.Context, d *plugin.QueryData) (*inspector.Client, error) {
-	cfg, err := getClientForQueryRegion(ctx, d)
+	cfg, err := getClientForQuerySupportedRegion(ctx, d, inspector.EndpointsID)
 	if err != nil {
 		return nil, err
 	}
@@ -484,7 +486,7 @@ func KafkaClient(ctx context.Context, d *plugin.QueryData) (*kafka.Client, error
 }
 
 func KMSClient(ctx context.Context, d *plugin.QueryData) (*kms.Client, error) {
-	cfg, err := getClientForQuerySupportedRegion(ctx, d, "kms")
+	cfg, err := getClientForQuerySupportedRegion(ctx, d, kmsEndpoint.EndpointsID)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/table_aws_fsx_file_system.go
+++ b/aws/table_aws_fsx_file_system.go
@@ -167,6 +167,11 @@ func listFsxFileSystems(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		return nil, err
 	}
 
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
 	// https://docs.aws.amazon.com/fsx/latest/APIReference/API_DescribeFileSystems.html
 	maxItems := int32(1000)
 	input := fsx.DescribeFileSystemsInput{}
@@ -218,6 +223,11 @@ func getFsxFileSystem(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_fsx_file_system.getFsxFileSystem", "connection_error", err)
 		return nil, err
+	}
+
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
 	}
 
 	quals := d.KeyColumnQuals

--- a/aws/table_aws_inspector_assessment_template.go
+++ b/aws/table_aws_inspector_assessment_template.go
@@ -250,6 +250,11 @@ func getAwsInspectorAssessmentTemplateTags(ctx context.Context, d *plugin.QueryD
 		plugin.Logger(ctx).Error("aws_inspector_assessment_template.getAwsInspectorAssessmentTemplateTags", "connection_error", err)
 		return nil, err
 	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
 
 	// Build the params
 	params := &inspector.ListTagsForResourceInput{
@@ -277,6 +282,12 @@ func listAwsInspectorAssessmentEventSubscriptions(ctx context.Context, d *plugin
 		plugin.Logger(ctx).Error("aws_inspector_assessment_template.listAwsInspectorAssessmentEventSubscriptions", "connection_error", err)
 		return nil, err
 	}
+
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
 
 	// Build the params
 	params := &inspector.ListEventSubscriptionsInput{

--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -191,6 +191,11 @@ func listKmsKeys(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 		return nil, err
 	}
 
+	if svc == nil {
+		// Unsupported region check
+		return nil, nil
+	}
+
 	maxItems := int32(1000)
 	input := &kms.ListKeysInput{}
 
@@ -248,6 +253,11 @@ func getKmsKey(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) 
 		return nil, err
 	}
 
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
 	params := &kms.DescribeKeyInput{
 		KeyId: aws.String(keyID),
 	}
@@ -276,6 +286,11 @@ func getAwsKmsKeyData(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		return nil, err
 	}
 
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
 	params := &kms.DescribeKeyInput{
 		KeyId: key.KeyId,
 	}
@@ -297,6 +312,11 @@ func getAwsKmsKeyRotationStatus(ctx context.Context, d *plugin.QueryData, h *plu
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_kms_key.getAwsKmsKeyRotationStatus", "connection_error", err)
 		return nil, err
+	}
+
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
 	}
 
 	params := &kms.GetKeyRotationStatusInput{
@@ -326,6 +346,11 @@ func getAwsKmsKeyTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_kms_key.getAwsKmsKeyTagging", "connection_error", err)
 		return nil, err
+	}
+
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
 	}
 
 	tagsData := map[string]interface{}{}
@@ -369,6 +394,11 @@ func getAwsKmsKeyAliases(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_kms_key.getAwsKmsKeyAliases", "connection_error", err)
 		return nil, err
+	}
+
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
 	}
 
 	params := &kms.ListAliasesInput{
@@ -417,6 +447,11 @@ func getAwsKmsKeyPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_kms_key.getAwsKmsKeyPolicy", "connection_error", err)
 		return nil, err
+	}
+
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
 	}
 
 	params := &kms.GetKeyPolicyInput{

--- a/aws/table_aws_lambda_alias.go
+++ b/aws/table_aws_lambda_alias.go
@@ -209,6 +209,11 @@ func getLambdaAlias(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 		return nil, err
 	}
 
+	if svc == nil {
+		// unsupported region check
+		return nil, nil
+	}
+
 	// Build params
 	params := &lambda.GetAliasInput{
 		FunctionName: aws.String(functionName),
@@ -233,6 +238,12 @@ func getLambdaAliasPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		plugin.Logger(ctx).Error("aws_lambda_function.getLambdaAliasPolicy", "connection_error", err)
 		return nil, err
 	}
+
+	if svc == nil {
+		// unsupported region check
+		return nil, nil
+	}
+
 	qualifier := getAliasQualifier(h.Item)
 
 	input := &lambda.GetPolicyInput{
@@ -265,6 +276,12 @@ func getLambdaAliasUrlConfig(ctx context.Context, d *plugin.QueryData, h *plugin
 		plugin.Logger(ctx).Error("aws_lambda_function.getLambdaAliasUrlConfig", "connection_error", err)
 		return nil, err
 	}
+
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
 	qualifier := getAliasQualifier(h.Item)
 	input := &lambda.GetFunctionUrlConfigInput{
 		FunctionName: alias.FunctionName,

--- a/aws/table_aws_lambda_function.go
+++ b/aws/table_aws_lambda_function.go
@@ -368,6 +368,11 @@ func getFunctionPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 		return nil, err
 	}
 
+	if svc == nil {
+		// unsupported region check
+		return nil, nil
+	}
+
 	input := &lambda.GetPolicyInput{
 		FunctionName: aws.String(functionName),
 	}
@@ -407,6 +412,11 @@ func getLambdaFunctionUrlConfig(ctx context.Context, d *plugin.QueryData, h *plu
 	svc, err := LambdaClient(ctx, d)
 	if err != nil {
 		return nil, err
+	}
+
+	if svc == nil {
+		// unsupported region check
+		return nil, nil
 	}
 
 	input := &lambda.GetFunctionUrlConfigInput{

--- a/aws/table_aws_lambda_layer.go
+++ b/aws/table_aws_lambda_layer.go
@@ -100,6 +100,11 @@ func listLambdaLayers(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		return nil, err
 	}
 
+	if svc == nil {
+		// unsupported region check
+		return nil, nil
+	}
+
 	// Set MaxItems to the maximum number allowed
 	maxItems := int32(50)
 	input := lambda.ListLayersInput{}

--- a/aws/table_aws_lambda_layer_version.go
+++ b/aws/table_aws_lambda_layer_version.go
@@ -141,6 +141,11 @@ func listLambdaLayerVersions(ctx context.Context, d *plugin.QueryData, h *plugin
 		return nil, err
 	}
 
+	if svc == nil {
+		// unsupported region check
+		return nil, nil
+	}
+
 	equalQuals := d.KeyColumnQuals
 	// Minimize the API call with the given layer name
 	if equalQuals["layer_name"] != nil {
@@ -254,6 +259,11 @@ func getLambdaLayerVersion(ctx context.Context, d *plugin.QueryData, h *plugin.H
 		return nil, err
 	}
 
+	if svc == nil {
+		// unsupported region check
+		return nil, nil
+	}
+
 	// Build the params
 	params := &lambda.GetLayerVersionInput{
 		LayerName:     aws.String(layerName),
@@ -287,6 +297,11 @@ func getLambdaLayerVersionPolicy(ctx context.Context, d *plugin.QueryData, h *pl
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_lambda_layer_version.getLambdaLayerVersionPolicy", "connection_error", err)
 		return nil, err
+	}
+
+	if svc == nil {
+		// unsupported region check
+		return nil, nil
 	}
 
 	// Build the params

--- a/aws/table_aws_lambda_version.go
+++ b/aws/table_aws_lambda_version.go
@@ -188,6 +188,11 @@ func listLambdaVersions(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 		return nil, err
 	}
 
+	if svc == nil {
+		// unsupported region check
+		return nil, nil
+	}
+
 	equalQuals := d.KeyColumnQuals
 
 	// Minimize the API call with the given function name
@@ -261,6 +266,11 @@ func getFunctionVersion(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		return nil, err
 	}
 
+	if svc == nil {
+		// unsupported region check
+		return nil, nil
+	}
+
 	input := &lambda.ListVersionsByFunctionInput{
 		FunctionName: aws.String(functionName),
 	}
@@ -295,6 +305,11 @@ func getFunctionVersionPolicy(ctx context.Context, d *plugin.QueryData, h *plugi
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_lambda_function.getFunctionVersionPolicy", "connection_error", err)
 		return nil, err
+	}
+
+	if svc == nil {
+		// unsupported region check
+		return nil, nil
 	}
 
 	input := &lambda.GetPolicyInput{


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
