### PR TITLE
Fix Integration test get query for aws_eventbridge_rule table. closes #1614

### DIFF
--- a/aws-test/tests/aws_eventbridge_rule/test-get-query.sql
+++ b/aws-test/tests/aws_eventbridge_rule/test-get-query.sql
@@ -1,3 +1,3 @@
 select arn , event_pattern , name , tags
 from aws.aws_eventbridge_rule
-where name = '{{ resourceName }}';
+where name = '{{ resourceName }}' and event_bus_name = 'default';

--- a/aws-test/tests/aws_eventbridge_rule/variables.tf
+++ b/aws-test/tests/aws_eventbridge_rule/variables.tf
@@ -51,6 +51,9 @@ data "null_data_source" "resource" {
 resource "aws_cloudwatch_event_rule" "named_test_resource" {
   name = var.resource_name
   event_pattern = "{\"detail-type\":[\"AWS Console Sign In via CloudTrail\"]}"
+
+  # event_bus_name - (Optional) The event bus to associate with this rule. If you omit this, the default event bus is used.
+
   tags = {
     name = var.resource_name
   }


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_eventbridge_rule []

PRETEST: tests/aws_eventbridge_rule

TEST: tests/aws_eventbridge_rule
Running terraform
data.aws_region.primary: Reading...
data.aws_region.alternate: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 2s [id=123456789876]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_cloudwatch_event_rule.named_test_resource will be created
  + resource "aws_cloudwatch_event_rule" "named_test_resource" {
      + arn            = (known after apply)
      + event_bus_name = "default"
      + event_pattern  = jsonencode(
            {
              + detail-type = [
                  + "AWS Console Sign In via CloudTrail",
                ]
            }
        )
      + id             = (known after apply)
      + is_enabled     = true
      + name           = "turbottest25640"
      + name_prefix    = (known after apply)
      + tags           = {
          + "name" = "turbottest25640"
        }
      + tags_all       = {
          + "name" = "turbottest25640"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "123456789876"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest25640"
aws_cloudwatch_event_rule.named_test_resource: Creating...
aws_cloudwatch_event_rule.named_test_resource: Creation complete after 3s [id=turbottest25640]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "123456789876"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:events:us-east-1:123456789876:rule/turbottest25640"
resource_name = "turbottest25640"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:events:us-east-1:123456789876:rule/turbottest25640",
    "event_pattern": {
      "detail-type": [
        "AWS Console Sign In via CloudTrail"
      ]
    },
    "name": "turbottest25640",
    "tags": {
      "name": "turbottest25640"
    }
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "arn": "arn:aws:events:us-east-1:123456789876:rule/turbottest25640",
    "name": "turbottest25640",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest25640"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:events:us-east-1:123456789876:rule/turbottest25640",
    "event_bus_name": "default",
    "name": "turbottest25640",
    "partition": "aws",
    "region": "us-east-1",
    "state": "ENABLED",
    "tags": {
      "name": "turbottest25640"
    },
    "title": "turbottest25640"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:events:us-east-1:123456789876:rule/turbottest25640"
    ],
    "name": "turbottest25640",
    "region": "us-east-1",
    "tags": {
      "name": "turbottest25640"
    },
    "title": "turbottest25640"
  }
]
✔ PASSED

POSTTEST: tests/aws_eventbridge_rule

TEARDOWN: tests/aws_eventbridge_rule

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_eventbridge_rule

+--------------------------------------------------------+---------------------------------------------------------------------------------------------------+------------------------------------------------------------------------+---------+----------------+----------->
| name                                                   | arn                                                                                               | description                                                            | state   | event_bus_name | created_by>
+--------------------------------------------------------+---------------------------------------------------------------------------------------------------+------------------------------------------------------------------------+---------+----------------+----------->
| turbot_aws_api_events_rds                              | arn:aws:events:ap-south-1:123456789876:rule/turbot_aws_api_events_rds                             | Capture AWS API events for RDS                                         | ENABLED | default        | 6329021525>
|                                                        |                                                                                                   |                                                                        |         |                |           >
| turbot_aws_api_events_config                           | arn:aws:events:ap-south-1:123456789876:rule/turbot_aws_api_events_config                          | Capture AWS API events for Config                                      | ENABLED | default        | 6329021525>
| turbot_aws_api_events_cloudtrail                       | arn:aws:events:ap-south-1:123456789876:rule/turbot_aws_api_events_cloudtrail                      | Capture AWS API events for CloudTrail                                  | ENABLED | default        | 6329021525>
| turbot_aws_api_events_s3                               | arn:aws:events:ap-south-1:123456789876:rule/turbot_aws_api_events_s3                              | Capture AWS API events for S3                                          | ENABLED | default        | 6329021525>

```
</details>
