### PR TITLE
The column insight_selectors in aws_cloudtrail_trail table return nil closes #1503

### DIFF
--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -406,7 +406,7 @@ func getCloudtrailTrailInsightSelector(ctx context.Context, d *plugin.QueryData,
 	// Create session
 	svc, err := CloudTrailRegionsClient(ctx, d, *trail.HomeRegion)
 	if err != nil {
-		plugin.Logger(ctx).Info("aws_cloudtrail_trail.getCloudtrailTrailInsightSelector", "client_error", err)
+		plugin.Logger(ctx).Error("aws_cloudtrail_trail.getCloudtrailTrailInsightSelector", "client_error", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -419,7 +419,7 @@ func getCloudtrailTrailInsightSelector(ctx context.Context, d *plugin.QueryData,
 	if err != nil {
 		var ae smithy.APIError
 		if errors.As(err, &ae) {
-			if helpers.StringSliceContains([]string{"TrailNotFoundException", "CloudTrailARNInvalidException", "InsightNotEnabledException"}, ae.ErrorCode()) {
+			if helpers.StringSliceContains([]string{"InsightNotEnabledException"}, ae.ErrorCode()) {
 				return nil, nil
 			}
 		}

--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -391,7 +391,7 @@ func getCloudtrailTrailInsightSelector(ctx context.Context, d *plugin.QueryData,
 	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
 	commonData, err := getCommonColumnsCached(ctx, d, h)
 	if err != nil {
-		plugin.Logger(ctx).Info("aws_cloudtrail_trail.getCloudtrailTrailInsightSelector", "common_data_error", err)
+		plugin.Logger(ctx).Error("aws_cloudtrail_trail.getCloudtrailTrailInsightSelector", "common_data_error", err)
 		return nil, err
 	}
 	commonColumnData := commonData.(*awsCommonColumnData)

--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -313,7 +313,7 @@ func getCloudtrailTrailStatus(ctx context.Context, d *plugin.QueryData, h *plugi
 	commonColumnData := commonData.(*awsCommonColumnData)
 	trail := h.Item.(types.Trail)
 
-	// Avoid api call if accountId is not equal to the accountId available in arn
+	// Avoid API call if Account ID of the client is not equal to the Account ID available in Trail ARN
 	accountId := arnToAccountId(*trail.TrailARN)
 	if commonColumnData.AccountId != accountId {
 		return nil, nil

--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -423,7 +423,7 @@ func getCloudtrailTrailInsightSelector(ctx context.Context, d *plugin.QueryData,
 				return nil, nil
 			}
 		}
-		plugin.Logger(ctx).Info("aws_cloudtrail_trail.getCloudtrailTrailInsightSelector", "api_error", err)
+		plugin.Logger(ctx).Error("aws_cloudtrail_trail.getCloudtrailTrailInsightSelector", "api_error", err)
 		return nil, err
 	}
 	return item, nil


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_cloudtrail_trail []

PRETEST: tests/aws_cloudtrail_trail

TEST: tests/aws_cloudtrail_trail
Running terraform
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 1s [id=485602159834]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_cloudtrail.named_test_resource will be created
  + resource "aws_cloudtrail" "named_test_resource" {
      + arn                           = (known after apply)
      + enable_log_file_validation    = false
      + enable_logging                = true
      + home_region                   = (known after apply)
      + id                            = (known after apply)
      + include_global_service_events = false
      + is_multi_region_trail         = false
      + is_organization_trail         = false
      + name                          = "turbottest55747"
      + s3_bucket_name                = (known after apply)
      + s3_key_prefix                 = "prefix"
      + tags                          = {
          + "name" = "turbottest55747"
        }
      + tags_all                      = {
          + "name" = "turbottest55747"
        }

      + event_selector {
          + include_management_events = true
          + read_write_type           = "All"

          + data_resource {
              + type   = "AWS::Lambda::Function"
              + values = [
                  + "arn:aws:lambda",
                ]
            }
        }
    }

  # aws_s3_bucket.named_test_resource will be created
  + resource "aws_s3_bucket" "named_test_resource" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "turbottest55747"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = true
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "s3:GetBucketAcl"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "cloudtrail.amazonaws.com"
                        }
                      + Resource  = "arn:aws:s3:::turbottest55747"
                      + Sid       = "AWSCloudTrailAclCheck"
                    },
                  + {
                      + Action    = "s3:PutObject"
                      + Condition = {
                          + StringEquals = {
                              + "s3:x-amz-acl" = "bucket-owner-full-control"
                            }
                        }
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "cloudtrail.amazonaws.com"
                        }
                      + Resource  = "arn:aws:s3:::turbottest55747/prefix/AWSLogs/485602159834/*"
                      + Sid       = "AWSCloudTrailWrite"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = (known after apply)
          + allowed_methods = (known after apply)
          + allowed_origins = (known after apply)
          + expose_headers  = (known after apply)
          + max_age_seconds = (known after apply)
        }

      + grant {
          + id          = (known after apply)
          + permissions = (known after apply)
          + type        = (known after apply)
          + uri         = (known after apply)
        }

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = (known after apply)
          + enabled                                = (known after apply)
          + id                                     = (known after apply)
          + prefix                                 = (known after apply)
          + tags                                   = (known after apply)

          + expiration {
              + date                         = (known after apply)
              + days                         = (known after apply)
              + expired_object_delete_marker = (known after apply)
            }

          + noncurrent_version_expiration {
              + days = (known after apply)
            }

          + noncurrent_version_transition {
              + days          = (known after apply)
              + storage_class = (known after apply)
            }

          + transition {
              + date          = (known after apply)
              + days          = (known after apply)
              + storage_class = (known after apply)
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = (known after apply)
        }

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "485602159834"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest55747"
aws_s3_bucket.named_test_resource: Creating...
aws_s3_bucket.named_test_resource: Creation complete after 7s [id=turbottest55747]
aws_cloudtrail.named_test_resource: Creating...
aws_cloudtrail.named_test_resource: Creation complete after 3s [id=turbottest55747]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: Argument is deprecated

  with aws_s3_bucket.named_test_resource,
  on variables.tf line 76, in resource "aws_s3_bucket" "named_test_resource":
  76:   policy = <<POLICY
  77: {
  78:     "Version": "2012-10-17",
  79:     "Statement": [
  80:         {
  81:             "Sid": "AWSCloudTrailAclCheck",
  82:             "Effect": "Allow",
  83:             "Principal": {
  84:               "Service": "cloudtrail.amazonaws.com"
  85:             },
  86:             "Action": "s3:GetBucketAcl",
  87:             "Resource": "arn:aws:s3:::${var.resource_name}"
  88:         },
  89:         {
  90:             "Sid": "AWSCloudTrailWrite",
  91:             "Effect": "Allow",
  92:             "Principal": {
  93:               "Service": "cloudtrail.amazonaws.com"
  94:             },
  95:             "Action": "s3:PutObject",
  96:             "Resource": "arn:aws:s3:::${var.resource_name}/prefix/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
  97:             "Condition": {
  98:                 "StringEquals": {
  99:                     "s3:x-amz-acl": "bucket-owner-full-control"
 100:                 }
 101:             }
 102:         }
 103:     ]
 104: }
 105: POLICY

Use the aws_s3_bucket_policy resource instead

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

account_id = "485602159834"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:cloudtrail:us-east-1:485602159834:trail/turbottest55747"
resource_name = "turbottest55747"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:cloudtrail:us-east-1:485602159834:trail/turbottest55747",
    "has_custom_event_selectors": true,
    "has_insight_selectors": false,
    "home_region": "us-east-1",
    "include_global_service_events": false,
    "is_multi_region_trail": false,
    "is_organization_trail": false,
    "log_file_validation_enabled": false,
    "name": "turbottest55747",
    "s3_bucket_name": "turbottest55747",
    "s3_key_prefix": "prefix"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "event_selectors": [
      {
        "DataResources": [
          {
            "Type": "AWS::Lambda::Function",
            "Values": [
              "arn:aws:lambda"
            ]
          }
        ],
        "ExcludeManagementEventSources": [],
        "IncludeManagementEvents": true,
        "ReadWriteType": "All"
      }
    ],
    "is_logging": true,
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest55747"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "arn": "arn:aws:cloudtrail:us-east-1:485602159834:trail/turbottest55747",
    "name": "turbottest55747"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:cloudtrail:us-east-1:485602159834:trail/turbottest55747"
    ],
    "tags": {
      "name": "turbottest55747"
    },
    "title": "turbottest55747"
  }
]
✔ PASSED

POSTTEST: tests/aws_cloudtrail_trail

TEARDOWN: tests/aws_cloudtrail_trail

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, insight_selectors from aws_cloudtrail_trail where name = 'test-delete'
+-------------+------------------------------------------------------------------------------+
| name        | insight_selectors                                                            |
+-------------+------------------------------------------------------------------------------+
| test-delete | [{"InsightType":"ApiErrorRateInsight"},{"InsightType":"ApiCallRateInsight"}] |
+-------------+------------------------------------------------------------------------------+
```
</details>
