### PR TITLE
Fix example query in aws_glue_dev_endpoint table doc to remove database_name column closes #1567

### DIFF
--- a/docs/tables/aws_glue_dev_endpoint.md
+++ b/docs/tables/aws_glue_dev_endpoint.md
@@ -10,7 +10,6 @@ A development endpoint is an environment that you can use to develop and test yo
 select
   endpoint_name,
   status,
-  database_name,
   availability_zone,
   created_timestamp,
   extra_jars_s3_path,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
