### PR TITLE
Add service_name column as optional quals for the table aws_iam_servi…

### DIFF
--- a/aws/table_aws_iam_service_specific_credential.go
+++ b/aws/table_aws_iam_service_specific_credential.go
@@ -76,7 +76,7 @@ func listAwsIamUserServiceSpecificCredentials(ctx context.Context, d *plugin.Que
 	// Create Session
 	svc, err := IAMClient(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_iam_user.listAwsIamUserServiceSpecificCredentials", "client_error", err)
+		plugin.Logger(ctx).Error("aws_iam_service_specific_credential.listAwsIamUserServiceSpecificCredentials", "client_error", err)
 		return nil, err
 	}
 
@@ -94,17 +94,19 @@ func listAwsIamUserServiceSpecificCredentials(ctx context.Context, d *plugin.Que
 
 	userData, _ := svc.ListServiceSpecificCredentials(ctx, params)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_iam_user.listAwsIamUserServiceSpecificCredentials", "api_error", err)
+		plugin.Logger(ctx).Error("aws_iam_service_specific_credential.listAwsIamUserServiceSpecificCredentials", "api_error", err)
 		return nil, err
 	}
 
-	if userData.ServiceSpecificCredentials != nil {
-		for _, cred := range userData.ServiceSpecificCredentials {
-			d.StreamListItem(ctx, cred)
+	if userData != nil {
+		if userData.ServiceSpecificCredentials != nil {
+			for _, cred := range userData.ServiceSpecificCredentials {
+				d.StreamListItem(ctx, cred)
 
-			// Context may get cancelled due to manual cancellation or if the limit has been reached
-			if d.QueryStatus.RowsRemaining(ctx) == 0 {
-				return nil, nil
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.QueryStatus.RowsRemaining(ctx) == 0 {
+					return nil, nil
+				}
 			}
 		}
 	}

--- a/aws/table_aws_iam_service_specific_credential.go
+++ b/aws/table_aws_iam_service_specific_credential.go
@@ -92,7 +92,7 @@ func listAwsIamUserServiceSpecificCredentials(ctx context.Context, d *plugin.Que
 		params.ServiceName = aws.String(d.KeyColumnQuals["service_name"].GetStringValue())
 	}
 
-	userData, _ := svc.ListServiceSpecificCredentials(ctx, params)
+	userData, err := svc.ListServiceSpecificCredentials(ctx, params)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_iam_service_specific_credential.listAwsIamUserServiceSpecificCredentials", "api_error", err)
 		return nil, err

--- a/aws/table_aws_iam_service_specific_credential.go
+++ b/aws/table_aws_iam_service_specific_credential.go
@@ -98,15 +98,13 @@ func listAwsIamUserServiceSpecificCredentials(ctx context.Context, d *plugin.Que
 		return nil, err
 	}
 
-	if userData != nil {
-		if userData.ServiceSpecificCredentials != nil {
-			for _, cred := range userData.ServiceSpecificCredentials {
-				d.StreamListItem(ctx, cred)
+	if userData != nil && userData.ServiceSpecificCredentials != nil {
+		for _, cred := range userData.ServiceSpecificCredentials {
+			d.StreamListItem(ctx, cred)
 
-				// Context may get cancelled due to manual cancellation or if the limit has been reached
-				if d.QueryStatus.RowsRemaining(ctx) == 0 {
-					return nil, nil
-				}
+			// Context may get cancelled due to manual cancellation or if the limit has been reached
+			if d.QueryStatus.RowsRemaining(ctx) == 0 {
+				return nil, nil
 			}
 		}
 	}

--- a/aws/table_aws_iam_service_specific_credential.go
+++ b/aws/table_aws_iam_service_specific_credential.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
@@ -20,6 +21,7 @@ func tableAwsIamUserServiceSpecificCredential(ctx context.Context) *plugin.Table
 			ParentHydrate: listIamUsers,
 			Hydrate:       listAwsIamUserServiceSpecificCredentials,
 			KeyColumns: []*plugin.KeyColumn{
+				{Name: "service_name", Require: plugin.Optional},
 				{Name: "user_name", Require: plugin.Optional},
 			},
 		},
@@ -84,6 +86,10 @@ func listAwsIamUserServiceSpecificCredentials(ctx context.Context, d *plugin.Que
 
 	params := &iam.ListServiceSpecificCredentialsInput{
 		UserName: user.UserName,
+	}
+
+	if d.KeyColumnQuals["service_name"].GetStringValue() != "" {
+		params.ServiceName = aws.String(d.KeyColumnQuals["service_name"].GetStringValue())
 	}
 
 	userData, _ := svc.ListServiceSpecificCredentials(ctx, params)

--- a/docs/tables/aws_iam_service_specific_credential.md
+++ b/docs/tables/aws_iam_service_specific_credential.md
@@ -32,3 +32,36 @@ from
 where
   s.user_name = u.name;
 ```
+
+### List users those were not used password more than 30 days
+
+```sql
+select
+  s.service_name as service_name,
+  s.service_specific_credential_id as service_specific_credential_id,
+  u.name as user_name,
+  u.user_id as user_id,
+  u.password_last_used as password_last_used,
+  u.mfa_enabled as mfa_enabled
+from
+  aws_iam_service_specific_credential as s,
+  aws_iam_user as u
+where
+  s.user_name = u.name
+and
+  u.password_last_used <= current_date - interval '30' day;
+```
+
+### List service specific credentials older than 30 days
+
+```sql
+select
+  service_name,
+  service_specific_credential_id,
+  create_date,
+  user_name
+from
+  aws.aws_iam_service_specific_credential
+where
+  create_date <= current_date - interval '30' day;
+```

--- a/docs/tables/aws_iam_service_specific_credential.md
+++ b/docs/tables/aws_iam_service_specific_credential.md
@@ -26,11 +26,9 @@ select
   u.user_id as user_id,
   u.password_last_used as password_last_used,
   u.mfa_enabled as mfa_enabled
-  iam_group ->> 'GroupId' as group_id,
-  iam_group ->> 'CreateDate' as create_date
 from
-  aws_iam_service_specific_credential as s,
-  aws_iam_user as u
+  aws.aws_iam_service_specific_credential as s,
+  aws.aws_iam_user as u
 where
   s.user_name = u.name;
 ```

--- a/docs/tables/aws_iam_service_specific_credential.md
+++ b/docs/tables/aws_iam_service_specific_credential.md
@@ -4,7 +4,7 @@ Service-specific credentials are associated with a specific IAM user and can onl
 
 ## Examples
 
-### Basic service specific credential info
+### Basic info
 
 ```sql
 select
@@ -16,7 +16,7 @@ from
   aws_iam_service_specific_credential;
 ```
 
-### IAM user details for the service specific credential
+### IAM user details for the service specific credentials
 
 ```sql
 select

--- a/docs/tables/aws_iam_service_specific_credential.md
+++ b/docs/tables/aws_iam_service_specific_credential.md
@@ -27,8 +27,8 @@ select
   u.password_last_used as password_last_used,
   u.mfa_enabled as mfa_enabled
 from
-  aws.aws_iam_service_specific_credential as s,
-  aws.aws_iam_user as u
+  aws_iam_service_specific_credential as s,
+  aws_iam_user as u
 where
   s.user_name = u.name;
 ```

--- a/docs/tables/aws_iam_service_specific_credential.md
+++ b/docs/tables/aws_iam_service_specific_credential.md
@@ -1,6 +1,6 @@
 # Table: aws_iam_service_specific_credential
 
-Service-specific credentials are associated with a specific IAM user and can only be used for the service they were created for. To give IAM roles or federated identities permissions to access all your AWS resources, you should create IAM access keys for AWS authentication and use the SigV4 authentication plugin.
+Service-specific credentials are associated with a specific IAM user and can only be used for the service they were created for.
 
 ## Examples
 
@@ -16,7 +16,7 @@ from
   aws_iam_service_specific_credential;
 ```
 
-### IAM user details for the service specific credentials
+### IAM user details for service specific credentials
 
 ```sql
 select
@@ -33,26 +33,7 @@ where
   s.user_name = u.name;
 ```
 
-### List users those were not used password in last 30 days
-
-```sql
-select
-  s.service_name as service_name,
-  s.service_specific_credential_id as service_specific_credential_id,
-  u.name as user_name,
-  u.user_id as user_id,
-  u.password_last_used as password_last_used,
-  u.mfa_enabled as mfa_enabled
-from
-  aws_iam_service_specific_credential as s,
-  aws_iam_user as u
-where
-  s.user_name = u.name
-and
-  u.password_last_used <= current_date - interval '30' day;
-```
-
-### List service specific credentials older than 30 days
+### Service specific credentials older than 30 days
 
 ```sql
 select
@@ -61,7 +42,7 @@ select
   create_date,
   user_name
 from
-  aws.aws_iam_service_specific_credential
+  aws_iam_service_specific_credential
 where
   create_date <= current_date - interval '30' day;
 ```

--- a/docs/tables/aws_iam_service_specific_credential.md
+++ b/docs/tables/aws_iam_service_specific_credential.md
@@ -33,7 +33,7 @@ where
   s.user_name = u.name;
 ```
 
-### List users those were not used password more than 30 days
+### List users those were not used password in last 30 days
 
 ```sql
 select


### PR DESCRIPTION
…ce_specific_credential closes #1392

# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_iam_service_specific_credential []

PRETEST: tests/aws_iam_service_specific_credential

TEST: tests/aws_iam_service_specific_credential
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 2s [id=874502154756]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_iam_service_specific_credential.named_test_resource will be created
  + resource "aws_iam_service_specific_credential" "named_test_resource" {
      + id                             = (known after apply)
      + service_name                   = "codecommit.amazonaws.com"
      + service_password               = (sensitive value)
      + service_specific_credential_id = (known after apply)
      + service_user_name              = (known after apply)
      + status                         = "Active"
      + user_name                      = "turbottest75299"
    }

  # aws_iam_user.named_test_resource will be created
  + resource "aws_iam_user" "named_test_resource" {
      + arn           = (known after apply)
      + force_destroy = false
      + id            = (known after apply)
      + name          = "turbottest75299"
      + path          = "/"
      + tags          = {
          + "name" = "turbottest75299"
        }
      + tags_all      = {
          + "name" = "turbottest75299"
        }
      + unique_id     = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id                     = "874502154756"
  + aws_partition                  = "aws"
  + service_specific_credential_id = (known after apply)
  + service_user_name              = (known after apply)
aws_iam_user.named_test_resource: Creating...
aws_iam_user.named_test_resource: Creation complete after 2s [id=turbottest75299]
aws_iam_service_specific_credential.named_test_resource: Creating...
aws_iam_service_specific_credential.named_test_resource: Creation complete after 0s [id=codecommit.amazonaws.com:turbottest75299:ACCAZGW7IOFILMG2VRO5R]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

account_id = "874502154756"
aws_partition = "aws"
service_specific_credential_id = "ACCAZGW7IOFILMG2VRO5R"
service_user_name = "turbottest75299-at-874502154756"

Running SQL query: test-list-query.sql
[
  {
    "service_specific_credential_id": "ACCAZGW7IOFILMG2VRO5R",
    "service_user_name": "turbottest75299-at-874502154756"
  }
]
✔ PASSED

Running SQL query: test-turbot-fields-query.sql
[
  {
    "title": "codecommit.amazonaws.com"
  }
]
✔ PASSED

POSTTEST: tests/aws_iam_service_specific_credential

TEARDOWN: tests/aws_iam_service_specific_credential


Error: Unrecognized remote plugin message: 

This usually means that the plugin is either invalid or simply
needs to be recompiled to support the latest protocol.

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws.aws_iam_service_specific_credential where service_name = 'codecommit.amazonaws.com'
+--------------------------+--------------------------------+---------------------------+---------------------------------+--------+-----------------+--------------------------+-
| service_name             | service_specific_credential_id | create_date               | service_user_name               | status | user_name       | title                    | 
+--------------------------+--------------------------------+---------------------------+---------------------------------+--------+-----------------+--------------------------+-
| codecommit.amazonaws.com | ACCAZGW7IOFILS6H3XPIQ          | 2022-11-10T10:10:55+05:30 | turbottest3713-at-632902152528  | Active | turbottest3713  | codecommit.amazonaws.com | 
| codecommit.amazonaws.com | ACCAZGW7IOFILMG2VRO5R          | 2022-11-10T10:16:33+05:30 | turbottest75299-at-632902152528 | Active | turbottest75299 | codecommit.amazonaws.com | 
| codecommit.amazonaws.com | ACCAZGW7IOFIEEK2UEDJV          | 2022-11-08T15:44:04+05:30 | kiran-at-632902152528           | Active | kiran           | codecommit.amazonaws.com | 
| codecommit.amazonaws.com | ACCAZGW7IOFIDFBBDFXTK          | 2022-11-08T16:59:22+05:30 | kiran+1-at-632902152528         | Active | kiran           | codecommit.amazonaws.com | 
+--------------------------+--------------------------------+---------------------------+---------------------------------+--------+-----------------+--------------------------+-

```
</details>
