### PR TITLE
Update `aws_cloudwatch_metric` table to return a metric in each row instead of a metric dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.87.0 [TBD]
+
+_Breaking changes_
+
+- The `aws_cloudwatch_metric` table rows now contain a CloudWatch metric each, instead of a dimension name/value pair. Dimensions for each metric can be found in the `dimensions` column and to filter on specific dimensions, you can pass dimensions through the `dimensions_filter` key column. Please see [aws_cloudwatch_metric Examples](https://hub.steampipe.io/plugins/turbot/aws/tables/aws_cloudwatch_metric#examples) for query examples using the new columns.
+- Renamed column `name` to `metric_name` in the `aws_cloudwatch_metric` table.
+
 ## v0.86.0 [2022-11-28]
 
 _What's new?_

--- a/docs/tables/aws_cloudwatch_metric.md
+++ b/docs/tables/aws_cloudwatch_metric.md
@@ -2,58 +2,75 @@
 
 Metrics are data about the performance of your systems. By default, many services provide free metrics for resources (such as Amazon EC2 instances, Amazon EBS volumes, and Amazon RDS DB instances).
 
+**Note**: Up to 10 dimensions can be included in the `dimensions_filter` column.
+
 ## Examples
 
 ### Basic info
 
 ```sql
 select
-  name,
+  metric_name,
   namespace,
-  dimension_name,
-  dimension_value
+  dimensions
 from
   aws_cloudwatch_metric;
 ```
 
-### List metric by EBS namespace
+### List EBS metrics
 
 ```sql
 select
-  name,
+  metric_name,
   namespace,
-  dimension_name,
-  dimension_value
+  dimensions
 from
   aws_cloudwatch_metric
 where
   namespace = 'AWS/EBS';
 ```
 
-### List metric details for metric name VolumeReadOps
+### List EBS `VolumeReadOps` metrics
 
 ```sql
 select
-  name,
+  metric_name,
   namespace,
-  dimension_name,
-  dimension_value
+  dimensions
 from
   aws_cloudwatch_metric
 where
-  name = 'VolumeReadOps';
+  namespace = 'AWS/EBS'
+  and metric_name = 'VolumeReadOps';
 ```
 
-### List metric for a redshift cluster
+### List metrics for a specific Redshift cluster
 
 ```sql
 select
-  name,
+  metric_name,
   namespace,
-  dimension_name,
-  dimension_value
+  dimensions
 from
   aws_cloudwatch_metric
 where
-  dimension_name = 'ClusterIdentifier' and dimension_value = 'redshift-cluster-1';
+  dimensions_filter = '[
+    {"Name": "ClusterIdentifier", "Value": "my-cluster-1"}
+  ]'::jsonb;
+```
+
+### List EC2 API metrics
+
+```sql
+select
+  metric_name,
+  namespace,
+  dimensions
+from
+  aws_cloudwatch_metric
+where
+  dimensions_filter = '[
+    {"Name": "Type", "Value": "API"},
+    {"Name": "Service", "Value": "EC2"}
+  ]'::jsonb;
 ```


### PR DESCRIPTION
# Integration test logs

N/A

# Example query results
<details>
  <summary>Results</summary>

```
> select
  metric_name,
  namespace,
  dimensions
from
  aws_cloudwatch_metric limit 10
-[ RECORD 1  ]---------------------------------------------------------------------------
metric_name | CallCount
namespace   | AWS/Usage
dimensions  | [{"Name":"Type","Value":"API"},{"Name":"Resource","Value":"DescribeTransitGatewayRouteTables"},{"Name":"Service","Value":"EC2"},{"Name":"Class","Value":"None"}]
-[ RECORD 2  ]---------------------------------------------------------------------------
metric_name | CallCount
namespace   | AWS/Usage
dimensions  | [{"Name":"Type","Value":"API"},{"Name":"Resource","Value":"DescribeKeyPairs"},{"Name":"Service","Value":"EC2"},{"Name":"Class","Value":"None"}]
-[ RECORD 3  ]---------------------------------------------------------------------------
metric_name | CallCount
namespace   | AWS/Usage
dimensions  | [{"Name":"Type","Value":"API"},{"Name":"Resource","Value":"DescribeReservedDBInstances"},{"Name":"Service","Value":"RDS"},{"Name":"Class","Value":"None"}]
-[ RECORD 4  ]---------------------------------------------------------------------------
metric_name | CallCount
namespace   | AWS/Usage
dimensions  | [{"Name":"Type","Value":"API"},{"Name":"Resource","Value":"DescribeCapacityReservationFleets"},{"Name":"Service","Value":"EC2"},{"Name":"Class","Value":"None"}]
-[ RECORD 5  ]---------------------------------------------------------------------------
metric_name | CallCount
namespace   | AWS/Usage
dimensions  | [{"Name":"Type","Value":"API"},{"Name":"Resource","Value":"DescribeInstanceEventWindows"},{"Name":"Service","Value":"EC2"},{"Name":"Class","Value":"None"}]
-[ RECORD 6  ]---------------------------------------------------------------------------
metric_name | CallCount
namespace   | AWS/Usage
dimensions  | [{"Name":"Type","Value":"API"},{"Name":"Resource","Value":"DescribeVpnConnections"},{"Name":"Service","Value":"EC2"},{"Name":"Class","Value":"None"}]
-[ RECORD 7  ]---------------------------------------------------------------------------
metric_name | CallCount
namespace   | AWS/Usage
dimensions  | [{"Name":"Type","Value":"API"},{"Name":"Resource","Value":"ListStorageLensConfigurations"},{"Name":"Service","Value":"S3"},{"Name":"Class","Value":"None"}]
-[ RECORD 8  ]---------------------------------------------------------------------------
metric_name | CallCount
namespace   | AWS/Usage
dimensions  | [{"Name":"Type","Value":"API"},{"Name":"Resource","Value":"DescribeTrails"},{"Name":"Service","Value":"CloudTrail"},{"Name":"Class","Value":"None"}]
-[ RECORD 9  ]---------------------------------------------------------------------------
metric_name | CallCount
namespace   | AWS/Usage
dimensions  | [{"Name":"Type","Value":"API"},{"Name":"Resource","Value":"DescribeNetworkAcls"},{"Name":"Service","Value":"EC2"},{"Name":"Class","Value":"None"}]
-[ RECORD 10 ]---------------------------------------------------------------------------
metric_name | CallCount
namespace   | AWS/Usage
dimensions  | [{"Name":"Type","Value":"API"},{"Name":"Resource","Value":"DescribeVpcPeeringConnections"},{"Name":"Service","Value":"EC2"},{"Name":"Class","Value":"None"}]
```

```
> select
  metric_name,
  namespace,
  dimensions
from
  aws_cloudwatch_metric
where
  namespace = 'AWS/EBS';
-[ RECORD 1  ]---------------------------------------------------------------------------
metric_name | BurstBalance
namespace   | AWS/EBS
dimensions  | [{"Name":"VolumeId","Value":"vol-0d4e1f159999999"}]
-[ RECORD 2  ]---------------------------------------------------------------------------
metric_name | BurstBalance
namespace   | AWS/EBS
dimensions  | [{"Name":"VolumeId","Value":"vol-0d4e1f159999999"}]
-[ RECORD 3  ]---------------------------------------------------------------------------
metric_name | VolumeWriteBytes
namespace   | AWS/EBS
dimensions  | [{"Name":"VolumeId","Value":"vol-0d4e1f159999999"}]
-[ RECORD 4  ]---------------------------------------------------------------------------
metric_name | BurstBalance
namespace   | AWS/EBS
dimensions  | [{"Name":"VolumeId","Value":"vol-0d4e1f159999999"}]
-[ RECORD 5  ]---------------------------------------------------------------------------
metric_name | VolumeQueueLength
namespace   | AWS/EBS
dimensions  | [{"Name":"VolumeId","Value":"vol-0d4e1f159999999"}]
```
</details>
