### PR TITLE
Add column imds_support to aws_ec2_ami and aws_ec2_ami_shared table closes #1417

### DIFF
--- a/aws/table_aws_ec2_ami.go
+++ b/aws/table_aws_ec2_ami.go
@@ -104,6 +104,11 @@ func tableAwsEc2Ami(_ context.Context) *plugin.Table {
 				Default:     "self",
 			},
 			{
+				Name:        "imds_support",
+				Description: "Indicates that IMDSv2 is specified in the AMI",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "kernel_id",
 				Description: "The kernel associated with the image, if any. Only applicable for machine images.",
 				Type:        proto.ColumnType_STRING,

--- a/aws/table_aws_ec2_ami.go
+++ b/aws/table_aws_ec2_ami.go
@@ -105,7 +105,7 @@ func tableAwsEc2Ami(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "imds_support",
-				Description: "Indicates that IMDSv2 is specified in the AMI",
+				Description: "If v2.0, it indicates that IMDSv2 is specified in the AMI.",
 				Type:        proto.ColumnType_STRING,
 			},
 			{

--- a/aws/table_aws_ec2_ami_shared.go
+++ b/aws/table_aws_ec2_ami_shared.go
@@ -111,6 +111,11 @@ func tableAwsEc2AmiShared(_ context.Context) *plugin.Table {
 				Transform:   transform.FromValue(),
 			},
 			{
+				Name:        "imds_support",
+				Description: "Indicates that IMDSv2 is specified in the AMI",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "kernel_id",
 				Description: "The kernel associated with the image, if any. Only applicable for machine images.",
 				Type:        proto.ColumnType_STRING,

--- a/aws/table_aws_ec2_ami_shared.go
+++ b/aws/table_aws_ec2_ami_shared.go
@@ -112,7 +112,7 @@ func tableAwsEc2AmiShared(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "imds_support",
-				Description: "Indicates that IMDSv2 is specified in the AMI",
+				Description: "If v2.0, it indicates that IMDSv2 is specified in the AMI.",
 				Type:        proto.ColumnType_STRING,
 			},
 			{

--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dlm v1.12.4
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.19.11
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.15.9
-	github.com/aws/aws-sdk-go-v2/service/ec2 v1.52.1
+	github.com/aws/aws-sdk-go-v2/service/ec2 v1.72.1
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.17.16
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.13.15
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.18.19
@@ -127,7 +127,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.8 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.17 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.19 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.11.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.13.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -165,6 +165,8 @@ github.com/aws/aws-sdk-go-v2/service/dynamodb v1.15.9 h1:QTPDno4J5TyfpPi3dqCZpD+
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.15.9/go.mod h1:Req/32OLRbXpPX5TxHkwf2Ln9qclJCV6n1S7v0v+FWo=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.52.1 h1:A2hit+4GRYOdvs2aJxGhDrrRS17zSa66M+k1IqqgUic=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.52.1/go.mod h1:YbPg6ou7dlvFTJMmbV3zhec+A22S1Ow+ZB6k6xUs9oY=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.72.1 h1:iR8DtI9Jc9sMdOsvjiu6rs5jH+9csW88elgwpEMP8TU=
+github.com/aws/aws-sdk-go-v2/service/ec2 v1.72.1/go.mod h1:zul71QqzR4D1a90/5FloZiAnZ1CtuIjVH7R9MP997+A=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.17.16 h1:Fl+PSDkwzeNnI42wHAfRvreL6r7I2yAVYSCpXan9go4=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.17.16/go.mod h1:PKNfdxgouO2lS7Hl3p3LlEOsGS9ZHMu+P6E2ZfrdVxM=
 github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.13.15 h1:nY5bV/eL9iLzHDgZAxD8F793o28wrvukgrmQriQx0Ec=
@@ -219,6 +221,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.8/go.mod h1:rDV
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.12/go.mod h1:1TODGhheLWjpQWSuhYuAUWYTCKwEjx2iblIFKDHjeTc=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.17 h1:Jrd/oMh0PKQc6+BowB+pLEwLIgaQF29eYbe7E1Av9Ug=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.17/go.mod h1:4nYOrY41Lrbk2170/BGkcJKBhws9Pfn8MG3aGqjjeFI=
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.19 h1:GE25AWCdNUPh9AOJzI9KIJnja7IwUc1WyUqz/JTyJ/I=
+github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.19/go.mod h1:02CP6iuYP+IVnBX5HULVdSAku/85eHB2Y9EsFhrkEwU=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.8 h1:TlN1UC39A0LUNoD51ubO5h32haznA+oVe15jO9O4Lj0=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.8/go.mod h1:JlVwmWtT/1c5W+6oUsjXjAJ0iJZ+hlghdrDy/8JxGCU=
 github.com/aws/aws-sdk-go-v2/service/kafka v1.17.15 h1:MpzLGfgsFwY+rk5rERg22DiH2ijc9DvL2x42ccmj5z0=


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_ami []

PRETEST: tests/aws_ec2_ami

TEST: tests/aws_ec2_ami
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 1s [id=986502156756]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.template_file.resource_aka will be read during apply
  # (config refers to values not yet known)
 <= data "template_file" "resource_aka" {
      + id       = (known after apply)
      + rendered = (known after apply)
      + template = (known after apply)
      + vars     = {
          + "account_id" = "986502156756"
          + "partition"  = "aws"
          + "region"     = "us-east-1"
        }
    }

  # aws_ami.named_test_resource will be created
  + resource "aws_ami" "named_test_resource" {
      + architecture         = "x86_64"
      + arn                  = (known after apply)
      + description          = "This is a test image."
      + hypervisor           = (known after apply)
      + id                   = (known after apply)
      + image_location       = (known after apply)
      + image_owner_alias    = (known after apply)
      + image_type           = (known after apply)
      + manage_ebs_snapshots = (known after apply)
      + name                 = "turbottest12462"
      + owner_id             = (known after apply)
      + platform             = (known after apply)
      + platform_details     = (known after apply)
      + public               = (known after apply)
      + root_device_name     = "/dev/sda1"
      + root_snapshot_id     = (known after apply)
      + sriov_net_support    = "simple"
      + tags                 = {
          + "Name" = "turbottest12462"
        }
      + tags_all             = {
          + "Name" = "turbottest12462"
        }
      + usage_operation      = (known after apply)
      + virtualization_type  = "hvm"

      + ebs_block_device {
          + delete_on_termination = true
          + device_name           = "/dev/sda1"
          + snapshot_id           = (known after apply)
          + throughput            = (known after apply)
          + volume_size           = 8
          + volume_type           = "standard"
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + virtual_name = (known after apply)
        }
    }

  # aws_ami_launch_permission.allow_access will be created
  + resource "aws_ami_launch_permission" "allow_access" {
      + account_id = "388460667113"
      + id         = (known after apply)
      + image_id   = (known after apply)
    }

  # aws_ami_launch_permission.deny_access will be created
  + resource "aws_ami_launch_permission" "deny_access" {
      + account_id = "013122550996"
      + id         = (known after apply)
      + image_id   = (known after apply)
    }

  # aws_ebs_snapshot.my_snapshot will be created
  + resource "aws_ebs_snapshot" "my_snapshot" {
      + arn                    = (known after apply)
      + data_encryption_key_id = (known after apply)
      + encrypted              = (known after apply)
      + id                     = (known after apply)
      + kms_key_id             = (known after apply)
      + owner_alias            = (known after apply)
      + owner_id               = (known after apply)
      + storage_tier           = (known after apply)
      + tags                   = {
          + "Name" = "turbot-snapshot-test"
        }
      + tags_all               = {
          + "Name" = "turbot-snapshot-test"
        }
      + volume_id              = (known after apply)
      + volume_size            = (known after apply)
    }

  # aws_ebs_volume.my_volume will be created
  + resource "aws_ebs_volume" "my_volume" {
      + arn               = (known after apply)
      + availability_zone = "us-east-1a"
      + encrypted         = (known after apply)
      + final_snapshot    = false
      + id                = (known after apply)
      + iops              = (known after apply)
      + kms_key_id        = (known after apply)
      + size              = 8
      + snapshot_id       = (known after apply)
      + tags              = {
          + "Name" = "turbot-volume-test"
        }
      + tags_all          = {
          + "Name" = "turbot-volume-test"
        }
      + throughput        = (known after apply)
      + type              = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "986502156756"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest12462"
  + snapshot_id   = (known after apply)
aws_ebs_volume.my_volume: Creating...
aws_ebs_volume.my_volume: Still creating... [10s elapsed]
aws_ebs_volume.my_volume: Creation complete after 12s [id=vol-0d48d24f6727d619c]
aws_ebs_snapshot.my_snapshot: Creating...
aws_ebs_snapshot.my_snapshot: Still creating... [10s elapsed]
aws_ebs_snapshot.my_snapshot: Creation complete after 16s [id=snap-012303f649939f5ee]
aws_ami.named_test_resource: Creating...
aws_ami.named_test_resource: Creation complete after 7s [id=ami-0e98ce66cac1b8cd5]
aws_ami_launch_permission.deny_access: Creating...
aws_ami_launch_permission.allow_access: Creating...
data.template_file.resource_aka: Reading...
data.template_file.resource_aka: Read complete after 0s [id=3a87d665f7c8a2b2c6340c7389abc2b9db4a8dd3215bbdec7c94b627035f7f4d]
aws_ami_launch_permission.deny_access: Creation complete after 1s [id=ami-0e98ce66cac1b8cd5-013122550996]
aws_ami_launch_permission.allow_access: Creation complete after 2s [id=ami-0e98ce66cac1b8cd5-388460667113]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 54, in data "null_data_source" "resource":
  54: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "986502156756"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:ec2:us-east-1:986502156756:image/ami-0e98ce66cac1b8cd5"
resource_id = "ami-0e98ce66cac1b8cd5"
resource_name = "turbottest12462"
snapshot_id = "snap-012303f649939f5ee"

Running SQL query: query.sql
[
  {
    "image_id": "ami-0e98ce66cac1b8cd5",
    "name": "turbottest12462"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "architecture": "x86_64",
    "block_device_mappings": [
      {
        "DeviceName": "/dev/sda1",
        "Ebs": {
          "DeleteOnTermination": true,
          "Encrypted": false,
          "Iops": null,
          "KmsKeyId": null,
          "OutpostArn": null,
          "SnapshotId": "snap-012303f649939f5ee",
          "Throughput": null,
          "VolumeSize": 8,
          "VolumeType": "standard"
        },
        "NoDevice": null,
        "VirtualName": null
      }
    ],
    "description": "This is a test image.",
    "ena_support": false,
    "hypervisor": "xen",
    "image_id": "ami-0e98ce66cac1b8cd5",
    "image_location": "986502156756/turbottest12462",
    "image_type": "machine",
    "name": "turbottest12462",
    "owner_id": "986502156756",
    "platform_details": "Linux/UNIX",
    "public": false,
    "root_device_name": "/dev/sda1",
    "root_device_type": "ebs",
    "sriov_net_support": "simple",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest12462"
      }
    ],
    "usage_operation": "RunInstances",
    "virtualization_type": "hvm"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:986502156756:image/ami-0e98ce66cac1b8cd5"
    ],
    "image_id": "ami-0e98ce66cac1b8cd5",
    "launch_permissions": [
      {
        "Group": null,
        "OrganizationArn": null,
        "OrganizationalUnitArn": null,
        "UserId": "388460667113"
      },
      {
        "Group": null,
        "OrganizationArn": null,
        "OrganizationalUnitArn": null,
        "UserId": "013122550996"
      }
    ],
    "tags": {
      "Name": "turbottest12462"
    },
    "title": "turbottest12462"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "image_id": "ami-0e98ce66cac1b8cd5",
    "name": "turbottest12462"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_ami

TEARDOWN: tests/aws_ec2_ami

SUMMARY:

1/1 passed.
```

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_ami_shared []

PRETEST: tests/aws_ec2_ami_shared

TEST: tests/aws_ec2_ami_shared
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 2s [id=986502156756]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.template_file.resource_aka will be read during apply
  # (config refers to values not yet known)
 <= data "template_file" "resource_aka" {
      + id       = (known after apply)
      + rendered = (known after apply)
      + template = (known after apply)
      + vars     = {
          + "account_id" = "986502156756"
          + "partition"  = "aws"
          + "region"     = "us-east-1"
        }
    }

  # aws_ami.named_test_resource will be created
  + resource "aws_ami" "named_test_resource" {
      + architecture         = "x86_64"
      + arn                  = (known after apply)
      + description          = "turbottest57913"
      + hypervisor           = (known after apply)
      + id                   = (known after apply)
      + image_location       = (known after apply)
      + image_owner_alias    = (known after apply)
      + image_type           = (known after apply)
      + manage_ebs_snapshots = (known after apply)
      + name                 = "turbottest57913"
      + owner_id             = (known after apply)
      + platform             = (known after apply)
      + platform_details     = (known after apply)
      + public               = (known after apply)
      + root_device_name     = "/dev/sda1"
      + root_snapshot_id     = (known after apply)
      + sriov_net_support    = "simple"
      + tags_all             = (known after apply)
      + usage_operation      = (known after apply)
      + virtualization_type  = "hvm"

      + ebs_block_device {
          + delete_on_termination = true
          + device_name           = "/dev/sda1"
          + snapshot_id           = (known after apply)
          + throughput            = (known after apply)
          + volume_size           = 8
          + volume_type           = "standard"
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + virtual_name = (known after apply)
        }
    }

  # aws_ami_launch_permission.allow_access will be created
  + resource "aws_ami_launch_permission" "allow_access" {
      + account_id = "388460667113"
      + id         = (known after apply)
      + image_id   = (known after apply)
    }

  # aws_ami_launch_permission.deny_access will be created
  + resource "aws_ami_launch_permission" "deny_access" {
      + account_id = "013122550996"
      + id         = (known after apply)
      + image_id   = (known after apply)
    }

  # aws_ebs_snapshot.named_test_resource will be created
  + resource "aws_ebs_snapshot" "named_test_resource" {
      + arn                    = (known after apply)
      + data_encryption_key_id = (known after apply)
      + encrypted              = (known after apply)
      + id                     = (known after apply)
      + kms_key_id             = (known after apply)
      + owner_alias            = (known after apply)
      + owner_id               = (known after apply)
      + storage_tier           = (known after apply)
      + tags_all               = (known after apply)
      + volume_id              = (known after apply)
      + volume_size            = (known after apply)
    }

  # aws_ebs_volume.named_test_resource will be created
  + resource "aws_ebs_volume" "named_test_resource" {
      + arn               = (known after apply)
      + availability_zone = "us-east-1a"
      + encrypted         = (known after apply)
      + final_snapshot    = false
      + id                = (known after apply)
      + iops              = (known after apply)
      + kms_key_id        = (known after apply)
      + size              = 8
      + snapshot_id       = (known after apply)
      + tags_all          = (known after apply)
      + throughput        = (known after apply)
      + type              = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "986502156756"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest57913"
  + snapshot_id   = (known after apply)
aws_ebs_volume.named_test_resource: Creating...
aws_ebs_volume.named_test_resource: Still creating... [10s elapsed]
aws_ebs_volume.named_test_resource: Creation complete after 12s [id=vol-00855c85d4c3cb628]
aws_ebs_snapshot.named_test_resource: Creating...
aws_ebs_snapshot.named_test_resource: Still creating... [10s elapsed]
aws_ebs_snapshot.named_test_resource: Creation complete after 16s [id=snap-09bbf0f9734f8a53f]
aws_ami.named_test_resource: Creating...
aws_ami.named_test_resource: Creation complete after 7s [id=ami-0e1c9c7c24b6b97ef]
aws_ami_launch_permission.allow_access: Creating...
aws_ami_launch_permission.deny_access: Creating...
data.template_file.resource_aka: Reading...
data.template_file.resource_aka: Read complete after 0s [id=c1314671d5ecfcf79505ecff5d614afb7362dbfc67ad344fe90e6ab210312c38]
aws_ami_launch_permission.allow_access: Creation complete after 1s [id=ami-0e1c9c7c24b6b97ef-388460667113]
aws_ami_launch_permission.deny_access: Creation complete after 1s [id=ami-0e1c9c7c24b6b97ef-013122550996]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 53, in data "null_data_source" "resource":
  53: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "986502156756"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:ec2:us-east-1:986502156756:image/ami-0e1c9c7c24b6b97ef"
resource_id = "ami-0e1c9c7c24b6b97ef"
resource_name = "turbottest57913"
snapshot_id = "snap-09bbf0f9734f8a53f"

Running SQL query: test-get-query.sql
[
  {
    "architecture": "x86_64",
    "block_device_mappings": [
      {
        "DeviceName": "/dev/sda1",
        "Ebs": {
          "DeleteOnTermination": true,
          "Encrypted": false,
          "Iops": null,
          "KmsKeyId": null,
          "OutpostArn": null,
          "SnapshotId": "snap-09bbf0f9734f8a53f",
          "Throughput": null,
          "VolumeSize": 8,
          "VolumeType": "standard"
        },
        "NoDevice": null,
        "VirtualName": null
      }
    ],
    "description": "turbottest57913",
    "ena_support": false,
    "hypervisor": "xen",
    "image_id": "ami-0e1c9c7c24b6b97ef",
    "image_location": "986502156756/turbottest57913",
    "image_type": "machine",
    "name": "turbottest57913",
    "owner_id": "986502156756",
    "platform_details": "Linux/UNIX",
    "public": false,
    "root_device_name": "/dev/sda1",
    "root_device_type": "ebs",
    "sriov_net_support": "simple",
    "usage_operation": "RunInstances",
    "virtualization_type": "hvm"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "image_id": "ami-0e1c9c7c24b6b97ef",
    "name": "turbottest57913"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:986502156756:image/ami-0e1c9c7c24b6b97ef"
    ],
    "title": "turbottest57913"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_ami_shared

TEARDOWN: tests/aws_ec2_ami_shared

SUMMARY:

1/1 passed.
```

</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, image_id, imds_support from aws_ec2_ami;
+----------+-----------------------+--------------+
| name     | image_id              | imds_support |
+----------+-----------------------+--------------+
| test123  | ami-0a422d9e5229a06a9 |              |
| my-image | ami-051662b4f665cc54d | v2.0         |
+----------+-----------------------+--------------+

> select name, image_id, imds_support from aws_ec2_ami_shared where owner_id = '986502156756'
+----------+-----------------------+--------------+
| name     | image_id              | imds_support |
+----------+-----------------------+--------------+
| my-image | ami-051662b4f665cc54d | v2.0         |
| test123  | ami-0a422d9e5229a06a9 |              |
+----------+-----------------------+--------------+
```
</details>
