### PR TITLE
Fix `getTableBillingMode` transform for type casting error in `aws_dynamodb_table`

### DIFF
--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -77,6 +77,8 @@ func tableAwsDynamoDBTable(_ context.Context) *plugin.Table {
 				Hydrate:     getDynamboDbTable,
 				Transform:   transform.FromField("TableStatus"),
 			},
+			// If it is not available then it should default to "PROVISIONED"
+			// Possible values are "PAY_PER_REQUEST" or "PROVISIONED"
 			{
 				Name:        "billing_mode",
 				Description: "Controls how AWS charges for read and write throughput and manage capacity.",
@@ -84,8 +86,6 @@ func tableAwsDynamoDBTable(_ context.Context) *plugin.Table {
 				Default:     "PROVISIONED",
 				Hydrate:     getDynamboDbTable,
 				Transform:   transform.FromField("BillingModeSummary.BillingMode").Transform(getTableBillingMode),
-				// If it is not available then it should default to  "PROVISIONED"
-				// Billing mode can only be PAY_PER_REQUEST or PROVISIONED
 			},
 			{
 				Name:        "item_count",

--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -426,9 +426,9 @@ func getTableStreamingDestination(ctx context.Context, d *plugin.QueryData, h *p
 //// TRANSFORM FUNCTIONS
 
 func getTableBillingMode(_ context.Context, d *transform.TransformData) (interface{}, error) {
-	billingMode := "PROVISIONED"
+	billingMode := types.BillingModeProvisioned
 	if d.Value != nil {
-		billingMode = *d.Value.(*string)
+		billingMode = d.Value.(types.BillingMode)
 	}
 
 	return billingMode, nil


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
1380-error-when-querying-aws_dynamodb_table⚡ ⇒  ./tint.js aws_dynamodb_table
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_dynamodb_table []

PRETEST: tests/aws_dynamodb_table

TEST: tests/aws_dynamodb_table
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 2s [id=000011112222]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_dynamodb_table.named_test_resource will be created
  + resource "aws_dynamodb_table" "named_test_resource" {
      + arn              = (known after apply)
      + billing_mode     = "PROVISIONED"
      + hash_key         = "userId"
      + id               = (known after apply)
      + name             = "turbottest22217"
      + read_capacity    = 20
      + stream_arn       = (known after apply)
      + stream_label     = (known after apply)
      + stream_view_type = (known after apply)
      + tags             = {
          + "name" = "turbottest22217"
        }
      + tags_all         = {
          + "name" = "turbottest22217"
        }
      + write_capacity   = 20

      + attribute {
          + name = "userId"
          + type = "S"
        }

      + point_in_time_recovery {
          + enabled = (known after apply)
        }

      + server_side_encryption {
          + enabled     = (known after apply)
          + kms_key_arn = (known after apply)
        }

      + ttl {
          + attribute_name = (known after apply)
          + enabled        = (known after apply)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "000011112222"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest22217"
aws_dynamodb_table.named_test_resource: Creating...
aws_dynamodb_table.named_test_resource: Creation complete after 10s [id=turbottest22217]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 47, in data "null_data_source" "resource":
  47: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "000011112222"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:dynamodb:us-east-1:000011112222:table/turbottest22217"
resource_name = "turbottest22217"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:dynamodb:us-east-1:000011112222:table/turbottest22217",
    "name": "turbottest22217"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "continuous_backups_status": "ENABLED",
    "point_in_time_recovery_description": {
      "EarliestRestorableDateTime": null,
      "LatestRestorableDateTime": null,
      "PointInTimeRecoveryStatus": "DISABLED"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:dynamodb:us-east-1:000011112222:table/turbottest22217",
    "attribute_definitions": [
      {
        "AttributeName": "userId",
        "AttributeType": "S"
      }
    ],
    "key_schema": [
      {
        "AttributeName": "userId",
        "KeyType": "HASH"
      }
    ],
    "name": "turbottest22217",
    "read_capacity": 20,
    "write_capacity": 20
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "000011112222",
    "akas": [
      "arn:aws:dynamodb:us-east-1:000011112222:table/turbottest22217"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "title": "turbottest22217"
  }
]
✔ PASSED

POSTTEST: tests/aws_dynamodb_table

TEARDOWN: tests/aws_dynamodb_table

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
select * from aws_dynamodb_table
+----------+--------------------------------------------------------+--------------------------------------+---------------------------+-------------+--------------+-----------------+------------+----------------------+---------------+----------------+-------------------+---------------------+------------------+------------------+------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+-----------------+---------------------------+---------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------+----------+------+----------+------------------------------------------------------------+-----------+-----------+--------------+---------------------------+
| name     | arn                                                    | table_id                             | creation_date_time        | table_class | table_status | billing_mode    | item_count | global_table_version | read_capacity | write_capacity | latest_stream_arn | latest_stream_label | table_size_bytes | archival_summary | attribute_definitions                                                                          | key_schema                                                                                | sse_description | continuous_backups_status | streaming_destination                                                           | point_in_time_recovery_description                                                                         | tags_src | tags | title    | akas                                                       | partition | region    | account_id   | _ctx                      |
+----------+--------------------------------------------------------+--------------------------------------+---------------------------+-------------+--------------+-----------------+------------+----------------------+---------------+----------------+-------------------+---------------------+------------------+------------------+------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+-----------------+---------------------------+---------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------+----------+------+----------+------------------------------------------------------------+-----------+-----------+--------------+---------------------------+
| table-t1 | arn:aws:dynamodb:us-east-1:111100002222:table/table-t1 | 04a7dd33-e70c-4fd7-b7ef-215e4bf95919 | 2022-11-09T11:35:38+05:30 | STANDARD    | ACTIVE       | PAY_PER_REQUEST | 0          | <null>               | 0             | 0              | <null>            | <null>              | 0                | <null>           | [{"AttributeName":"name","AttributeType":"S"},{"AttributeName":"s_no","AttributeType":"N"}]    | [{"AttributeName":"name","KeyType":"HASH"},{"AttributeName":"s_no","KeyType":"RANGE"}]    | <null>          | ENABLED                   | {"KinesisDataStreamDestinations":[],"ResultMetadata":{},"TableName":"table-t1"} | {"EarliestRestorableDateTime":null,"LatestRestorableDateTime":null,"PointInTimeRecoveryStatus":"DISABLED"} | []       | {}   | table-t1 | ["arn:aws:dynamodb:us-east-1:111100002222:table/table-t1"] | aws       | us-east-1 | 111100002222 | {"connection_name":"aws"} |
| table-t2 | arn:aws:dynamodb:us-east-1:111100002222:table/table-t2 | f5b9ffe5-f1f7-44ab-9480-d1310e05ceb2 | 2022-11-09T11:42:26+05:30 | STANDARD    | ACTIVE       | PAY_PER_REQUEST | 0          | <null>               | 0             | 0              | <null>            | <null>              | 0                | <null>           | [{"AttributeName":"name","AttributeType":"S"},{"AttributeName":"roll_no","AttributeType":"N"}] | [{"AttributeName":"name","KeyType":"HASH"},{"AttributeName":"roll_no","KeyType":"RANGE"}] | <null>          | ENABLED                   | {"KinesisDataStreamDestinations":[],"ResultMetadata":{},"TableName":"table-t2"} | {"EarliestRestorableDateTime":null,"LatestRestorableDateTime":null,"PointInTimeRecoveryStatus":"DISABLED"} | []       | {}   | table-t2 | ["arn:aws:dynamodb:us-east-1:111100002222:table/table-t2"] | aws       | us-east-1 | 111100002222 | {"connection_name":"aws"} |
+----------+--------------------------------------------------------+--------------------------------------+---------------------------+-------------+--------------+-----------------+------------+----------------------+---------------+----------------+-------------------+---------------------+------------------+------------------+------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------+-----------------+---------------------------+---------------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------+----------+------+----------+------------------------------------------------------------+-----------+-----------+--------------+---------------------------+
```
</details>
