### PR TITLE
Add column `website_configuration` in table `aws_s3_bucket`

### DIFF
--- a/aws/table_aws_s3_bucket.go
+++ b/aws/table_aws_s3_bucket.go
@@ -209,7 +209,7 @@ func tableAwsS3Bucket(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "website_configuration",
-				Description: "The replication configuration of a bucket.",
+				Description: "The website configuration information of the bucket.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getBucketWebsite,
 				Transform:   transform.FromValue(),
@@ -697,6 +697,8 @@ func getBucketTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 }
 
 func getBucketWebsite(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	// Bucket location will be nil if getBucketLocation returned an error but
+	// was ignored through ignore_error_codes config arg
 	if h.HydrateResults["getBucketLocation"] == nil {
 		return nil, nil
 	}

--- a/docs/tables/aws_s3_bucket.md
+++ b/docs/tables/aws_s3_bucket.md
@@ -180,3 +180,15 @@ from
 where
   object_lock_configuration ->> 'ObjectLockEnabled' = 'Enabled';
 ```
+
+### List buckets with website hosting enabled
+
+```sql
+select
+  name,
+  website_configuration -> 'IndexDocument' ->> 'Suffix' as suffix
+from
+  aws_s3_bucket
+where
+  website_configuration -> 'IndexDocument' ->> 'Suffix' is not null;
+  ```

--- a/docs/tables/aws_s3_bucket.md
+++ b/docs/tables/aws_s3_bucket.md
@@ -203,25 +203,3 @@ from
   aws_s3_bucket as b,
   jsonb_array_elements(object_ownership_controls -> 'Rules') as r;
 ```
-
-### List object ownership control rules of buckets
-
-```sql
-select
-  b.name,
-  r ->> 'ObjectOwnership' as object_ownership
-from
-  aws_s3_bucket as b,
-  jsonb_array_elements(object_ownership_controls -> 'Rules') as r;
-```
-### List buckets with website hosting enabled
-
-```sql
-select
-  name,
-  website_configuration -> 'IndexDocument' ->> 'Suffix' as suffix
-from
-  aws_s3_bucket
-where
-  website_configuration -> 'IndexDocument' ->> 'Suffix' is not null;
-  ```

--- a/docs/tables/aws_s3_bucket.md
+++ b/docs/tables/aws_s3_bucket.md
@@ -191,7 +191,7 @@ from
   aws_s3_bucket
 where
   website_configuration -> 'IndexDocument' ->> 'Suffix' is not null;
-  ```
+```
 
 ### List object ownership control rules of buckets
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```sql
No env file present for the current environment:  staging 
Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_s3_bucket []

PRETEST: tests/aws_s3_bucket

TEST: tests/aws_s3_bucket
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Reading...
data.aws_canonical_user_id.current_user: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 2s [id=123412341234]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]
data.aws_canonical_user_id.current_user: Read complete after 2s [id=251ed2ba3d3954ed2f3011390c9e41c903bf2e2914d6c6af96ef6b804d9f4330]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_kms_key.mykey will be created
  + resource "aws_kms_key" "mykey" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 10
      + description                        = "This key is used to encrypt bucket objects"
      + enable_key_rotation                = false
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = (known after apply)
      + tags_all                           = (known after apply)
    }

  # aws_s3_bucket.named_test_resource will be created
  + resource "aws_s3_bucket" "named_test_resource" {
      + acceleration_status         = (known after apply)
      + acl                         = (known after apply)
      + arn                         = (known after apply)
      + bucket                      = "turbottest7153"
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags                        = {
          + "name" = "turbottest7153"
        }
      + tags_all                    = {
          + "name" = "turbottest7153"
        }
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = [
              + "*",
            ]
          + allowed_methods = [
              + "PUT",
              + "POST",
            ]
          + allowed_origins = [
              + "https://s3-website-test.hashicorp.com",
            ]
          + expose_headers  = [
              + "ETag",
            ]
          + max_age_seconds = 3000
        }

      + grant {
          + id          = "251ed2ba3d3954ed2f3011390c9e41c903bf2e2914d6c6af96ef6b804d9f4330"
          + permissions = [
              + "FULL_CONTROL",
            ]
          + type        = "CanonicalUser"
        }

      + lifecycle_rule {
          + enabled = true
          + id      = "log"
          + prefix  = "log/"
          + tags    = {
              + "autoclean" = "true"
              + "rule"      = "log"
            }

          + expiration {
              + days = 90
            }

          + transition {
              + days          = 30
              + storage_class = "STANDARD_IA"
            }
          + transition {
              + days          = 60
              + storage_class = "GLACIER"
            }
        }
      + lifecycle_rule {
          + enabled = true
          + id      = "tmp"
          + prefix  = "tmp/"

          + expiration {
              + date = "2022-01-12"
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = (known after apply)
        }

      + object_lock_configuration {
          + object_lock_enabled = "Enabled"
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = true
          + mfa_delete = false
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

  # aws_s3_bucket_policy.b will be created
  + resource "aws_s3_bucket_policy" "b" {
      + bucket = (known after apply)
      + id     = (known after apply)
      + policy = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id        = "123412341234"
  + aws_partition     = "aws"
  + canonical_user_id = "251ed2ba3d3954ed2f3011390c9e41c903bf2e2914d6c6af96ef6b804d9f4330"
  + kms_key_id        = (known after apply)
  + resource_aka      = (known after apply)
  + resource_name     = "turbottest7153"
aws_kms_key.mykey: Creating...
aws_s3_bucket.named_test_resource: Creating...
aws_kms_key.mykey: Creation complete after 2s [id=58c50e7a-e679-4557-a614-0a8dd8beff5b]
aws_s3_bucket.named_test_resource: Still creating... [10s elapsed]
aws_s3_bucket.named_test_resource: Creation complete after 10s [id=turbottest7153]
aws_s3_bucket_policy.b: Creating...
aws_s3_bucket_policy.b: Creation complete after 1s [id=turbottest7153]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 48, in data "null_data_source" "resource":
  48: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: Argument is deprecated

  with aws_s3_bucket.named_test_resource,
  on variables.tf line 59, in resource "aws_s3_bucket" "named_test_resource":
  59: resource "aws_s3_bucket" "named_test_resource" {

Use the aws_s3_bucket_lifecycle_configuration resource instead

(and 16 more similar warnings elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "123412341234"
aws_partition = "aws"
canonical_user_id = "251ed2ba3d3954ed2f3011390c9e41c903bf2e2914d6c6af96ef6b804d9f4330"
kms_key_id = "arn:aws:kms:us-east-2:533793682495:key/58c50e7a-e679-4557-a614-0a8dd8beff5b"
resource_aka = "arn:aws:s3:::turbottest7153"
resource_name = "turbottest7153"

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:s3:::turbottest7153"
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "acl": {
      "Grants": [
        {
          "Grantee": {
            "DisplayName": null,
            "EmailAddress": null,
            "ID": "251ed2ba3d3954ed2f3011390c9e41c903bf2e2914d6c6af96ef6b804d9f4330",
            "Type": "CanonicalUser",
            "URI": null
          },
          "Permission": "FULL_CONTROL"
        }
      ],
      "Owner": {
        "DisplayName": null,
        "ID": "251ed2ba3d3954ed2f3011390c9e41c903bf2e2914d6c6af96ef6b804d9f4330"
      }
    },
    "bucket_policy_is_public": false,
    "logging": null,
    "name": "turbottest7153",
    "object_lock_configuration": {
      "ObjectLockEnabled": "Enabled",
      "Rule": null
    },
    "replication": null,
    "versioning_enabled": true,
    "versioning_mfa_delete": false
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:s3:::turbottest7153"
    ],
    "bucket_policy_is_public": false,
    "logging": null,
    "name": "turbottest7153",
    "partition": "aws",
    "tags": {
      "name": "turbottest7153"
    },
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest7153"
      }
    ],
    "title": "turbottest7153",
    "versioning_enabled": true,
    "versioning_mfa_delete": false
  }
]
✔ PASSED

POSTTEST: tests/aws_s3_bucket

TEARDOWN: tests/aws_s3_bucket

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```sql
select name, jsonb_pretty(website_configuration) from aws_s3_bucket where title = 'turbot-123412341234-us-east-1'
+-------------------------------+-----------------------------------+
| name                          | jsonb_pretty                      |
+-------------------------------+-----------------------------------+
| turbot-123412341234-us-east-1 | {                                 |
|                               |     "RoutingRules": null,         |
|                               |     "ErrorDocument": null,        |
|                               |     "IndexDocument": {            |
|                               |         "Suffix": "index.html"    |
|                               |     },                            |
|                               |     "ResultMetadata": {           |
|                               |     },                            |
|                               |     "RedirectAllRequestsTo": null |
|                               | }                                 |
+-------------------------------+-----------------------------------+
```
</details>

