### PR TITLE
Fix usage of WithCache for getCommonColumns

### DIFF
--- a/aws/table_aws_account.go
+++ b/aws/table_aws_account.go
@@ -116,7 +116,6 @@ func listAccountAlias(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		return nil, err
 	}
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_account.listAccountAlias", "common_data_error", err)

--- a/aws/table_aws_account_alternate_contact.go
+++ b/aws/table_aws_account_alternate_contact.go
@@ -93,7 +93,6 @@ type accountAlternateContactData = struct {
 func listAwsAccountAlternateContacts(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_account_contact.go
+++ b/aws/table_aws_account_contact.go
@@ -128,7 +128,6 @@ type accountContactData = struct {
 func listAwsAccountContacts(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_api_gateway_api_authorizer.go
+++ b/aws/table_aws_api_gateway_api_authorizer.go
@@ -200,7 +200,6 @@ func getAPIGatewayAuthorizerAkas(ctx context.Context, d *plugin.QueryData, h *pl
 		id = *item.Id
 	}
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_api_gateway_api_key.go
+++ b/aws/table_aws_api_gateway_api_key.go
@@ -207,7 +207,6 @@ func getAwsAPIKeysAkas(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 		id = *h.Item.(types.ApiKey).Id
 	}
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_api_gateway_rest_api.go
+++ b/aws/table_aws_api_gateway_rest_api.go
@@ -228,7 +228,6 @@ func getAwsRestAPITurbotData(ctx context.Context, d *plugin.QueryData, h *plugin
 		id = *h.Item.(types.RestApi).Id
 	}
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_api_gateway_stage.go
+++ b/aws/table_aws_api_gateway_stage.go
@@ -253,7 +253,6 @@ func getAPIGatewayStageARN(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	apiStage := h.Item.(*stageRowData)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_api_gateway_usage_plan.go
+++ b/aws/table_aws_api_gateway_usage_plan.go
@@ -178,7 +178,6 @@ func getUsagePlanAkas(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		id = *h.Item.(types.UsagePlan).Id
 	}
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_api_gatewayv2_api.go
+++ b/aws/table_aws_api_gatewayv2_api.go
@@ -208,7 +208,6 @@ func getAPIGatewayV2APIAkas(ctx context.Context, d *plugin.QueryData, h *plugin.
 		id = *h.Item.(types.Api).ApiId
 	}
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_api_gatewayv2_domain_name.go
+++ b/aws/table_aws_api_gatewayv2_domain_name.go
@@ -178,7 +178,6 @@ func getapiGatewayV2DomainNameAkas(ctx context.Context, d *plugin.QueryData, h *
 		domainName = *h.Item.(types.DomainName).DomainName
 	}
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_api_gatewayv2_integration.go
+++ b/aws/table_aws_api_gatewayv2_integration.go
@@ -292,7 +292,6 @@ func getAPIGatewayV2Integration(ctx context.Context, d *plugin.QueryData, _ *plu
 func getAPIGatewayV2IntegrationARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	data := h.Item.(integrationInfo)
 	region := d.KeyColumnQualString(matrixKeyRegion)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_api_gatewayv2_stage.go
+++ b/aws/table_aws_api_gatewayv2_stage.go
@@ -277,7 +277,6 @@ func getAPIGatewayV2Stage(ctx context.Context, d *plugin.QueryData, _ *plugin.Hy
 func apiGatewayV2StageAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	data := h.Item.(*v2StageRowData)
 	region := d.KeyColumnQualString(matrixKeyRegion)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_appconfig_application.go
+++ b/aws/table_aws_appconfig_application.go
@@ -193,7 +193,6 @@ func getArnFormat(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	id := h.Item.(types.Application).Id
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_appconfig_application.getArnFormat", "cache_error", err)

--- a/aws/table_aws_auditmanager_evidence.go
+++ b/aws/table_aws_auditmanager_evidence.go
@@ -348,7 +348,6 @@ func getAuditManagerEvidenceARN(ctx context.Context, d *plugin.QueryData, h *plu
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	evidenceID := *h.Item.(evidenceInfo).Evidence.Id
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_auditmanager_evidence.getAuditManagerEvidenceARN", "common_data_error", err)

--- a/aws/table_aws_auditmanager_evidence_folder.go
+++ b/aws/table_aws_auditmanager_evidence_folder.go
@@ -257,7 +257,6 @@ func getAuditManagerEvidenceFolderARN(ctx context.Context, d *plugin.QueryData, 
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	evidenceFolderID := *h.Item.(types.AssessmentEvidenceFolder).Id
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_auditmanager_evidence_folder.getAuditManagerEvidenceFolderARN", "common_data_error", err)

--- a/aws/table_aws_availability_zone.go
+++ b/aws/table_aws_availability_zone.go
@@ -193,7 +193,6 @@ func getAwsAvailabilityZone(ctx context.Context, d *plugin.QueryData, _ *plugin.
 func getAwsAvailabilityZoneAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	zone := h.Item.(types.AvailabilityZone)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_backup_selection.go
+++ b/aws/table_aws_backup_selection.go
@@ -217,7 +217,6 @@ func getBackupSelectionARN(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	data := selectionID(h.Item)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_cloudfront_cache_policy.go
+++ b/aws/table_aws_cloudfront_cache_policy.go
@@ -195,7 +195,6 @@ func getCloudFrontCachePolicy(ctx context.Context, d *plugin.QueryData, h *plugi
 
 func getCloudfrontCachePolicyAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	id := cloudFrontCachePolicyAka(h.Item)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_cloudfront_cache_policy.getCloudfrontCachePolicyAkas", "common_data_error", err)

--- a/aws/table_aws_cloudfront_origin_access_identity.go
+++ b/aws/table_aws_cloudfront_origin_access_identity.go
@@ -178,7 +178,6 @@ func getCloudFrontOriginAccessIdentity(ctx context.Context, d *plugin.QueryData,
 func getCloudFrontOriginAccessIdentityARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	originAccessIdentityData := *originAccessIdentityID(h.Item)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_cloudfront_origin_access_identity.getCloudFrontOriginAccessIdentityARN", "common_data_error", err)

--- a/aws/table_aws_cloudfront_origin_request_policy.go
+++ b/aws/table_aws_cloudfront_origin_request_policy.go
@@ -191,7 +191,6 @@ func getCloudFrontOriginRequestPolicy(ctx context.Context, d *plugin.QueryData, 
 func getCloudFrontOriginRequestPolicyAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	policyID := *originRequestPolicyID(h.Item)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_cloudfront_response_headers_policy.go
+++ b/aws/table_aws_cloudfront_response_headers_policy.go
@@ -177,7 +177,6 @@ func getETagValue(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 
 func getAccountARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// Get common columns which will be used to create the ARN
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	response, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_cloudfront_response_headers_policy.getAccountARN", "common_data_error", err)

--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -304,7 +304,6 @@ func getCloudtrailTrail(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 }
 
 func getCloudtrailTrailStatus(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Info("aws_cloudtrail_trail.getCloudtrailTrailStatus", "common_data_error", err)
@@ -346,7 +345,6 @@ func getCloudtrailTrailStatus(ctx context.Context, d *plugin.QueryData, h *plugi
 }
 
 func getCloudtrailTrailEventSelector(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Info("aws_cloudtrail_trail.getCloudtrailTrailEventSelector", "common_data_error", err)
@@ -388,7 +386,6 @@ func getCloudtrailTrailEventSelector(ctx context.Context, d *plugin.QueryData, h
 }
 
 func getCloudtrailTrailTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Info("aws_cloudtrail_trail.getCloudtrailTrailTags", "common_data_error", err)

--- a/aws/table_aws_cloudwatch_log_metric_filter.go
+++ b/aws/table_aws_cloudwatch_log_metric_filter.go
@@ -207,7 +207,6 @@ func getCloudwatchLogMetricFilterAkas(ctx context.Context, d *plugin.QueryData, 
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	metricFilter := h.Item.(types.MetricFilter)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_cloudwatch_log_metric_filter.getCloudwatchLogMetricFilter", "api_error", err)

--- a/aws/table_aws_cloudwatch_log_subscription_filter.go
+++ b/aws/table_aws_cloudwatch_log_subscription_filter.go
@@ -207,7 +207,6 @@ func getCloudwatchLogSubscriptionFilterAkas(ctx context.Context, d *plugin.Query
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	subscriptionFilter := h.Item.(types.SubscriptionFilter)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_cloudwatch_log_subscription_filter.getCloudwatchLogSubscriptionFilterAkas", "cache_error", err)

--- a/aws/table_aws_codedeploy_app.go
+++ b/aws/table_aws_codedeploy_app.go
@@ -227,7 +227,6 @@ func codeDeployApplicationArn(ctx context.Context, d *plugin.QueryData, h *plugi
 	name := *h.Item.(*types.ApplicationInfo).ApplicationName
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	logger := plugin.Logger(ctx)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		logger.Error("aws_codedeploy_app.getCodeDeployApplicationArn", "caching_error", err)

--- a/aws/table_aws_codepipeline_pipeline.go
+++ b/aws/table_aws_codepipeline_pipeline.go
@@ -269,7 +269,6 @@ func pipelineARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
 	// Get region, partition, account id
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return ""

--- a/aws/table_aws_config_configuration_recorder.go
+++ b/aws/table_aws_config_configuration_recorder.go
@@ -176,7 +176,6 @@ func getAwsConfigurationRecorderARN(ctx context.Context, d *plugin.QueryData, h 
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
 	configurationRecorder := h.Item.(types.ConfigurationRecorder)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_config_configuration_recorder.getAwsConfigurationRecorderARN", "api_error", err)

--- a/aws/table_aws_dax_subnet_group.go
+++ b/aws/table_aws_dax_subnet_group.go
@@ -144,7 +144,6 @@ func getDaxSubnetGroupsAkas(ctx context.Context, d *plugin.QueryData, h *plugin.
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	name := *h.Item.(types.SubnetGroup).SubnetGroupName
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_dax_subnet_group.getDaxSubnetGroupsAkas", "cache_error", err)

--- a/aws/table_aws_directory_service_directory.go
+++ b/aws/table_aws_directory_service_directory.go
@@ -356,7 +356,6 @@ func getDirectoryServiceSharedDirectory(ctx context.Context, d *plugin.QueryData
 func getDirectoryARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	directory := h.Item.(types.DirectoryDescription)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -355,7 +355,6 @@ func getTableTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	table := h.Item.(types.TableDescription)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_dynamodb_table_export.go
+++ b/aws/table_aws_dynamodb_table_export.go
@@ -160,7 +160,6 @@ func listTableExports(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_dynamodb_table_export.listTableExports", "common_data_error", err)

--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -265,7 +265,6 @@ func getAwsEBSSnapshot(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 // getAwsEBSSnapshotCreateVolumePermissions :: Describes the users and groups that have the permissions for creating volumes from the snapshot
 func getAwsEBSSnapshotCreateVolumePermissions(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	snapshotData := h.Item.(types.Snapshot)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err
@@ -300,7 +299,6 @@ func getEBSSnapshotARN(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	plugin.Logger(ctx).Trace("getEBSSnapshotARN")
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	snapshotData := h.Item.(types.Snapshot)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err
@@ -364,7 +362,6 @@ func buildEbsSnapshotFilter(ctx context.Context, d *plugin.QueryData, h *plugin.
 		ownerFilter.Values = []string{equalQuals["owner_id"].GetStringValue()}
 	} else {
 		// Use this section later and compare the results
-		getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 		c, err := getCommonColumnsCached(ctx, d, h)
 		if err != nil {
 			return filters

--- a/aws/table_aws_ebs_volume.go
+++ b/aws/table_aws_ebs_volume.go
@@ -306,7 +306,6 @@ func getEBSVolumeARN(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	volume := h.Item.(types.Volume)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_ec2_ami.go
+++ b/aws/table_aws_ec2_ami.go
@@ -304,7 +304,6 @@ func getAwsEc2AmiLaunchPermissionData(ctx context.Context, d *plugin.QueryData, 
 func getAwsEc2AmiAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	image := h.Item.(types.Image)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_ec2_ami_shared.go
+++ b/aws/table_aws_ec2_ami_shared.go
@@ -250,7 +250,6 @@ func listAmisByOwner(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 func getImageOwnerAlias(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	image := h.Item.(types.Image)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err
@@ -318,7 +317,6 @@ func buildAmisWithOwnerFilter(quals plugin.KeyColumnQualMap, amiType string, ctx
 			ownerFilter.Values = []string{getQualsValueByColumn(quals, "owner_id", "string").(string)}
 		} else {
 			// Use this section later and compare the results
-			getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 			c, err := getCommonColumnsCached(ctx, d, h)
 			if err != nil {
 				return filters

--- a/aws/table_aws_ec2_classic_load_balancer.go
+++ b/aws/table_aws_ec2_classic_load_balancer.go
@@ -399,7 +399,6 @@ func getEc2ClassicLoadBalancerARN(ctx context.Context, d *plugin.QueryData, h *p
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
 	classicLoadBalancer := h.Item.(types.LoadBalancerDescription)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ec2_classic_load_balancer.getEc2ClassicLoadBalancerARN", "get_common_data_error", err)

--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -522,7 +522,6 @@ func getEc2InstanceARN(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	instance := h.Item.(types.Instance)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("getEc2InstanceARN", "getCommonColumnsCached_error", err)

--- a/aws/table_aws_ec2_instance_availability.go
+++ b/aws/table_aws_ec2_instance_availability.go
@@ -135,7 +135,6 @@ func listAwsAvailableInstanceTypes(ctx context.Context, d *plugin.QueryData, h *
 
 func getAwsInstanceAvailableAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	instanceType := h.Item.(types.InstanceTypeOffering)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_ec2_instance_type.go
+++ b/aws/table_aws_ec2_instance_type.go
@@ -174,7 +174,6 @@ func tableAwsInstanceType(_ context.Context) *plugin.Table {
 func listAwsInstanceTypesOfferings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 
 	// get the primary region for aws based on its partition
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err
@@ -264,7 +263,6 @@ func describeInstanceType(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	}
 
 	// get the primary region for aws based on its partition
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err
@@ -318,7 +316,6 @@ func instanceTypeDataToAkas(ctx context.Context, d *plugin.QueryData, h *plugin.
 		instanceType = h.Item.(types.InstanceTypeInfo).InstanceType
 	}
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ec2_instance_type.instanceTypeDataToAkas", "common_data_error", err)

--- a/aws/table_aws_ec2_key_pair.go
+++ b/aws/table_aws_ec2_key_pair.go
@@ -146,7 +146,6 @@ func getEc2KeyPair(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 func getAwsEc2KeyPairAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	keyPair := h.Item.(types.KeyPairInfo)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ec2_key_pair.getAwsEc2KeyPairAkas", "common_data_error", err)

--- a/aws/table_aws_ec2_network_interface.go
+++ b/aws/table_aws_ec2_network_interface.go
@@ -354,7 +354,6 @@ func getEc2NetworkInterface(ctx context.Context, d *plugin.QueryData, _ *plugin.
 func getAwsEc2NetworkInterfaceAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	networkInterface := h.Item.(types.NetworkInterface)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_ec2_reserved_instance.go
+++ b/aws/table_aws_ec2_reserved_instance.go
@@ -253,7 +253,6 @@ func getEc2ReservedInstanceARN(ctx context.Context, d *plugin.QueryData, h *plug
 	instance := h.Item.(types.ReservedInstances)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_ec2_ssl_policy.go
+++ b/aws/table_aws_ec2_ssl_policy.go
@@ -165,7 +165,6 @@ func getEc2SslPolicyAkas(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	data := h.Item.(types.SslPolicy)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_ec2_transit_gateway_route.go
+++ b/aws/table_aws_ec2_transit_gateway_route.go
@@ -158,7 +158,6 @@ func listEc2TransitGatewayRoute(ctx context.Context, d *plugin.QueryData, h *plu
 func getAwsEc2TransitGatewayRouteAka(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	route := h.Item.(*RouteDetails)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_ec2_transit_gateway_route_table.go
+++ b/aws/table_aws_ec2_transit_gateway_route_table.go
@@ -205,7 +205,6 @@ func getEc2TransitGatewayRouteTable(ctx context.Context, d *plugin.QueryData, _ 
 func getAwsEc2TransitGatewayRouteTableTurbotData(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	transitGatewayRouteTable := h.Item.(types.TransitGatewayRouteTable)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ec2_transit_gateway_route_table.getAwsEc2TransitGatewayRouteTableTurbotData", "api_error", err)

--- a/aws/table_aws_ec2_transit_gateway_vpc_attachment.go
+++ b/aws/table_aws_ec2_transit_gateway_vpc_attachment.go
@@ -217,7 +217,6 @@ func getAwsEc2TransitGatewayVpcAttachmentAkas(ctx context.Context, d *plugin.Que
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	transitGatewayAttachment := h.Item.(types.TransitGatewayAttachment)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_efs_mount_target.go
+++ b/aws/table_aws_efs_mount_target.go
@@ -238,7 +238,6 @@ func getAwsEfsMountTargetSecurityGroup(ctx context.Context, d *plugin.QueryData,
 func getAwsEfsMountTargetAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	data := h.Item.(types.MountTargetDescription)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_efs_mount_target.getAwsEfsMountTargetAkas", "common_data_error", err)

--- a/aws/table_aws_eks_addon_version.go
+++ b/aws/table_aws_eks_addon_version.go
@@ -145,7 +145,6 @@ func getAddonVersionAkas(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	version := h.Item.(addonVersion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_eks_addon_version.getAddonVersionAkas", "api_error", err)

--- a/aws/table_aws_emr_instance.go
+++ b/aws/table_aws_emr_instance.go
@@ -209,7 +209,6 @@ func getEmrInstanceAkas(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	data := h.Item.(*emrInstanceInfo)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_emr_instance.getEmrInstanceAkas", "common_data_error", err)

--- a/aws/table_aws_emr_instance_fleet.go
+++ b/aws/table_aws_emr_instance_fleet.go
@@ -183,7 +183,6 @@ func getEmrInstanceFleetARN(ctx context.Context, d *plugin.QueryData, h *plugin.
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	data := h.Item.(instanceFleetDetails)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_emr_instance_fleet.getEmrInstanceFleetARN", "common_data_error", err)

--- a/aws/table_aws_emr_instance_group.go
+++ b/aws/table_aws_emr_instance_group.go
@@ -216,7 +216,6 @@ func getEmrInstanceGroupARN(ctx context.Context, d *plugin.QueryData, h *plugin.
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	data := h.Item.(instanceGroupDetails)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_glacier_vault.go
+++ b/aws/table_aws_glacier_vault.go
@@ -142,7 +142,6 @@ func listGlacierVault(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		return nil, nil
 	}
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_glacier_vault.listGlacierVault", "api_error", err)
@@ -196,7 +195,6 @@ func getGlacierVault(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	quals := d.KeyColumnQuals
 	vaultName := quals["vault_name"].GetStringValue()
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_glacier_vault.getGlacierVault", "api_error", err)

--- a/aws/table_aws_glue_catalog_database.go
+++ b/aws/table_aws_glue_catalog_database.go
@@ -185,7 +185,6 @@ func getGlueCatalogDatabaseAkas(ctx context.Context, d *plugin.QueryData, h *plu
 	data := h.Item.(types.Database)
 
 	// Get common columns
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_glue_catalog_database.getGlueCatalogDatabaseAkas", "common_data_error", err)

--- a/aws/table_aws_glue_catalog_table.go
+++ b/aws/table_aws_glue_catalog_table.go
@@ -262,7 +262,6 @@ func getGlueCatalogTableAkas(ctx context.Context, d *plugin.QueryData, h *plugin
 	data := h.Item.(types.Table)
 
 	// Get common columns
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_glue_catalog_table.getGlueCatalogTableAkas", "common_data_error", err)

--- a/aws/table_aws_glue_connection.go
+++ b/aws/table_aws_glue_connection.go
@@ -213,7 +213,6 @@ func getGlueConnectionArn(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	data := h.Item.(types.Connection)
 
 	// Get common columns
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_glue_connection.getGlueConnectionArn", "api_error", err)

--- a/aws/table_aws_glue_crawler.go
+++ b/aws/table_aws_glue_crawler.go
@@ -249,7 +249,6 @@ func getGlueCrawlerArn(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	data := h.Item.(types.Crawler)
 
 	// Get common columns
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_glue_crawler.getGlueCrawlerArn", "common_data_error", err)

--- a/aws/table_aws_glue_dev_endpoint.go
+++ b/aws/table_aws_glue_dev_endpoint.go
@@ -273,7 +273,6 @@ func getGlueDevEndpointArn(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	data := h.Item.(types.DevEndpoint)
 
 	// Get common columns
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_glue_dev_endpoint.getGlueDevEndpointArn", "coomon_data_error", err)

--- a/aws/table_aws_glue_job.go
+++ b/aws/table_aws_glue_job.go
@@ -291,7 +291,6 @@ func getGlueJobArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	data := h.Item.(types.Job)
 
 	// Get common columns
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_glue_job.getGlueJobArn", "common_error", err)

--- a/aws/table_aws_glue_security_configuration.go
+++ b/aws/table_aws_glue_security_configuration.go
@@ -162,7 +162,6 @@ func getGlueSecurityConfigurationArn(ctx context.Context, d *plugin.QueryData, h
 	data := h.Item.(types.SecurityConfiguration)
 
 	// Get common columns
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_glue_security_configuration.getGlueSecurityConfigurationArn", "common_data_error", err)

--- a/aws/table_aws_guardduty_detector.go
+++ b/aws/table_aws_guardduty_detector.go
@@ -220,7 +220,6 @@ func getGuardDutyDetectorARN(ctx context.Context, d *plugin.QueryData, h *plugin
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	data := h.Item.(detectorInfo)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_guardduty_detector.getGuardDutyDetectorARN", "error", err)

--- a/aws/table_aws_guardduty_filter.go
+++ b/aws/table_aws_guardduty_filter.go
@@ -203,7 +203,6 @@ func getAwsGuardDutyFilterAkas(ctx context.Context, d *plugin.QueryData, h *plug
 	data := h.Item.(filterInfo)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_guardduty_filter.getAwsGuardDutyFilterAkas", "api_error", err)

--- a/aws/table_aws_guardduty_ipset.go
+++ b/aws/table_aws_guardduty_ipset.go
@@ -203,7 +203,6 @@ func getAwsGuardDutyIPSetAkas(ctx context.Context, d *plugin.QueryData, h *plugi
 	data := h.Item.(ipsetInfo)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_guardduty_ipset.getAwsGuardDutyIPSetAkas", "api_error", err)

--- a/aws/table_aws_guardduty_publishing_destination.go
+++ b/aws/table_aws_guardduty_publishing_destination.go
@@ -225,7 +225,6 @@ func getPublishingDestinationArn(ctx context.Context, d *plugin.QueryData, h *pl
 	data := h.Item.(DestinationInfo)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_guardduty_publishing_destination.getPublishingDestinationArn", "api_error", err)

--- a/aws/table_aws_guardduty_threat_intel_set.go
+++ b/aws/table_aws_guardduty_threat_intel_set.go
@@ -204,7 +204,6 @@ func getAwsGuardDutyThreatIntelSetAkas(ctx context.Context, d *plugin.QueryData,
 	data := h.Item.(threatIntelSetInfo)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_guardduty_threat_intel_set.getAwsGuardDutyThreatIntelSetAkas", "api_error", err)

--- a/aws/table_aws_iam_access_advisor.go
+++ b/aws/table_aws_iam_access_advisor.go
@@ -94,7 +94,6 @@ func listAccessAdvisor(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	granularity := "ACTION_LEVEL"
 	principalArn := d.KeyColumnQuals["principal_arn"].GetStringValue()
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_iam_access_advisor.listAccessAdvisor", "get_common_data_error", err)

--- a/aws/table_aws_iam_policy.go
+++ b/aws/table_aws_iam_policy.go
@@ -248,7 +248,6 @@ func getPolicyVersion(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 // isPolicyAwsManaged returns true if policy is aws managed
 func isPolicyAwsManaged(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	policy := h.Item.(types.Policy)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_kinesis_consumer.go
+++ b/aws/table_aws_kinesis_consumer.go
@@ -81,7 +81,6 @@ func listKinesisConsumers(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	streamName := *h.Item.(*kinesis.DescribeStreamOutput).StreamDescription.StreamName
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_kinesis_consumer.listKinesisConsumers", "api_error", err)

--- a/aws/table_aws_redshift_cluster.go
+++ b/aws/table_aws_redshift_cluster.go
@@ -472,7 +472,6 @@ func getRedshiftClusterARN(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	cluster := h.Item.(types.Cluster)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_redshift_cluster.getRedshiftClusterARN", "getCommonColumnsCached_error", err)

--- a/aws/table_aws_redshift_event_subscription.go
+++ b/aws/table_aws_redshift_event_subscription.go
@@ -198,7 +198,6 @@ func getRedshiftEventSubscription(ctx context.Context, d *plugin.QueryData, _ *p
 func getRedshiftEventSubscriptionAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	parameterData := h.Item.(types.EventSubscription)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_redshift_event_subscription.getRedshiftEventSubscriptionAkas", "getCommonColumnsCached_error", err)

--- a/aws/table_aws_redshift_parameter_group.go
+++ b/aws/table_aws_redshift_parameter_group.go
@@ -200,7 +200,6 @@ func getAwsRedshiftParameterGroupAkas(ctx context.Context, d *plugin.QueryData, 
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	parameterData := h.Item.(types.ClusterParameterGroup)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_redshift_parameter_group.getAwsRedshiftParameterGroupAkas", "getCommonColumnsCached_error", err)

--- a/aws/table_aws_redshift_snapshot.go
+++ b/aws/table_aws_redshift_snapshot.go
@@ -345,7 +345,6 @@ func getRedshiftSnapshotAkas(ctx context.Context, d *plugin.QueryData, h *plugin
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	snapshot := h.Item.(types.Snapshot)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_redshift_snapshot.getRedshiftSnapshotAkas", "getCommonColumnsCached_error", err)

--- a/aws/table_aws_redshift_subnet_group.go
+++ b/aws/table_aws_redshift_subnet_group.go
@@ -175,7 +175,6 @@ func getRedshiftSubnetGroup(ctx context.Context, d *plugin.QueryData, _ *plugin.
 func getRedshiftSubnetGroupAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	data := h.Item.(types.ClusterSubnetGroup)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_redshift_subnet_group.getRedshiftSubnetGroupAkas", "getCommonColumnsCached_error", err)

--- a/aws/table_aws_region.go
+++ b/aws/table_aws_region.go
@@ -56,7 +56,7 @@ func tableAwsRegion(_ context.Context) *plugin.Table {
 				Name:        "partition",
 				Description: "The AWS partition in which the resource is located (aws, aws-cn, or aws-us-gov).",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getCommonColumns,
+				Hydrate:     getCommonColumnsCached,
 			},
 			{
 				Name:        "region",
@@ -68,7 +68,7 @@ func tableAwsRegion(_ context.Context) *plugin.Table {
 				Name:        "account_id",
 				Description: "The AWS Account ID in which the resource is located.",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getCommonColumns,
+				Hydrate:     getCommonColumnsCached,
 				Transform:   transform.FromCamel(),
 			},
 		},
@@ -141,7 +141,6 @@ func getAwsRegion(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDat
 func getAwsRegionAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := h.Item.(types.Region)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_route53_domain.go
+++ b/aws/table_aws_route53_domain.go
@@ -309,7 +309,6 @@ func getRoute53DomainARN(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 
 	name := domainName(h.Item)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_route53_health_check.go
+++ b/aws/table_aws_route53_health_check.go
@@ -243,7 +243,6 @@ func getHealthCheckTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 
 func getRoute53HealthCheckTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	healthCheck := h.Item.(types.HealthCheck)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_route53_record.go
+++ b/aws/table_aws_route53_record.go
@@ -242,7 +242,6 @@ func flattenResourceRecords(_ context.Context, d *transform.TransformData) (inte
 
 func getRoute53RecordSetAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	recordData := h.Item.(*recordInfo)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Trace("aws_route53_record.getRoute53RecordSetAkas", "common_data_error", err)

--- a/aws/table_aws_route53_traffic_policy.go
+++ b/aws/table_aws_route53_traffic_policy.go
@@ -230,7 +230,6 @@ func getTrafficPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 func getRoute53TrafficPolicyTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	trafficPolicy := h.Item.(types.TrafficPolicy)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_route53_traffic_policy_instance.go
+++ b/aws/table_aws_route53_traffic_policy_instance.go
@@ -187,7 +187,6 @@ func getTrafficPolicyInstance(ctx context.Context, d *plugin.QueryData, h *plugi
 func getRoute53TrafficPolicyInstanceTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	instanceId := *h.Item.(types.TrafficPolicyInstance).Id
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_route53_traffic_policy_instance.getRoute53TrafficPolicyInstanceTurbotAkas", "api_error", err)

--- a/aws/table_aws_route53_zone.go
+++ b/aws/table_aws_route53_zone.go
@@ -324,7 +324,6 @@ func getHostedZoneDNSSEC(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 
 func getRoute53HostedZoneTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	hostedZone := h.Item.(HostedZoneResult)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_s3_access_point.go
+++ b/aws/table_aws_s3_access_point.go
@@ -146,7 +146,6 @@ func tableAwsS3AccessPoint(_ context.Context) *plugin.Table {
 
 func listS3AccessPoints(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// Get account details
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_s3_access_point.listS3AccessPoints", "common_data_error", err)
@@ -217,7 +216,6 @@ func getS3AccessPoint(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	matrixRegion := d.KeyColumnQualString(matrixKeyRegion)
 
 	// Get account details
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_s3_access_point.getS3AccessPoint", "common_data_error", err)
@@ -266,7 +264,6 @@ func getS3AccessPointPolicyStatus(ctx context.Context, d *plugin.QueryData, h *p
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
 	// Get account details
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_s3_access_point.getS3AccessPointPolicyStatus", "common_data_error", err)
@@ -308,7 +305,6 @@ func getS3AccessPointPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
 	// Get account details
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_s3_access_point.getS3AccessPointPolicy", "common_data_error", err)
@@ -351,7 +347,6 @@ func getAccessPointArn(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
 	// Get account details
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_s3_access_point.getAccessPointArn", "common_data_error", err)

--- a/aws/table_aws_s3_account_settings.go
+++ b/aws/table_aws_s3_account_settings.go
@@ -71,7 +71,6 @@ func tableAwsS3AccountSettings(_ context.Context) *plugin.Table {
 
 func listS3Account(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_s3_account_settings.listS3Account", "common_data_error", err)

--- a/aws/table_aws_s3_bucket.go
+++ b/aws/table_aws_s3_bucket.go
@@ -711,7 +711,6 @@ func getBucketTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 func getBucketARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	bucket := h.Item.(types.Bucket)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_s3_bucket.getBucketARN", "get_common_columns_error", err)

--- a/aws/table_aws_sagemaker_app.go
+++ b/aws/table_aws_sagemaker_app.go
@@ -237,7 +237,6 @@ func getSageMakerApp(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 func sageMakerAppArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	switch item := h.Item.(type) {
 	case types.AppDetails:
-		getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 		c, err := getCommonColumnsCached(ctx, d, h)
 		if err != nil {
 			return "", err

--- a/aws/table_aws_securityhub_standards_control.go
+++ b/aws/table_aws_securityhub_standards_control.go
@@ -99,7 +99,6 @@ func listSecurityHubStandardsControls(ctx context.Context, d *plugin.QueryData, 
 
 	standardsArn := *h.Item.(types.Standard).StandardsArn
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_servicequotas_service_quota_change_request.go
+++ b/aws/table_aws_servicequotas_service_quota_change_request.go
@@ -276,7 +276,6 @@ func getServiceQuotaChangeRequestAkas(ctx context.Context, d *plugin.QueryData, 
 	data := h.Item.(types.RequestedServiceQuotaChange)
 
 	// Get common columns
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_servicequotas_service_quota_change_request.getServiceQuotaChangeRequestAkas", "common_data_error", err)

--- a/aws/table_aws_ses_email_identity.go
+++ b/aws/table_aws_ses_email_identity.go
@@ -187,7 +187,6 @@ func getSESIdentityARN(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	identity := h.Item.(string)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ses_email_identity.getSESIdentityARN", "api_error", err)

--- a/aws/table_aws_ssm_association.go
+++ b/aws/table_aws_ssm_association.go
@@ -319,7 +319,6 @@ func getAwsSSMAssociation(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 func getSSMAssociationARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	associationData := associationID(h.Item)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ssm_association.getSSMAssociationARN", "common_data_error", err)

--- a/aws/table_aws_ssm_document.go
+++ b/aws/table_aws_ssm_document.go
@@ -367,7 +367,6 @@ func getAwsSSMDocumentPermissionDetail(ctx context.Context, d *plugin.QueryData,
 func getAwsSSMDocumentAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	name := documentName(h.Item)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ssm_document.getAwsSSMDocumentAkas", "common_data_error", err)

--- a/aws/table_aws_ssm_maintenance_window.go
+++ b/aws/table_aws_ssm_maintenance_window.go
@@ -357,7 +357,6 @@ func getAwsSSMMaintenanceWindowAkas(ctx context.Context, d *plugin.QueryData, h 
 	plugin.Logger(ctx).Trace("getAwsSSMMaintenanceWindowAkas")
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	id := maintenanceWindowID(h.Item)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_ssm_managed_instance.go
+++ b/aws/table_aws_ssm_managed_instance.go
@@ -216,7 +216,6 @@ func getSsmManagedInstanceARN(ctx context.Context, d *plugin.QueryData, h *plugi
 	data := h.Item.(types.InstanceInformation)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ssm_managed_instance.getSsmManagedInstanceARN", "common_data_error", err)

--- a/aws/table_aws_ssm_managed_instance_compliance.go
+++ b/aws/table_aws_ssm_managed_instance_compliance.go
@@ -165,7 +165,6 @@ func getSSMManagedInstanceComplianceAkas(ctx context.Context, d *plugin.QueryDat
 	data := h.Item.(types.ComplianceItem)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ssm_managed_instance_compliance.getSSMInstanceComplianceAkas", "common_data_error", err)

--- a/aws/table_aws_ssm_parameter.go
+++ b/aws/table_aws_ssm_parameter.go
@@ -317,7 +317,6 @@ func getAwsSSMParameterTags(ctx context.Context, d *plugin.QueryData, h *plugin.
 func getAwsSSMParameterAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	parameterData := h.Item.(types.ParameterMetadata)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ssm_parameter.getAwsSSMParameterTags", "common_data_error", err)

--- a/aws/table_aws_ssm_patch_baseline.go
+++ b/aws/table_aws_ssm_patch_baseline.go
@@ -311,7 +311,6 @@ func getAwsSSMPatchBaselineAkas(ctx context.Context, d *plugin.QueryData, h *plu
 	baselineId := getPatchBaselineID(h.Item)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ssm_patch_baseline.getAwsSSMPatchBaselineAkas", "common_data_error", err)

--- a/aws/table_aws_vpc.go
+++ b/aws/table_aws_vpc.go
@@ -219,7 +219,6 @@ func getVpcARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) 
 	vpc := h.Item.(types.Vpc)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc.getVpcARN", "common_data_error", err)

--- a/aws/table_aws_vpc_customer_gateway.go
+++ b/aws/table_aws_vpc_customer_gateway.go
@@ -172,7 +172,6 @@ func getVpcCustomerGateway(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 func getVpcCustomerGatewayTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	customerGateway := h.Item.(types.CustomerGateway)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_customer_gateway.getVpcCustomerGatewayTurbotAkas", "common_data_error", err)

--- a/aws/table_aws_vpc_dhcp_options.go
+++ b/aws/table_aws_vpc_dhcp_options.go
@@ -197,7 +197,6 @@ func getVpcDhcpOption(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 func getVpcDhcpOptionAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	dhcpOption := h.Item.(types.DhcpOptions)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_dhcp_options.getVpcDhcpOptionAkas", "common_data_error", err)

--- a/aws/table_aws_vpc_egress_only_internet_gateway.go
+++ b/aws/table_aws_vpc_egress_only_internet_gateway.go
@@ -155,7 +155,6 @@ func getVpcEgressOnlyInternetGatewayTurbotAkas(ctx context.Context, d *plugin.Qu
 
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	egw := h.Item.(types.EgressOnlyInternetGateway)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_egress_only_internet_gateway.getVpcEgressOnlyInternetGatewayTurbotAkas", "common_data_error", err)

--- a/aws/table_aws_vpc_eip.go
+++ b/aws/table_aws_vpc_eip.go
@@ -225,7 +225,6 @@ func getVpcEipARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 
 	eip := h.Item.(types.Address)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_eip.getVpcEipARN", "common_data_error", err)

--- a/aws/table_aws_vpc_endpoint.go
+++ b/aws/table_aws_vpc_endpoint.go
@@ -238,7 +238,6 @@ func getVpcEndpoint(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 func getVpcEndpointAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	vpcEndpoint := h.Item.(types.VpcEndpoint)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_endpoint.getVpcEndpointAkas", "common_data_error", err)

--- a/aws/table_aws_vpc_endpoint_service.go
+++ b/aws/table_aws_vpc_endpoint_service.go
@@ -289,7 +289,6 @@ func getVpcEndpointServiceAkas(ctx context.Context, d *plugin.QueryData, h *plug
 
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	endpointService := h.Item.(types.ServiceDetail)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_endpoint_service.getVpcEndpointServiceAkas", "common_data_error", err)

--- a/aws/table_aws_vpc_flow_log.go
+++ b/aws/table_aws_vpc_flow_log.go
@@ -243,7 +243,6 @@ func getVpcFlowlog(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateDa
 func getVpcFlowlogAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	vpcFlowlog := h.Item.(types.FlowLog)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_flow_log.getVpcFlowlogAkas", "common_data_error", err)

--- a/aws/table_aws_vpc_internet_gateway.go
+++ b/aws/table_aws_vpc_internet_gateway.go
@@ -171,7 +171,6 @@ func getVpcInternetGateway(ctx context.Context, d *plugin.QueryData, h *plugin.H
 func getVpcInternetGatewayTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	internetGateway := h.Item.(types.InternetGateway)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_internet_gateway.getVpcInternetGatewayTurbotAkas", "common_data_error", err)

--- a/aws/table_aws_vpc_nat_gateway.go
+++ b/aws/table_aws_vpc_nat_gateway.go
@@ -218,7 +218,6 @@ func getVpcNatGateway(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 func getVpcNatGatewayARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	natGateway := h.Item.(types.NatGateway)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_nat_gateway.getVpcNatGatewayARN", "common_data_error", err)

--- a/aws/table_aws_vpc_network_acl.go
+++ b/aws/table_aws_vpc_network_acl.go
@@ -197,7 +197,6 @@ func getVpcNetworkACLARN(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	networkACL := h.Item.(types.NetworkAcl)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_network_acl.getVpcNetworkACLARN", "common_data_error", err)

--- a/aws/table_aws_vpc_route.go
+++ b/aws/table_aws_vpc_route.go
@@ -173,7 +173,6 @@ func getAwsVpcRouteTurbotData(ctx context.Context, d *plugin.QueryData, h *plugi
 	routeData := h.Item.(*routeTableRoute)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err

--- a/aws/table_aws_vpc_route_table.go
+++ b/aws/table_aws_vpc_route_table.go
@@ -191,7 +191,6 @@ func getVpcRouteTableAkas(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 	routeTable := h.Item.(types.RouteTable)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_route_table.getVpcRouteTableAkas", "common_data_error", err)

--- a/aws/table_aws_vpc_security_group.go
+++ b/aws/table_aws_vpc_security_group.go
@@ -207,7 +207,6 @@ func getVpcSecurityGroupARN(ctx context.Context, d *plugin.QueryData, h *plugin.
 	securityGroup := h.Item.(types.SecurityGroup)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_security_group.getVpcSecurityGroupARN", "common_data_error", err)

--- a/aws/table_aws_vpc_security_group_rule.go
+++ b/aws/table_aws_vpc_security_group_rule.go
@@ -368,7 +368,6 @@ func getSecurityGroupRuleTurbotData(ctx context.Context, d *plugin.QueryData, h 
 	sgRule := h.Item.(types.SecurityGroupRule)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_security_group_rule.getSecurityGroupRuleTurbotData", "common_data_error", err)

--- a/aws/table_aws_vpc_vpn_connection.go
+++ b/aws/table_aws_vpc_vpn_connection.go
@@ -213,7 +213,6 @@ func getVpcVpnConnectionARN(ctx context.Context, d *plugin.QueryData, h *plugin.
 	vpnConnection := h.Item.(types.VpnConnection)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_vpn_connection.getVpcVpnConnectionARN", "common_data_error", err)

--- a/aws/table_aws_vpc_vpn_gateway.go
+++ b/aws/table_aws_vpc_vpn_gateway.go
@@ -170,7 +170,6 @@ func getVpcVpnGatewayTurbotAkas(ctx context.Context, d *plugin.QueryData, h *plu
 	vpnGateway := h.Item.(types.VpnGateway)
 	region := d.KeyColumnQualString(matrixKeyRegion)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_vpn_gateway.getVpcVpnGatewayTurbotAkas", "common_data_error", err)

--- a/aws/table_aws_waf_rate_based_rule.go
+++ b/aws/table_aws_waf_rate_based_rule.go
@@ -224,7 +224,6 @@ func listAwsWafRateBasedRuleTags(ctx context.Context, d *plugin.QueryData, h *pl
 
 func getAwsWafRateBasedRuleAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	id := rateBasedRuleData(h.Item)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 
 	if err != nil {

--- a/aws/table_aws_waf_rule.go
+++ b/aws/table_aws_waf_rule.go
@@ -212,7 +212,6 @@ func getAwsWAFRuleTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 func getAwsWAFRuleAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	id := ruleData(h.Item)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_waf_rule.getAwsWAFRuleAkas", "api_error", err)

--- a/aws/table_aws_waf_rule_group.go
+++ b/aws/table_aws_waf_rule_group.go
@@ -253,7 +253,6 @@ func classicRuleGroupTagListToTurbotTags(ctx context.Context, d *transform.Trans
 func classicRuleGroupData(item interface{}, ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) map[string]string {
 	data := map[string]string{}
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_waf_rule_group.classicRuleGroupData", "cache_error", err)

--- a/aws/table_aws_waf_web_acl.go
+++ b/aws/table_aws_waf_web_acl.go
@@ -278,7 +278,6 @@ func classicWebAclData(item interface{}, ctx context.Context, d *plugin.QueryDat
 		data["Name"] = *item.Name
 	case types.WebACLSummary:
 		data["ID"] = *item.WebACLId
-		getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 		commonData, err := getCommonColumnsCached(ctx, d, h)
 		if err != nil {
 			plugin.Logger(ctx).Error("aws_waf_web_acl.classicWebAclData", "api_error", err)

--- a/aws/table_aws_wafregional_rule.go
+++ b/aws/table_aws_wafregional_rule.go
@@ -183,7 +183,6 @@ func getAwsWAFRegionalRuleArn(ctx context.Context, d *plugin.QueryData, h *plugi
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	id := regionalRuleData(h.Item)
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	c, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_wafregional_rule.getAwsWAFRegionalRuleArn", "api_error", err)

--- a/aws/table_aws_wafv2_ip_set.go
+++ b/aws/table_aws_wafv2_ip_set.go
@@ -109,7 +109,7 @@ func tableAwsWafv2IpSet(_ context.Context) *plugin.Table {
 				Name:        "partition",
 				Description: "The AWS partition in which the resource is located (aws, aws-cn, or aws-us-gov).",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getCommonColumns,
+				Hydrate:     getCommonColumnsCached,
 			},
 			{
 				Name:        "region",
@@ -121,7 +121,7 @@ func tableAwsWafv2IpSet(_ context.Context) *plugin.Table {
 				Name:        "account_id",
 				Description: "The AWS Account ID in which the resource is located.",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getCommonColumns,
+				Hydrate:     getCommonColumnsCached,
 			},
 		},
 	}

--- a/aws/table_aws_wafv2_regex_pattern_set.go
+++ b/aws/table_aws_wafv2_regex_pattern_set.go
@@ -107,7 +107,7 @@ func tableAwsWafv2RegexPatternSet(_ context.Context) *plugin.Table {
 				Name:        "partition",
 				Description: "The AWS partition in which the resource is located (aws, aws-cn, or aws-us-gov).",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getCommonColumns,
+				Hydrate:     getCommonColumnsCached,
 			},
 			{
 				Name:        "region",
@@ -119,7 +119,7 @@ func tableAwsWafv2RegexPatternSet(_ context.Context) *plugin.Table {
 				Name:        "account_id",
 				Description: "The AWS Account ID in which the resource is located.",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getCommonColumns,
+				Hydrate:     getCommonColumnsCached,
 			},
 		},
 	}

--- a/aws/table_aws_wafv2_rule_group.go
+++ b/aws/table_aws_wafv2_rule_group.go
@@ -121,7 +121,7 @@ func tableAwsWafv2RuleGroup(_ context.Context) *plugin.Table {
 				Name:        "partition",
 				Description: "The AWS partition in which the resource is located (aws, aws-cn, or aws-us-gov).",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getCommonColumns,
+				Hydrate:     getCommonColumnsCached,
 			},
 			{
 				Name:        "region",
@@ -133,7 +133,7 @@ func tableAwsWafv2RuleGroup(_ context.Context) *plugin.Table {
 				Name:        "account_id",
 				Description: "The AWS Account ID in which the resource is located.",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getCommonColumns,
+				Hydrate:     getCommonColumnsCached,
 			},
 		},
 	}

--- a/aws/table_aws_wafv2_web_acl.go
+++ b/aws/table_aws_wafv2_web_acl.go
@@ -155,7 +155,7 @@ func tableAwsWafv2WebAcl(_ context.Context) *plugin.Table {
 				Name:        "partition",
 				Description: "The AWS partition in which the resource is located (aws, aws-cn, or aws-us-gov).",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getCommonColumns,
+				Hydrate:     getCommonColumnsCached,
 			},
 			{
 				Name:        "region",
@@ -167,7 +167,7 @@ func tableAwsWafv2WebAcl(_ context.Context) *plugin.Table {
 				Name:        "account_id",
 				Description: "The AWS Account ID in which the resource is located.",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getCommonColumns,
+				Hydrate:     getCommonColumnsCached,
 			},
 		},
 	}

--- a/aws/table_aws_workspaces_workspace.go
+++ b/aws/table_aws_workspaces_workspace.go
@@ -300,7 +300,6 @@ func getWorkspaceArn(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	workspaceId := h.Item.(types.Workspace).WorkspaceId
 
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fix the usage of `.WithCache` for `getCommonColumns`:
- declare single cached version of `getCommonColumns` -  `getCommonColumnsCached`
- declare function to return cache key which includes the region
- remove unnecessary caching from `getCallerIdentity`