### PR TITLE
Add column access_log_settings in table aws_api_gatewayv2_stage closes #1538

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v0.91.0 [2023-01-09]
+
+_What's new?_
+
+- New tables added
+  - [aws_glue_data_quality_ruleset](https://hub.steampipe.io/plugins/turbot/aws/tables/aws_glue_data_quality_ruleset) ([#1513](https://github.com/turbot/steampipe-plugin-aws/pull/1513))
+
+_Bug fixes_
+
+- Fixed `aws_s3_access_point` table to return access points from all the configured regions instead of only `us-east-1`. ([#1522](https://github.com/turbot/steampipe-plugin-aws/pull/1522))
+- Fixed the `aws_ebs_snapshot` table to return snapshots from different AWS accounts when an `owner_alias` or an `owner_id` or a `snapshot_id` is passed in the `where` clause. ([#1530](https://github.com/turbot/steampipe-plugin-aws/pull/1530))
+
 ## v0.90.0 [2022-12-28]
 
 _What's new?_

--- a/aws/table_aws_api_gatewayv2_stage.go
+++ b/aws/table_aws_api_gatewayv2_stage.go
@@ -123,6 +123,12 @@ func tableAwsAPIGatewayV2Stage(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Stage.Description"),
 			},
 			{
+				Name:        "access_log_settings",
+				Description: "Settings for logging access in this stage.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Stage.AccessLogSettings"),
+			},
+			{
 				Name:        "stage_variables",
 				Description: "A map that defines the stage variables for a stage resource",
 				Type:        proto.ColumnType_JSON,

--- a/docs/tables/aws_api_gatewayv2_stage.md
+++ b/docs/tables/aws_api_gatewayv2_stage.md
@@ -4,7 +4,7 @@ A stage is a named reference to a deployment, which is a snapshot of the API.
 
 ## Examples
 
-### List of API gateway v2 stages which does not send logs to cloud watch log
+### List of API gateway V2 stages which does not send logs to cloud watch log
 
 ```sql
 select
@@ -17,7 +17,7 @@ where
   not default_route_data_trace_enabled;
 ```
 
-### Default route settings info of each API gateway v2 stages
+### Default route settings info of each API gateway V2 stage
 
 ```sql
 select
@@ -31,7 +31,7 @@ from
   aws_api_gatewayv2_stage;
 ```
 
-### Count of api gatewayv2 stages by APIs
+### Count of API gateway V2 stages by APIs
 
 ```sql
 select
@@ -43,7 +43,7 @@ group by
   api_id;
 ```
 
-### Get access log settings for the stages
+### Get access log settings of API gateway V2 stages
 
 ```sql
 select

--- a/docs/tables/aws_api_gatewayv2_stage.md
+++ b/docs/tables/aws_api_gatewayv2_stage.md
@@ -17,7 +17,6 @@ where
   not default_route_data_trace_enabled;
 ```
 
-
 ### Default route settings info of each API gateway v2 stages
 
 ```sql
@@ -32,7 +31,6 @@ from
   aws_api_gatewayv2_stage;
 ```
 
-
 ### Count of api gatewayv2 stages by APIs
 
 ```sql
@@ -43,4 +41,16 @@ from
   aws_api_gatewayv2_stage
 group by
   api_id;
+```
+
+### Get access log settings for the stages
+
+```sql
+select
+  stage_name,
+  api_id,
+  default_route_data_trace_enabled,
+  jsonb_pretty(access_log_settings) as access_log_settings
+from
+  aws_api_gatewayv2_stage;
 ```


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>

```
➜  aws-test git:(issue-1538) ✗ ./tint.js aws_api_gatewayv2_stage
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_api_gatewayv2_stage []

PRETEST: tests/aws_api_gatewayv2_stage

TEST: tests/aws_api_gatewayv2_stage
Running terraform
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 1s [id=632902152528]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_apigatewayv2_api.test will be created
  + resource "aws_apigatewayv2_api" "test" {
      + api_endpoint                 = (known after apply)
      + api_key_selection_expression = "$request.header.x-api-key"
      + arn                          = (known after apply)
      + execution_arn                = (known after apply)
      + id                           = (known after apply)
      + name                         = "turbottest11888"
      + protocol_type                = "HTTP"
      + route_selection_expression   = "$request.method $request.path"
      + tags_all                     = (known after apply)
    }

  # aws_apigatewayv2_stage.named_test_resource will be created
  + resource "aws_apigatewayv2_stage" "named_test_resource" {
      + api_id        = (known after apply)
      + arn           = (known after apply)
      + auto_deploy   = false
      + deployment_id = (known after apply)
      + execution_arn = (known after apply)
      + id            = (known after apply)
      + invoke_url    = (known after apply)
      + name          = "turbottest11888"
      + tags          = {
          + "name" = "turbottest11888"
        }
      + tags_all      = {
          + "name" = "turbottest11888"
        }
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + api_id        = (known after apply)
  + resource_aka  = (known after apply)
  + resource_name = "turbottest11888"
aws_apigatewayv2_api.test: Creating...
aws_apigatewayv2_api.test: Creation complete after 3s [id=2ecj15gr3d]
aws_apigatewayv2_stage.named_test_resource: Creating...
aws_apigatewayv2_stage.named_test_resource: Creation complete after 2s [id=turbottest11888]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

api_id = "2ecj15gr3d"
resource_aka = "arn:aws:apigateway:us-east-1::/apis/2ecj15gr3d/stages/turbottest11888"
resource_name = "turbottest11888"

Running SQL query: query.sql
[
  {
    "stage_name": "turbottest11888"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:apigateway:us-east-1::/apis/2ecj15gr3d/stages/turbottest11888"
    ],
    "tags": {
      "name": "turbottest11888"
    },
    "title": "turbottest11888"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:apigateway:us-east-1::/apis/2ecj15gr3d/stages/turbottest11888"
    ],
    "api_id": "2ecj15gr3d",¯
    "stage_name": "turbottest11888",
    "tags": {
      "name": "turbottest11888"
    },
    "title": "turbottest11888"
  }
]
✔ PASSED

POSTTEST: tests/aws_api_gatewayv2_stage

TEARDOWN: tests/aws_api_gatewayv2_stage

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select stage_name, api_id, access_log_settings from aws_api_gatewayv2_stage
+------------+------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| stage_name | api_id     | access_log_settings                                                                                                                                                                                                                               
+------------+------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| test       | bg593jrpm9 | {"DestinationArn":"arn:aws:logs:us-east-1:632902152528:log-group:turbottest19624","Format":"{ \"requestId\":\"$context.requestId\", \"ip\": \"$context.identity.sourceIp\", \"requestTime\":\"$context.requestTime\", \"httpMethod\":\"$context.ht
| $default   | ccm80pro8g | <null>                                                                                                                                                                                                                                            
+------------+------------+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------


```
</details>
