### PR TITLE
Fix `APIGatewayV2Client` for `deserialization failed, failed to decode response body, invalid character '\'' in string escape code` error due to unsupported regions

### DIFF
--- a/aws/service.go
+++ b/aws/service.go
@@ -213,7 +213,7 @@ func APIGatewayClient(ctx context.Context, d *plugin.QueryData) (*apigateway.Cli
 }
 
 func APIGatewayV2Client(ctx context.Context, d *plugin.QueryData) (*apigatewayv2.Client, error) {
-	// APIGatewayV2 has an endpoint ID which is the same as for APIGateway but doesn't give the correct region list for supported regions. Still, it's unavailable in region `me-central-1(i.e. Middle East UAE).`
+	// APIGatewayV2's endpoint ID is the same as APIGateway's, but me-central-1 does not support API Gateway v2 yet
 	//cfg, err := getClientForQuerySupportedRegion(ctx, d, apigatewayv2Endpoint.EndpointsID)
 
 	region := d.KeyColumnQualString(matrixKeyRegion)

--- a/aws/service.go
+++ b/aws/service.go
@@ -113,7 +113,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 
 	amplifyEndpoint "github.com/aws/aws-sdk-go/service/amplify"
-	apigatewayv2Endpoint "github.com/aws/aws-sdk-go/service/apigatewayv2"
 	auditmanagerEndpoint "github.com/aws/aws-sdk-go/service/auditmanager"
 	backupEndpoint "github.com/aws/aws-sdk-go/service/backup"
 	codeartifactEndpoint "github.com/aws/aws-sdk-go/service/codeartifact"
@@ -214,7 +213,17 @@ func APIGatewayClient(ctx context.Context, d *plugin.QueryData) (*apigateway.Cli
 }
 
 func APIGatewayV2Client(ctx context.Context, d *plugin.QueryData) (*apigatewayv2.Client, error) {
-	cfg, err := getClientForQuerySupportedRegion(ctx, d, apigatewayv2Endpoint.EndpointsID)
+	// APIGatewayV2 has an endpoint ID which is the same as for APIGateway but doesn't give the correct region list for supported regions. Still, it's unavailable in region `me-central-1(i.e. Middle East UAE).`
+	//cfg, err := getClientForQuerySupportedRegion(ctx, d, apigatewayv2Endpoint.EndpointsID)
+
+	region := d.KeyColumnQualString(matrixKeyRegion)
+	validRegions := []string{"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1", "us-iso-east-1"}
+
+	if !helpers.StringSliceContains(validRegions, region) {
+		return nil, nil
+	}
+
+	cfg, err := getClientForQueryRegion(ctx, d)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
lalit@Lalits-MacBook-Pro:~/WORK/Turbot/steampipe/plugins/steampipe-plugin-aws/aws-test|1379-querying-apigatewayv2-fails-with-error-message-deserialization-failed-due-to-invalid-character⚡ ⇒  ./tint.js aws_api_gatewayv2_api 
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_api_gatewayv2_api []

PRETEST: tests/aws_api_gatewayv2_api

TEST: tests/aws_api_gatewayv2_api
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 1s [id=000011112222]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_apigatewayv2_api.named_test_resource will be created
  + resource "aws_apigatewayv2_api" "named_test_resource" {
      + api_endpoint                 = (known after apply)
      + api_key_selection_expression = "$request.header.x-api-key"
      + arn                          = (known after apply)
      + execution_arn                = (known after apply)
      + id                           = (known after apply)
      + name                         = "turbottest48203"
      + protocol_type                = "HTTP"
      + route_selection_expression   = "$request.method $request.path"
      + tags                         = {
          + "name" = "turbottest48203"
        }
      + tags_all                     = {
          + "name" = "turbottest48203"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + api_endpoint  = (known after apply)
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest48203"
aws_apigatewayv2_api.named_test_resource: Creating...
aws_apigatewayv2_api.named_test_resource: Creation complete after 2s [id=88d3oejlrf]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

api_endpoint = "https://88d3oejlrf.execute-api.us-east-1.amazonaws.com"
resource_aka = "arn:aws:apigateway:us-east-1::/apis/88d3oejlrf"
resource_id = "88d3oejlrf"
resource_name = "turbottest48203"

Running SQL query: query.sql
[
  {
    "name": "turbottest48203"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:apigateway:us-east-1::/apis/88d3oejlrf"
    ],
    "tags": {
      "name": "turbottest48203"
    },
    "title": "turbottest48203"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:apigateway:us-east-1::/apis/88d3oejlrf"
    ],
    "api_endpoint": "https://88d3oejlrf.execute-api.us-east-1.amazonaws.com",
    "api_id": "88d3oejlrf",
    "name": "turbottest48203",
    "tags": {
      "name": "turbottest48203"
    },
    "title": "turbottest48203"
  }
]
✔ PASSED

POSTTEST: tests/aws_api_gatewayv2_api

TEARDOWN: tests/aws_api_gatewayv2_api

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

Before FIX
```
select * from aws_api_gateway_rest_api
+------+------------+---------+----------------+---------------------------+-------------+--------------------------+--------+------------+--------------------+------------------------------+---------------------->
| name | api_id     | version | api_key_source | created_date              | description | minimum_compression_size | policy | policy_std | binary_media_types | endpoint_configuration_types | endpoint_configuratio>
+------+------------+---------+----------------+---------------------------+-------------+--------------------------+--------+------------+--------------------+------------------------------+---------------------->
| api1 | w7lenlw524 | <null>  | HEADER         | 2022-11-09T12:30:52+05:30 | test        | <null>                   | <null> | <null>     | <null>             | ["REGIONAL"]                 | <null>               >
+------+------------+---------+----------------+---------------------------+-------------+--------------------------+--------+------------+--------------------+------------------------------+---------------------->
> select * from aws_api_gatewayv2_api

Error: operation error ApiGatewayV2: GetApis, https response error StatusCode: 400, RequestID: 83e78c1b-caed-45d4-ba5d-982ad37676bf, deserialization failed, failed to decode response body, invalid character '\'' in string escape code (SQLSTATE HV000)

+------+--------+--------------+---------------+------------------------------+------------------------------+----------------------------+--------------+------+-------+------+-----------+--------+------------+--->
| name | api_id | api_endpoint | protocol_type | api_key_selection_expression | disable_execute_api_endpoint | route_selection_expression | created_date | tags | title | akas | partition | region | account_id | _c>
+------+--------+--------------+---------------+------------------------------+------------------------------+----------------------------+--------------+------+-------+------+-----------+--------+------------+--->
+------+--------+--------------+---------------+------------------------------+------------------------------+----------------------------+--------------+------+-------+------+-----------+--------+------------+--->
> select * from aws_api_gatewayv2_domain_name

Error: operation error ApiGatewayV2: GetDomainNames, https response error StatusCode: 400, RequestID: 4a5aa257-cad2-4b1a-964a-adde2dc26a78, deserialization failed, failed to decode response body, invalid character '\'' in string escape code (SQLSTATE HV000)

+-------------+----------------------------+---------------------------+------+-------+------+-----------+--------+------------+------+
| domain_name | domain_name_configurations | mutual_tls_authentication | tags | title | akas | partition | region | account_id | _ctx |
+-------------+----------------------------+---------------------------+------+-------+------+-----------+--------+------------+------+
+-------------+----------------------------+---------------------------+------+-------+------+-----------+--------+------------+------+
> select * from aws_api_gatewayv2_integration

Error: operation error ApiGatewayV2: GetApis, https response error StatusCode: 400, RequestID: 9f11dfc8-800e-416d-9238-3ade17b28ba5, deserialization failed, failed to decode response body, invalid character '\'' in string escape code (SQLSTATE HV000)

+----------------+--------+-----+-------------+--------------------+------------------+-----------------+---------------------+---------------+-----------------+---------------------------+-----------------+------>
| integration_id | api_id | arn | description | integration_method | integration_type | integration_uri | api_gateway_managed | connection_id | connection_type | content_handling_strategy | credentials_arn | integ>
+----------------+--------+-----+-------------+--------------------+------------------+-----------------+---------------------+---------------+-----------------+---------------------------+-----------------+------>
+----------------+--------+-----+-------------+--------------------+------------------+-----------------+---------------------+---------------+-----------------+---------------------------+-----------------+------>
> select * from aws_api_gatewayv2_stage

Error: operation error ApiGatewayV2: GetApis, https response error StatusCode: 400, RequestID: bb204b4a-330d-4972-adba-45a71d304d4f, deserialization failed, failed to decode response body, invalid character '\'' in string escape code (SQLSTATE HV000)

+------------+--------+---------------------+-------------+-----------------------+--------------+---------------+----------------------------------+----------------------------------------+----------------------->
| stage_name | api_id | api_gateway_managed | auto_deploy | client_certificate_id | created_date | deployment_id | default_route_data_trace_enabled | default_route_detailed_metrics_enabled | default_route_logging_>
+------------+--------+---------------------+-------------+-----------------------+--------------+---------------+----------------------------------+----------------------------------------+----------------------->
+------------+--------+---------------------+-------------+-----------------------+--------------+---------------+----------------------------------+----------------------------------------+----------------------->
> .quit


```

After Fix
```
lalit@Lalits-MacBook-Pro:~/WORK/Turbot/steampipe/plugins/steampipe-plugin-aws|1379-querying-apigatewayv2-fails-with-error-message-deserialization-failed-due-to-invalid-character⚡ ⇒  make
go build -o  ~/.steampipe/plugins/hub.steampipe.io/plugins/turbot/aws@latest/steampipe-plugin-aws.plugin  *.go

lalit@Lalits-MacBook-Pro:~/WORK/Turbot/steampipe/plugins/steampipe-plugin-aws|1379-querying-apigatewayv2-fails-with-error-message-deserialization-failed-due-to-invalid-character⚡ ⇒  steampipe query
Welcome to Steampipe v0.18.0-dev.0

For more information, type .help
> select * from aws_gov.aws_api_gatewayv2_api
+------+--------+--------------+---------------+------------------------------+------------------------------+----------------------------+--------------+------+-------+------+-----------+--------+------------+--->
| name | api_id | api_endpoint | protocol_type | api_key_selection_expression | disable_execute_api_endpoint | route_selection_expression | created_date | tags | title | akas | partition | region | account_id | _c>
+------+--------+--------------+---------------+------------------------------+------------------------------+----------------------------+--------------+------+-------+------+-----------+--------+------------+--->
+------+--------+--------------+---------------+------------------------------+------------------------------+----------------------------+--------------+------+-------+------+-----------+--------+------------+--->

> select * from aws_api_gatewayv2_api
+------+--------+--------------+---------------+------------------------------+------------------------------+----------------------------+--------------+------+-------+------+-----------+--------+------------+--->
| name | api_id | api_endpoint | protocol_type | api_key_selection_expression | disable_execute_api_endpoint | route_selection_expression | created_date | tags | title | akas | partition | region | account_id | _c>
+------+--------+--------------+---------------+------------------------------+------------------------------+----------------------------+--------------+------+-------+------+-----------+--------+------------+--->
+------+--------+--------------+---------------+------------------------------+------------------------------+----------------------------+--------------+------+-------+------+-----------+--------+------------+--->

> select * from aws_api_gatewayv2_domain_name
+-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>
| domain_name | domain_name_configurations                                                                                                                                                                           >

+-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>
| turbot.com  | [{"ApiGatewayDomainName":"d-z3kh3vjy97.execute-api.us-east-1.amazonaws.com","CertificateArn":"arn:aws:acm:us-east-1:000011112222:certificate/24c967dc-da4a-4ed7-9866-019f766ae32b","CertificateName":>
+-------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>

> select * from aws_api_gatewayv2_integration
+----------------+--------+-----+-------------+--------------------+------------------+-----------------+---------------------+---------------+-----------------+---------------------------+-----------------+------>
| integration_id | api_id | arn | description | integration_method | integration_type | integration_uri | api_gateway_managed | connection_id | connection_type | content_handling_strategy | credentials_arn | integ>
+----------------+--------+-----+-------------+--------------------+------------------+-----------------+---------------------+---------------+-----------------+---------------------------+-----------------+------>
+----------------+--------+-----+-------------+--------------------+------------------+-----------------+---------------------+---------------+-----------------+---------------------------+-----------------+------>


> select * from aws_api_gatewayv2_stage
+------------+--------+---------------------+-------------+-----------------------+--------------+---------------+----------------------------------+----------------------------------------+----------------------->
| stage_name | api_id | api_gateway_managed | auto_deploy | client_certificate_id | created_date | deployment_id | default_route_data_trace_enabled | default_route_detailed_metrics_enabled | default_route_logging_>
+------------+--------+---------------------+-------------+-----------------------+--------------+---------------+----------------------------------+----------------------------------------+----------------------->
+------------+--------+---------------------+-------------+-----------------------+--------------+---------------+----------------------------------+----------------------------------------+----------------------->
> .quit
```
</details>
