### PR TITLE
Fix typo and formatting in aws_cost_usage table

### DIFF
--- a/docs/tables/aws_cost_usage.md
+++ b/docs/tables/aws_cost_usage.md
@@ -1,6 +1,6 @@
 # Table: aws_cost_usage
 
-Amazon Cost Explorer helps you visualize, understand, and manage your AWS costs and usage.  The `aws_cost_usage` table provides a simplified yet flexible view of cost for your account (or all linked accounts when run against the organization master).  You must specify a granularity (`MONTHLY`, `DAILY`), and 2 dimension types (`AZ` , `INSTANCE_TYPE`, `LEGAL_ENTITY_NAME`, `LINKED_ACCOUNT`, `OPERATION`, `PLATFORM`, `PURCHASE_TYPE`, `SERVICE`, `TAGS`, `TENANCY`, `RECORD_TYPE`, and `USAGE_TYPE`)
+Amazon Cost Explorer helps you visualize, understand, and manage your AWS costs and usage.  The `aws_cost_usage` table provides a simplified yet flexible view of cost for your account (or all linked accounts when run against the organization master).  You must specify a granularity (`MONTHLY`, `DAILY`), and 2 dimension types (`AZ` , `INSTANCE_TYPE`, `LEGAL_ENTITY_NAME`, `LINKED_ACCOUNT`, `OPERATION`, `PLATFORM`, `PURCHASE_TYPE`, `SERVICE`, `TENANCY`, `RECORD_TYPE`, and `USAGE_TYPE`)
 
 This tables requires an '=' qualifier for all of the following columns: granularity,dimension_type_1,dimension_type_2
 
@@ -9,15 +9,16 @@ Note that [pricing for the Cost Explorer API](https://aws.amazon.com/aws-cost-ma
 ## Examples
 
 ### Monthly net unblended cost by account and service
+
 ```sql
-select 
+select
   period_start,
   dimension_1 as account_id,
   dimension_2 as service_name,
   net_unblended_cost_amount::numeric::money
-from 
-  aws_cost_usage 
-where 
+from
+  aws_cost_usage
+where
   granularity = 'MONTHLY'
   and dimension_type_1 = 'LINKED_ACCOUNT'
   and dimension_type_2 = 'SERVICE'
@@ -27,23 +28,23 @@ order by
 ```
 
 ### Top 5 most expensive services (net unblended cost) in each account
+
 ```sql
 with ranked_costs as (
-  select 
+  select
     dimension_1 as account_id,
     dimension_2 as service_name,
     sum(net_unblended_cost_amount)::numeric::money as net_unblended_cost,
     rank() over(partition by dimension_1 order by sum(net_unblended_cost_amount) desc)
-
-  from 
-    aws_cost_usage 
-  where 
+  from
+    aws_cost_usage
+  where
     granularity = 'MONTHLY'
     and dimension_type_1 = 'LINKED_ACCOUNT'
     and dimension_type_2 = 'SERVICE'
   group by
-  dimension_1,
-  dimension_2
+    dimension_1,
+    dimension_2
   order by
     dimension_1,
     net_unblended_cost desc
@@ -51,18 +52,17 @@ with ranked_costs as (
 select * from ranked_costs where rank <=5
 ```
 
-
 ### Monthly net unblended cost by account and record type
 
 ```sql
-select 
+select
   period_start,
   dimension_1 as account_id,
   dimension_2 as record_type,
   net_unblended_cost_amount::numeric::money
-from 
-  aws_cost_usage 
-where 
+from
+  aws_cost_usage
+where
   granularity = 'MONTHLY'
   and dimension_type_1 = 'LINKED_ACCOUNT'
   and dimension_type_2 = 'RECORD_TYPE'
@@ -71,19 +71,17 @@ order by
   period_start;
 ```
 
-
-
-### List monthly discounts and credits by account 
+### List monthly discounts and credits by account
 
 ```sql
-select 
+select
   period_start,
   dimension_1 as account_id,
   dimension_2 as record_type,
   net_unblended_cost_amount::numeric::money
-from 
-  aws_cost_usage 
-where 
+from
+  aws_cost_usage
+where
   granularity = 'MONTHLY'
   and dimension_type_1 = 'LINKED_ACCOUNT'
   and dimension_type_2 = 'RECORD_TYPE'


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>

This PR corrects a mistake in the documentation of the `aws_cost_usage` table, where the valid values of the `dimension_*` columns included `TAGS` as a valid value. However, as per [AWS](https://docs.aws.amazon.com/aws-cost-management/latest/APIReference/API_GetCostAndUsage.html), the columns don't support `TAGS` and can be misleading as mentioned in https://github.com/turbot/steampipe-plugin-aws/issues/1342