### PR TITLE
Fix:Example queries update

### DIFF
--- a/docs/tables/aws_cloudcontrol_resource.md
+++ b/docs/tables/aws_cloudcontrol_resource.md
@@ -58,8 +58,8 @@ from
   aws_cloudcontrol_resource
 where
   type_name = 'AWS::ElasticLoadBalancingV2::Listener'
-  and resource_model = '{"LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/test-lb/4e695b8755d7003c"}';
-  and region = 'us-east-1'
+  and resource_model = '{"LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/test-lb/4e695b8755d7003c"}'
+  and region = 'us-east-1';
 ```
 
 ### Get details for a CloudTrail trail

--- a/docs/tables/aws_cloudfront_origin_request_policy.md
+++ b/docs/tables/aws_cloudfront_origin_request_policy.md
@@ -11,9 +11,8 @@ select
   name,
   id,
   comment,
-  e_tag,
-  last_modified_time,
-  type
+  etag,
+  last_modified_time
 from
   aws_cloudfront_origin_request_policy;
 ```

--- a/docs/tables/aws_cloudtrail_query.md
+++ b/docs/tables/aws_cloudtrail_query.md
@@ -52,7 +52,7 @@ from
   aws_cloudtrail_query as q,
   aws_cloudtrail_event_data_store as s
 where
- s.event_data_store_arn = q.event_data_store_arn;
+ s.arn = q.event_data_store_arn;
 ```
 
 ## List queries created within the last 3 days

--- a/docs/tables/aws_ec2_network_interface.md
+++ b/docs/tables/aws_ec2_network_interface.md
@@ -31,7 +31,7 @@ select
 from
   aws_ec2_network_interface
 where
-  private_ip_address :: cidr < <= '10.66.0.0/16';
+  private_ip_address :: cidr <<= '10.66.0.0/16';
 ```
 
 ### Count of ENIs by interface type

--- a/docs/tables/aws_inspector_exclusion.md
+++ b/docs/tables/aws_inspector_exclusion.md
@@ -70,9 +70,9 @@ select
   jsonb_pretty(e.attributes) as attributes, 
   e.recommendation 
 from 
-  test_aab.aws_inspector_exclusion e, 
-  test_aab.aws_inspector_assessment_run r, 
-  test_aab.aws_inspector_assessment_template t 
+  aws_inspector_exclusion e, 
+  aws_inspector_assessment_run r, 
+  aws_inspector_assessment_template t 
 where 
   e.assessment_run_arn = r.arn 
 and 

--- a/docs/tables/aws_inspector_finding.md
+++ b/docs/tables/aws_inspector_finding.md
@@ -96,7 +96,7 @@ select
   i.instance_type,
   f.title,
   f.service,
-  f.severity
+  f.severity,
   f.confidence
 from
   aws_ec2_instance as i,

--- a/docs/tables/aws_networkfirewall_firewall_policy.md
+++ b/docs/tables/aws_networkfirewall_firewall_policy.md
@@ -57,10 +57,9 @@ select
   name as firewall_policy_name,
   firewall_policy_status,
   firewall_policy -> 'StatefulDefaultActions' as stateful_default_actions,
-  r as stateful_rule_group_references
+  firewall_policy -> 'StatefulRuleGroupReferences' as stateful_rule_group_references
 from
-  aws_networkfirewall_firewall_policy,
-  jsonb_array_elements(firewall_policy -> 'StatefulRuleGroupReferences') as r;
+  aws_networkfirewall_firewall_policy;
 ```
 
 ### Get policy's default stateless actions and rule group details for full packets
@@ -71,10 +70,9 @@ select
   name as firewall_policy_name,
   firewall_policy_status,
   firewall_policy -> 'StatelessDefaultActions' as stateless_default_actions,
-  r as stateless_rule_group_references
+  firewall_policy -> 'StatelessRuleGroupReferences' as stateless_rule_group_references
 from
-  aws_networkfirewall_firewall_policy,
-  jsonb_array_elements(firewall_policy -> 'StatelessRuleGroupReferences') as r;
+  aws_networkfirewall_firewall_policy;
 ```
 
 ### Get policy's default stateless actions and rule group details for fragmented packets
@@ -85,10 +83,9 @@ select
   name as firewall_policy_name,
   firewall_policy_status,
   firewall_policy -> 'StatelessFragmentDefaultActions' as stateless_default_actions,
-  r as stateless_rule_group_references
+  firewall_policy -> 'StatelessRuleGroupReferences' as stateless_rule_group_references
 from
