### PR TITLE
Add column `tracing_config` in table `aws_lambda_function` closes #1595

### DIFF
--- a/aws/table_aws_lambda_function.go
+++ b/aws/table_aws_lambda_function.go
@@ -221,6 +221,12 @@ func tableAwsLambdaFunction(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Policy").Transform(unescape).Transform(policyToCanonical),
 			},
 			{
+				Name:        "tracing_config",
+				Description: "The function's X-Ray tracing configuration.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Configuration.TracingConfig", "TracingConfig"),
+			},
+			{
 				Name:        "snap_start",
 				Description: "Set ApplyOn to PublishedVersions to create a snapshot of the initialized execution environment when you publish a function version.",
 				Type:        proto.ColumnType_JSON,

--- a/docs/tables/aws_lambda_function.md
+++ b/docs/tables/aws_lambda_function.md
@@ -135,7 +135,7 @@ from
   aws_lambda_function;
 ```
 
-### List functions that have tracing enabled
+### List functions that have tracing disabled
 
 ```sql
 select
@@ -145,5 +145,5 @@ select
 from
   aws_lambda_function
 where
-  tracing_config ->> 'Mode' = 'Active';
+  tracing_config ->> 'Mode' = 'PassThrough';
 ```

--- a/docs/tables/aws_lambda_function.md
+++ b/docs/tables/aws_lambda_function.md
@@ -134,3 +134,16 @@ select
 from
   aws_lambda_function;
 ```
+
+### List functions that have tracing enabled
+
+```sql
+select
+  name,
+  arn,
+  jsonb_pretty(tracing_config) as tracing_config
+from
+  aws_lambda_function
+where
+  tracing_config ->> 'Mode' = 'Active';
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_lambda_function []

PRETEST: tests/aws_lambda_function

TEST: tests/aws_lambda_function
Running terraform
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 1s [id=533793682495]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.archive_file.zip will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "archive_file" "zip" {
      + id                  = (known after apply)
      + output_base64sha256 = (known after apply)
      + output_md5          = (known after apply)
      + output_path         = "/private/var/folders/d6/qj13fxh53b11_m3scw1m8g8w0000gp/T/tests/aws_lambda_function/terraform/test/../../test.zip"
      + output_sha          = (known after apply)
      + output_size         = (known after apply)
      + source_file         = "/private/var/folders/d6/qj13fxh53b11_m3scw1m8g8w0000gp/T/tests/aws_lambda_function/terraform/test/../../test.py"
      + type                = "zip"
    }

  # aws_iam_role.aws_lambda_function will be created
  + resource "aws_iam_role" "aws_lambda_function" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "lambda.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest28037"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_lambda_function.named_test_resource will be created
  + resource "aws_lambda_function" "named_test_resource" {
      + architectures                  = (known after apply)
      + arn                            = (known after apply)
      + filename                       = "/private/var/folders/d6/qj13fxh53b11_m3scw1m8g8w0000gp/T/tests/aws_lambda_function/terraform/test/../../test.zip"
      + function_name                  = "turbottest28037"
      + handler                        = "test.test"
      + id                             = (known after apply)
      + invoke_arn                     = (known after apply)
      + last_modified                  = (known after apply)
      + memory_size                    = 128
      + package_type                   = "Zip"
      + publish                        = false
      + qualified_arn                  = (known after apply)
      + qualified_invoke_arn           = (known after apply)
      + reserved_concurrent_executions = 2
      + role                           = (known after apply)
      + runtime                        = "python3.7"
      + signing_job_arn                = (known after apply)
      + signing_profile_version_arn    = (known after apply)
      + source_code_hash               = (known after apply)
      + source_code_size               = (known after apply)
      + tags                           = {
          + "name" = "turbottest28037"
        }
      + tags_all                       = {
          + "name" = "turbottest28037"
        }
      + timeout                        = 3
      + version                        = (known after apply)

      + ephemeral_storage {
          + size = (known after apply)
        }

      + tracing_config {
          + mode = (known after apply)
        }
    }

  # aws_lambda_permission.with_sns will be created
  + resource "aws_lambda_permission" "with_sns" {
      + action              = "lambda:InvokeFunction"
      + function_name       = "turbottest28037"
      + id                  = (known after apply)
      + principal           = "sns.amazonaws.com"
      + source_arn          = (known after apply)
      + statement_id        = "AllowExecutionFromSNS"
      + statement_id_prefix = (known after apply)
    }

  # aws_sns_topic.default will be created
  + resource "aws_sns_topic" "default" {
      + arn                         = (known after apply)
      + content_based_deduplication = false
      + fifo_topic                  = false
      + id                          = (known after apply)
      + name                        = "call-lambda-maybe"
      + name_prefix                 = (known after apply)
      + owner                       = (known after apply)
      + policy                      = (known after apply)
      + tags_all                    = (known after apply)
    }

  # local_file.python_file will be created
  + resource "local_file" "python_file" {
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "/private/var/folders/d6/qj13fxh53b11_m3scw1m8g8w0000gp/T/tests/aws_lambda_function/terraform/test/../../test.py"
      + id                   = (known after apply)
      + sensitive_content    = (sensitive value)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "533793682495"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest28037"
  + sns_arn       = (known after apply)
local_file.python_file: Creating...
local_file.python_file: Creation complete after 0s [id=31a055a187e07d0bd8fca8ceb1f633aa4497fe53]
data.archive_file.zip: Reading...
data.archive_file.zip: Read complete after 0s [id=3d2780bc13324b697460b666c413908a395d952e]
aws_iam_role.aws_lambda_function: Creating...
aws_sns_topic.default: Creating...
aws_iam_role.aws_lambda_function: Creation complete after 2s [id=turbottest28037]
aws_lambda_function.named_test_resource: Creating...
aws_sns_topic.default: Creation complete after 3s [id=arn:aws:sns:us-east-1:533793682495:call-lambda-maybe]
aws_lambda_function.named_test_resource: Still creating... [10s elapsed]
aws_lambda_function.named_test_resource: Creation complete after 17s [id=turbottest28037]
aws_lambda_permission.with_sns: Creating...
aws_lambda_permission.with_sns: Creation complete after 1s [id=AllowExecutionFromSNS]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: Attribute Deprecated

  with local_file.python_file,
  on variables.tf line 53, in resource "local_file" "python_file":
  53:   sensitive_content = "def test (event, context):\n\tprint ('This is a test for integration testing to check creation of a lambda function')"

Use the `local_sensitive_file` resource instead

(and 2 more similar warnings elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "533793682495"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:lambda:us-east-1:533793682495:function:turbottest28037"
resource_name = "turbottest28037"
sns_arn = "arn:aws:sns:us-east-1:533793682495:call-lambda-maybe"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:lambda:us-east-1:533793682495:function:turbottest28037",
    "description": "",
    "name": "turbottest28037",
    "role": "arn:aws:iam::533793682495:role/turbottest28037",
    "version": "$LATEST"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "policy": {
      "Id": "default",
      "Statement": [
        {
          "Action": "lambda:InvokeFunction",
          "Condition": {
            "ArnLike": {
              "AWS:SourceArn": "arn:aws:sns:us-east-1:533793682495:call-lambda-maybe"
            }
          },
          "Effect": "Allow",
          "Principal": {
            "Service": "sns.amazonaws.com"
          },
          "Resource": "arn:aws:lambda:us-east-1:533793682495:function:turbottest28037",
          "Sid": "AllowExecutionFromSNS"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Id": "default",
      "Statement": [
        {
          "Action": [
            "lambda:invokefunction"
          ],
          "Condition": {
            "ArnLike": {
              "aws:sourcearn": [
                "arn:aws:sns:us-east-1:533793682495:call-lambda-maybe"
              ]
            }
          },
          "Effect": "Allow",
          "Principal": {
            "Service": [
              "sns.amazonaws.com"
            ]
          },
          "Resource": [
            "arn:aws:lambda:us-east-1:533793682495:function:turbottest28037"
          ],
          "Sid": "AllowExecutionFromSNS"
        }
      ],
      "Version": "2012-10-17"
    },
    "reserved_concurrent_executions": 2,
    "tags": {
      "name": "turbottest28037"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:lambda:us-east-1:533793682495:function:turbottest28037",
    "description": "",
    "name": "turbottest28037",
    "role": "arn:aws:iam::533793682495:role/turbottest28037",
    "version": "$LATEST"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "533793682495",
    "akas": [
      "arn:aws:lambda:us-east-1:533793682495:function:turbottest28037"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "title": "turbottest28037"
  }
]
✔ PASSED

POSTTEST: tests/aws_lambda_function

TEARDOWN: tests/aws_lambda_function

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, region, tracing_config from aws_lambda_function
+-----------------------------------------------------------+----------------+------------------------+
| name                                                      | region         | tracing_config         |
+-----------------------------------------------------------+----------------+------------------------+
| sp-graph-lambda                                           | ap-south-1     | {"Mode":"Active"}      |
| test1                                                     | ap-south-1     | {"Mode":"PassThrough"} |
| tets                                                      | ap-northeast-3 | {"Mode":"PassThrough"} |
| graviton2                                                 | us-east-2      | {"Mode":"PassThrough"} |
| tetest0vpc                                                | us-east-2      | {"Mode":"PassThrough"} |
| SecurityLake_Glue_Partition_Updater_Lambda_ap-northeast-1 | ap-northeast-1 | {"Mode":"PassThrough"} |
| cloud9-TestApp-lambdaone-A71A4OKVLX6D                     | eu-west-1      | {"Mode":"PassThrough"} |
| SecurityLake_Glue_Partition_Updater_Lambda_ap-southeast-2 | ap-southeast-2 | {"Mode":"PassThrough"} |
| cloud9-AppTwo-funcone-W408ZRFMCP4Q                        | eu-west-1      | {"Mode":"PassThrough"} |
| SecurityLake_Glue_Partition_Updater_Lambda_us-east-2      | us-east-2      | {"Mode":"PassThrough"} |
| SecurityLake_Glue_Partition_Updater_Lambda_us-west-2      | us-west-2      | {"Mode":"PassThrough"} |
| testfn                                                    | us-west-2      | {"Mode":"PassThrough"} |
| SecurityLake_Glue_Partition_Updater_Lambda_eu-central-1   | eu-central-1   | {"Mode":"PassThrough"} |
| SecurityLake_Glue_Partition_Updater_Lambda_eu-west-1      | eu-west-1      | {"Mode":"PassThrough"} |
+-----------------------------------------------------------+----------------+------------------------+
```
```
> select name, region, tracing_config from aws_lambda_function where name = 'testfn'
+--------+-----------+------------------------+
| name   | region    | tracing_config         |
+--------+-----------+------------------------+
| testfn | us-west-2 | {"Mode":"PassThrough"} |
+--------+-----------+------------------------+
```
</details>
