### PR TITLE
Fixed ServiceNotFoundException in aws_ecs_task table closes #1415

### DIFF
--- a/aws/table_aws_ecs_task.go
+++ b/aws/table_aws_ecs_task.go
@@ -313,6 +313,10 @@ func listEcsTasks(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 	for paginator.HasMorePages() {
 		output, err := paginator.NextPage(ctx)
 		if err != nil {
+			// Error could not be caught by ignore config, we need to handle it manually
+			if strings.Contains(err.Error(), "ServiceNotFoundException") {
+				return nil, nil
+			}
 			plugin.Logger(ctx).Error("aws_ecs_task.listEcsTasks", "list_tasks_api_error", err)
 			return nil, err
 		}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_ecs_task where service_name = 'tesgs'
+----------+------------------------+--------------+----------------+-------------+-------------------+------------------------+-------------+--------------+-----------------+-----+------------+------------------------+----------------------+-------+---------------+----
| task_arn | container_instance_arn | cluster_name | desired_status | launch_type | availability_zone | capacity_provider_name | cluster_arn | connectivity | connectivity_at | cpu | created_at | enable_execute_command | execution_stopped_at | group | health_status | las
+----------+------------------------+--------------+----------------+-------------+-------------------+------------------------+-------------+--------------+-----------------+-----+------------+------------------------+----------------------+-------+---------------+----
+----------+------------------------+--------------+----------------+-------------+-------------------+------------------------+-------------+--------------+-----------------+-----+------------+------------------------+----------------------+-------+---------------+----
```
</details>
