### PR TITLE
fix: fix invalid pointer usage in aws_pricing_service_attribute which returns randomly the same column

### DIFF
--- a/aws/table_aws_pricing_service_attribute.go
+++ b/aws/table_aws_pricing_service_attribute.go
@@ -46,7 +46,7 @@ func tableAwsPricingServiceAttribute(_ context.Context) *plugin.Table {
 }
 
 type ServiceDetail struct {
-	AttributeName *string
+	AttributeName string
 	ServiceCode   *string
 }
 
@@ -98,7 +98,7 @@ func listPricingServiceAttributes(ctx context.Context, d *plugin.QueryData, _ *p
 
 		for _, items := range output.Services {
 			for _, attributeName := range items.AttributeNames {
-				d.StreamListItem(ctx, ServiceDetail{&attributeName, items.ServiceCode})
+				d.StreamListItem(ctx, ServiceDetail{attributeName, items.ServiceCode})
 			}
 
 			// Context can be cancelled due to manual cancellation or the limit has been hit
@@ -139,7 +139,7 @@ func listAttributeValues(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	}
 
 	input := &pricing.GetAttributeValuesInput{
-		AttributeName: attributeName,
+		AttributeName: &attributeName,
 		ServiceCode:   serviceCode,
 		MaxResults:    maxLimit,
 	}


### PR DESCRIPTION
# Context

Sometimes `aws_pricing_service_attribute" table returns the multiples times the same column.
It seem a pointer shoud not be used in the for loop, before streaming item.

# How to reproduce 

## Before

``` 
 select
service_code, attribute_name
from bedrock_root_us.aws_pricing_service_attribute
where service_code = 'AmazonRDS'
+--------------+----------------+
| service_code | attribute_name |
+--------------+----------------+
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
| AmazonRDS    | operation      |
+--------------+----------------+
```

##  After

```
select
service_code, attribute_name
from bedrock_root_us.aws_pricing_service_attribute
where service_code = 'AmazonRDS'
+--------------+-----------------------------+
| service_code | attribute_name              |
+--------------+-----------------------------+
| AmazonRDS    | operation                   |
| AmazonRDS    | productFamily               |
| AmazonRDS    | volumeType                  |
| AmazonRDS    | deploymentModel             |
| AmazonRDS    | engineCode                  |
| AmazonRDS    | enhancedNetworkingSupported |
| AmazonRDS    | memory                      |
| AmazonRDS    | dedicatedEbsThroughput      |
| AmazonRDS    | vcpu                        |
| AmazonRDS    | OfferingClass               |
| AmazonRDS    | termType                    |
| AmazonRDS    | locationType                |
| AmazonRDS    | storage                     |
| AmazonRDS    | instanceFamily              |
| AmazonRDS    | storageMedia                |
| AmazonRDS    | databaseEdition             |
| AmazonRDS    | regionCode                  |
| AmazonRDS    | acu                         |
| AmazonRDS    | physicalProcessor           |
| AmazonRDS    | LeaseContractLength         |
| AmazonRDS    | clockSpeed                  |
| AmazonRDS    | networkPerformance          |
| AmazonRDS    | deploymentOption            |
| AmazonRDS    | servicename                 |
| AmazonRDS    | PurchaseOption              |
| AmazonRDS    | minVolumeSize               |
| AmazonRDS    | group                       |
| AmazonRDS    | instanceTypeFamily          |
| AmazonRDS    | instanceType                |
| AmazonRDS    | usagetype                   |
| AmazonRDS    | normalizationSizeFactor     |
| AmazonRDS    | maxVolumeSize               |
| AmazonRDS    | engineMediaType             |
| AmazonRDS    | databaseEngine              |
| AmazonRDS    | processorFeatures           |
| AmazonRDS    | Restriction                 |
| AmazonRDS    | servicecode                 |
| AmazonRDS    | groupDescription            |
| AmazonRDS    | licenseModel                |
| AmazonRDS    | currentGeneration           |
| AmazonRDS    | volumeName                  |
| AmazonRDS    | location                    |
| AmazonRDS    | processorArchitecture       |
+--------------+-----------------------------+
```