### PR TITLE
Fix `aws_ebs_snapshot` not returning details for shared snapshots

### DIFF
--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -18,6 +18,9 @@ func tableAwsEBSSnapshot(_ context.Context) *plugin.Table {
 		Description: "AWS EBS Snapshot",
 		List: &plugin.ListConfig{
 			Hydrate: listAwsEBSSnapshots,
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"InvalidSnapshot.NotFound", "InvalidSnapshotID.Malformed", "InvalidParameterValue"}),
+			},
 			KeyColumns: []*plugin.KeyColumn{
 				{
 					Name:    "description",
@@ -27,7 +30,6 @@ func tableAwsEBSSnapshot(_ context.Context) *plugin.Table {
 					Name:    "encrypted",
 					Require: plugin.Optional,
 				},
-
 				{
 					Name:       "owner_alias",
 					Require:    plugin.Optional,

--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -347,6 +347,6 @@ func buildEbsSnapshotFilter(ctx context.Context, d *plugin.QueryData, h *plugin.
 		commonColumnData := c.(*awsCommonColumnData)
 		input.OwnerIds = append(input.OwnerIds, commonColumnData.AccountId)
 	}
-	plugin.Logger(ctx).Error("input - ", input.OwnerIds, "filter-", filters)
+	
 	return filters
 }

--- a/docs/tables/aws_ebs_snapshot.md
+++ b/docs/tables/aws_ebs_snapshot.md
@@ -2,6 +2,10 @@
 
 An EBS snapshot is a point-in-time copy of Amazon EBS volume, which is copied to Amazon Simple Storage Service.
 
+The `aws_ebs_snapshot` table lists all private snapshots by default.
+
+**You should specify an owner ID** in the `where` clause (`where owner_id='`) to list public or shared snapshots from a specific AWS account.
+
 ## Examples
 
 ### List of snapshots which are not encrypted
@@ -55,4 +59,17 @@ from
   aws_ebs_snapshot
 group by
   volume_id;
+```
+
+### List snapshots owned by a specific AWS account
+
+```sql
+select
+  snapshot_id,
+  arn,
+  encrypted
+from
+  aws_ebs_snapshot
+where
+  owner_id = '859788737657';
 ```

--- a/docs/tables/aws_ebs_snapshot.md
+++ b/docs/tables/aws_ebs_snapshot.md
@@ -4,7 +4,7 @@ An EBS snapshot is a point-in-time copy of Amazon EBS volume, which is copied to
 
 The `aws_ebs_snapshot` table lists all private snapshots by default.
 
-**You should specify an owner ID** in the `where` clause (`where owner_id='`) to list public or shared snapshots from a specific AWS account.
+**You can specify an owner alias, owner ID or snapshot ID** in the `where` clause (`where owner_alias=''`), (`where owner_id=''`) or (`where snapshot_id=''`) to list public or shared snapshots from a specific AWS account.
 
 ## Examples
 
@@ -72,4 +72,17 @@ from
   aws_ebs_snapshot
 where
   owner_id = '859788737657';
+```
+
+### Get a snapshot owned by a specific AWS account
+
+```sql
+select
+  snapshot_id,
+  arn,
+  encrypted
+from
+  aws_ebs_snapshot
+where
+  snapshot_id = 'snap-07bf4f91353ad71ae';
 ```

--- a/docs/tables/aws_ebs_snapshot.md
+++ b/docs/tables/aws_ebs_snapshot.md
@@ -86,3 +86,16 @@ from
 where
   snapshot_id = 'snap-07bf4f91353ad71ae';
 ```
+
+### List snapshots owned by amazon
+
+```sql
+select
+  snapshot_id,
+  arn,
+  encrypted
+from
+  aws_ebs_snapshot
+where
+  owner_alias= 'amazon'
+```

--- a/docs/tables/aws_ebs_snapshot.md
+++ b/docs/tables/aws_ebs_snapshot.md
@@ -67,35 +67,38 @@ group by
 select
   snapshot_id,
   arn,
-  encrypted
+  encrypted,
+  owner_id
 from
   aws_ebs_snapshot
 where
   owner_id = '859788737657';
 ```
 
-### Get a snapshot owned by a specific AWS account
+### Get a specific snapshot by ID
 
 ```sql
 select
   snapshot_id,
   arn,
-  encrypted
+  encrypted,
+  owner_id
 from
   aws_ebs_snapshot
 where
   snapshot_id = 'snap-07bf4f91353ad71ae';
 ```
 
-### List snapshots owned by amazon
+### List snapshots owned by Amazon (Note: This will attempt to list ALL public snapshots)
 
 ```sql
 select
   snapshot_id,
   arn,
-  encrypted
+  encrypted,
+  owner_id
 from
   aws_ebs_snapshot
 where
-  owner_alias= 'amazon'
+  owner_alias = 'amazon'
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```sql
> select arn, owner_id, account_id from aws_ebs_snapshot limit 5
+--------------------------------------------------------------------+--------------+--------------+
| arn                                                                | owner_id     | account_id   |
+--------------------------------------------------------------------+--------------+--------------+
| arn:aws:ec2:us-east-1:111222333444:snapshot/snap-0d741ecs455725d05 | 111222333444 | 111222333444 |
| arn:aws:ec2:us-east-1:111222333444:snapshot/snap-0c086de5a79eb01d5 | 111222333444 | 111222333444 |
| arn:aws:ec2:us-east-1:111222333444:snapshot/snap-007e4fg96da1949ab | 111222333444 | 111222333444 |
| arn:aws:ec2:us-east-1:111222333444:snapshot/snap-09bbf0a9734f8a53f | 111222333444 | 111222333444 |
| arn:aws:ec2:us-east-2:111222333444:snapshot/snap-07aaaesfd6a02ca59 | 111222333444 | 111222333444 |
+--------------------------------------------------------------------+--------------+--------------+
> select arn, owner_id, account_id from aws_ebs_snapshot where snapshot_id = 'snap-030bcc6f9e110e5d7'
+--------------------------------------------------------------------+--------------+--------------+
| arn                                                                | owner_id     | account_id   |
+--------------------------------------------------------------------+--------------+--------------+
| arn:aws:ec2:us-east-2:123456789123:snapshot/snap-030bcc6f9e110e5d7 | 123456789123 | 111222333444 |
+--------------------------------------------------------------------+--------------+--------------+
```
</details>
