### PR TITLE
fix: fix invalid pointer usage when your ecr image doesn't have any finding

### DIFF
--- a/aws/table_aws_ecr_image_scan_finding.go
+++ b/aws/table_aws_ecr_image_scan_finding.go
@@ -163,6 +163,10 @@ func listAwsEcrImageScanFindings(ctx context.Context, d *plugin.QueryData, _ *pl
 			return nil, err
 		}
 
+		if output.ImageScanFindings == nil || output.ImageScanFindings.Findings == nil {
+			return nil, nil
+		}
+
 		for _, finding := range output.ImageScanFindings.Findings {
 			result := &ImageScanFindingsOutput{
 				ImageDigest:      output.ImageId.ImageDigest,


### PR DESCRIPTION

# Description

When you query a non existing aws image, or when there is still no finding, aws api returns an nil `output.ImageScanFindings.Findings` object.

This results in a `[HV000] ERROR: rpc error: code = Internal desc = hydrate function listAwsEcrImageScanFindings failed with panic runtime error: invalid memory address or nil pointer dereference` error.


This PR fixes this issue.
