### PR TITLE
Add table aws_codebuild_build

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -100,6 +100,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_cloudwatch_metric":                                        tableAwsCloudWatchMetric(ctx),
 			"aws_codeartifact_domain":                                      tableAwsCodeArtifactDomain(ctx),
 			"aws_codeartifact_repository":                                  tableAwsCodeArtifactRepository(ctx),
+			"aws_codebuild_build":                                          tableAwsCodeBuildBuild(ctx),
 			"aws_codebuild_project":                                        tableAwsCodeBuildProject(ctx),
 			"aws_codebuild_source_credential":                              tableAwsCodeBuildSourceCredential(ctx),
 			"aws_codecommit_repository":                                    tableAwsCodeCommitRepository(ctx),

--- a/aws/table_aws_codebuild_build.go
+++ b/aws/table_aws_codebuild_build.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"context"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/service/codebuild"
 
@@ -223,7 +222,7 @@ func listCodeBuildBuilds(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	buildId := quals["id"].GetStringValue()
 
 	// If the user specifies a build id in optional quals, restrict BatchGetBuilds for other build ids.
-	if strings.Trim(buildId, " ") != "" {
+	if buildId != "" {
 		// Build param for a single build id
 		params := &codebuild.BatchGetBuildsInput{
 			Ids: []string{buildId},
@@ -255,10 +254,12 @@ func listCodeBuildBuilds(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		if len(output.Ids) > 0 {
 			// Adding ids to a slice in order to do batch operations
 			buildIds = append(buildIds, output.Ids...)
+		} else {
+			return nil, nil
 		}
 	}
 
-	if len(buildIds) <= 0 {
+	if len(buildIds) == 0 {
 		return nil, nil
 	}
 

--- a/aws/table_aws_codebuild_build.go
+++ b/aws/table_aws_codebuild_build.go
@@ -118,7 +118,7 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "file_system_locations",
-				Description: "An array of ProjectFileSystemLocation objects for a CodeBuild build project..",
+				Description: "An array of ProjectFileSystemLocation objects for a CodeBuild build project.",
 				Type:        proto.ColumnType_JSON,
 			},
 			{

--- a/aws/table_aws_codebuild_build.go
+++ b/aws/table_aws_codebuild_build.go
@@ -58,6 +58,11 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
+				Name:        "current_phase",
+				Description: "The current build phase.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "encryption_key",
 				Description: "The Key Management Service customer master key (CMK) to be used for encrypting the build output artifacts.",
 				Type:        proto.ColumnType_STRING,
@@ -66,6 +71,11 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 				Name:        "end_time",
 				Description: "The date and time that the build process ended, expressed in Unix time format.",
 				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "initiator",
+				Description: "The entity that started the build.",
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "project_name",
@@ -93,6 +103,11 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_INT,
 			},
 			{
+				Name:        "resolved_source_version",
+				Description: "The identifier of the resolved version of this build's source code.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "artifacts",
 				Description: "A BuildArtifacts object the defines the build artifacts for this build.",
 				Type:        proto.ColumnType_JSON,
@@ -101,11 +116,6 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 				Name:        "cache",
 				Description: "Information about the cache for the build.",
 				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "current_phase",
-				Description: "The current build phase.",
-				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "debug_session",
@@ -128,11 +138,6 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
-				Name:        "initiator",
-				Description: "The entity that started the build.",
-				Type:        proto.ColumnType_STRING,
-			},
-			{
 				Name:        "logs",
 				Description: "Information about the build's logs in CloudWatch Logs.",
 				Type:        proto.ColumnType_JSON,
@@ -151,11 +156,6 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 				Name:        "report_arns",
 				Description: "An array of the ARNs associated with this build's reports.",
 				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "resolved_source_version",
-				Description: "The identifier of the resolved version of this build's source code.",
-				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "secondary_artifacts",

--- a/aws/table_aws_codebuild_build.go
+++ b/aws/table_aws_codebuild_build.go
@@ -207,6 +207,7 @@ func listCodeBuildBuilds(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	// Create Session
 	svc, err := CodeBuildClient(ctx, d)
 	if err != nil {
+		plugin.Logger(ctx).Error("aws_codebuild_build.listCodeBuildBuild", "get_client_error", err)
 		return nil, err
 	}
 
@@ -223,7 +224,6 @@ func listCodeBuildBuilds(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 			plugin.Logger(ctx).Error("aws_codebuild_build.listCodeBuildBuild", "api_error", err)
 			return nil, err
 		}
-		plugin.Logger(ctx).Error("listCodeBuildBuild", "output.Ids", output.Ids)
 		if len(output.Ids) > 0 {
 			params := &codebuild.BatchGetBuildsInput{
 				Ids: output.Ids,

--- a/aws/table_aws_codebuild_build.go
+++ b/aws/table_aws_codebuild_build.go
@@ -25,56 +25,31 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 				Name:        "arn",
 				Description: "The ARN of the batch build.",
 				Type:        proto.ColumnType_STRING,
-			},
+			},			
 			{
-				Name:        "artifacts",
-				Description: "A BuildArtifacts object the defines the build artifacts for this batch build.",
-				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "build_batch_configuration",
-				Description: "Contains configuration information about a batch build project.",
-				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "build_batch_number",
-				Description: "The number of the batch build.",
-				Type:        proto.ColumnType_INT,
-			},
-			{
-				Name:        "batch_build_status",
-				Description: "The status of the batch build.",
+				Name:        "id",
+				Description: "The unique identifier of the  build.",
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "build_groups",
-				Description: "An array of BuildGroup objects that define the build groups for the batch build.",
-				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "build_timeout_in_minutes",
-				Description: "Specifies the maximum amount of time, in minutes, that the build in a batch must be completed in.",
-				Type:        proto.ColumnType_INT,
-			},
-			{
-				Name:        "cache",
-				Description: "Information about the cache for the build project.",
+				Name:        "build_batch_arn",
+				Description: "The ARN of the batch build that this build is a member of, if applicable.",
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "complete",
-				Description: "Indicates if the batch build is complete.",
+				Name:        "build_complete",
+				Description: "Indicates if the build is complete.",
 				Type:        proto.ColumnType_BOOL,
 			},
 			{
-				Name:        "current_phase",
-				Description: "The current phase of the batch build.",
-				Type:        proto.ColumnType_STRING,
+				Name:        "build_number",
+				Description: "The number of the build.",
+				Type:        proto.ColumnType_INT,
 			},
 			{
-				Name:        "debug_session_enabled",
-				Description: "Specifies if session debugging is enabled for this batch build.",
-				Type:        proto.ColumnType_BOOL,
+				Name:        "build_status",
+				Description: "The status of the build.",
+				Type:        proto.ColumnType_JSON,
 			},
 			{
 				Name:        "encryption_key",
@@ -83,38 +58,8 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "end_time",
-				Description: "The date and time that the batch build ended.",
+				Description: "The date and time that the build process ended, expressed in Unix time forma.",
 				Type:        proto.ColumnType_TIMESTAMP,
-			},
-			{
-				Name:        "environment",
-				Description: "Information about the build environment of the build project.",
-				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "file_system_locations",
-				Description: "An array of ProjectFileSystemLocation objects for the batch build project.",
-				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "id",
-				Description: "The identifier of the batch build.",
-				Type:        proto.ColumnType_STRING,
-			},
-			{
-				Name:        "initiator",
-				Description: "The entity that started the batch build.",
-				Type:        proto.ColumnType_STRING,
-			},
-			{
-				Name:        "log_config",
-				Description: "Information about logs for a build project. These can be logs in CloudWatch Logs, built in a specified S3 bucket, or both.",
-				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "phases",
-				Description: "An array of BuildBatchPhase objects the specify the phases of the batch build.",
-				Type:        proto.ColumnType_JSON,
 			},
 			{
 				Name:        "project_name",
@@ -123,17 +68,92 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "queued_timeout_in_minutes",
-				Description: "Specifies the amount of time, in minutes, that the batch build is allowed to be queued before it times out.",
+				Description: "Specifies the amount of time, in minutes, that a build is allowed to be queued before it times out.",
 				Type:        proto.ColumnType_INT,
 			},
 			{
+				Name:        "source_version",
+				Description: "The identifier of the version of the source code to be built.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "start_time",
+				Description: "The date and time that the build started.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "timeout_in_minutes",
+				Description: "How long, in minutes, for CodeBuild to wait before timing out this build if it does not get marked as completed.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "artifacts",
+				Description: "A BuildArtifacts object the defines the build artifacts for this batch build.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "cache",
+				Description: "Information about the cache for the build.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "current_phase",
+				Description: "The current build phase.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "debug_session",
+				Description: "Contains information about the debug session for this build.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "environment",
+				Description: "Information about the build environment for this build project.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "exported_environment_variables",
+				Description: "A list of exported environment variables for this build.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "file_system_locations",
+				Description: "An array of ProjectFileSystemLocation objects for a CodeBuild build project..",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "initiator",
+				Description: "The entity that started the build.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "logs",
+				Description: "Information about the build's logs in CloudWatch Logs.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "network_interfaces",
+				Description: " Describes a network interface.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "phases",
+				Description: "Information about all previous build phases that are complete and information about any current build phase that is not yet complete.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "report_arns",
+				Description: "An array of the ARNs associated with this build's reports.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
 				Name:        "resolved_source_version",
-				Description: "The identifier of the resolved version of this batch build's source code.",
+				Description: "The identifier of the resolved version of this build's source code.",
 				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "secondary_artifacts",
-				Description: "An array of BuildArtifacts objects the define the build artifacts for this batch build.",
+				Description: "An array of BuildArtifacts objects the define the build artifacts for this build.",
 				Type:        proto.ColumnType_JSON,
 			},
 			{
@@ -143,28 +163,13 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "secondary_sources",
-				Description: "An array of ProjectSource objects that define the sources for the batch build.",
+				Description: "An array of ProjectSource objects that define the sources for the build.",
 				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "service_role",
-				Description: "The name of a service role used for builds in the batch.",
-				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "source",
 				Description: "Information about the build input source code for the build project.",
 				Type:        proto.ColumnType_JSON,
-			},
-			{
-				Name:        "source_version",
-				Description: "The identifier of the version of the source code to be built.",
-				Type:        proto.ColumnType_STRING,
-			},
-			{
-				Name:        "start_time",
-				Description: "The date and time that the batch build started.",
-				Type:        proto.ColumnType_TIMESTAMP,
 			},
 			{
 				Name:        "vpc_config",
@@ -175,7 +180,7 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("BuildBatch.Arn"),
+				Transform:   transform.FromField("Arn"),
 			},
 			{
 				Name:        "akas",
@@ -191,7 +196,7 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 
 // listCodeBuildBuilds handles both listing and describing of the codebuild builds.
 //
-// The reason for this is the BatchGetBuildBatches call can accept up to 100 IDs. If we moved it out to another
+// The reason for this is the BatchGetBuilds call can accept up to 100 IDs. If we moved it out to another
 // hydrate functions we may save a request or two if we only wanted to retrieve the IDs but the tradeoff is we need
 // to get any other info an API call per codebuild build would need to be made. So in the case where we need to get
 // all info for less then 100 instances including the BatchGetBuild request here, and batching requests means only making
@@ -204,19 +209,6 @@ func listCodeBuildBuilds(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	if err != nil {
 		return nil, err
 	}
-
-	// Limiting the results
-	// maxLimit := int32(100)
-	// if d.QueryContext.Limit != nil {
-	// 	limit := int32(*d.QueryContext.Limit)
-	// 	if limit < maxLimit {
-	// 		if limit < 1 {
-	// 			maxLimit = 1
-	// 		} else {
-	// 			maxLimit = limit
-	// 		}
-	// 	}
-	// }
 
 	input := &codebuild.ListBuildsInput{}
 

--- a/aws/table_aws_codebuild_build.go
+++ b/aws/table_aws_codebuild_build.go
@@ -1,0 +1,259 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/codebuild"
+
+	codebuildv1 "github.com/aws/aws-sdk-go/service/codebuild"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_codebuild_build",
+		Description: "AWS CodeBuild Build",
+		List: &plugin.ListConfig{
+			Hydrate: listCodeBuildBuilds,
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(codebuildv1.EndpointsID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "arn",
+				Description: "The ARN of the batch build.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "artifacts",
+				Description: "A BuildArtifacts object the defines the build artifacts for this batch build.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "build_batch_configuration",
+				Description: "Contains configuration information about a batch build project.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "build_batch_number",
+				Description: "The number of the batch build.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "batch_build_status",
+				Description: "The status of the batch build.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "build_groups",
+				Description: "An array of BuildGroup objects that define the build groups for the batch build.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "build_timeout_in_minutes",
+				Description: "Specifies the maximum amount of time, in minutes, that the build in a batch must be completed in.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "cache",
+				Description: "Information about the cache for the build project.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "complete",
+				Description: "Indicates if the batch build is complete.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "current_phase",
+				Description: "The current phase of the batch build.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "debug_session_enabled",
+				Description: "Specifies if session debugging is enabled for this batch build.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "encryption_key",
+				Description: "The Key Management Service customer master key (CMK) to be used for encrypting the batch build output artifacts.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "end_time",
+				Description: "The date and time that the batch build ended.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "environment",
+				Description: "Information about the build environment of the build project.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "file_system_locations",
+				Description: "An array of ProjectFileSystemLocation objects for the batch build project.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "id",
+				Description: "The identifier of the batch build.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "initiator",
+				Description: "The entity that started the batch build.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "log_config",
+				Description: "Information about logs for a build project. These can be logs in CloudWatch Logs, built in a specified S3 bucket, or both.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "phases",
+				Description: "An array of BuildBatchPhase objects the specify the phases of the batch build.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "project_name",
+				Description: "The name of the batch build project.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "queued_timeout_in_minutes",
+				Description: "Specifies the amount of time, in minutes, that the batch build is allowed to be queued before it times out.",
+				Type:        proto.ColumnType_INT,
+			},			
+			{
+				Name:        "resolved_source_version",
+				Description: "The identifier of the resolved version of this batch build's source code.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "secondary_artifacts",
+				Description: "An array of BuildArtifacts objects the define the build artifacts for this batch build.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "secondary_source_versions",
+				Description: "An array of ProjectSourceVersion objects.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "secondary_sources",
+				Description: "An array of ProjectSource objects that define the sources for the batch build.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "service_role",
+				Description: "The name of a service role used for builds in the batch.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "source",
+				Description: "Information about the build input source code for the build project.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "source_version",
+				Description: "The identifier of the version of the source code to be built.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "start_time",
+				Description: "The date and time that the batch build started.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "vpc_config",
+				Description: "Information about the VPC configuration that CodeBuild accesses.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("BuildBatch.Arn"),
+			},
+			{
+				Name:        "akas",
+				Description: resourceInterfaceDescription("akas"),
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Arn").Transform(arnToAkas),
+			},
+		}),
+	}
+}
+//// LIST FUNCTION
+
+// listCodeBuildBuilds handles both listing and describing of the codebuild builds.
+//
+// The reason for this is the BatchGetBuildBatches call can accept up to 100 IDs. If we moved it out to another
+// hydrate functions we may save a request or two if we only wanted to retrieve the IDs but the tradeoff is we need
+// to get any other info an API call per codebuild build would need to be made. So in the case where we need to get
+// all info for less then 100 instances including the BatchGetBuild request here, and batching requests means only making
+// two API calls as opposed to 101.
+func listCodeBuildBuilds(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("listCodeBuildBuilds")
+
+	// Create Session
+	svc, err := CodeBuildClient(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+
+	// Limiting the results
+	maxLimit := int32(100)
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxLimit {
+			if limit < 1 {
+				maxLimit = 1
+			} else {
+				maxLimit = limit
+			}
+		}
+	}
+
+	input := &codebuild.ListBuildBatchesInput{
+		MaxResults: aws.Int32(maxLimit),
+	}
+
+	paginator := codebuild.NewListBuildBatchesPaginator(svc, input, func(o *codebuild.ListBuildBatchesPaginatorOptions) {
+		o.Limit = maxLimit
+		o.StopOnDuplicateToken = true
+	})
+
+	// List call
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_codebuild_build.listCodeBuildBuild", "api_error", err)
+			return nil, err
+		}
+		if len(output.Ids) > 0 {
+			params := &codebuild.BatchGetBuildBatchesInput{
+				Ids: output.Ids,
+			}
+			op, err := svc.BatchGetBuildBatches(ctx, params)
+			if err != nil {
+				plugin.Logger(ctx).Error("aws_codebuild_project.getCodeBuildProject", "api_error", err)
+				return nil, err
+			}
+
+			for _, build := range op.BuildBatches {
+				d.StreamListItem(ctx, build)
+	
+				// Context may get cancelled due to manual cancellation or if the limit has been reached
+				if d.RowsRemaining(ctx) == 0 {
+					return nil, nil
+				}
+			}
+		}
+	}
+
+	return nil, nil
+}

--- a/aws/table_aws_codebuild_build.go
+++ b/aws/table_aws_codebuild_build.go
@@ -23,7 +23,7 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 		Columns: awsRegionalColumns([]*plugin.Column{
 			{
 				Name:        "arn",
-				Description: "The ARN of the batch build.",
+				Description: "The ARN of the build.",
 				Type:        proto.ColumnType_STRING,
 			},			
 			{
@@ -53,7 +53,7 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "encryption_key",
-				Description: "The Key Management Service customer master key (CMK) to be used for encrypting the batch build output artifacts.",
+				Description: "The Key Management Service customer master key (CMK) to be used for encrypting the build output artifacts.",
 				Type:        proto.ColumnType_STRING,
 			},
 			{
@@ -63,7 +63,7 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "project_name",
-				Description: "The name of the batch build project.",
+				Description: "The name of the build project.",
 				Type:        proto.ColumnType_STRING,
 			},
 			{
@@ -88,7 +88,7 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "artifacts",
-				Description: "A BuildArtifacts object the defines the build artifacts for this batch build.",
+				Description: "A BuildArtifacts object the defines the build artifacts for this build.",
 				Type:        proto.ColumnType_JSON,
 			},
 			{

--- a/aws/table_aws_codebuild_build.go
+++ b/aws/table_aws_codebuild_build.go
@@ -58,7 +58,7 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "end_time",
-				Description: "The date and time that the build process ended, expressed in Unix time forma.",
+				Description: "The date and time that the build process ended, expressed in Unix time format.",
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
 			{
@@ -133,7 +133,7 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "network_interfaces",
-				Description: " Describes a network interface.",
+				Description: "Describes a network interface.",
 				Type:        proto.ColumnType_JSON,
 			},
 			{
@@ -176,6 +176,8 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 				Description: "Information about the VPC configuration that CodeBuild accesses.",
 				Type:        proto.ColumnType_JSON,
 			},
+			
+			// Steampipe standard columns
 			{
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
@@ -202,12 +204,11 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 // all info for less then 100 instances including the BatchGetBuild request here, and batching requests means only making
 // two API calls as opposed to 101.
 func listCodeBuildBuilds(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("listCodeBuildBuilds")
 
 	// Create Session
 	svc, err := CodeBuildClient(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_codebuild_build.listCodeBuildBuild", "get_client_error", err)
+		plugin.Logger(ctx).Error("aws_codebuild_build.listCodeBuildBuilds", "connection_error", err)
 		return nil, err
 	}
 
@@ -221,7 +222,7 @@ func listCodeBuildBuilds(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	for paginator.HasMorePages() {
 		output, err := paginator.NextPage(ctx)
 		if err != nil {
-			plugin.Logger(ctx).Error("aws_codebuild_build.listCodeBuildBuild", "api_error", err)
+			plugin.Logger(ctx).Error("aws_codebuild_build.listCodeBuildBuilds", "api_error", err)
 			return nil, err
 		}
 		if len(output.Ids) > 0 {

--- a/aws/table_aws_codebuild_build.go
+++ b/aws/table_aws_codebuild_build.go
@@ -203,12 +203,12 @@ func tableAwsCodeBuildBuild(_ context.Context) *plugin.Table {
 //// LIST FUNCTION
 
 // listCodeBuildBuilds handles both listing and describing of the codebuild builds.
-//
-// The reason for this is the BatchGetBuilds call can accept up to 100 IDs. If we moved it out to another
-// hydrate functions we may save a request or two if we only wanted to retrieve the IDs but the tradeoff is we need
-// to get any other info an API call per codebuild build would need to be made. So in the case where we need to get
-// all info for less then 100 instances including the BatchGetBuild request here, and batching requests means only making
+// The reason for this is the BatchGetBuilds API call can accept up to 100 IDs. If we moved it out to another
+// hydrate function we may save a request or two if we only wanted to retrieve the IDs but the tradeoff is that we would need
+// to make an API call per codebuild build. So in cases where we need to get all information
+// for less then 100 instances, including the BatchGetBuild request here, and batching requests means only making
 // two API calls as opposed to 101.
+
 func listCodeBuildBuilds(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 
 	// Create Session

--- a/docs/tables/aws_codebuild_build.md
+++ b/docs/tables/aws_codebuild_build.md
@@ -1,0 +1,62 @@
+# Table: aws_codebuild_project
+
+AWS CodeBuild is a fully managed build service in the cloud. CodeBuild compiles your source code, runs unit tests, and produces artifacts that are ready to deploy. CodeBuild eliminates the need to provision, manage, and scale your own build servers. It provides prepackaged build environments for the most popular programming languages and build tools, such as Apache Maven, Gradle, and more.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  arn,
+  id,
+  complete,
+  build_timeout_in_minutes,
+  build_groups,
+  batch_build_status,
+  encryption_key,
+  end_time,
+  region
+from
+  aws_codebuild_build;
+```
+
+### List VPC configuration that CodeBuild accesses
+
+```sql
+select
+  arn,
+  id,
+  vpc_config
+from
+  aws_codebuild_build
+where
+  vpc_config is not null;
+```
+
+
+### List encrypted batch build output artifacts
+
+```sql
+select
+  arn,
+  id,
+  encryption_key
+from
+  aws_codebuild_build
+where
+  encryption_key is not null;
+```
+
+### List complete batch build
+
+```sql
+select
+  id,
+  arn,
+  artifacts
+from
+  aws_codebuild_build
+where
+  complete;
+```

--- a/docs/tables/aws_codebuild_build.md
+++ b/docs/tables/aws_codebuild_build.md
@@ -10,29 +10,15 @@ AWS CodeBuild is a fully managed build service in the cloud. CodeBuild compiles 
 select
   arn,
   id,
-  complete,
-  build_timeout_in_minutes,
-  build_groups,
-  batch_build_status,
+  build_complete,
+  timeout_in_minutes,
+  project_name,
+  build_status,
   encryption_key,
   end_time,
   region
 from
   aws_codebuild_build;
-```
-
-
-### List VPC configuration that CodeBuild accesses
-
-```sql
-select
-  arn,
-  id,
-  vpc_config
-from
-  aws_codebuild_build
-where
-  vpc_config is not null;
 ```
 
 
@@ -56,12 +42,14 @@ where
 select
   id,
   arn,
-  artifacts
+  artifacts,
+  build_complete
 from
   aws_codebuild_build
 where
-  complete;
+  build_complete;
 ```
+
 
 ### List VPC configuration details of build 
 

--- a/docs/tables/aws_codebuild_build.md
+++ b/docs/tables/aws_codebuild_build.md
@@ -53,7 +53,7 @@ where
 
 ### List VPC configuration details of build 
 
-```
+```sql
 select
   id,
   arn,
@@ -62,5 +62,4 @@ select
   vpc_config ->> 'VpcId' as vpc_id
 from
   aws_codebuild_build;
-
 ```

--- a/docs/tables/aws_codebuild_build.md
+++ b/docs/tables/aws_codebuild_build.md
@@ -63,3 +63,18 @@ select
 from
   aws_codebuild_build;
 ```
+
+
+### List artifacts details of build 
+
+```sql
+select
+  id,
+  arn,
+  artifacts ->> 'ArtifactIdentifier' as artifact_id,
+  artifacts ->> 'BucketOwnerAccess' as bucket_owner_access,
+  artifacts ->> 'EncryptionDisabled' as encryption_disabled,
+  artifacts ->> 'OverrideArtifactName' as override_artifact_name
+from
+  aws_codebuild_build;
+```

--- a/docs/tables/aws_codebuild_build.md
+++ b/docs/tables/aws_codebuild_build.md
@@ -21,6 +21,7 @@ from
   aws_codebuild_build;
 ```
 
+
 ### List VPC configuration that CodeBuild accesses
 
 ```sql
@@ -35,7 +36,7 @@ where
 ```
 
 
-### List encrypted batch build output artifacts
+### List encrypted build output artifacts
 
 ```sql
 select
@@ -48,7 +49,8 @@ where
   encryption_key is not null;
 ```
 
-### List complete batch build
+
+### List complete build
 
 ```sql
 select
@@ -59,4 +61,18 @@ from
   aws_codebuild_build
 where
   complete;
+```
+
+### List VPC configuration details of build 
+
+```
+select
+  id,
+  arn,
+  vpc_config ->> 'SecurityGroupIds' as security_groups,
+  vpc_config ->> 'Subnets' as subnets,
+  vpc_config ->> 'VpcId' as vpc_id
+from
+  aws_codebuild_build;
+
 ```

--- a/docs/tables/aws_codebuild_build.md
+++ b/docs/tables/aws_codebuild_build.md
@@ -21,7 +21,6 @@ from
   aws_codebuild_build;
 ```
 
-
 ### List encrypted build output artifacts
 
 ```sql
@@ -34,7 +33,6 @@ from
 where
   encryption_key is not null;
 ```
-
 
 ### List complete build
 
@@ -50,7 +48,6 @@ where
   build_complete;
 ```
 
-
 ### List VPC configuration details of build 
 
 ```sql
@@ -63,7 +60,6 @@ select
 from
   aws_codebuild_build;
 ```
-
 
 ### List artifacts details of build 
 

--- a/docs/tables/aws_codebuild_build.md
+++ b/docs/tables/aws_codebuild_build.md
@@ -48,7 +48,7 @@ where
   build_complete;
 ```
 
-### List VPC configuration details of builds 
+### List VPC configuration details of builds
 
 ```sql
 select
@@ -61,7 +61,7 @@ from
   aws_codebuild_build;
 ```
 
-### List artifact details of builds 
+### List artifact details of builds
 
 ```sql
 select
@@ -73,4 +73,105 @@ select
   artifacts ->> 'OverrideArtifactName' as override_artifact_name
 from
   aws_codebuild_build;
+```
+
+### Get environment details of builds
+
+```sql
+select
+  id,
+  environment ->> 'Certificate' as environment_certificate,
+  environment ->> 'ComputeType' as environment_compute_type,
+  environment ->> 'EnvironmentVariables' as environment_variables,
+  environment ->> 'Image' as environment_image,
+  environment ->> 'ImagePullCredentialsType' as environment_image_pull_credentials_type,
+  environment ->> 'PrivilegedMode' as environment_privileged_mode,
+  environment ->> 'RegistryCredential' as environment_registry_credential,
+  environment ->> 'Type' as environment_type
+from
+  aws_codebuild_build;
+```
+
+### Get log details of builds
+
+```sql
+select
+  id,
+  logs -> 'S3Logs' ->> 'Status' as s3_log_status,
+  logs -> 'S3Logs' ->> 'Location' as s3_log_location,
+  logs -> 'S3Logs' ->> 'BucketOwnerAccess' as s3_log_bucket_owner_access,
+  logs -> 'S3Logs' ->> 'EncryptionDisabled' as s3_log_encryption_disabled,
+  logs ->> 'DeepLink' as deep_link,
+  logs ->> 'GroupName' as group_name,
+  logs ->> 'S3LogsArn' as s3_logs_arn,
+  logs ->> 'S3DeepLink' as s3_deep_link,
+  logs ->> 'StreamName' as stream_name,
+  logs ->> 'CloudWatchLogsArn' as cloud_watch_logs_arn,
+  logs -> 'CloudWatchLogs' ->> 'Status' as cloud_watch_logs_status,
+  logs -> 'CloudWatchLogs' ->> 'GroupName' as cloud_watch_logs_group_name,
+  logs -> 'CloudWatchLogs' ->> 'StreamName' as cloud_watch_logs_stream_name
+from
+  aws_codebuild_build;
+```
+
+### Get network interface details of builds
+
+```sql
+select
+  id,
+  network_interfaces ->> 'NetworkInterfaceId' as network_interface_id,
+  network_interfaces ->> 'SubnetId' as subnet_id,
+from
+  aws_codebuild_build;
+```
+
+### List phase details of builds
+
+```sql
+select
+  id,
+  p ->> 'EndTime' as end_time,
+  p ->> 'Contexts' as contexts,
+  p ->> 'PhaseType' as phase_type,
+  p ->> 'StartTime' as start_time,
+  p ->> 'DurationInSeconds' as duration_in_seconds,
+  p ->> 'PhaseStatus' as phase_status
+from
+  aws_codebuild_build,
+  jsonb_array_elements(phases) as p;
+```
+
+### Get source details of builds
+
+```sql
+select
+  id,
+  source ->> 'Auth' as source_auth,
+  source ->> 'BuildStatusConfig' as source_BuildStatusConfig,
+  source ->> 'Buildspec' as source_buildspec,
+  source ->> 'GitCloneDepth' as source_git_clone_depth,
+  source ->> 'GitSubmodulesConfig' as source_git_submodules_config,
+  source ->> 'GitCloneDepth' as source_git_clone_depth,
+  source ->> 'InsecureSsl' as source_insecure_ssl,
+  source ->> 'Location' as source_location,
+  source ->> 'ReportBuildStatus' as source_report_build_status,
+  source ->> 'SourceIdentifier' as source_identifier,
+  source ->> 'Type' as source_type
+from
+  aws_codebuild_build;
+```
+
+### List file system location details of builds
+
+```sql
+select
+  id,
+  f ->> 'Identifier' as file_system_identifier,
+  f ->> 'Location' as file_system_location,
+  f ->> 'MountOptions' as file_system_mount_options,
+  f ->> 'MountPoint' as file_system_mount_point,
+  f ->> 'Type' as file_system_type
+from
+  aws_codebuild_build,
+  jsonb_array_elements(file_system_locations) as f;
 ```

--- a/docs/tables/aws_codebuild_build.md
+++ b/docs/tables/aws_codebuild_build.md
@@ -34,7 +34,7 @@ where
   encryption_key is not null;
 ```
 
-### List complete build
+### List complete builds
 
 ```sql
 select
@@ -48,20 +48,20 @@ where
   build_complete;
 ```
 
-### List VPC configuration details of build 
+### List VPC configuration details of builds 
 
 ```sql
 select
   id,
   arn,
-  vpc_config ->> 'SecurityGroupIds' as security_groups,
+  vpc_config ->> 'SecurityGroupIds' as security_group_id,
   vpc_config ->> 'Subnets' as subnets,
   vpc_config ->> 'VpcId' as vpc_id
 from
   aws_codebuild_build;
 ```
 
-### List artifacts details of build 
+### List artifact details of builds 
 
 ```sql
 select


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No integration test exist.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
select
  arn,
  id,
  build_complete,
  timeout_in_minutes,
  project_name,
  build_status,
  encryption_key,
  end_time,
  region
from
  aws_codebuild_build;
+--------------------------------------------------------------------------------------------------+---------------------------------------------------+----------------+--------------------+--------------+--------------+--------------------------------------------------+>
| arn                                                                                              | id                                                | build_complete | timeout_in_minutes | project_name | build_status | encryption_key                                   |>
+--------------------------------------------------------------------------------------------------+---------------------------------------------------+----------------+--------------------+--------------+--------------+--------------------------------------------------+>
| arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:5befbc41-36ae-45d1-9d3a-f12525622fa9    | test-bp1:5befbc41-36ae-45d1-9d3a-f12525622fa9     | true           | 60                 | test-bp1     | "FAILED"     | arn:aws:kms:ap-south-1:222222222222:alias/aws/s3 |>
| arn:aws:codebuild:ap-south-1:222222222222:build/test-p:ddbc61bd-2f5e-4607-808d-54bcb47462f9      | test-p:ddbc61bd-2f5e-4607-808d-54bcb47462f9       | true           | 60                 | test-p       | "FAILED"     | arn:aws:kms:ap-south-1:222222222222:alias/aws/s3 |>
| arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:01ad56f8-0790-4b9d-a354-dec00c310d40    | test-bp1:01ad56f8-0790-4b9d-a354-dec00c310d40     | true           | 60                 | test-bp1     | "FAILED"     | arn:aws:kms:ap-south-1:222222222222:alias/aws/s3 |>
| arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:4a836a33-9f56-4247-a06e-b62e60b7b8d0    | test-bp1:4a836a33-9f56-4247-a06e-b62e60b7b8d0     | true           | 60                 | test-bp1     | "FAILED"     | arn:aws:kms:ap-south-1:222222222222:alias/aws/s3 |>
| arn:aws:codebuild:ap-south-1:222222222222:build/test-2:8862f58c-edeb-4789-a302-d56057204ada      | test-2:8862f58c-edeb-4789-a302-d56057204ada       | true           | 60                 | test-2       | "FAILED"     | arn:aws:kms:ap-south-1:222222222222:alias/aws/s3 |>
| arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:4d332dab-2d9c-4b04-8cd9-2a75bb5de053    | test-bp1:4d332dab-2d9c-4b04-8cd9-2a75bb5de053     | true           | 60                 | test-bp1     | "FAILED"     | arn:aws:kms:ap-south-1:222222222222:alias/aws/s3 |>
| arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:1c3e858b-48fd-40f4-954f-1e86f237b3dd    | test-bp1:1c3e858b-48fd-40f4-954f-1e86f237b3dd     | true           | 60                 | test-bp1     | "SUCCEEDED"  | arn:aws:kms:ap-south-1:222222222222:alias/aws/s3 |>
| arn:aws:codebuild:us-east-2:222222222222:build/testbp12:fcaeba73-401c-4d3c-8805-22b0552e1caf     | testbp12:fcaeba73-401c-4d3c-8805-22b0552e1caf     | true           | 60                 | testbp12     | "FAILED"     | arn:aws:kms:us-east-2:222222222222:alias/aws/s3  |>
| arn:aws:codebuild:us-east-2:222222222222:build/test-cb12345:16d11b0f-c816-4885-b292-b21197f53568 | test-cb12345:16d11b0f-c816-4885-b292-b21197f53568 | true           | 5                  | test-cb12345 | "FAILED"     | arn:aws:kms:us-east-2:222222222222:alias/aws/s3  |>
+--------------------------------------------------------------------------------------------------+---------------------------------------------------+----------------+--------------------+--------------+--------------+--------------------------------------------------+>

select
  id,
  arn,
  artifacts,
  build_complete
from
  aws_codebuild_build
where
  build_complete;
+---------------------------------------------------+--------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------->
| id                                                | arn                                                                                              | artifacts                                                                                                             >
+---------------------------------------------------+--------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------->
| test-bp1:5befbc41-36ae-45d1-9d3a-f12525622fa9     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:5befbc41-36ae-45d1-9d3a-f12525622fa9    | {"ArtifactIdentifier":null,"BucketOwnerAccess":"","EncryptionDisabled":null,"Location":"","Md5sum":null,"OverrideArtif>
| test-p:ddbc61bd-2f5e-4607-808d-54bcb47462f9       | arn:aws:codebuild:ap-south-1:222222222222:build/test-p:ddbc61bd-2f5e-4607-808d-54bcb47462f9      | {"ArtifactIdentifier":null,"BucketOwnerAccess":"","EncryptionDisabled":false,"Location":"arn:aws:s3:::aa-parth-test/te>
| test-bp1:01ad56f8-0790-4b9d-a354-dec00c310d40     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:01ad56f8-0790-4b9d-a354-dec00c310d40    | {"ArtifactIdentifier":null,"BucketOwnerAccess":"","EncryptionDisabled":null,"Location":"","Md5sum":null,"OverrideArtif>
| test-bp1:4a836a33-9f56-4247-a06e-b62e60b7b8d0     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:4a836a33-9f56-4247-a06e-b62e60b7b8d0    | {"ArtifactIdentifier":null,"BucketOwnerAccess":"","EncryptionDisabled":null,"Location":"","Md5sum":null,"OverrideArtif>
| test-2:8862f58c-edeb-4789-a302-d56057204ada       | arn:aws:codebuild:ap-south-1:222222222222:build/test-2:8862f58c-edeb-4789-a302-d56057204ada      | {"ArtifactIdentifier":null,"BucketOwnerAccess":"","EncryptionDisabled":null,"Location":"","Md5sum":null,"OverrideArtif>
| test-bp1:4d332dab-2d9c-4b04-8cd9-2a75bb5de053     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:4d332dab-2d9c-4b04-8cd9-2a75bb5de053    | {"ArtifactIdentifier":null,"BucketOwnerAccess":"","EncryptionDisabled":null,"Location":"","Md5sum":null,"OverrideArtif>
| test-bp1:1c3e858b-48fd-40f4-954f-1e86f237b3dd     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:1c3e858b-48fd-40f4-954f-1e86f237b3dd    | {"ArtifactIdentifier":null,"BucketOwnerAccess":"","EncryptionDisabled":null,"Location":"","Md5sum":null,"OverrideArtif>
| testbp12:fcaeba73-401c-4d3c-8805-22b0552e1caf     | arn:aws:codebuild:us-east-2:222222222222:build/testbp12:fcaeba73-401c-4d3c-8805-22b0552e1caf     | {"ArtifactIdentifier":null,"BucketOwnerAccess":"","EncryptionDisabled":null,"Location":"","Md5sum":null,"OverrideArtif>
| test-cb12345:16d11b0f-c816-4885-b292-b21197f53568 | arn:aws:codebuild:us-east-2:222222222222:build/test-cb12345:16d11b0f-c816-4885-b292-b21197f53568 | {"ArtifactIdentifier":null,"BucketOwnerAccess":"","EncryptionDisabled":null,"Location":"","Md5sum":null,"OverrideArtif>

select
  id,
  arn,
  vpc_config ->> 'SecurityGroupIds' as security_groups,
  vpc_config ->> 'Subnets' as subnets,
  vpc_config ->> 'VpcId' as vpc_id
from
  aws_codebuild_build;
+---------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------------------+----------------------------------------------------------+-----------------------+
| id                                                | arn                                                                                              | security_groups          | subnets                                                  | vpc_id                |
+---------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------------------+----------------------------------------------------------+-----------------------+
| test-bp1:5befbc41-36ae-45d1-9d3a-f12525622fa9     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:5befbc41-36ae-45d1-9d3a-f12525622fa9    | <null>                   | <null>                                                   | <null>                |
| test-p:ddbc61bd-2f5e-4607-808d-54bcb47462f9       | arn:aws:codebuild:ap-south-1:222222222222:build/test-p:ddbc61bd-2f5e-4607-808d-54bcb47462f9      | <null>                   | <null>                                                   | <null>                |
| test-bp1:01ad56f8-0790-4b9d-a354-dec00c310d40     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:01ad56f8-0790-4b9d-a354-dec00c310d40    | <null>                   | <null>                                                   | <null>                |
| test-bp1:4a836a33-9f56-4247-a06e-b62e60b7b8d0     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:4a836a33-9f56-4247-a06e-b62e60b7b8d0    | <null>                   | <null>                                                   | <null>                |
| test-2:8862f58c-edeb-4789-a302-d56057204ada       | arn:aws:codebuild:ap-south-1:222222222222:build/test-2:8862f58c-edeb-4789-a302-d56057204ada      | <null>                   | <null>                                                   | <null>                |
| test-bp1:4d332dab-2d9c-4b04-8cd9-2a75bb5de053     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:4d332dab-2d9c-4b04-8cd9-2a75bb5de053    | <null>                   | <null>                                                   | <null>                |
| test-bp1:1c3e858b-48fd-40f4-954f-1e86f237b3dd     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:1c3e858b-48fd-40f4-954f-1e86f237b3dd    | <null>                   | <null>                                                   | <null>                |
| testbp12:fcaeba73-401c-4d3c-8805-22b0552e1caf     | arn:aws:codebuild:us-east-2:222222222222:build/testbp12:fcaeba73-401c-4d3c-8805-22b0552e1caf     | <null>                   | <null>                                                   | <null>                |
| test-cb12345:16d11b0f-c816-4885-b292-b21197f53568 | arn:aws:codebuild:us-east-2:222222222222:build/test-cb12345:16d11b0f-c816-4885-b292-b21197f53568 | ["sg-0024adac213a69357"] | ["subnet-05ec8288f0b9be5aa", "subnet-0b349fd9ce6590352"] | vpc-0a93262e0a9f10dda |
+---------------------------------------------------+--------------------------------------------------------------------------------------------------+--------------------------+----------------------------------------------------------+-----------------------+

select
  id,
  arn,
  artifacts ->> 'ArtifactIdentifier' as artifact_id,
  artifacts ->> 'BucketOwnerAccess' as bucket_owner_access,
  artifacts ->> 'EncryptionDisabled' as encryption_disabled,
  artifacts ->> 'OverrideArtifactName' as override_artifact_name
from
  aws_codebuild_build;
+---------------------------------------------------+--------------------------------------------------------------------------------------------------+-------------+---------------------+---------------------+------------------------+
| id                                                | arn                                                                                              | artifact_id | bucket_owner_access | encryption_disabled | override_artifact_name |
+---------------------------------------------------+--------------------------------------------------------------------------------------------------+-------------+---------------------+---------------------+------------------------+
| test-bp1:01ad56f8-0790-4b9d-a354-dec00c310d40     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:01ad56f8-0790-4b9d-a354-dec00c310d40    | <null>      |                     | <null>              | <null>                 |
| test-p:ddbc61bd-2f5e-4607-808d-54bcb47462f9       | arn:aws:codebuild:ap-south-1:222222222222:build/test-p:ddbc61bd-2f5e-4607-808d-54bcb47462f9      | <null>      |                     | false               | false                  |
| test-2:8862f58c-edeb-4789-a302-d56057204ada       | arn:aws:codebuild:ap-south-1:222222222222:build/test-2:8862f58c-edeb-4789-a302-d56057204ada      | <null>      |                     | <null>              | <null>                 |
| test-bp1:5befbc41-36ae-45d1-9d3a-f12525622fa9     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:5befbc41-36ae-45d1-9d3a-f12525622fa9    | <null>      |                     | <null>              | <null>                 |
| test-bp1:4d332dab-2d9c-4b04-8cd9-2a75bb5de053     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:4d332dab-2d9c-4b04-8cd9-2a75bb5de053    | <null>      |                     | <null>              | <null>                 |
| test-bp1:1c3e858b-48fd-40f4-954f-1e86f237b3dd     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:1c3e858b-48fd-40f4-954f-1e86f237b3dd    | <null>      |                     | <null>              | <null>                 |
| test-bp1:4a836a33-9f56-4247-a06e-b62e60b7b8d0     | arn:aws:codebuild:ap-south-1:222222222222:build/test-bp1:4a836a33-9f56-4247-a06e-b62e60b7b8d0    | <null>      |                     | <null>              | <null>                 |
| test-cb12345:16d11b0f-c816-4885-b292-b21197f53568 | arn:aws:codebuild:us-east-2:222222222222:build/test-cb12345:16d11b0f-c816-4885-b292-b21197f53568 | <null>      |                     | <null>              | <null>                 |
| testbp12:fcaeba73-401c-4d3c-8805-22b0552e1caf     | arn:aws:codebuild:us-east-2:222222222222:build/testbp12:fcaeba73-401c-4d3c-8805-22b0552e1caf     | <null>      |                     | <null>              | <null>                 |
+---------------------------------------------------+--------------------------------------------------------------------------------------------------+-------------+---------------------+---------------------+------------------------+
```
</details>