-  aws_networkfirewall_firewall_policy,
-  jsonb_array_elements(firewall_policy -> 'StatelessRuleGroupReferences') as r;
+  aws_networkfirewall_firewall_policy;
 ```
 
 ### Get policy's custom stateless actions
@@ -98,9 +95,8 @@ select
   arn,
   name as firewall_policy_name,
   firewall_policy_status,
-  c ->> 'ActionName' as custom_action_name,
-  c ->> 'ActionDefinition' as custom_action_definition
+  firewall_policy -> 'StatelessRuleGroupReferences' ->> 'ActionName' as custom_action_name,
+  firewall_policy -> 'StatelessRuleGroupReferences' ->> 'ActionDefinition' as custom_action_definition
 from
-  aws_networkfirewall_firewall_policy,
-  jsonb_array_elements(firewall_policy -> 'StatelessCustomActions') as c;
+  aws_networkfirewall_firewall_policy;
 ```

--- a/docs/tables/aws_oam_link.md
+++ b/docs/tables/aws_oam_link.md
@@ -11,7 +11,7 @@ select
   id,
   arn,
   sink_arn,
-  lable,
+  label,
   resource_types
 from
   aws_oam_link;

--- a/docs/tables/aws_oam_link.md
+++ b/docs/tables/aws_oam_link.md
@@ -22,7 +22,7 @@ from
 ```sql
 select
   l.id,
-  l.arn
+  l.arn,
   s.name as sink_name,
   l.sink_arn
 from

--- a/docs/tables/aws_pipes_pipe.md
+++ b/docs/tables/aws_pipes_pipe.md
@@ -86,7 +86,7 @@ where
 ```sql
 select
   p.name,
-  r.arn as role_arn
+  r.arn as role_arn,
   r.role_id,
   r.permissions_boundary_arn,
   r.role_last_used_region,

--- a/docs/tables/aws_securityhub_finding.md
+++ b/docs/tables/aws_securityhub_finding.md
@@ -262,7 +262,7 @@ order by
   criticality,
   confidence
 from 
-  aws_redhood.aws_securityhub_finding
+  aws_securityhub_finding
 where 
   standards_control_arn like '%cis-aws-foundations-benchmark%';
 ```

--- a/docs/tables/aws_securityhub_finding_aggregator.md
+++ b/docs/tables/aws_securityhub_finding_aggregator.md
@@ -49,8 +49,8 @@ select
   arn,
   a.name as linked_region
 from
-  aws_redhood.aws_securityhub_finding_aggregator as f,
-  aws_redhood.aws_region as a,
+  aws_securityhub_finding_aggregator as f,
+  aws_region as a,
   jsonb_array_elements_text(f.regions) as r
 where
   region_linking_mode = 'ALL_REGIONS_EXCEPT_SPECIFIED'

--- a/docs/tables/aws_vpc_verified_access_trust_provider.md
+++ b/docs/tables/aws_vpc_verified_access_trust_provider.md
@@ -46,5 +46,5 @@ select
 from
   aws_vpc_verified_access_trust_provider
 where
-  creation_time >= now() - interval '90' days;
+  creation_time >= now() - interval '90' day;
 ```


