### PR TITLE
Fix architectures, snap_start column in aws_lambda_function table to correctly return data instead of null. Closes #1615

### DIFF
--- a/aws/table_aws_lambda_function.go
+++ b/aws/table_aws_lambda_function.go
@@ -204,7 +204,7 @@ func tableAwsLambdaFunction(_ context.Context) *plugin.Table {
 				Name:        "file_system_configs",
 				Description: "Connection settings for an Amazon EFS file system.",
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Configuration.FileSystemConfigs","FileSystemConfigs"),
+				Transform:   transform.FromField("Configuration.FileSystemConfigs", "FileSystemConfigs"),
 			},
 			{
 				Name:        "policy",

--- a/aws/table_aws_lambda_function.go
+++ b/aws/table_aws_lambda_function.go
@@ -186,6 +186,7 @@ func tableAwsLambdaFunction(_ context.Context) *plugin.Table {
 				Name:        "architectures",
 				Description: "The instruction set architecture that the function supports. Architecture is a string array with one of the valid values.",
 				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Configuration.Architectures", "Architectures"),
 			},
 			{
 				Name:        "code",
@@ -224,6 +225,7 @@ func tableAwsLambdaFunction(_ context.Context) *plugin.Table {
 				Name:        "snap_start",
 				Description: "Set ApplyOn to PublishedVersions to create a snapshot of the initialized execution environment when you publish a function version.",
 				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Configuration.SnapStart", "SnapStart"),
 			},
 			{
 				Name:        "url_config",

--- a/aws/table_aws_lambda_function.go
+++ b/aws/table_aws_lambda_function.go
@@ -204,8 +204,7 @@ func tableAwsLambdaFunction(_ context.Context) *plugin.Table {
 				Name:        "file_system_configs",
 				Description: "Connection settings for an Amazon EFS file system.",
 				Type:        proto.ColumnType_JSON,
-				Hydrate:     getAwsLambdaFunction,
-				Transform:   transform.FromField("Configuration.FileSystemConfigs"),
+				Transform:   transform.FromField("Configuration.FileSystemConfigs","FileSystemConfigs"),
 			},
 			{
 				Name:        "policy",


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_lambda_function []

PRETEST: tests/aws_lambda_function

TEST: tests/aws_lambda_function
Running terraform

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.archive_file.zip will be read during apply
  # (config refers to values not yet known)
 <= data "archive_file" "zip"  {
      + id                  = (known after apply)
      + output_base64sha256 = (known after apply)
      + output_md5          = (known after apply)
      + output_path         = "/private/var/folders/f7/88mg03s54199g2vg0kvgs78m0000gn/T/tests/aws_lambda_function/terraform/test/../../test.zip"
      + output_sha          = (known after apply)
      + output_size         = (known after apply)
      + source_file         = "/private/var/folders/f7/88mg03s54199g2vg0kvgs78m0000gn/T/tests/aws_lambda_function/terraform/test/../../test.py"
      + type                = "zip"
    }

  # aws_iam_role.aws_lambda_function will be created
  + resource "aws_iam_role" "aws_lambda_function" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "lambda.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest52911"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)

      + inline_policy {
          + name   = (known after apply)
          + policy = (known after apply)
        }
    }

  # aws_lambda_function.named_test_resource will be created
  + resource "aws_lambda_function" "named_test_resource" {
      + architectures                  = (known after apply)
      + arn                            = (known after apply)
      + filename                       = "/private/var/folders/f7/88mg03s54199g2vg0kvgs78m0000gn/T/tests/aws_lambda_function/terraform/test/../../test.zip"
      + function_name                  = "turbottest52911"
      + handler                        = "test.test"
      + id                             = (known after apply)
      + invoke_arn                     = (known after apply)
      + last_modified                  = (known after apply)
      + memory_size                    = 128
      + package_type                   = "Zip"
      + publish                        = false
      + qualified_arn                  = (known after apply)
      + qualified_invoke_arn           = (known after apply)
      + reserved_concurrent_executions = 2
      + role                           = (known after apply)
      + runtime                        = "python3.7"
      + signing_job_arn                = (known after apply)
      + signing_profile_version_arn    = (known after apply)
      + source_code_hash               = (known after apply)
      + source_code_size               = (known after apply)
      + tags                           = {
          + "name" = "turbottest52911"
        }
      + tags_all                       = {
          + "name" = "turbottest52911"
        }
      + timeout                        = 3
      + version                        = (known after apply)

      + ephemeral_storage {
          + size = (known after apply)
        }

      + tracing_config {
          + mode = (known after apply)
        }
    }

  # aws_lambda_permission.with_sns will be created
  + resource "aws_lambda_permission" "with_sns" {
      + action              = "lambda:InvokeFunction"
      + function_name       = "turbottest52911"
      + id                  = (known after apply)
      + principal           = "sns.amazonaws.com"
      + source_arn          = (known after apply)
      + statement_id        = "AllowExecutionFromSNS"
      + statement_id_prefix = (known after apply)
    }

  # aws_sns_topic.default will be created
  + resource "aws_sns_topic" "default" {
      + arn                         = (known after apply)
      + content_based_deduplication = false
      + fifo_topic                  = false
      + id                          = (known after apply)
      + name                        = "call-lambda-maybe"
      + name_prefix                 = (known after apply)
      + owner                       = (known after apply)
      + policy                      = (known after apply)
      + tags_all                    = (known after apply)
    }

  # local_file.python_file will be created
  + resource "local_file" "python_file" {
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "/private/var/folders/f7/88mg03s54199g2vg0kvgs78m0000gn/T/tests/aws_lambda_function/terraform/test/../../test.py"
      + id                   = (known after apply)
      + sensitive_content    = (sensitive value)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "5XXXXXXXXXXX"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest52911"
  + sns_arn       = (known after apply)
local_file.python_file: Creating...
local_file.python_file: Creation complete after 0s [id=31a055a187e07d0bd8fca8ceb1f633aa4497fe53]
data.archive_file.zip: Reading...
data.archive_file.zip: Read complete after 0s [id=3d2780bc13324b697460b666c413908a395d952e]
aws_iam_role.aws_lambda_function: Creating...
aws_sns_topic.default: Creating...
aws_iam_role.aws_lambda_function: Creation complete after 1s [id=turbottest52911]
aws_lambda_function.named_test_resource: Creating...
aws_sns_topic.default: Creation complete after 3s [id=arn:aws:sns:us-east-1:5XXXXXXXXXXX:call-lambda-maybe]
aws_lambda_function.named_test_resource: Still creating... [10s elapsed]
aws_lambda_function.named_test_resource: Creation complete after 16s [id=turbottest52911]
aws_lambda_permission.with_sns: Creating...
aws_lambda_permission.with_sns: Creation complete after 1s [id=AllowExecutionFromSNS]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: Attribute Deprecated

  with local_file.python_file,
  on variables.tf line 53, in resource "local_file" "python_file":
  53:   sensitive_content = "def test (event, context):\n\tprint ('This is a test for integration testing to check creation of a lambda function')"

Use the `local_sensitive_file` resource instead

(and 2 more similar warnings elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "5XXXXXXXXXXX"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:lambda:us-east-1:5XXXXXXXXXXX:function:turbottest52911"
resource_name = "turbottest52911"
sns_arn = "arn:aws:sns:us-east-1:5XXXXXXXXXXX:call-lambda-maybe"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:lambda:us-east-1:5XXXXXXXXXXX:function:turbottest52911",
    "description": "",
    "name": "turbottest52911",
    "role": "arn:aws:iam::5XXXXXXXXXXX:role/turbottest52911",
    "version": "$LATEST"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "policy": {
      "Id": "default",
      "Statement": [
        {
          "Action": "lambda:InvokeFunction",
          "Condition": {
            "ArnLike": {
              "AWS:SourceArn": "arn:aws:sns:us-east-1:5XXXXXXXXXXX:call-lambda-maybe"
            }
          },
          "Effect": "Allow",
          "Principal": {
            "Service": "sns.amazonaws.com"
          },
          "Resource": "arn:aws:lambda:us-east-1:5XXXXXXXXXXX:function:turbottest52911",
          "Sid": "AllowExecutionFromSNS"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Id": "default",
      "Statement": [
        {
          "Action": [
            "lambda:invokefunction"
          ],
          "Condition": {
            "ArnLike": {
              "aws:sourcearn": [
                "arn:aws:sns:us-east-1:5XXXXXXXXXXX:call-lambda-maybe"
              ]
            }
          },
          "Effect": "Allow",
          "Principal": {
            "Service": [
              "sns.amazonaws.com"
            ]
          },
          "Resource": [
            "arn:aws:lambda:us-east-1:5XXXXXXXXXXX:function:turbottest52911"
          ],
          "Sid": "AllowExecutionFromSNS"
        }
      ],
      "Version": "2012-10-17"
    },
    "reserved_concurrent_executions": 2,
    "tags": {
      "name": "turbottest52911"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:lambda:us-east-1:5XXXXXXXXXXX:function:turbottest52911",
    "description": "",
    "name": "turbottest52911",
    "role": "arn:aws:iam::5XXXXXXXXXXX:role/turbottest52911",
    "version": "$LATEST"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "5XXXXXXXXXXX",
    "akas": [
      "arn:aws:lambda:us-east-1:5XXXXXXXXXXX:function:turbottest52911"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "title": "turbottest52911"
  }
]
✔ PASSED

POSTTEST: tests/aws_lambda_function

TEARDOWN: tests/aws_lambda_function

SUMMARY:

1/1 passed.
```

</details>

# Example query results
<details>
  <summary>Results</summary>
  
Fix aws_lambda_function:

```
select name, architectures from aws_lambda_function
+---------------------------------------+---------------+
| name                                  | architectures |
+---------------------------------------+---------------+
| test1                                 | ["x86_64"]    |
| sp-graph-lambda                       | ["x86_64"]    |
| tets                                  | ["x86_64"]    |
| cloud9-TestApp-lambdaone-A71A4OKVLX6D | ["x86_64"]    |
| cloud9-AppTwo-funcone-W408ZRFMCP4Q    | ["x86_64"]    |
| tetest0vpc                            | ["x86_64"]    |
| graviton2                             | ["arm64"]     |
+---------------------------------------+---------------+
> select name, snap_start from aws_lambda_function
+---------------------------------------+-----------------------------------------------+
| name                                  | snap_start                                    |
+---------------------------------------+-----------------------------------------------+
| test1                                 | <null>                                        |
| sp-graph-lambda                       | <null>                                        |
| tets                                  | <null>                                        |
| cloud9-AppTwo-funcone-W408ZRFMCP4Q    | {"ApplyOn":"None","OptimizationStatus":"Off"} |
| cloud9-TestApp-lambdaone-A71A4OKVLX6D | {"ApplyOn":"None","OptimizationStatus":"Off"} |
| tetest0vpc                            | {"ApplyOn":"None","OptimizationStatus":"Off"} |
| graviton2                             | {"ApplyOn":"None","OptimizationStatus":"Off"} |
+---------------------------------------+-----------------------------------------------+
> select name, snap_start from aws_lambda_function where name = 'graviton2'
+-----------+-----------------------------------------------+
| name      | snap_start                                    |
+-----------+-----------------------------------------------+
| graviton2 | {"ApplyOn":"None","OptimizationStatus":"Off"} |
+-----------+-----------------------------------------------+
> select name, architectures from aws_lambda_function where name = 'sp-graph-lambda'
+-----------------+---------------+
| name            | architectures |
+-----------------+---------------+
| sp-graph-lambda | ["x86_64"]    |
+-----------------+---------------+

select name, file_system_configs from aws_lambda_function
+---------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
| name                                  | file_system_configs                                                                                                            |
+---------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+
| test1                                 | [{"Arn":"arn:aws:elasticfilesystem:ap-south-1:555555555555:access-point/fsap-0d0ebf83eb90270a7","LocalMountPath":"/mnt/test"}] |
| sp-graph-lambda                       | <null>                                                                                                                         |
| tets                                  | <null>                                                                                                                         |
| cloud9-AppTwo-funcone-W408ZRFMCP4Q    | <null>                                                                                                                         |
| cloud9-TestApp-lambdaone-A71A4OKVLX6D | <null>                                                                                                                         |
| tetest0vpc                            | <null>                                                                                                                         |
| graviton2                             | <null>                                                                                                                         |
+---------------------------------------+--------------------------------------------------------------------------------------------------------------------------------+


select name, file_system_configs from aws_lambda_function where name = 'test1'
+-------+--------------------------------------------------------------------------------------------------------------------------------+
| name  | file_system_configs                                                                                                            |
+-------+--------------------------------------------------------------------------------------------------------------------------------+
| test1 | [{"Arn":"arn:aws:elasticfilesystem:ap-south-1:555555555555:access-point/fsap-0d0ebf83eb90270a7","LocalMountPath":"/mnt/test"}] |
+-------+--------------------------------------------------------------------------------------------------------------------------------+
```
</details>
