### PR TITLE
Fix `getDefaultAwsRegion` to infer AWS default region based off of the region prefix in `aws.spc` regions argument.

### DIFF
--- a/aws/multi_region.go
+++ b/aws/multi_region.go
@@ -30,14 +30,6 @@ var (
 	awsUsIsobRegions = []string{"us-isob-east-1"}
 )
 
-func getAllAwsRegions() []string {
-	awsRegions := append(awsCommercialRegions, awsUsGovRegions...)
-	awsRegions = append(awsRegions, awsChinaRegions...)
-	awsRegions = append(awsRegions, awsUsIsoRegions...)
-	awsRegions = append(awsRegions, awsUsIsobRegions...)
-	return awsRegions
-}
-
 // BuildRegionList :: return a list of matrix items, one per region specified in the connection config.
 // Plugin supports wildcards "*" and "?" in the connection config for the regions.
 //

--- a/aws/service.go
+++ b/aws/service.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"math/rand"
 	"os"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -856,7 +855,8 @@ func PricingClient(ctx context.Context, d *plugin.QueryData) (*pricing.Client, e
 	// Pricing API is a global API that supports only us-east-1 and ap-south-1 regions
 	// getDefaultAwsRegion doesn't return the good region at the moment (it should use specified API endpoints but it doesn't).
 	// Set us-east-1 for now
-	cfg, err := getClient(ctx, d, "us-east-1")
+	region := getDefaultAwsRegion(d)
+	cfg, err := getClient(ctx, d, region)
 	if err != nil {
 		return nil, err
 	}
@@ -1431,17 +1431,14 @@ func GetSupportedRegionsForClient(ctx context.Context, d *plugin.QueryData, serv
 }
 
 // getDefaultAwsRegion returns the default region for AWS partiton
-// if not set by Env variable or in aws profile
 func getDefaultAwsRegion(d *plugin.QueryData) string {
-	allAwsRegions := getAllAwsRegions()
-
-	// have we already created and cached the service?
+	// Have we already created and cached the service?
 	serviceCacheKey := "getDefaultAwsRegion"
 	if cachedData, ok := d.ConnectionManager.Cache.Get(serviceCacheKey); ok {
 		return cachedData.(string)
 	}
 
-	// get aws config info
+	// Get AWS config info
 	awsConfig := GetConfig(d.Connection)
 
 	var regions []string
@@ -1449,8 +1446,13 @@ func getDefaultAwsRegion(d *plugin.QueryData) string {
 
 	if awsConfig.Regions != nil {
 		regions = awsConfig.Regions
+		// Pick the first region from the regions list to determine the default
+		// region for the AWS partition based on the region prefix.
 		region = regions[0]
 	} else {
+		// If the regions are not set in the aws.spc. This will try to pick the
+		// AWS region based on the SDK logic similar to the AWS CLI command
+		// "aws configure list"
 		session, err := session.NewSessionWithOptions(session.Options{
 			SharedConfigState: session.SharedConfigEnable,
 		})
@@ -1460,42 +1462,18 @@ func getDefaultAwsRegion(d *plugin.QueryData) string {
 		if session != nil && session.Config != nil {
 			region = *session.Config.Region
 		}
-
-		if region != "" {
-			regions = []string{region}
-		}
-	}
-
-	invalidPatterns := []string{}
-	for _, namePattern := range regions {
-		validRegions := []string{}
-		for _, validRegion := range allAwsRegions {
-			if ok, _ := path.Match(namePattern, validRegion); ok {
-				validRegions = append(validRegions, validRegion)
-			}
-		}
-
-		// Region items with wildcards that match on 0 regions should not be
-		// considered invalid
-		if len(validRegions) == 0 && !strings.ContainsAny(namePattern, "?*") {
-			invalidPatterns = append(invalidPatterns, namePattern)
-		}
-	}
-
-	if len(invalidPatterns) > 0 {
-		panic("\nconnection config has invalid \"regions\": " + strings.Join(invalidPatterns, ", ") + ". Edit your connection configuration file and then restart Steampipe.")
 	}
 
 	// most of the global services like IAM, S3, Route 53, etc. in all cloud types target these regions
-	if strings.HasPrefix(region, "us-gov") && !helpers.StringSliceContains(allAwsRegions, region) {
+	if strings.HasPrefix(region, "us-gov") {
 		region = "us-gov-west-1"
-	} else if strings.HasPrefix(region, "cn") && !helpers.StringSliceContains(allAwsRegions, region) {
+	} else if strings.HasPrefix(region, "cn") {
 		region = "cn-northwest-1"
-	} else if strings.HasPrefix(region, "us-isob") && !helpers.StringSliceContains(allAwsRegions, region) {
+	} else if strings.HasPrefix(region, "us-isob") {
 		region = "us-isob-east-1"
-	} else if strings.HasPrefix(region, "us-iso") && !helpers.StringSliceContains(allAwsRegions, region) {
+	} else if strings.HasPrefix(region, "us-iso") {
 		region = "us-iso-east-1"
-	} else if !helpers.StringSliceContains(allAwsRegions, region) {
+	} else {
 		region = "us-east-1"
 	}
 

--- a/aws/service.go
+++ b/aws/service.go
@@ -855,8 +855,7 @@ func PricingClient(ctx context.Context, d *plugin.QueryData) (*pricing.Client, e
 	// Pricing API is a global API that supports only us-east-1 and ap-south-1 regions
 	// getDefaultAwsRegion doesn't return the good region at the moment (it should use specified API endpoints but it doesn't).
 	// Set us-east-1 for now
-	region := getDefaultAwsRegion(d)
-	cfg, err := getClient(ctx, d, region)
+	cfg, err := getClient(ctx, d, "us-east-1")
 	if err != nil {
 		return nil, err
 	}

--- a/aws/service.go
+++ b/aws/service.go
@@ -1445,11 +1445,11 @@ func getDefaultAwsRegion(d *plugin.QueryData) string {
 
 	if awsConfig.Regions != nil {
 		regions = awsConfig.Regions
-		// Pick the first region from the regions list to determine the default
-		// region for the AWS partition based on the region prefix.
+		// Pick the first region from the regions list as a best guess to determine
+		// the default region for the AWS partition based on the region prefix.
 		region = regions[0]
 	} else {
-		// If the regions are not set in the aws.spc. This will try to pick the
+		// If the regions are not set in the aws.spc, this will try to pick the
 		// AWS region based on the SDK logic similar to the AWS CLI command
 		// "aws configure list"
 		session, err := session.NewSessionWithOptions(session.Options{
@@ -1463,7 +1463,7 @@ func getDefaultAwsRegion(d *plugin.QueryData) string {
 		}
 	}
 
-	// most of the global services like IAM, S3, Route 53, etc. in all cloud types target these regions
+	// Most of the global services like IAM, S3, Route 53, target these regions
 	if strings.HasPrefix(region, "us-gov") {
 		region = "us-gov-west-1"
 	} else if strings.HasPrefix(region, "cn") {


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

### Connection profiles
```
connection "aws" {
  plugin  = "aws"
  regions = ["*"]
}

connection "aws_1" {
  plugin  = "aws"
  regions = ["eu-south-2"]
}
```

### EARLIER
```
lalit@Lalits-MacBook-Pro:~/WORK/Turbot/steampipe/plugins/steampipe-plugin-aws|main⚡ ⇒  steampipe query                                                                              
Welcome to Steampipe v0.18.0-dev.8
For more information, type .help
> select * from aws_1.aws_sns_topic

Error: connection config has invalid "regions": eu-south-2. Edit your connection configuration file and then restart Steampipe. (SQLSTATE HV000)

+-----------+--------------+---------------------------------------+---------------------------------------+------------------------------------------+------------------------------------+------------------------->
| topic_arn | display_name | application_failure_feedback_role_arn | application_success_feedback_role_arn | application_success_feedback_sample_rate | firehose_failure_feedback_role_arn | firehose_success_feedbac>
+-----------+--------------+---------------------------------------+---------------------------------------+------------------------------------------+------------------------------------+------------------------->
+-----------+--------------+---------------------------------------+---------------------------------------+------------------------------------------+------------------------------------+-------------------------
```

### NOW
```
fix-getDefaultAwsRegion-function⚡ ⇒  steampipe query
Welcome to Steampipe v0.18.0-dev.8
For more information, type .help
> select * from aws.aws_sns_topic
+------------------------------------------------------------------------------+---------------------+---------------------------------------+---------------------------------------+------------------------------->
| topic_arn                                                                    | display_name        | application_failure_feedback_role_arn | application_success_feedback_role_arn | application_success_feedback_s>
+------------------------------------------------------------------------------+---------------------+---------------------------------------+---------------------------------------+------------------------------->
| arn:aws:sns:ap-south-1:111122223333:turbot_v5_aws_api_handler                |                     | <null>                                | <null>                                | <null>                        >
| arn:aws:sns:eu-west-1:111122223333:config-topic                              |                     | <null>                                | <null>                                | <null>                        >
| arn:aws:sns:eu-central-1:111122223333:turbot_aws_api_handler                 |                     | <null>                                | <null>                                | <null>                        >
| arn:aws:sns:eu-north-1:111122223333:turbot_aws_api_handler                   |                     | <null>                                | <null>                                | <null>                        >
| arn:aws:sns:ap-southeast-1:111122223333:turbot_aws_api_handler               |                     | <null>                                | <null>                                | <null>                        >
| arn:aws:sns:us-east-2:111122223333:turbot_aws_api_handler                    |                     | <null>                                | <null>                                | <null>                        >
| arn:aws:sns:eu-west-2:111122223333:turbot_aws_api_handler                    |                     | <null>                                | <null>                                | <null>                        >
| arn:aws:sns:ca-central-1:111122223333:turbot_aws_api_handler                 |                     | <null>                                | <null>                                | <null>                        >
| arn:aws:sns:us-east-1:111122223333:cloudwatch-alarms                         | cloudwatch-alarms   | <null>                                | <null>                                | 0                             >
|                                                                              |                     |                                       |                                       |                               >
| arn:aws:sns:us-east-2:111122223333:check-event-handler                       | check-event-handler | <null>                                | <null>                                | <null>                        >
| arn:aws:sns:us-east-1:111122223333:aws-cloudtrail-logs-111122223333-d3158c5a |                     | <null>                                | <null>                                | <null>                        >
| arn:aws:sns:us-east-1:111122223333:turbot_aws_api_handler                    |                     | <null>                                | <null>                                | <null>                        >
+------------------------------------------------------------------------------+---------------------+---------------------------------------+---------------------------------------+------------------------------->
> select * from aws_1.aws_sns_topic
+-----------+--------------+---------------------------------------+---------------------------------------+------------------------------------------+------------------------------------+------------------------->
| topic_arn | display_name | application_failure_feedback_role_arn | application_success_feedback_role_arn | application_success_feedback_sample_rate | firehose_failure_feedback_role_arn | firehose_success_feedbac>
+-----------+--------------+---------------------------------------+---------------------------------------+------------------------------------------+------------------------------------+------------------------->
+-----------+--------------+---------------------------------------+---------------------------------------+------------------------------------------+------------------------------------+------------------------->
> .quit

fix-getDefaultAwsRegion-function⚡ ⇒  aws sns create-topic --region eu-south-2 --name test
fix-getDefaultAwsRegion-function⚡ ⇒  steampipe query                                     
Welcome to Steampipe v0.18.0-dev.8
For more information, type .help
> select * from aws_1.aws_sns_topic
+------------------------------------------+--------------+---------------------------------------+---------------------------------------+------------------------------------------+------------------------------->
| topic_arn                                | display_name | application_failure_feedback_role_arn | application_success_feedback_role_arn | application_success_feedback_sample_rate | firehose_failure_feedback_role>
+------------------------------------------+--------------+---------------------------------------+---------------------------------------+------------------------------------------+------------------------------->
| arn:aws:sns:eu-south-2:111122223333:test |              | <null>                                | <null>                                | <null>                                   | <null>                        >
+----
```
</details>
