### PR TITLE
Add column evaluation_modes to aws_config_rule table closes #1471

### DIFF
--- a/aws-test/tests/aws_config_rule/variables.tf
+++ b/aws-test/tests/aws_config_rule/variables.tf
@@ -52,7 +52,7 @@ resource "aws_config_configuration_recorder" "aws_config_rule" {
 }
 
 resource "aws_iam_role" "r" {
-  name = "awsconfig-example"
+  name = var.resource_name
 
   assume_role_policy = <<POLICY
 {

--- a/aws/table_aws_config_rule.go
+++ b/aws/table_aws_config_rule.go
@@ -81,6 +81,11 @@ func tableAwsConfigRule(_ context.Context) *plugin.Table {
 				Transform:   transform.FromValue(),
 			},
 			{
+				Name:        "evaluation_modes",
+				Description: "The modes the Config rule can be evaluated in. The valid values are distinct objects. By default, the value is Detective evaluation mode only.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
 				Name:        "input_parameters",
 				Description: "A string, in JSON format, that is passed to the AWS Config rule Lambda function.",
 				Type:        proto.ColumnType_JSON,

--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.13.17
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.14.16
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.13.15
-	github.com/aws/aws-sdk-go-v2/service/configservice v1.26.1
+	github.com/aws/aws-sdk-go-v2/service/configservice v1.28.0
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.19.2
 	github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.21.10
 	github.com/aws/aws-sdk-go-v2/service/dax v1.11.15

--- a/go.sum
+++ b/go.sum
@@ -149,6 +149,8 @@ github.com/aws/aws-sdk-go-v2/service/codepipeline v1.13.15 h1:2G2MLWFTuQUthcGdl4
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.13.15/go.mod h1:dgLPQSGyVApizubbVkV28uzElgdIiEqmXlCWxmrrEic=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.26.1 h1:AXRaDlKTpTwZSNDJ45lFBNffVr7HgsnKJVCsIGOazfU=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.26.1/go.mod h1:gUkX23mhePjv7vi+bUA+i9YHjN3n+cowzwa+o8GeEGQ=
+github.com/aws/aws-sdk-go-v2/service/configservice v1.28.0 h1:geHY2zZSPf/SS0Ylx4jOK9ekbiOpcV0LKbyGXq4FIGQ=
+github.com/aws/aws-sdk-go-v2/service/configservice v1.28.0/go.mod h1:YRQyy4b5FEc0SCSKOlZU68rzv6xnIWfw5fFkxPr5sgc=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.19.2 h1:nJaGBmIqOTCjTchh2O8BAAOW8bbKqlJNtYw+ZA3yyq4=
 github.com/aws/aws-sdk-go-v2/service/costexplorer v1.19.2/go.mod h1:ZMw6d2oE+YYAAoSmoLO1BhW7jIUcKvtLyiLlwHWpG1o=
 github.com/aws/aws-sdk-go-v2/service/databasemigrationservice v1.21.10 h1:hgc5d0hwVa5/7mYtgtvElieuSK2Z/ub5F6vsZdBnwPw=


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_config_rule []

PRETEST: tests/aws_config_rule

TEST: tests/aws_config_rule
Running terraform
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 1s [id=384702153875]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_config_config_rule.named_test_resource will be created
  + resource "aws_config_config_rule" "named_test_resource" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + name     = "turbottest36225"
      + rule_id  = (known after apply)
      + tags     = {
          + "name" = "turbottest36225"
        }
      + tags_all = {
          + "name" = "turbottest36225"
        }

      + source {
          + owner             = "AWS"
          + source_identifier = "S3_BUCKET_VERSIONING_ENABLED"
        }
    }

  # aws_config_configuration_recorder.aws_config_rule will be created
  + resource "aws_config_configuration_recorder" "aws_config_rule" {
      + id       = (known after apply)
      + name     = "default"
      + role_arn = (known after apply)

      + recording_group {
          + all_supported                 = (known after apply)
          + include_global_resource_types = (known after apply)
          + resource_types                = (known after apply)
        }
    }

  # aws_iam_role.r will be created
  + resource "aws_iam_role" "r" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "config.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest36225"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "384702153875"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest36225"
  + rule_id       = (known after apply)
aws_iam_role.r: Creating...
aws_iam_role.r: Creation complete after 3s [id=turbottest36225]
aws_config_configuration_recorder.aws_config_rule: Creating...
aws_config_configuration_recorder.aws_config_rule: Creation complete after 1s [id=default]
aws_config_config_rule.named_test_resource: Creating...
aws_config_config_rule.named_test_resource: Creation complete after 1s [id=turbottest36225]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "384702153875"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:config:us-east-1:384702153875:config-rule/config-rule-ravsui"
resource_name = "turbottest36225"
rule_id = "config-rule-ravsui"

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:config:us-east-1:384702153875:config-rule/config-rule-ravsui"
    ],
    "arn": "arn:aws:config:us-east-1:384702153875:config-rule/config-rule-ravsui",
    "description": null,
    "name": "turbottest36225",
    "rule_id": "config-rule-ravsui",
    "rule_state": "ACTIVE",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest36225"
      }
    ],
    "title": "turbottest36225"
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "arn": "arn:aws:config:us-east-1:384702153875:config-rule/config-rule-ravsui",
    "name": "turbottest36225",
    "rule_id": "config-rule-ravsui",
    "title": "turbottest36225"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:config:us-east-1:384702153875:config-rule/config-rule-ravsui"
    ],
    "arn": "arn:aws:config:us-east-1:384702153875:config-rule/config-rule-ravsui",
    "tags": {
      "name": "turbottest36225"
    },
    "title": "turbottest36225"
  }
]
✔ PASSED

POSTTEST: tests/aws_config_rule

TEARDOWN: tests/aws_config_rule

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, description, evaluation_modes from aws_config_rule where name = 'test34'
+--------+-----------------------------------+---------------------------------------------+
| name   | description                       | evaluation_modes                            |
+--------+-----------------------------------+---------------------------------------------+
| test34 | Testing Proactive evaluation mode | [{"Mode":"PROACTIVE"},{"Mode":"DETECTIVE"}] |
+--------+-----------------------------------+---------------------------------------------+

```
</details>
