### PR TITLE
feat: add aws_pricing_product table

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -274,6 +274,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_opensearch_domain":                                        tableAwsOpenSearchDomain(ctx),
 			"aws_organizations_account":                                    tableAwsOrganizationsAccount(ctx),
 			"aws_pinpoint_app":                                             tableAwsPinpointApp(ctx),
+			"aws_pricing_product":                                          tableAwsPricingProduct(ctx),
 			"aws_pricing_service_attribute":                                tableAwsPricingServiceAttribute(ctx),
 			"aws_ram_principal_association":                                tableAwsRAMPrincipalAssociation(ctx),
 			"aws_ram_resource_association":                                 tableAwsRAMResourceAssociation(ctx),

--- a/aws/service.go
+++ b/aws/service.go
@@ -852,7 +852,10 @@ func PinpointClient(ctx context.Context, d *plugin.QueryData) (*pinpoint.Client,
 }
 
 func PricingServiceClient(ctx context.Context, d *plugin.QueryData) (*pricing.Client, error) {
-	cfg, err := getClient(ctx, d, getDefaultAwsRegion(d))
+	// Pricing API is a global API that supports only us-east-1 and ap-south-1 regions
+	// getDefaultAwsRegion doesn't return the good region at the moment (it should use specified API endpoints but it doesn't).
+	// Set us-east-1 for now
+	cfg, err := getClient(ctx, d, "us-east-1")
 	if err != nil {
 		return nil, err
 	}

--- a/aws/table_aws_pricing_product.go
+++ b/aws/table_aws_pricing_product.go
@@ -216,8 +216,11 @@ func extractCurrency(_ context.Context, d *transform.TransformData) (interface{}
 
 // build pricing list call input filter
 func buildPricingFilter(qual *plugin.KeyColumnQuals) ([]types.Filter, error) {
-	filters := make([]types.Filter, 0)
+	if qual == nil {
+		return nil, nil
+	}
 
+	filters := make([]types.Filter, 0)
 	for _, qual := range qual.Quals {
 		qualFilter := make(map[string]*string)
 		err := json.Unmarshal([]byte(qual.Value.GetJsonbValue()), &qualFilter)

--- a/aws/table_aws_pricing_product.go
+++ b/aws/table_aws_pricing_product.go
@@ -1,0 +1,238 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/aws/aws-sdk-go-v2/service/pricing"
+	"github.com/aws/aws-sdk-go-v2/service/pricing/types"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin/transform"
+	"time"
+
+	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
+)
+
+//// TABLE DEFINITION
+
+func tableAwsPricingProduct(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_pricing_product",
+		Description: "AWS Pricing Product",
+		List: &plugin.ListConfig{
+			Hydrate: listPricingProduct,
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "service_code", Require: plugin.Required},
+				{Name: "filters", Require: plugin.Optional, CacheMatch: "exact"},
+			},
+		},
+		Columns: awsDefaultColumns([]*plugin.Column{
+			{Name: "rate_code", Description: "A unique code for a product/ offer/ pricing-tier combination.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.RateCode")},
+			{Name: "service_code", Description: "This identifies the specific AWS service to the customer as a unique short abbreviation.", Type: proto.ColumnType_STRING, Transform: transform.FromField("ServiceCode")},
+			{Name: "term", Description: "Whether your AWS usage is Reserved or On-Demand.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.Term")},
+			{Name: "purchase_option", Description: "How you chose to pay for this line item (All Upfront, Partial Upfront, No Upfront).", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.TermAttributes.PurchaseOption")},
+			{Name: "lease_contract_length", Description: "The length of time that your RI is reserved for.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.TermAttributes.LeaseContractLength")},
+			{Name: "description", Description: "Description for a product / offer / pricing-tier combination.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.Description")},
+			{Name: "begin_range", Description: "Start of billing range, by unit", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.BeginRange")},
+			{Name: "end_range", Description: "Enf of billing range, by unit", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.EndRange")},
+			{Name: "unit", Description: "The pricing unit that AWS used for calculating your usage cost (ex: hours)", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.Unit")},
+			{Name: "price_per_unit", Description: "Price by unit", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.PricePerUnit").Transform(extractPricePerUnit)},
+			{Name: "currency", Description: "Currency used for the price", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.PricePerUnit").Transform(extractCurrency)},
+			{Name: "publication_date", Description: "The publication date of the offer.", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("PublicationDate")},
+			{Name: "effective_date", Description: "The effective date of the pricing details.", Type: proto.ColumnType_TIMESTAMP, Transform: transform.FromField("Offer.EffectiveDate")},
+			{Name: "version", Description: "The publication version of the offer.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Version")},
+			// product attributes
+			{Name: "attributes", Description: "Product attributes.", Type: proto.ColumnType_JSON, Transform: transform.FromField("Product.Attributes")},
+			// product attributes filters
+			{Name: "filters", Description: "Product filtering by attribute.", Type: proto.ColumnType_JSON, Transform: transform.FromQual("filters")},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+type Product struct {
+	_             struct{} `type:"structure"`
+	ProductFamily *string
+	Attributes    map[string]*string
+}
+
+type Term map[string]*Offer
+
+type PriceDimension struct {
+	Unit         *string
+	BeginRange   *string
+	EndRange     *string
+	Description  *string
+	RateCode     *string
+	PricePerUnit map[string]*string
+}
+
+type TermAttributes struct {
+	_                   struct{} `type:"structure"`
+	PurchaseOption      *string
+	LeaseContractLength *string
+}
+
+type Offer struct {
+	_               struct{} `type:"structure"`
+	PriceDimensions map[string]*PriceDimension
+	EffectiveDate   *time.Time
+	OfferTermCode   *string
+	TermAttributes  *TermAttributes
+}
+
+type PriceList struct {
+	_               struct{} `type:"structure"`
+	Product         *Product
+	ServiceCode     *string
+	Terms           map[string]*Term
+	Version         *string
+	PublicationDate *time.Time
+}
+
+func listPricingProduct(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	// Create Session
+	svc, err := PricingServiceClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_pricing_product.listPricingProduct", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	// Limiting the results
+	maxItems := int32(100)
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxItems {
+			if limit < 20 {
+				maxItems = 20
+			} else {
+				maxItems = limit
+			}
+		}
+	}
+
+	equalQual := d.KeyColumnQuals
+	input := pricing.GetProductsInput{
+		ServiceCode:   aws.String(equalQual["service_code"].GetStringValue()),
+		FormatVersion: aws.String("aws_v1"),
+		MaxResults:    maxItems,
+	}
+
+	type OfferOutput struct {
+		_              struct{} `type:"structure"`
+		PriceDimension *PriceDimension
+		Term           string
+		EffectiveDate  *time.Time
+		OfferTermCode  *string
+		TermAttributes *TermAttributes
+	}
+
+	type PriceOutput struct {
+		_               struct{} `type:"structure"`
+		Product         *Product
+		ServiceCode     *string
+		Offer           *OfferOutput
+		Version         *string
+		PublicationDate *time.Time
+	}
+
+	filters, err := buildPricingFilter(d.Quals["filters"])
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_pricing_product.listPricingProduct", "filters_building_error", err)
+		return nil, err
+	}
+
+	if len(filters) > 0 {
+		input.Filters = filters
+	}
+
+	paginator := pricing.NewGetProductsPaginator(svc, &input, func(o *pricing.GetProductsPaginatorOptions) {
+		o.Limit = maxItems
+		o.StopOnDuplicateToken = true
+	})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_pricing_product.listPricingProduct", "api_error", err)
+			return nil, err
+		}
+
+		for _, priceList := range output.PriceList {
+			var priceListObject PriceList
+
+			err = json.Unmarshal([]byte(priceList), &priceListObject)
+			if err != nil {
+				plugin.Logger(ctx).Error("aws_pricing_product.listPricingProduct", "unmarshal_err", err)
+				return nil, err
+			}
+
+			for term, termDetail := range priceListObject.Terms {
+				for _, offer := range *termDetail {
+					for _, priceDimension := range offer.PriceDimensions {
+						d.StreamListItem(ctx, PriceOutput{
+							Product:         priceListObject.Product,
+							ServiceCode:     priceListObject.ServiceCode,
+							Version:         priceListObject.Version,
+							PublicationDate: priceListObject.PublicationDate,
+							Offer:           &OfferOutput{PriceDimension: priceDimension, Term: term, EffectiveDate: offer.EffectiveDate, OfferTermCode: offer.OfferTermCode, TermAttributes: offer.TermAttributes},
+						})
+					}
+				}
+			}
+
+			// Context may get cancelled due to manual cancellation or if the limit has been reached
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+func extractPricePerUnit(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	priceMap := d.Value.(map[string]*string)
+
+	for _, units := range priceMap {
+		return units, nil
+	}
+	return nil, nil
+}
+
+func extractCurrency(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	priceMap := d.Value.(map[string]*string)
+
+	for currency := range priceMap {
+		return currency, nil
+	}
+	return nil, nil
+}
+
+// build pricing list call input filter
+func buildPricingFilter(qual *plugin.KeyColumnQuals) ([]types.Filter, error) {
+	filters := make([]types.Filter, 0)
+
+	for _, qual := range qual.Quals {
+		qualFilter := make(map[string]*string)
+		err := json.Unmarshal([]byte(qual.Value.GetJsonbValue()), &qualFilter)
+		if err != nil {
+			return nil, err
+		}
+
+		for attributeName, attributeValue := range qualFilter {
+			filter := types.Filter{
+				Field: aws.String(attributeName),
+				Type:  types.FilterTypeTermMatch,
+			}
+			filter.Value = attributeValue
+			filters = append(filters, filter)
+		}
+	}
+	return filters, nil
+}

--- a/docs/tables/aws_pricing_product.md
+++ b/docs/tables/aws_pricing_product.md
@@ -1,0 +1,91 @@
+# Table: aws_pricing_product
+
+Returns costs, and offer definition, for the corresponding service.
+
+## Examples
+
+### List pricing offers for on-demand shared EC2 c5.2xlarge without pre-installed software, with Linux OS
+
+```sql
+select
+  term,
+  purchase_option,
+  lease_contract_length,
+  unit,
+  price_per_unit::numeric::money,
+  currency,
+  begin_range,
+  end_range,
+  effective_date,
+  description,
+  attributes ->> 'instanceType',
+  attributes ->> 'vcpu',
+  attributes ->> 'memory',
+  attributes ->> 'operatingSystem',
+  attributes ->> 'preInstalledSw'
+from
+  aws_pricing_product 
+where
+  service_code = 'AmazonEC2' 
+  and filters = '{
+  "regionCode": "eu-west-3",
+  "locationType": "AWS Region",
+  "instanceType": "c5.2xlarge",
+  "operatingSystem": "Linux",
+  "tenancy": "Shared",
+  "preInstalledSw": "NA",
+  "capacityStatus": "Used" }'::jsonb;
+```
+
+
+### List pricing offers for Mysql RDS db.m5.xlarge instance in eu-west-3 in single-az deployment
+
+```sql
+select
+  term,
+  purchase_option,
+  lease_contract_length,
+  unit,
+  price_per_unit::numeric::money,
+  currency,
+  attributes ->> 'instanceType',
+  attributes ->> 'vcpu',
+  attributes ->> 'memory',
+  attributes ->> 'databaseEngine',
+  attributes ->> 'deploymentOption' 
+from
+  aws_pricing_product 
+where
+  service_code = 'AmazonRDS' 
+  and filters = '{
+  "regionCode": "eu-west-3",
+  "locationType": "AWS Region",
+  "instanceType": "db.m5.xlarge",
+  "databaseEngine": "MySQL",
+  "deploymentOption": "Single-AZ" }'::jsonb;
+```
+
+### List pricing offers for Redis ElasticCache cache.m5.xlarge instances in eu-west-3
+
+```sql
+select
+  term,
+  purchase_option,
+  lease_contract_length,
+  unit,
+  price_per_unit::numeric::money,
+  currency,
+  attributes ->> 'instanceType',
+  attributes ->> 'vcpu',
+  attributes ->> 'memory',
+  attributes ->> 'cacheEngine' 
+from
+  aws_pricing_product 
+where
+  service_code = 'AmazonElastiCache' 
+  and filters = '{
+  "regionCode": "eu-west-3",
+  "locationType": "AWS Region",
+  "instanceType": "cache.m5.xlarge",
+  "cacheEngine": "Redis" }'::jsonb;
+```


### PR DESCRIPTION
# Context

Allowing usage of aws pricing API

</details>

# Example query results
<details>
  <summary>Results</summary>

```
select
    service_code,
    instance_type,
    cache_engine,
    term,
    purchase_option,
    lease_contract_length,
    description,
    price_per_unit,
    currency
from
    aws_pricing_product
where
    service_code = 'AmazonElastiCache'
  and region_code = 'eu-west-3'
  and location_type = 'AWS Region'
  and instance_type = 'cache.m5.xlarge'
  and cache_engine = 'Redis';
```

| service\_code     | instance\_type  | cache\_engine | term     | purchase\_option | lease\_contract\_length | description                                             | price\_per\_unit | currency |
| ----------------- | --------------- | ------------- | -------- | ---------------- | ----------------------- | ------------------------------------------------------- | ---------------- | -------- |
| AmazonElastiCache | cache.m5.xlarge | Redis         | Reserved | No Upfront       | 3yr                     | Redis, cache.m5.xlarge reserved instance applied        | 0.1870000000     | USD      |
| AmazonElastiCache | cache.m5.xlarge | Redis         | OnDemand |                  |                         | $0.36 per Gen Purpose M5.xlarge node hour running Redis | 0.3600000000     | USD      |
| AmazonElastiCache | cache.m5.xlarge | Redis         | Reserved | Partial Upfront  | 1yr                     | Redis, cache.m5.xlarge reserved instance applied        | 0.1170000000     | USD      |
| AmazonElastiCache | cache.m5.xlarge | Redis         | Reserved | All Upfront      | 1yr                     | Upfront Fee                                             | 2009             | USD      |
| AmazonElastiCache | cache.m5.xlarge | Redis         | Reserved | All Upfront      | 3yr                     | Redis, cache.m5.xlarge reserved instance applied        | 0.0000000000     | USD      |
| AmazonElastiCache | cache.m5.xlarge | Redis         | Reserved | No Upfront       | 1yr                     | Redis, cache.m5.xlarge reserved instance applied        | 0.2460000000     | USD      |
| AmazonElastiCache | cache.m5.xlarge | Redis         | Reserved | All Upfront      | 1yr                     | Redis, cache.m5.xlarge reserved instance applied        | 0.0000000000     | USD      |
| AmazonElastiCache | cache.m5.xlarge | Redis         | Reserved | Partial Upfront  | 3yr                     | Redis, cache.m5.xlarge reserved instance applied        | 0.0860000000     | USD      |
| AmazonElastiCache | cache.m5.xlarge | Redis         | Reserved | All Upfront      | 3yr                     | Upfront Fee                                             | 4269             | USD      |
| AmazonElastiCache | cache.m5.xlarge | Redis         | Reserved | Partial Upfront  | 3yr                     | Upfront Fee                                             | 2271             | USD      |
| AmazonElastiCache | cache.m5.xlarge | Redis         | Reserved | Partial Upfront  | 1yr                     | Upfront Fee                                             | 1025             | USD      |

</details>
