### PR TITLE
Fixed ResourceNotFoundException in aws_cloudwatch_log_metric_filter table closes #1419

### DIFF
--- a/aws/table_aws_cloudwatch_log_metric_filter.go
+++ b/aws/table_aws_cloudwatch_log_metric_filter.go
@@ -22,6 +22,9 @@ func tableAwsCloudwatchLogMetricFilter(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listCloudwatchLogMetricFilters,
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ResourceNotFoundException"}),
+			},
 			KeyColumns: []*plugin.KeyColumn{
 				{
 					Name:    "name",


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_aab.aws_cloudwatch_log_metric_filter where log_group_name = 'hdalkjl'
+------+----------------+---------------+----------------+----------------------------+---------------------------------+-----------------------------+-------+------+-----------+--------+------------+------+
| name | log_group_name | creation_time | filter_pattern | metric_transformation_name | metric_transformation_namespace | metric_transformation_value | title | akas | partition | region | account_id | _ctx |
+------+----------------+---------------+----------------+----------------------------+---------------------------------+-----------------------------+-------+------+-----------+--------+------------+------+
+------+----------------+---------------+----------------+----------------------------+---------------------------------+-----------------------------+-------+------+-----------+--------+------------+------+

> select
      g.arn as from_id,
      f.name as to_id
    from
      aws_cloudwatch_log_group as g
      left join aws_cloudwatch_log_metric_filter as f on g.name = f.log_group_name
    where
      f.region = g.region
+--------------------------------------------------------------------------------------------+-----------+
| from_id                                                                                    | to_id     |
+--------------------------------------------------------------------------------------------+-----------+
| arn:aws:logs:ap-south-1:472802157586:log-group:aws-cloudtrail-logs-632902152528-1c4bf776:* | metrci4.1 |
+--------------------------------------------------------------------------------------------+-----------+
```
</details>
