### PR TITLE
Remove unsupported region(ap-southeast-3) for aws_api_gatewayv2_api service client closes #1526

### DIFF
--- a/aws/service.go
+++ b/aws/service.go
@@ -228,11 +228,11 @@ func APIGatewayClient(ctx context.Context, d *plugin.QueryData) (*apigateway.Cli
 }
 
 func APIGatewayV2Client(ctx context.Context, d *plugin.QueryData) (*apigatewayv2.Client, error) {
-	// APIGatewayV2's endpoint ID is the same as APIGateway's, but me-central-1 does not support API Gateway v2 yet
+	// APIGatewayV2's endpoint ID is the same as APIGateway's, but me-central-1 and ap-southeast-3 does not support API Gateway v2 yet
 	//cfg, err := getClientForQuerySupportedRegion(ctx, d, apigatewayv2Endpoint.EndpointsID)
 
 	region := d.KeyColumnQualString(matrixKeyRegion)
-	validRegions := []string{"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ap-southeast-3", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1", "us-iso-east-1"}
+	validRegions := []string{"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1", "us-iso-east-1"}
 
 	if !helpers.StringSliceContains(validRegions, region) {
 		return nil, nil

--- a/aws/service.go
+++ b/aws/service.go
@@ -230,6 +230,7 @@ func APIGatewayClient(ctx context.Context, d *plugin.QueryData) (*apigateway.Cli
 func APIGatewayV2Client(ctx context.Context, d *plugin.QueryData) (*apigatewayv2.Client, error) {
 	// APIGatewayV2's endpoint ID is the same as APIGateway's, but me-central-1 and ap-southeast-3 does not support API Gateway v2 yet
 	//cfg, err := getClientForQuerySupportedRegion(ctx, d, apigatewayv2Endpoint.EndpointsID)
+	// https://www.aws-services.info/apigatewayv2.html
 
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	validRegions := []string{"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1", "us-iso-east-1"}

--- a/aws/service.go
+++ b/aws/service.go
@@ -228,9 +228,8 @@ func APIGatewayClient(ctx context.Context, d *plugin.QueryData) (*apigateway.Cli
 }
 
 func APIGatewayV2Client(ctx context.Context, d *plugin.QueryData) (*apigatewayv2.Client, error) {
-	// APIGatewayV2's endpoint ID is the same as APIGateway's, but me-central-1 and ap-southeast-3 does not support API Gateway v2 yet
+	// APIGatewayV2's endpoint ID is the same as APIGateway's, but me-central-1 and ap-southeast-3 do not support API Gateway v2 yet
 	//cfg, err := getClientForQuerySupportedRegion(ctx, d, apigatewayv2Endpoint.EndpointsID)
-	// https://www.aws-services.info/apigatewayv2.html
 
 	region := d.KeyColumnQualString(matrixKeyRegion)
 	validRegions := []string{"af-south-1", "ap-east-1", "ap-northeast-1", "ap-northeast-2", "ap-northeast-3", "ap-south-1", "ap-southeast-1", "ap-southeast-2", "ca-central-1", "eu-central-1", "eu-north-1", "eu-south-1", "eu-west-1", "eu-west-2", "eu-west-3", "me-south-1", "sa-east-1", "us-east-1", "us-east-2", "us-west-1", "us-west-2", "cn-north-1", "cn-northwest-1", "us-gov-east-1", "us-gov-west-1", "us-iso-east-1"}


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_api_gatewayv2_api []

PRETEST: tests/aws_api_gatewayv2_api

TEST: tests/aws_api_gatewayv2_api
Running terraform
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 2s [id=347802154958]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_apigatewayv2_api.named_test_resource will be created
  + resource "aws_apigatewayv2_api" "named_test_resource" {
      + api_endpoint                 = (known after apply)
      + api_key_selection_expression = "$request.header.x-api-key"
      + arn                          = (known after apply)
      + execution_arn                = (known after apply)
      + id                           = (known after apply)
      + name                         = "turbottest51829"
      + protocol_type                = "HTTP"
      + route_selection_expression   = "$request.method $request.path"
      + tags                         = {
          + "name" = "turbottest51829"
        }
      + tags_all                     = {
          + "name" = "turbottest51829"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + api_endpoint  = (known after apply)
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest51829"
aws_apigatewayv2_api.named_test_resource: Creating...
aws_apigatewayv2_api.named_test_resource: Creation complete after 3s [id=cgga3ylyz6]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

api_endpoint = "https://cgga3ylyz6.execute-api.us-east-1.amazonaws.com"
resource_aka = "arn:aws:apigateway:us-east-1::/apis/cgga3ylyz6"
resource_id = "cgga3ylyz6"
resource_name = "turbottest51829"

Running SQL query: query.sql
[
  {
    "name": "turbottest51829"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:apigateway:us-east-1::/apis/cgga3ylyz6"
    ],
    "tags": {
      "name": "turbottest51829"
    },
    "title": "turbottest51829"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:apigateway:us-east-1::/apis/cgga3ylyz6"
    ],
    "api_endpoint": "https://cgga3ylyz6.execute-api.us-east-1.amazonaws.com",
    "api_id": "cgga3ylyz6",
    "name": "turbottest51829",
    "tags": {
      "name": "turbottest51829"
    },
    "title": "turbottest51829"
  }
]
✔ PASSED

POSTTEST: tests/aws_api_gatewayv2_api

TEARDOWN: tests/aws_api_gatewayv2_api

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_api_gatewayv2_api
+---------------------+------------+--------------------------------------------------------+---------------+------------------------------+------------------------------+-------------------------------+---------------------------+---------------------------+-----------
| name                | api_id     | api_endpoint                                           | protocol_type | api_key_selection_expression | disable_execute_api_endpoint | route_selection_expression    | created_date              | tags                      | title     
+---------------------+------------+--------------------------------------------------------+---------------+------------------------------+------------------------------+-------------------------------+---------------------------+---------------------------+-----------
| turbottest5806      | bg593jrpm9 | https://bg593jrpm9.execute-api.us-east-1.amazonaws.com | HTTP          | $request.header.x-api-key    | false                        | $request.method $request.path | 2022-12-26T18:53:17+05:30 | {"name":"turbottest5806"} | turbottest
| sp-flow-api-gateway | ccm80pro8g | https://ccm80pro8g.execute-api.us-west-2.amazonaws.com | HTTP          | $request.header.x-api-key    | false                        | $request.method $request.path | 2022-07-28T17:06:51+05:30 | {}                        | sp-flow-ap
+---------------------+------------+--------------------------------------------------------+---------------+------------------------------+------------------------------+-------------------------------+---------------------------+---------------------------+-----------

```
</details>
