### PR TITLE
Update aws_cloudwatch_log_group table and fix ValidationException issue in getLogGroupTagging function

### DIFF
--- a/aws/table_aws_cloudwatch_log_group.go
+++ b/aws/table_aws_cloudwatch_log_group.go
@@ -34,6 +34,10 @@ func tableAwsCloudwatchLogGroup(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("LogGroupName"),
 			},
+
+			// Most CloudWatch APIs' inputs only accept a CloudWatch log group ARN without ":" at the end, but the
+			// DescribeLogGroups API returns an ARN with ":*", which we've chosen to keep to better match what AWS shows
+			// in their console and documentation.
 			{
 				Name:        "arn",
 				Description: "The Amazon Resource Name (ARN) of the log group.",

--- a/aws/table_aws_cloudwatch_log_group.go
+++ b/aws/table_aws_cloudwatch_log_group.go
@@ -25,12 +25,6 @@ func tableAwsCloudwatchLogGroup(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listCloudwatchLogGroups,
-			KeyColumns: []*plugin.KeyColumn{
-				{
-					Name:    "name",
-					Require: plugin.Optional,
-				},
-			},
 		},
 		GetMatrixItemFunc: SupportedRegionMatrix(cloudwatchlogsv1.EndpointsID),
 		Columns: awsRegionalColumns([]*plugin.Column{
@@ -99,7 +93,7 @@ func listCloudwatchLogGroups(ctx context.Context, d *plugin.QueryData, _ *plugin
 	// Get client
 	svc, err := CloudWatchLogsClient(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Info("aws_cloudwatch_log_group.listCloudwatchLogGroups", "client_error", err)
+		plugin.Logger(ctx).Error("aws_cloudwatch_log_group.listCloudwatchLogGroups", "client_error", err)
 		return nil, err
 	}
 
@@ -126,16 +120,10 @@ func listCloudwatchLogGroups(ctx context.Context, d *plugin.QueryData, _ *plugin
 		o.StopOnDuplicateToken = true
 	})
 
-	// Additonal Filter
-	equalQuals := d.EqualsQuals
-	if equalQuals["name"] != nil {
-		input.LogGroupNamePrefix = aws.String(equalQuals["name"].GetStringValue())
-	}
-
 	for paginator.HasMorePages() {
 		output, err := paginator.NextPage(ctx)
 		if err != nil {
-			plugin.Logger(ctx).Info("aws_cloudwatch_log_group.listCloudwatchLogGroups", "api_error", err)
+			plugin.Logger(ctx).Error("aws_cloudwatch_log_group.listCloudwatchLogGroups", "api_error", err)
 			return nil, err
 		}
 
@@ -158,10 +146,11 @@ func getCloudwatchLogGroup(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	// Get client
 	svc, err := CloudWatchLogsClient(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Info("aws_cloudwatch_log_group.getCloudwatchLogGroup", "client_error", err)
+		plugin.Logger(ctx).Error("aws_cloudwatch_log_group.getCloudwatchLogGroup", "client_error", err)
 		return nil, err
 	}
 
+	// check if name is empty
 	name := d.EqualsQuals["name"].GetStringValue()
 	if strings.TrimSpace(name) == "" {
 		return nil, nil
@@ -171,22 +160,14 @@ func getCloudwatchLogGroup(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 		LogGroupNamePrefix: aws.String(name),
 	}
 
-	paginator := cloudwatchlogs.NewDescribeLogGroupsPaginator(svc, params, func(o *cloudwatchlogs.DescribeLogGroupsPaginatorOptions) {
-		o.StopOnDuplicateToken = true
-	})
+	item, err := svc.DescribeLogGroups(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_cloudwatch_log_group.getCloudwatchLogGroup", "api_error", err)
+		return nil, err
+	}
 
-	for paginator.HasMorePages() {
-		output, err := paginator.NextPage(ctx)
-		if err != nil {
-			plugin.Logger(ctx).Info("aws_cloudwatch_log_group.getCloudwatchLogGroup", "api_error", err)
-			return nil, err
-		}
-
-		for _, logGroup := range output.LogGroups {
-			if *logGroup.LogGroupName == name {
-				return logGroup, nil
-			}
-		}
+	if len(item.LogGroups) > 0 {
+		return item.LogGroups[0], nil
 	}
 
 	return nil, nil
@@ -195,22 +176,28 @@ func getCloudwatchLogGroup(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 func getLogGroupTagging(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logGroup := h.Item.(types.LogGroup)
 
+	// https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/iam-access-control-overview-cwl.html
+	// DescribeLogGroups API returns the logGroup arn format arn:aws:logs:region:account-id:log-group:log_group_name:*
+	// ListTagsForResource API support the logGroup arn format arn:aws:logs:region:account-id:log-group:log_group_name
+	logGroupArn := strings.TrimSuffix(*logGroup.Arn, ":*")
+
 	// Create session
 	svc, err := CloudWatchLogsClient(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Info("aws_cloudwatch_log_group.getLogGroupTagging", "client_error", err)
+		plugin.Logger(ctx).Error("aws_cloudwatch_log_group.getLogGroupTagging", "client_error", err)
 		return nil, err
 	}
 
 	params := &cloudwatchlogs.ListTagsForResourceInput{
-		ResourceArn: logGroup.Arn,
+		ResourceArn: aws.String(logGroupArn),
 	}
 
 	// List resource tags
 	logGroupData, err := svc.ListTagsForResource(ctx, params)
 	if err != nil {
-		plugin.Logger(ctx).Info("aws_cloudwatch_log_group.getLogGroupTagging", "api_error", err)
+		plugin.Logger(ctx).Error("aws_cloudwatch_log_group.getLogGroupTagging", "api_error", err)
 		return nil, err
 	}
+
 	return logGroupData, nil
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
SETUP: tests/aws_cloudwatch_log_group []

PRETEST: tests/aws_cloudwatch_log_group

TEST: tests/aws_cloudwatch_log_group
Running terraform
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 1s [id=533793682495]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_cloudwatch_log_group.named_test_resource will be created
  + resource "aws_cloudwatch_log_group" "named_test_resource" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + name              = "turbottest190"
      + name_prefix       = (known after apply)
      + retention_in_days = 0
      + skip_destroy      = false
      + tags              = {
          + "name" = "turbottest190"
        }
      + tags_all          = {
          + "name" = "turbottest190"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "533793682495"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest190"
aws_cloudwatch_log_group.named_test_resource: Creating...
aws_cloudwatch_log_group.named_test_resource: Creation complete after 2s [id=turbottest190]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "533793682495"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:logs:us-east-1:533793682495:log-group:turbottest190"
resource_name = "turbottest190"

Running SQL query: test-get-query.sql
[
  {
    "name": "turbottest190"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "tags": {
      "name": "turbottest190"
    }
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
[
  {
    "arn": "arn:aws:logs:us-east-1:533793682495:log-group:turbottest190:*",
    "metric_filter_count": 0,
    "name": "turbottest190",
    "retention_in_days": null,
    "stored_bytes": 0
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "533793682495",
    "akas": [
      "arn:aws:logs:us-east-1:533793682495:log-group:turbottest190:*"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "tags": {
      "name": "turbottest190"
    },
    "title": "turbottest190"
  }
]
✔ PASSED

POSTTEST: tests/aws_cloudwatch_log_group

TEARDOWN: tests/aws_cloudwatch_log_group

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
  name,
  kms_key_id,
  metric_filter_count,
  retention_in_days
from
  aws_cloudwatch_log_group
where
  kms_key_id is not null;
+------------+-----------------------------------------------------------------------------+---------------------+-------------------+
| name       | kms_key_id                                                                  | metric_filter_count | retention_in_days |
+------------+-----------------------------------------------------------------------------+---------------------+-------------------+
| test-graph | arn:aws:kms:us-east-1:533*****495:key/c50d0f9b-f6b4-4c5b-97e7-895673dc210e | 0                   | 1                 |
+------------+-----------------------------------------------------------------------------+---------------------+-------------------+

> select name, tags from aws_cloudwatch_log_group where name = '/aws-glue/jobs/error'
+----------------------+-------------------------------+
| name                 | tags                          |
+----------------------+-------------------------------+
| /aws-glue/jobs/error | {"turbot:CreatedBy":"sourav"} |
+----------------------+-------------------------------+


```
</details>
