### PR TITLE
Fix eventbus rule query for non-default eventbus closes #1591

### DIFF
--- a/aws/table_aws_eventbridge_rule.go
+++ b/aws/table_aws_eventbridge_rule.go
@@ -208,9 +208,11 @@ func listAwsEventBridgeRules(ctx context.Context, d *plugin.QueryData, h *plugin
 
 func getAwsEventBridgeRule(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 
+	var eventbusname string
 	var name string
 	if h.Item != nil {
 		name = *h.Item.(*eventbridge.DescribeRuleOutput).Name
+		eventbusname = *h.Item.(*eventbridge.DescribeRuleOutput).EventBusName
 	} else {
 		name = d.EqualsQuals["name"].GetStringValue()
 	}
@@ -228,7 +230,8 @@ func getAwsEventBridgeRule(ctx context.Context, d *plugin.QueryData, h *plugin.H
 
 	// Build the params
 	params := &eventbridge.DescribeRuleInput{
-		Name: &name,
+		EventBusName: &eventbusname,
+		Name:         &name,
 	}
 
 	// Get call

--- a/aws/table_aws_eventbridge_rule.go
+++ b/aws/table_aws_eventbridge_rule.go
@@ -208,14 +208,14 @@ func listAwsEventBridgeRules(ctx context.Context, d *plugin.QueryData, h *plugin
 
 func getAwsEventBridgeRule(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 
-	var name, eventbusname string
+	var name, eventBusName string
 
 	if h.Item != nil {
 		name = *h.Item.(*eventbridge.DescribeRuleOutput).Name
-		eventbusname = *h.Item.(*eventbridge.DescribeRuleOutput).EventBusName
+		eventBusName = *h.Item.(*eventbridge.DescribeRuleOutput).EventBusName
 	} else {
 		name = d.EqualsQuals["name"].GetStringValue()
-		eventbusname = d.EqualsQuals["event_bus_name"].GetStringValue()
+		eventBusName = d.EqualsQuals["event_bus_name"].GetStringValue()
 	}
 
 	// Create Session
@@ -230,9 +230,9 @@ func getAwsEventBridgeRule(ctx context.Context, d *plugin.QueryData, h *plugin.H
 	}
 
 	// Build the params
-	// If you do not provide value for the EventBusName parameter, By Default DescribeRule API, will only look into the default event bus.
+	// Always provide an event bus name since the default event bus is used if not specified
 	params := &eventbridge.DescribeRuleInput{
-		EventBusName: &eventbusname,
+		EventBusName: &eventBusName,
 		Name:         &name,
 	}
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
select name, event_pattern from aws_eventbridge_rule where event_bus_name = 'non-default-eventbus-name'

+------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>
| name                                                             | event_pattern                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          >
+------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>
| TestRuleName                                 | {"detail-type":["detail"],"source":["source"]}                                                                                                                                                                         
```
</details>
