### PR TITLE
aws_route53_record results incomplete or broken closes #1374

### DIFF
--- a/aws/table_aws_route53_record.go
+++ b/aws/table_aws_route53_record.go
@@ -23,6 +23,7 @@ func tableAwsRoute53Record(_ context.Context) *plugin.Table {
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "zone_id", Require: plugin.Required},
 				{Name: "name", Require: plugin.Optional},
+				{Name: "set_identifier", Require: plugin.Optional},
 				{Name: "type", Require: plugin.Optional},
 			},
 			Hydrate: listRoute53Records,
@@ -170,9 +171,16 @@ func listRoute53Records(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	if equalQuals["name"] != nil {
 		input.StartRecordName = aws.String(equalQuals["name"].GetStringValue())
 
-		// Constraint: Specifying record type without specifying record name returns an InvalidInput error
+		// Specifying record type without specifying record name returns an
+		// InvalidInput error
 		if equalQuals["type"] != nil {
 			input.StartRecordType = route53Types.RRType(equalQuals["type"].GetStringValue())
+
+			// Specifying record identifier without specifying record name and type
+			// returns an InvalidInput error
+			if equalQuals["set_identifier"] != nil {
+				input.StartRecordIdentifier = aws.String(equalQuals["set_identifier"].GetStringValue())
+			}
 		}
 	}
 

--- a/aws/table_aws_route53_record.go
+++ b/aws/table_aws_route53_record.go
@@ -27,7 +27,7 @@ func tableAwsRoute53Record(_ context.Context) *plugin.Table {
 			},
 			Hydrate: listRoute53Records,
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: isNotFoundErrorV2([]string{"NoSuchHostedZone"}),
+				ShouldIgnoreErrorFunc: isNotFoundErrorV2([]string{"NoSuchHostedZone", "InvalidInput"}),
 			},
 		},
 		Columns: awsColumns([]*plugin.Column{
@@ -180,22 +180,6 @@ func listRoute53Records(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		}
 
 		for _, record := range op.ResourceRecordSets {
-			// The StartRecordName and StartRecordType input parameters only tell
-			// the API where to start when returning results, so any records/types
-			// that are greater in lexicographic order will also be returned.
-			// Since Postgres will filter on exact matches anyway, check for exact
-			// matches as an optimization to reduce the number of requests.
-
-			if input.StartRecordName != nil && *record.Name != *input.StartRecordName {
-				plugin.Logger(ctx).Debug("aws_route53_record.listRoute53Records mismatched record name", "input.StartRecordName", *input.StartRecordName, "record.Name", *record.Name)
-				continue
-			}
-
-			if string(input.StartRecordType) != "" && record.Type != input.StartRecordType {
-				plugin.Logger(ctx).Debug("aws_route53_record.listRoute53Records mismatched record type", "input.StartRecordType", input.StartRecordType, "record.Type", record.Type)
-				continue
-			}
-
 			d.StreamListItem(ctx, &recordInfo{&hostedZoneID, record})
 
 			// Context may get cancelled due to manual cancellation or if the limit has been reached

--- a/aws/table_aws_route53_record.go
+++ b/aws/table_aws_route53_record.go
@@ -190,7 +190,7 @@ func listRoute53Records(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		}
 
 		for _, record := range op.ResourceRecordSets {
-			d.StreamListItem(ctx, &recordInfo{&hostedZoneID, record})
+			d.StreamListItem(ctx, &recordInfo{aws.String(hostedZoneID), record})
 
 			// Context may get cancelled due to manual cancellation or if the limit has been reached
 			if d.QueryStatus.RowsRemaining(ctx) == 0 {

--- a/aws/table_aws_route53_record.go
+++ b/aws/table_aws_route53_record.go
@@ -27,7 +27,7 @@ func tableAwsRoute53Record(_ context.Context) *plugin.Table {
 			},
 			Hydrate: listRoute53Records,
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: isNotFoundErrorV2([]string{"NoSuchHostedZone", "InvalidInput"}),
+				ShouldIgnoreErrorFunc: isNotFoundErrorV2([]string{"NoSuchHostedZone"}),
 			},
 		},
 		Columns: awsColumns([]*plugin.Column{
@@ -199,7 +199,15 @@ func listRoute53Records(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 			break
 		}
 
-		input.StartRecordName = op.NextRecordName
+		if op.NextRecordName != nil {
+			input.StartRecordName = op.NextRecordName
+		}
+		if op.NextRecordType != "" {
+			input.StartRecordType = op.NextRecordType
+		}
+		if op.NextRecordIdentifier != nil {
+			input.StartRecordIdentifier = op.NextRecordIdentifier
+		}
 	}
 
 	return nil, nil


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_route53_record []

PRETEST: tests/aws_route53_record

TEST: tests/aws_route53_record
Running terraform
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 1s [id=546902152798]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_eip.named_test_resource will be created
  + resource "aws_eip" "named_test_resource" {
      + allocation_id        = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags_all             = (known after apply)
      + vpc                  = true
    }

  # aws_route53_record.named_test_resource will be created
  + resource "aws_route53_record" "named_test_resource" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "www.turbottest858.com"
      + records         = (known after apply)
      + set_identifier  = "live"
      + ttl             = 300
      + type            = "A"
      + zone_id         = (known after apply)

      + weighted_routing_policy {
          + weight = 90
        }
    }

  # aws_route53_zone.named_test_resource will be created
  + resource "aws_route53_zone" "named_test_resource" {
      + arn                 = (known after apply)
      + comment             = "Managed by Terraform"
      + force_destroy       = true
      + id                  = (known after apply)
      + name                = "turbottest858.com"
      + name_servers        = (known after apply)
      + primary_name_server = (known after apply)
      + tags_all            = (known after apply)
      + zone_id             = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "546902152798"
  + aws_region    = "us-east-1"
  + public_ip     = (known after apply)
  + resource_aka  = (known after apply)
  + resource_name = "turbottest858"
  + zone_id       = (known after apply)
aws_route53_zone.named_test_resource: Creating...
aws_eip.named_test_resource: Creating...
aws_eip.named_test_resource: Creation complete after 1s [id=eipalloc-0e07e2edb3906d9c4]
aws_route53_zone.named_test_resource: Still creating... [10s elapsed]
aws_route53_zone.named_test_resource: Still creating... [20s elapsed]
aws_route53_zone.named_test_resource: Still creating... [30s elapsed]
aws_route53_zone.named_test_resource: Creation complete after 37s [id=Z07244571C5HM5NU19N95]
aws_route53_record.named_test_resource: Creating...
aws_route53_record.named_test_resource: Still creating... [10s elapsed]
aws_route53_record.named_test_resource: Still creating... [20s elapsed]
aws_route53_record.named_test_resource: Still creating... [30s elapsed]
aws_route53_record.named_test_resource: Creation complete after 40s [id=Z07244571C5HM5NU19N95_www.turbottest858.com_A_live]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "546902152798"
aws_region = "us-east-1"
public_ip = "3.209.46.168"
resource_aka = "arn:aws:route53:::hostedzone/Z07244571C5HM5NU19N95/recordset/www.turbottest858.com./A/live"
resource_name = "turbottest858"
zone_id = "Z07244571C5HM5NU19N95"

Running SQL query: test-list-query.sql
[
  {
    "name": "www.turbottest858.com.",
    "records": [
      "3.209.46.168"
    ],
    "set_identifier": "live",
    "ttl": "300",
    "type": "A",
    "weight": 90,
    "zone_id": "Z07244571C5HM5NU19N95"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:route53:::hostedzone/Z07244571C5HM5NU19N95/recordset/www.turbottest858.com./A/live"
    ],
    "title": "www.turbottest858.com."
  }
]
✔ PASSED

POSTTEST: tests/aws_route53_record

TEARDOWN: tests/aws_route53_record

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
      count(*)
      
    from
      aws_route53_zone as aws_prodz,
      aws_route53_record as aws_prodr
    where
      aws_prodr.zone_id = aws_prodz.id
+-------+
| count |
+-------+
| 1508  |
+-------+

> select
      count(*)
      
    from
      aws_old.aws_route53_zone as aws_prodz,
      aws_old.aws_route53_record as aws_prodr
    where
      aws_prodr.zone_id = aws_prodz.id
+-------+
| count |
+-------+
| 1508  |
+-------+
> select
      count(*)
      
    from
      aws_route53_zone as aws_prodz,
      aws_route53_record as aws_prodr
    where
      aws_prodr.zone_id = aws_prodz.id
+-------+
| count |
+-------+
| 1508  |
+-------+

> select
      count(*)
      
    from
      aws_old.aws_route53_zone as aws_prodz,
      aws_old.aws_route53_record as aws_prodr
    where
      aws_prodr.zone_id = aws_prodz.id
+-------+
| count |
+-------+
| 1508  |
+-------+
```
</details>
