### PR TITLE
Security Hub Workflow Status field and filter

### DIFF
--- a/aws/table_aws_securityhub_finding.go
+++ b/aws/table_aws_securityhub_finding.go
@@ -146,7 +146,7 @@ func tableAwsSecurityHubFinding(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "workflow_status",
-				Description: "The workflow status of a finding.",
+				Description: "The workflow status of a finding. Possible values are NEW, NOTIFIED, SUPPRESSED, RESOLVED.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("Workflow.Status"),
 			},

--- a/aws/table_aws_securityhub_finding.go
+++ b/aws/table_aws_securityhub_finding.go
@@ -39,6 +39,7 @@ func tableAwsSecurityHubFinding(_ context.Context) *plugin.Table {
 				{Name: "title", Require: plugin.Optional, Operators: []string{"=", "<>"}},
 				{Name: "verification_state", Require: plugin.Optional, Operators: []string{"=", "<>"}},
 				{Name: "workflow_state", Require: plugin.Optional, Operators: []string{"=", "<>"}},
+				{Name: "workflow_status", Require: plugin.Optional, Operators: []string{"=", "<>"}},
 			},
 			IgnoreConfig: &plugin.IgnoreConfig{
 				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"InvalidAccessException"}),
@@ -140,8 +141,14 @@ func tableAwsSecurityHubFinding(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "workflow_state",
-				Description: "The workflow state of a finding.",
+				Description: "DEPRECATED. The workflow state of a finding.",
 				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "workflow_status",
+				Description: "The workflow status of a finding.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Workflow.Status"),
 			},
 			{
 				Name:        "standards_control_arn",
@@ -367,7 +374,7 @@ func buildListFindingsParam(quals plugin.KeyColumnQualMap) *types.AwsSecurityFin
 	securityFindingsFilter := &types.AwsSecurityFindingFilters{}
 	strFilter := types.StringFilter{}
 
-	strColumns := []string{"company_name", "compliance_status", "generator_id", "product_arn", "product_name", "record_state", "title", "verification_state", "workflow_state"}
+	strColumns := []string{"company_name", "compliance_status", "generator_id", "product_arn", "product_name", "record_state", "title", "verification_state", "workflow_state", "workflow_status"}
 
 	for _, s := range strColumns {
 		if quals[s] == nil {
@@ -414,6 +421,9 @@ func buildListFindingsParam(quals plugin.KeyColumnQualMap) *types.AwsSecurityFin
 			case "workflow_state":
 				strFilter.Value = aws.String(value)
 				securityFindingsFilter.WorkflowState = append(securityFindingsFilter.WorkflowState, strFilter)
+			case "workflow_status":
+				strFilter.Value = aws.String(value)
+				securityFindingsFilter.WorkflowStatus = append(securityFindingsFilter.WorkflowStatus, strFilter)
 			}
 
 		}

--- a/aws/table_aws_securityhub_finding.go
+++ b/aws/table_aws_securityhub_finding.go
@@ -141,7 +141,7 @@ func tableAwsSecurityHubFinding(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "workflow_state",
-				Description: "DEPRECATED. The workflow state of a finding.",
+				Description: "[DEPRECATED] This column has been deprecated and will be removed in a future release. The workflow state of a finding.",
 				Type:        proto.ColumnType_STRING,
 			},
 			{

--- a/docs/tables/aws_securityhub_finding.md
+++ b/docs/tables/aws_securityhub_finding.md
@@ -134,7 +134,8 @@ where
    updated_at >= now() - interval '30' day;
 ```
 
-### DEPRECATED, List findings with assigned workflow state
+### [DEPRECATED] This column has been deprecated and will be removed in a future release. (Use Worfklow Status (`worfklow_status`)). 
+### List findings with assigned workflow state
 
 ```sql
 select
@@ -149,7 +150,7 @@ where
   workflow_state = 'ASSIGNED';
 ```
 
-### List findings with NOTIFIED workflow status
+### List findings with Workflow Status (`worfklow_status`) NOTIFIED. (All Workflow Status: NEW, NOTIFIED, SUPPRESSED, RESOLVED)
 
 ```sql
 select

--- a/docs/tables/aws_securityhub_finding.md
+++ b/docs/tables/aws_securityhub_finding.md
@@ -150,7 +150,7 @@ where
   workflow_state = 'ASSIGNED';
 ```
 
-### List findings with Workflow Status (`worfklow_status`) NOTIFIED. (All Workflow Status: NEW, NOTIFIED, SUPPRESSED, RESOLVED)
+### List findings with workflow status NOTIFIED
 
 ```sql
 select

--- a/docs/tables/aws_securityhub_finding.md
+++ b/docs/tables/aws_securityhub_finding.md
@@ -134,7 +134,6 @@ where
    updated_at >= now() - interval '30' day;
 ```
 
-### [DEPRECATED] This column has been deprecated and will be removed in a future release. (Use Worfklow Status (`worfklow_status`)). 
 ### List findings with assigned workflow state
 
 ```sql

--- a/docs/tables/aws_securityhub_finding.md
+++ b/docs/tables/aws_securityhub_finding.md
@@ -134,7 +134,7 @@ where
    updated_at >= now() - interval '30' day;
 ```
 
-### List findings with assigned workflow state
+### DEPRECATED, List findings with assigned workflow state
 
 ```sql
 select
@@ -147,6 +147,21 @@ from
   aws_securityhub_finding
 where 
   workflow_state = 'ASSIGNED';
+```
+
+### List findings with NOTIFIED workflow status
+
+```sql
+select
+  title,
+  id,
+  product_arn,
+  product_name,
+  workflow_status
+from
+  aws_securityhub_finding
+where 
+  workflow_status = 'NOTIFIED';
 ```
 
 ### Get network detail for a particular finding


### PR DESCRIPTION
The field `WorkflowState` is deprecated:

`Note that in the available filter fields, WorkflowState is deprecated. To search for a finding based on its workflow status, use WorkflowStatus .`

Link: https://docs.aws.amazon.com/cli/latest/reference/securityhub/get-findings.html

I added the `WorkflowStatus` field and the filter to use in the queries. 

I left the previous one, `WorfklowState` with a note "DEPRECATED."


# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
select
      title,
      product_arn,
      product_name,
      workflow_status
    from
      local.aws_securityhub_finding
    where
      record_state = 'ACTIVE' and
      workflow_status = 'NOTIFIED' and
      severity ->> 'Original' = 'CRITICAL'
```

```
+----------------------------------------------------+--------------------------------------------------------+--------------+-----------------+
| title                                              | product_arn                                            | product_name | workflow_status |
+----------------------------------------------------+--------------------------------------------------------+--------------+-----------------+
| S3.2 S3 buckets should prohibit public read access | arn:aws:securityhub:eu-west-1::product/aws/securityhub | Security Hub | NOTIFIED        |
+----------------------------------------------------+--------------------------------------------------------+--------------+-----------------+
```

</details>
