### PR TITLE
Add column launch_configuration in aws_drs_source_server table. closes #1459

### DIFF
--- a/aws/table_aws_drs_source_server.go
+++ b/aws/table_aws_drs_source_server.go
@@ -95,7 +95,7 @@ func tableAwsDRSSourceServer(_ context.Context) *plugin.Table {
 				Name:        "launch_configuration",
 				Description: "The launch configuration settings of the source server.",
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getAwsDRSSourceServerLaunchConfiguration,
+				Hydrate:     getAwsDrsSourceServerLaunchConfiguration,
 				Transform:   transform.FromValue(),
 			},
 			{
@@ -205,13 +205,13 @@ func listAwsDRSSourceServers(ctx context.Context, d *plugin.QueryData, _ *plugin
 	return nil, nil
 }
 
-func getAwsDRSSourceServerLaunchConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+func getAwsDrsSourceServerLaunchConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	sourceServer := h.Item.(types.SourceServer)
 
 	// Create Session
 	svc, err := DRSClient(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_drs_source_server.getAwsDRSSourceServerLaunchConfiguration", "connection_error", err)
+		plugin.Logger(ctx).Error("aws_drs_source_server.getAwsDrsSourceServerLaunchConfiguration", "connection_error", err)
 		return nil, err
 	}
 
@@ -223,7 +223,7 @@ func getAwsDRSSourceServerLaunchConfiguration(ctx context.Context, d *plugin.Que
 	// Get call
 	launchConfiguration, err := svc.GetLaunchConfiguration(ctx, params)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_drs_source_server.getAwsDRSSourceServerLaunchConfiguration", "api_error", err)
+		plugin.Logger(ctx).Error("aws_drs_source_server.getAwsDrsSourceServerLaunchConfiguration", "api_error", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_drs_source_server.go
+++ b/aws/table_aws_drs_source_server.go
@@ -95,7 +95,7 @@ func tableAwsDRSSourceServer(_ context.Context) *plugin.Table {
 				Name:        "launch_configuration",
 				Description: "The launch configuration settings of the source server.",
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getAwsDrsSourceServerLaunchConfiguration,
+				Hydrate:     getAwsDRSSourceServerLaunchConfiguration,
 				Transform:   transform.FromValue(),
 			},
 			{
@@ -205,14 +205,19 @@ func listAwsDRSSourceServers(ctx context.Context, d *plugin.QueryData, _ *plugin
 	return nil, nil
 }
 
-func getAwsDrsSourceServerLaunchConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+func getAwsDRSSourceServerLaunchConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	sourceServer := h.Item.(types.SourceServer)
 
 	// Create Session
 	svc, err := DRSClient(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_drs_source_server.getAwsDrsSourceServerLaunchConfiguration", "connection_error", err)
+		plugin.Logger(ctx).Error("aws_drs_source_server.getAwsDRSSourceServerLaunchConfiguration", "connection_error", err)
 		return nil, err
+	}
+
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
 	}
 
 	// Build the params
@@ -223,7 +228,7 @@ func getAwsDrsSourceServerLaunchConfiguration(ctx context.Context, d *plugin.Que
 	// Get call
 	launchConfiguration, err := svc.GetLaunchConfiguration(ctx, params)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_drs_source_server.getAwsDrsSourceServerLaunchConfiguration", "api_error", err)
+		plugin.Logger(ctx).Error("aws_drs_source_server.getAwsDRSSourceServerLaunchConfiguration", "api_error", err)
 		return nil, err
 	}
 

--- a/docs/tables/aws_drs_source_server.md
+++ b/docs/tables/aws_drs_source_server.md
@@ -62,6 +62,24 @@ from
   aws_drs_source_server;
 ```
 
+### Get launch configuration settings of all source servers
+
+```sql
+select
+  arn,
+  title,
+  launch_configuration ->> 'Name' as launch_configuration_name,
+  launch_configuration ->> 'CopyPrivateIp' as launch_configuration_copy_private_ip,
+  launch_configuration ->> 'CopyTags' as launch_configuration_copy_tags,
+  launch_configuration ->> 'Ec2LaunchTemplateID' as ec2_launch_template_id,
+  launch_configuration ->> 'LaunchDisposition' as launch_configuration_disposition,
+  launch_configuration ->> 'TargetInstanceTypeRightSizingMethod' as target_instance_type_right_sizing_method,
+  launch_configuration -> 'Licensing' as launch_configuration_licensing,
+  launch_configuration -> 'ResultMetadata' as launch_configuration_result_metadata
+from
+  aws_drs_source_server;
+```
+
 ### List source servers that failed last recovery launch
 
 ```sql

--- a/docs/tables/aws_drs_source_server.md
+++ b/docs/tables/aws_drs_source_server.md
@@ -71,9 +71,9 @@ select
   launch_configuration ->> 'Name' as launch_configuration_name,
   launch_configuration ->> 'CopyPrivateIp' as launch_configuration_copy_private_ip,
   launch_configuration ->> 'CopyTags' as launch_configuration_copy_tags,
-  launch_configuration ->> 'Ec2LaunchTemplateID' as ec2_launch_template_id,
+  launch_configuration ->> 'Ec2LaunchTemplateID' as launch_configuration_ec2_launch_template_id,
   launch_configuration ->> 'LaunchDisposition' as launch_configuration_disposition,
-  launch_configuration ->> 'TargetInstanceTypeRightSizingMethod' as target_instance_type_right_sizing_method,
+  launch_configuration ->> 'TargetInstanceTypeRightSizingMethod' as launch_configuration_target_instance_type_right_sizing_method,
   launch_configuration -> 'Licensing' as launch_configuration_licensing,
   launch_configuration -> 'ResultMetadata' as launch_configuration_result_metadata
 from


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
  arn,
  title,
  launch_configuration ->> 'Name' as launch_configuration_name,
  launch_configuration ->> 'CopyPrivateIp' as launch_configuration_copy_private_ip,
  launch_configuration ->> 'CopyTags' as launch_configuration_copy_tags,
  launch_configuration ->> 'Ec2LaunchTemplateID' as ec2_launch_template_id,
  launch_configuration ->> 'LaunchDisposition' as launch_configuration_disposition,
  launch_configuration ->> 'TargetInstanceTypeRightSizingMethod' as target_instance_type_right_sizing_method,
  launch_configuration -> 'Licensing' as launch_configuration_licensing,
  launch_configuration -> 'ResultMetadata' as launch_configuration_result_metadata
from
  aws_drs_source_server;
+----------------------------------------------------------------------+---------------------+------------------------------------------------------------+--------------------------------------+--------------------------------+------------------------+----------------------------------+------------------------------------------+--------------------------------+--------------------------------------+
| arn                                                                  | title               | launch_configuration_name                                  | launch_configuration_copy_private_ip | launch_configuration_copy_tags | ec2_launch_template_id | launch_configuration_disposition | target_instance_type_right_sizing_method | launch_configuration_licensing | launch_configuration_result_metadata |
+----------------------------------------------------------------------+---------------------+------------------------------------------------------------+--------------------------------------+--------------------------------+------------------------+----------------------------------+------------------------------------------+--------------------------------+--------------------------------------+
| arn:aws:drs:us-east-1:123456789012:source-server/s-3b5e3dc9c3bfc2a0d | s-3b5e3dc9c3bfc2a0d | Launch Configuration for Source Server s-3b5e3dc9c3bfc2a0d | false                                | false                          | lt-063e64185cd2df61d   | STARTED                          | BASIC                                    | {"OsByol":true}                | {}                                   |
+----------------------------------------------------------------------+---------------------+------------------------------------------------------------+--------------------------------------+--------------------------------+------------------------+----------------------------------+------------------------------------------+--------------------------------+--------------------------------------+
>

```
</details>
