### PR TITLE
Add column launch_template_data in table aws_ec2_instance closes #1552

### DIFF
--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -355,6 +355,13 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
+				Name:        "launch_template_data",
+				Description: "The configuration data of the specified instance.",
+				Hydrate:     getEc2LaunchTemplateData,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromValue(),
+			},
+			{
 				Name:        "metadata_options",
 				Description: "The metadata options for the instance.",
 				Type:        proto.ColumnType_JSON,
@@ -677,6 +684,31 @@ func getInstanceUserData(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	}
 
 	return instanceData, nil
+}
+
+
+func getEc2LaunchTemplateData(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	// Get the details of load balancer
+	instance := h.Item.(types.Instance)
+
+	// create service
+	svc, err := EC2Client(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ec2_instance.getEc2LaunchTemplateData", "connection_error", err)
+		return nil, err
+	}
+
+	params := &ec2.GetLaunchTemplateDataInput{
+		InstanceId: instance.InstanceId,
+	}
+
+	op, err := svc.GetLaunchTemplateData(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ec2_instance.getEc2LaunchTemplateData", "api_error", err)
+		return nil, err
+	}
+
+	return op.LaunchTemplateData, err
 }
 
 func getInstanceStatus(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/docs/tables/aws_ec2_instance.md
+++ b/docs/tables/aws_ec2_instance.md
@@ -136,3 +136,19 @@ where
   user_data like any (array ['%pass%', '%secret%','%token%','%key%'])
   or user_data ~ '(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]';
 ```
+
+### Get launch template data for the instances
+
+```sql
+select
+  instance_id,
+  launch_template_data -> 'ImageId' as image_id,
+  launch_template_data -> 'Placement' as placement,
+  launch_template_data -> 'DisableApiStop' as disable_api_stop,
+  launch_template_data -> 'MetadataOptions' as metadata_options,
+  launch_template_data -> 'NetworkInterfaces' as network_interfaces,
+  launch_template_data -> 'BlockDeviceMappings' as block_device_mappings,
+  launch_template_data -> 'CapacityReservationSpecification' as capacity_reservation_specification
+from
+  aws_ec2_instance;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_instance []

PRETEST: tests/aws_ec2_instance

TEST: tests/aws_ec2_instance
Running terraform
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_ami.ubuntu: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 2s [id=432504854533]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]
data.aws_ami.ubuntu: Read complete after 2s [id=ami-0c96a2f29d78f9d2f]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_instance.named_test_resource will be created
  + resource "aws_instance" "named_test_resource" {
      + ami                                  = "ami-0c96a2f29d78f9d2f"
      + arn                                  = (known after apply)
      + associate_public_ip_address          = false
      + availability_zone                    = (known after apply)
      + cpu_core_count                       = (known after apply)
      + cpu_threads_per_core                 = (known after apply)
      + disable_api_stop                     = (known after apply)
      + disable_api_termination              = (known after apply)
      + ebs_optimized                        = (known after apply)
      + get_password_data                    = false
      + host_id                              = (known after apply)
      + host_resource_group_arn              = (known after apply)
      + iam_instance_profile                 = (known after apply)
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = (known after apply)
      + instance_state                       = (known after apply)
      + instance_type                        = "t2.micro"
      + ipv6_address_count                   = (known after apply)
      + ipv6_addresses                       = (known after apply)
      + key_name                             = (known after apply)
      + monitoring                           = (known after apply)
      + outpost_arn                          = (known after apply)
      + password_data                        = (known after apply)
      + placement_group                      = (known after apply)
      + placement_partition_number           = (known after apply)
      + primary_network_interface_id         = (known after apply)
      + private_dns                          = (known after apply)
      + private_ip                           = (known after apply)
      + public_dns                           = (known after apply)
      + public_ip                            = (known after apply)
      + secondary_private_ips                = (known after apply)
      + security_groups                      = (known after apply)
      + source_dest_check                    = true
      + subnet_id                            = (known after apply)
      + tags                                 = {
          + "Name" = "turbottest65434"
        }
      + tags_all                             = {
          + "Name" = "turbottest65434"
        }
      + tenancy                              = (known after apply)
      + user_data                            = "ddd424ea1a8baca5cbf4860d0758cfd8cd4fe667"
      + user_data_base64                     = (known after apply)
      + user_data_replace_on_change          = false
      + vpc_security_group_ids               = (known after apply)

      + capacity_reservation_specification {
          + capacity_reservation_preference = (known after apply)

          + capacity_reservation_target {
              + capacity_reservation_id                 = (known after apply)
              + capacity_reservation_resource_group_arn = (known after apply)
            }
        }

      + ebs_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + snapshot_id           = (known after apply)
          + tags                  = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }

      + enclave_options {
          + enabled = (known after apply)
        }

      + ephemeral_block_device {
          + device_name  = (known after apply)
          + no_device    = (known after apply)
          + virtual_name = (known after apply)
        }

      + maintenance_options {
          + auto_recovery = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = (known after apply)
          + http_put_response_hop_limit = (known after apply)
          + http_tokens                 = (known after apply)
          + instance_metadata_tags      = (known after apply)
        }

      + network_interface {
          + delete_on_termination = (known after apply)
          + device_index          = (known after apply)
          + network_card_index    = (known after apply)
          + network_interface_id  = (known after apply)
        }

      + private_dns_name_options {
          + enable_resource_name_dns_a_record    = (known after apply)
          + enable_resource_name_dns_aaaa_record = (known after apply)
          + hostname_type                        = (known after apply)
        }

      + root_block_device {
          + delete_on_termination = (known after apply)
          + device_name           = (known after apply)
          + encrypted             = (known after apply)
          + iops                  = (known after apply)
          + kms_key_id            = (known after apply)
          + tags                  = (known after apply)
          + throughput            = (known after apply)
          + volume_id             = (known after apply)
          + volume_size           = (known after apply)
          + volume_type           = (known after apply)
        }
    }

  # aws_subnet.named_test_resource will be created
  + resource "aws_subnet" "named_test_resource" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = (known after apply)
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.1.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags                                           = {
          + "name" = "turbottest65434"
        }
      + tags_all                                       = {
          + "name" = "turbottest65434"
        }
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.main will be created
  + resource "aws_vpc" "main" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_classiclink                   = (known after apply)
      + enable_classiclink_dns_support       = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags                                 = {
          + "name" = "turbottest65434"
        }
      + tags_all                             = {
          + "name" = "turbottest65434"
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id        = "432504854533"
  + availability_zone = (known after apply)
  + aws_partition     = "aws"
  + image_id          = "ami-0c96a2f29d78f9d2f"
  + region_name       = "us-east-1"
  + resource_aka      = (known after apply)
  + resource_id       = (known after apply)
  + resource_name     = "turbottest65434"
  + subnet_id         = (known after apply)
  + vpc_id            = (known after apply)
aws_vpc.main: Creating...
aws_vpc.main: Creation complete after 6s [id=vpc-0df10896bcf9f81fc]
aws_subnet.named_test_resource: Creating...
aws_subnet.named_test_resource: Creation complete after 3s [id=subnet-0cc98bf7cbc405028]
aws_instance.named_test_resource: Creating...
aws_instance.named_test_resource: Still creating... [10s elapsed]
aws_instance.named_test_resource: Still creating... [20s elapsed]
aws_instance.named_test_resource: Still creating... [30s elapsed]
aws_instance.named_test_resource: Creation complete after 37s [id=i-066853c44cd7905ff]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "432504854533"
availability_zone = "us-east-1a"
aws_partition = "aws"
image_id = "ami-0c96a2f29d78f9d2f"
region_name = "us-east-1"
resource_aka = "arn:aws:ec2:us-east-1:432504854533:instance/i-066853c44cd7905ff"
resource_id = "i-066853c44cd7905ff"
resource_name = "turbottest65434"
subnet_id = "subnet-0cc98bf7cbc405028"
vpc_id = "vpc-0df10896bcf9f81fc"

Running SQL query: query.sql
[
  {
    "image_id": "ami-0c96a2f29d78f9d2f",
    "instance_id": "i-066853c44cd7905ff"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:432504854533:instance/i-066853c44cd7905ff"
    ],
    "arn": "arn:aws:ec2:us-east-1:432504854533:instance/i-066853c44cd7905ff",
    "cpu_options_core_count": 1,
    "cpu_options_threads_per_core": 1,
    "ebs_optimized": false,
    "hypervisor": "xen",
    "image_id": "ami-0c96a2f29d78f9d2f",
    "instance_id": "i-066853c44cd7905ff",
    "instance_type": "t2.micro",
    "monitoring_state": "disabled",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest65434"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:432504854533:instance/i-066853c44cd7905ff"
    ],
    "disable_api_termination": false,
    "instance_id": "i-066853c44cd7905ff",
    "instance_initiated_shutdown_behavior": "stop",
    "instance_status": {
      "AvailabilityZone": "us-east-1a",
      "Events": null,
      "InstanceId": "i-066853c44cd7905ff",
      "InstanceState": {
        "Code": 16,
        "Name": "running"
      },
      "InstanceStatus": {
        "Details": [
          {
            "ImpairedSince": null,
            "Name": "reachability",
            "Status": "initializing"
          }
        ],
        "Status": "initializing"
      },
      "OutpostArn": null,
      "SystemStatus": {
        "Details": [
          {
            "ImpairedSince": null,
            "Name": "reachability",
            "Status": "initializing"
          }
        ],
        "Status": "initializing"
      }
    },
    "kernel_id": null,
    "ram_disk_id": null,
    "sriov_net_support": "simple",
    "tags": {
      "Name": "turbottest65434"
    },
    "title": "turbottest65434",
    "user_data": "turbot"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "image_id": "ami-0c96a2f29d78f9d2f",
    "instance_id": "i-066853c44cd7905ff"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_instance

TEARDOWN: tests/aws_ec2_instance

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select instance_id, launch_template_data from aws_ec2_instance
+---------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| instance_id         | launch_template_data                                                                                                                                                              
+---------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
| i-03d7408cb16fa36ee | {"BlockDeviceMappings":[{"DeviceName":"/dev/xvda","Ebs":{"DeleteOnTermination":true,"Encrypted":false,"Iops":null,"KmsKeyId":null,"SnapshotId":"snap-097c82c1f068b49cb","Throughpu
|                     | "HttpPutResponseHopLimit":1,"HttpTokens":"optional","InstanceMetadataTags":"disabled","State":""},"Monitoring":{"Enabled":false},"NetworkInterfaces":[{"AssociateCarrierIpAddress"
|                     | ":null,"SecurityGroupIds":null,"SecurityGroups":null,"TagSpecifications":[{"ResourceType":"instance","Tags":[{"Key":"Name","Value":"testInstance23"}]}],"UserData":null}          
+---------------------+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

```
</details>
