### PR TITLE
List call is breaking when passing optional column in aws_s3_access_point table closes #1394

### DIFF
--- a/aws/table_aws_s3_access_point.go
+++ b/aws/table_aws_s3_access_point.go
@@ -22,6 +22,9 @@ func tableAwsS3AccessPoint(_ context.Context) *plugin.Table {
 		Description: "AWS S3 Access Point",
 		List: &plugin.ListConfig{
 			Hydrate: listS3AccessPoints,
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"NoSuchAccessPoint", "InvalidParameter", "InvalidRequest"}),
+			},
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "bucket_name", Require: plugin.Optional},
 			},
@@ -30,7 +33,7 @@ func tableAwsS3AccessPoint(_ context.Context) *plugin.Table {
 			KeyColumns: plugin.AllColumns([]string{"name", "region"}),
 			Hydrate:    getS3AccessPoint,
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"NoSuchAccessPoint", "InvalidParameter"}),
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"NoSuchAccessPoint", "InvalidParameter", "InvalidRequest"}),
 			},
 		},
 		GetMatrixItemFunc: BuildRegionList,


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_s3_access_point []

PRETEST: tests/aws_s3_access_point

TEST: tests/aws_s3_access_point
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 2s [id=548702155676]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_s3_access_point.named_test_resource will be created
  + resource "aws_s3_access_point" "named_test_resource" {
      + account_id               = (known after apply)
      + alias                    = (known after apply)
      + arn                      = (known after apply)
      + bucket                   = (known after apply)
      + domain_name              = (known after apply)
      + endpoints                = (known after apply)
      + has_public_access_policy = (known after apply)
      + id                       = (known after apply)
      + name                     = "turbottest70643"
      + network_origin           = (known after apply)
      + policy                   = (known after apply)

      + public_access_block_configuration {
          + block_public_acls       = true
          + block_public_policy     = false
          + ignore_public_acls      = true
          + restrict_public_buckets = false
        }

      + vpc_configuration {
          + vpc_id = (known after apply)
        }
    }

  # aws_s3_bucket.named_test_resource will be created
  + resource "aws_s3_bucket" "named_test_resource" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "turbottest70643"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = (known after apply)
          + allowed_methods = (known after apply)
          + allowed_origins = (known after apply)
          + expose_headers  = (known after apply)
          + max_age_seconds = (known after apply)
        }

      + grant {
          + id          = (known after apply)
          + permissions = (known after apply)
          + type        = (known after apply)
          + uri         = (known after apply)
        }

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = (known after apply)
          + enabled                                = (known after apply)
          + id                                     = (known after apply)
          + prefix                                 = (known after apply)
          + tags                                   = (known after apply)

          + expiration {
              + date                         = (known after apply)
              + days                         = (known after apply)
              + expired_object_delete_marker = (known after apply)
            }

          + noncurrent_version_expiration {
              + days = (known after apply)
            }

          + noncurrent_version_transition {
              + days          = (known after apply)
              + storage_class = (known after apply)
            }

          + transition {
              + date          = (known after apply)
              + days          = (known after apply)
              + storage_class = (known after apply)
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = (known after apply)
        }

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

  # aws_s3control_access_point_policy.access_point_policy will be created
  + resource "aws_s3control_access_point_policy" "access_point_policy" {
      + access_point_arn         = (known after apply)
      + has_public_access_policy = (known after apply)
      + id                       = (known after apply)
      + policy                   = (known after apply)
    }

  # aws_vpc.named_test_resource will be created
  + resource "aws_vpc" "named_test_resource" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags_all                             = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id               = "548702155676"
  + arn                      = (known after apply)
  + aws_partition            = "aws"
  + has_public_access_policy = (known after apply)
  + network_origin           = (known after apply)
  + region_id                = (known after apply)
  + resource_id              = (known after apply)
  + resource_name            = "turbottest70643"
  + vpc_id                   = (known after apply)
aws_vpc.named_test_resource: Creating...
aws_s3_bucket.named_test_resource: Creating...
aws_vpc.named_test_resource: Creation complete after 4s [id=vpc-066b145ab2dde146c]
aws_s3_bucket.named_test_resource: Creation complete after 7s [id=turbottest70643]
aws_s3_access_point.named_test_resource: Creating...
aws_s3_access_point.named_test_resource: Creation complete after 2s [id=548702155676:turbottest70643]
aws_s3control_access_point_policy.access_point_policy: Creating...
aws_s3control_access_point_policy.access_point_policy: Creation complete after 1s [id=548702155676:turbottest70643]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

account_id = "548702155676"
arn = "arn:aws:s3:us-east-1:548702155676:accesspoint/turbottest70643"
aws_partition = "aws"
has_public_access_policy = false
network_origin = "VPC"
region_id = "us-east-1"
resource_id = "548702155676:turbottest70643"
resource_name = "turbottest70643"
vpc_id = "vpc-066b145ab2dde146c"

Running SQL query: test-get-query.sql
[
  {
    "access_point_arn": "arn:aws:s3:us-east-1:548702155676:accesspoint/turbottest70643",
    "account_id": "548702155676",
    "block_public_acls": true,
    "block_public_policy": false,
    "bucket_name": "turbottest70643",
    "ignore_public_acls": true,
    "name": "turbottest70643",
    "network_origin": "VPC",
    "partition": "aws",
    "region": "us-east-1",
    "restrict_public_buckets": false,
    "vpc_id": "vpc-066b145ab2dde146c"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "access_point_policy_is_public": false,
    "name": "turbottest70643",
    "policy": {
      "Statement": [
        {
          "Action": "s3:GetObjectTagging",
          "Effect": "Allow",
          "Principal": {
            "AWS": "*"
          },
          "Resource": "arn:aws:s3:us-east-1:548702155676:accesspoint/turbottest70643/object/*"
        }
      ],
      "Version": "2008-10-17"
    },
    "policy_std": {
      "Statement": [
        {
          "Action": [
            "s3:getobjecttagging"
          ],
          "Effect": "Allow",
          "Principal": {
            "AWS": [
              "*"
            ]
          },
          "Resource": [
            "arn:aws:s3:us-east-1:548702155676:accesspoint/turbottest70643/object/*"
          ]
        }
      ],
      "Version": "2008-10-17"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "access_point_arn": "arn:aws:s3:us-east-1:548702155676:accesspoint/turbottest70643",
    "name": "turbottest70643"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:s3:us-east-1:548702155676:accesspoint/turbottest70643"
    ],
    "title": "turbottest70643"
  }
]
✔ PASSED

POSTTEST: tests/aws_s3_access_point

TEARDOWN: tests/aws_s3_access_point


Error: Unrecognized remote plugin message: 

This usually means that the plugin is either invalid or simply
needs to be recompiled to support the latest protocol.

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws.aws_s3_access_point where bucket_name = 'test-log-fine234'
+------+------------------+-------------+-------------------------------+-------------------+---------------------+--------------------+-------------------------+---------------+
| name | access_point_arn | bucket_name | access_point_policy_is_public | block_public_acls | block_public_policy | ignore_public_acls | restrict_public_buckets | creation_date |
+------+------------------+-------------+-------------------------------+-------------------+---------------------+--------------------+-------------------------+---------------+
+------+------------------+-------------+-------------------------------+-------------------+---------------------+--------------------+-------------------------+---------------+
```
</details>
