### PR TITLE
Handle ResourceNotFoundException in ListTagsOfResource API of aws_dynamodb_table. Fixes #1516

### DIFF
--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -389,7 +389,7 @@ func getTableTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 		if err != nil {
 			var ae smithy.APIError
 			if errors.As(err, &ae) {
-				// Added to support regex in not found errors
+				// Handled not found error code
 				if ok, _ := path.Match("ResourceNotFoundException", ae.ErrorCode()); ok {
 					return nil, nil
 				}

--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -2,10 +2,13 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"path"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
+	"github.com/aws/smithy-go"
 	"github.com/turbot/steampipe-plugin-sdk/v4/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v4/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v4/plugin/transform"
@@ -384,6 +387,13 @@ func getTableTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 	for pagesLeft {
 		result, err := svc.ListTagsOfResource(ctx, params)
 		if err != nil {
+			var ae smithy.APIError
+		if errors.As(err, &ae) {
+			// Added to support regex in not found errors
+			if ok, _ := path.Match("ResourceNotFoundException", ae.ErrorCode()); ok {
+				return nil, nil
+			}
+		}
 			plugin.Logger(ctx).Error("aws_dynamodb_table.getTableTagging", "api_error", err)
 			return nil, err
 		}

--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -388,12 +388,12 @@ func getTableTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 		result, err := svc.ListTagsOfResource(ctx, params)
 		if err != nil {
 			var ae smithy.APIError
-		if errors.As(err, &ae) {
-			// Added to support regex in not found errors
-			if ok, _ := path.Match("ResourceNotFoundException", ae.ErrorCode()); ok {
-				return nil, nil
+			if errors.As(err, &ae) {
+				// Added to support regex in not found errors
+				if ok, _ := path.Match("ResourceNotFoundException", ae.ErrorCode()); ok {
+					return nil, nil
+				}
 			}
-		}
 			plugin.Logger(ctx).Error("aws_dynamodb_table.getTableTagging", "api_error", err)
 			return nil, err
 		}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_dynamodb_table []

PRETEST: tests/aws_dynamodb_table

TEST: tests/aws_dynamodb_table
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 1s [id=394802159485]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_dynamodb_table.named_test_resource will be created
  + resource "aws_dynamodb_table" "named_test_resource" {
      + arn              = (known after apply)
      + billing_mode     = "PROVISIONED"
      + hash_key         = "userId"
      + id               = (known after apply)
      + name             = "turbottest33969"
      + read_capacity    = 20
      + stream_arn       = (known after apply)
      + stream_label     = (known after apply)
      + stream_view_type = (known after apply)
      + tags             = {
          + "name" = "turbottest33969"
        }
      + tags_all         = {
          + "name" = "turbottest33969"
        }
      + write_capacity   = 20

      + attribute {
          + name = "userId"
          + type = "S"
        }

      + point_in_time_recovery {
          + enabled = (known after apply)
        }

      + server_side_encryption {
          + enabled     = (known after apply)
          + kms_key_arn = (known after apply)
        }

      + ttl {
          + attribute_name = (known after apply)
          + enabled        = (known after apply)
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "394802159485"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest33969"
aws_dynamodb_table.named_test_resource: Creating...
aws_dynamodb_table.named_test_resource: Still creating... [10s elapsed]
aws_dynamodb_table.named_test_resource: Creation complete after 11s [id=turbottest33969]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 47, in data "null_data_source" "resource":
  47: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "394802159485"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:dynamodb:us-east-1:394802159485:table/turbottest33969"
resource_name = "turbottest33969"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:dynamodb:us-east-1:394802159485:table/turbottest33969",
    "name": "turbottest33969"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "continuous_backups_status": "ENABLED",
    "point_in_time_recovery_description": {
      "EarliestRestorableDateTime": null,
      "LatestRestorableDateTime": null,
      "PointInTimeRecoveryStatus": "DISABLED"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:dynamodb:us-east-1:394802159485:table/turbottest33969",
    "attribute_definitions": [
      {
        "AttributeName": "userId",
        "AttributeType": "S"
      }
    ],
    "key_schema": [
      {
        "AttributeName": "userId",
        "KeyType": "HASH"
      }
    ],
    "name": "turbottest33969",
    "read_capacity": 20,
    "write_capacity": 20
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "394802159485",
    "akas": [
      "arn:aws:dynamodb:us-east-1:394802159485:table/turbottest33969"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "title": "turbottest33969"
  }
]
✔ PASSED

TEARDOWN: tests/aws_dynamodb_table

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_aab.aws_dynamodb_table
+-----------------+---------------------------------------------------------------+--------------------------------------+---------------------------+-------------+--------------+-----------------+------------+----------------------+---------------+----------------+----
| name            | arn                                                           | table_id                             | creation_date_time        | table_class | table_status | billing_mode    | item_count | global_table_version | read_capacity | write_capacity | lat
+-----------------+---------------------------------------------------------------+--------------------------------------+---------------------------+-------------+--------------+-----------------+------------+----------------------+---------------+----------------+----
| steampipe-test1 | arn:aws:dynamodb:us-east-1:435302153453:table/steampipe-test1 | 7af7001b-35cc-48dd-9091-3c45b9996b92 | 2022-10-18T13:56:05+05:30 | STANDARD    | ARCHIVED     | PAY_PER_REQUEST | 0          | <null>               | 0             | 0              | <nu
+-----------------+---------------------------------------------------------------+--------------------------------------+---------------------------+-------------+--------------+-----------------+------------+----------------------+---------------+----------------+----
```
</details>