### PR DESCRIPTION
- [x]  In aws_ec2_network_interface fix example query:
```pgsql
select
network_interface_id,
interface_type,
description,
private_ip_address,
association_public_ip,
mac_address
from
aws_ec2_network_interface
where
private_ip_address :: cidr <<= '10.66.0.0/16';
```
- [x] In aws_vpc_verified_access_trust_provider fix example query:
```pgsql
select
verified_access_trust_provider_id,
creation_time,
last_updated_time,
policy_reference_name,
trust_provider_type
from
aws_vpc_verified_access_trust_provider
where
creation_time >= now() - interval '90' day;
```
- [x] In aws_cloudcontrol_resource fix example query:
```pgsql
select
identifier,
properties ->> 'AlpnPolicy' as alpn_policy,
properties ->> 'Certificates' as certificates,
properties ->> 'Port' as port,
properties ->> 'Protocol' as protocol,
region,
account_id
from
aws_cloudcontrol_resource
where
type_name = 'AWS::ElasticLoadBalancingV2::Listener'
and resource_model = '{"LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/test-lb/4e695b8755d7003c"}'
and region = 'us-east-1';
```
- [x] In aws_cloudfront_origin_request_policy fix example query:
```pgsql
select
name,
id,
comment,
etag,
last_modified_time
from
aws_cloudfront_origin_request_policy;
```
- [x] In aws_cloudtrail_event_data_store fix example query:
```pgsql
select
q.query_id as query_id,
q.event_data_store_arn as event_data_store_arn,
s.name as event_data_store_name,
s.status as event_data_store_status,
s.multi_region_enabled as multi_region_enabled,
s.termination_protection_enabled as termination_protection_enabled,
s.updated_timestamp as event_data_store_updated_timestamp
from
aws_cloudtrail_query as q,
aws_cloudtrail_event_data_store as s
where
s.arn = q.event_data_store_arn;
```
- [x] In aws_inspector_exclusion fix example query:
```pgsql
select
e.arn,
e.title,
jsonb_pretty(e.attributes) as attributes,
e.recommendation
from
aws_inspector_exclusion e,
aws_inspector_assessment_run r,
aws_inspector_assessment_template t
where
e.assessment_run_arn = r.arn
and
r.assessment_template_arn = t.arn;
```
- [x] In aws_inspector_finding fix example query:
```pgsql
select
distinct i.instance_id,
i.instance_state,
i.instance_type,
f.title,
f.service,
f.severity,
f.confidence
from
aws_ec2_instance as i,
aws_inspector_finding as f
where
severity = 'High'
and
i.instance_id = f.agent_id;
```
- [x] In aws_networkfirewall_firewall_policy fix example query:
```pgsql
select
  arn,
  name as firewall_policy_name,
  firewall_policy_status,
  firewall_policy -> 'StatefulDefaultActions' as stateful_default_actions,
  firewall_policy -> 'StatefulRuleGroupReferences' as stateful_rule_group_references
from
  aws_networkfirewall_firewall_policy;
 ``` 
- [x] In aws_networkfirewall_firewall_policy fix example query:
```pgsql
select
  arn,
  name as firewall_policy_name,
  firewall_policy_status,
  firewall_policy -> 'StatelessDefaultActions' as stateless_default_actions,
  firewall_policy -> 'StatelessRuleGroupReferences' as stateless_rule_group_references
from
  aws_networkfirewall_firewall_policy;
  ```

 - [x] In aws_networkfirewall_firewall_policy fix example query:
```pgsql
select
  arn,
  name as firewall_policy_name,
  firewall_policy_status,
  firewall_policy -> 'StatelessFragmentDefaultActions' as stateless_default_actions,
  firewall_policy -> 'StatelessRuleGroupReferences' as stateless_rule_group_references
from
  aws_networkfirewall_firewall_policy;
  ```

  - [x] In aws_networkfirewall_firewall_policy fix example query:
```pgsql
select
  arn,
  name as firewall_policy_name,
  firewall_policy_status,
  firewall_policy -> 'StatelessRuleGroupReferences' ->> 'ActionName' as custom_action_name,
  firewall_policy -> 'StatelessRuleGroupReferences' ->> 'ActionDefinition' as custom_action_definition
from
  aws_networkfirewall_firewall_policy;
  ```
  
- [x] In aws_oam_link fix example query:
```pgsql
select
  id,
  arn,
  sink_arn,
  label,
  resource_types
from
  aws_oam_link;
```

- [x] In aws_oam_link fix example query:
```pgsql
select
  l.id,
  l.arn,
  s.name as sink_name,
  l.sink_arn
from
  aws_oam_link as l,
  aws_oam_sink as s;
```

- [x] In aws_pipes_pipe fix example query:
```pgsql
select
  p.name,
  r.arn as role_arn,
  r.role_id,
  r.permissions_boundary_arn,
  r.role_last_used_region,
  r.inline_policies,
  r.assume_role_policy
from
  aws_pipes_pipe as p,
  aws_iam_role as r
where
  p.role_arn = r.arn;
```

- [x] In aws_securityhub_finding fix example query:
```pgsql
select 
  title,
  id,
  company_name,
  created_at,
  criticality,
  confidence
from 
  aws_securityhub_finding
where 
  standards_control_arn like '%cis-aws-foundations-benchmark%';
```

- [x] In aws_securityhub_finding_aggregator fix example query:
```pgsql
select
  arn,
  a.name as linked_region
from
  aws_securityhub_finding_aggregator as f,
  aws_region as a,
  jsonb_array_elements_text(f.regions) as r
where
  region_linking_mode = 'ALL_REGIONS_EXCEPT_SPECIFIED'
and
  a.name <> r;
```