### PR TITLE
Update `aws_ebs_volume` table docs to handle the `attachments` column correctly when empty in the `aws_ebs_volume` table closes #1366

### DIFF
--- a/docs/tables/aws_ebs_volume.md
+++ b/docs/tables/aws_ebs_volume.md
@@ -16,7 +16,6 @@ where
   not encrypted;
 ```
 
-
 ### List of unattached EBS volumes
 
 ```sql
@@ -26,9 +25,8 @@ select
 from
   aws_ebs_volume
 where
-  attachments is null;
+  jsonb_array_length(attachments) = 0;
 ```
-
 
 ### List of Provisioned IOPS SSD (io1) volumes
 
@@ -42,7 +40,6 @@ where
   volume_type = 'io1';
 ```
 
-
 ### List of EBS volumes with size more than 100GiB
 
 ```sql
@@ -55,7 +52,6 @@ where
   size > '100';
 ```
 
-
 ### Count the number of EBS volumes by volume type
 
 ```sql
@@ -67,7 +63,6 @@ from
 group by
   volume_type;
 ```
-
 
 ### Find EBS Volumes Attached To Stopped EC2 Instances
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
