### PR TITLE
Fix aws_s3_access_point table to return resources from all the regions instead of only us-east-1 closes #1406

### DIFF
--- a/aws/service.go
+++ b/aws/service.go
@@ -1047,7 +1047,6 @@ func S3Client(ctx context.Context, d *plugin.QueryData, region string) (*s3.Clie
 }
 
 func S3ControlClient(ctx context.Context, d *plugin.QueryData, region string) (*s3control.Client, error) {
-	// cfg, err := getClient(ctx, d, getDefaultAwsRegion(d))
 	cfg, err := getClientForQuerySupportedRegion(ctx, d, s3ControlEndpoint.EndpointsID)
 	if err != nil {
 		return nil, err

--- a/aws/service.go
+++ b/aws/service.go
@@ -150,6 +150,7 @@ import (
 	pipesEndpoint "github.com/aws/aws-sdk-go/service/pipes"
 	redshiftserverlessEndpoint "github.com/aws/aws-sdk-go/service/redshiftserverless"
 	route53resolverEndpoint "github.com/aws/aws-sdk-go/service/route53resolver"
+	s3ControlEndpoint "github.com/aws/aws-sdk-go/service/s3control"
 	sagemakerEndpoint "github.com/aws/aws-sdk-go/service/sagemaker"
 	securityhubEndpoint "github.com/aws/aws-sdk-go/service/securityhub"
 	securitylakeEndpoint "github.com/aws/aws-sdk-go/service/securitylake"
@@ -1046,9 +1047,13 @@ func S3Client(ctx context.Context, d *plugin.QueryData, region string) (*s3.Clie
 }
 
 func S3ControlClient(ctx context.Context, d *plugin.QueryData, region string) (*s3control.Client, error) {
-	cfg, err := getClient(ctx, d, getDefaultAwsRegion(d))
+	// cfg, err := getClient(ctx, d, getDefaultAwsRegion(d))
+	cfg, err := getClientForQuerySupportedRegion(ctx, d, s3ControlEndpoint.EndpointsID)
 	if err != nil {
 		return nil, err
+	}
+	if cfg == nil {
+		return nil, nil
 	}
 	return s3control.NewFromConfig(*cfg), nil
 }

--- a/aws/table_aws_s3_access_point.go
+++ b/aws/table_aws_s3_access_point.go
@@ -162,6 +162,11 @@ func listS3AccessPoints(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 		return nil, err
 	}
 
+	if svc == nil {
+		// Unsupported region check
+		return nil, nil
+	}
+
 	maxItems := int32(100)
 
 	// If the requested number of items is less than the paging max limit
@@ -232,6 +237,11 @@ func getS3AccessPoint(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 		return nil, err
 	}
 
+	if svc == nil {
+		// Unsupported region check
+		return nil, nil
+	}
+
 	var name, region string
 	if h.Item != nil {
 		name = *h.Item.(types.AccessPoint).Name
@@ -280,6 +290,12 @@ func getS3AccessPointPolicyStatus(ctx context.Context, d *plugin.QueryData, h *p
 		plugin.Logger(ctx).Error("aws_s3_access_point.getS3AccessPointPolicyStatus", "client_error", err)
 		return nil, err
 	}
+
+	if svc == nil {
+		// Unsupported region check
+		return nil, nil
+	}
+
 	accessPointName := accessPointName(h.Item)
 
 	// Build params
@@ -322,6 +338,12 @@ func getS3AccessPointPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.
 		plugin.Logger(ctx).Error("aws_s3_access_point.getS3AccessPointPolicy", "client_error", err)
 		return nil, err
 	}
+
+	if svc == nil {
+		// Unsupported region check
+		return nil, nil
+	}
+
 	accessPointName := accessPointName(h.Item)
 
 	// Build params


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_s3_access_point []

PRETEST: tests/aws_s3_access_point

TEST: tests/aws_s3_access_point
Running terraform
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Read complete after 1s [id=us-east-1]
data.aws_partition.current: Read complete after 1s [id=aws]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 2s [id=758602159384]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_s3_access_point.named_test_resource will be created
  + resource "aws_s3_access_point" "named_test_resource" {
      + account_id               = (known after apply)
      + alias                    = (known after apply)
      + arn                      = (known after apply)
      + bucket                   = (known after apply)
      + domain_name              = (known after apply)
      + endpoints                = (known after apply)
      + has_public_access_policy = (known after apply)
      + id                       = (known after apply)
      + name                     = "turbottest69626"
      + network_origin           = (known after apply)
      + policy                   = (known after apply)

      + public_access_block_configuration {
          + block_public_acls       = true
          + block_public_policy     = false
          + ignore_public_acls      = true
          + restrict_public_buckets = false
        }

      + vpc_configuration {
          + vpc_id = (known after apply)
        }
    }

  # aws_s3_bucket.named_test_resource will be created
  + resource "aws_s3_bucket" "named_test_resource" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "turbottest69626"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = (known after apply)
          + allowed_methods = (known after apply)
          + allowed_origins = (known after apply)
          + expose_headers  = (known after apply)
          + max_age_seconds = (known after apply)
        }

      + grant {
          + id          = (known after apply)
          + permissions = (known after apply)
          + type        = (known after apply)
          + uri         = (known after apply)
        }

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = (known after apply)
          + enabled                                = (known after apply)
          + id                                     = (known after apply)
          + prefix                                 = (known after apply)
          + tags                                   = (known after apply)

          + expiration {
              + date                         = (known after apply)
              + days                         = (known after apply)
              + expired_object_delete_marker = (known after apply)
            }

          + noncurrent_version_expiration {
              + days = (known after apply)
            }

          + noncurrent_version_transition {
              + days          = (known after apply)
              + storage_class = (known after apply)
            }

          + transition {
              + date          = (known after apply)
              + days          = (known after apply)
              + storage_class = (known after apply)
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = (known after apply)
        }

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

  # aws_s3control_access_point_policy.access_point_policy will be created
  + resource "aws_s3control_access_point_policy" "access_point_policy" {
      + access_point_arn         = (known after apply)
      + has_public_access_policy = (known after apply)
      + id                       = (known after apply)
      + policy                   = (known after apply)
    }

  # aws_vpc.named_test_resource will be created
  + resource "aws_vpc" "named_test_resource" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags_all                             = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id               = "758602159384"
  + arn                      = (known after apply)
  + aws_partition            = "aws"
  + has_public_access_policy = (known after apply)
  + network_origin           = (known after apply)
  + region_id                = (known after apply)
  + resource_id              = (known after apply)
  + resource_name            = "turbottest69626"
  + vpc_id                   = (known after apply)
aws_vpc.named_test_resource: Creating...
aws_s3_bucket.named_test_resource: Creating...
aws_vpc.named_test_resource: Creation complete after 6s [id=vpc-0dd6b1adc594836d8]
aws_s3_bucket.named_test_resource: Creation complete after 6s [id=turbottest69626]
aws_s3_access_point.named_test_resource: Creating...
aws_s3_access_point.named_test_resource: Creation complete after 2s [id=758602159384:turbottest69626]
aws_s3control_access_point_policy.access_point_policy: Creating...
aws_s3control_access_point_policy.access_point_policy: Creation complete after 2s [id=758602159384:turbottest69626]

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

account_id = "758602159384"
arn = "arn:aws:s3:us-east-1:758602159384:accesspoint/turbottest69626"
aws_partition = "aws"
has_public_access_policy = false
network_origin = "VPC"
region_id = "us-east-1"
resource_id = "758602159384:turbottest69626"
resource_name = "turbottest69626"
vpc_id = "vpc-0dd6b1adc594836d8"

Running SQL query: test-get-query.sql
[
  {
    "access_point_arn": "arn:aws:s3:us-east-1:758602159384:accesspoint/turbottest69626",
    "account_id": "758602159384",
    "block_public_acls": true,
    "block_public_policy": false,
    "bucket_name": "turbottest69626",
    "ignore_public_acls": true,
    "name": "turbottest69626",
    "network_origin": "VPC",
    "partition": "aws",
    "region": "us-east-1",
    "restrict_public_buckets": false,
    "vpc_id": "vpc-0dd6b1adc594836d8"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "access_point_policy_is_public": false,
    "name": "turbottest69626",
    "policy": {
      "Statement": [
        {
          "Action": "s3:GetObjectTagging",
          "Effect": "Allow",
          "Principal": {
            "AWS": "*"
          },
          "Resource": "arn:aws:s3:us-east-1:758602159384:accesspoint/turbottest69626/object/*"
        }
      ],
      "Version": "2008-10-17"
    },
    "policy_std": {
      "Statement": [
        {
          "Action": [
            "s3:getobjecttagging"
          ],
          "Effect": "Allow",
          "Principal": {
            "AWS": [
              "*"
            ]
          },
          "Resource": [
            "arn:aws:s3:us-east-1:758602159384:accesspoint/turbottest69626/object/*"
          ]
        }
      ],
      "Version": "2008-10-17"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "access_point_arn": "arn:aws:s3:us-east-1:758602159384:accesspoint/turbottest69626",
    "name": "turbottest69626"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:s3:us-east-1:758602159384:accesspoint/turbottest69626"
    ],
    "title": "turbottest69626"
  }
]
✔ PASSED

POSTTEST: tests/aws_s3_access_point

TEARDOWN: tests/aws_s3_access_point

SUMMARY:

1/1 passed.
```
</details>
