### PR TITLE
Fix API limits in the ListConfig of aws_glue_security_configuration table. closes #1573

### DIFF
--- a/aws/table_aws_glue_security_configuration.go
+++ b/aws/table_aws_glue_security_configuration.go
@@ -89,7 +89,7 @@ func listGlueSecurityConfigurations(ctx context.Context, d *plugin.QueryData, _ 
 		return nil, err
 	}
 	// Reduce the basic request limit down if the user has only requested a small number of rows
-	maxLimit := int32(1000)
+	maxLimit := int32(200)
 	limit := d.QueryContext.Limit
 	if d.QueryContext.Limit != nil {
 		if *limit < int64(maxLimit) {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_glue_security_configuration []

PRETEST: tests/aws_glue_security_configuration

TEST: tests/aws_glue_security_configuration
Running terraform
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 2s [id=123453412343]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_glue_security_configuration.named_test_resource will be created
  + resource "aws_glue_security_configuration" "named_test_resource" {
      + id   = (known after apply)
      + name = "turbottest8434"

      + encryption_configuration {
          + cloudwatch_encryption {
              + cloudwatch_encryption_mode = "DISABLED"
            }

          + job_bookmarks_encryption {
              + job_bookmarks_encryption_mode = "DISABLED"
            }

          + s3_encryption {
              + s3_encryption_mode = "SSE-S3"
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + aws_account   = "123453412343"
  + aws_region    = "us-east-1"
  + database_name = "turbottest8434"
  + resource_aka  = "arn:aws:glue:us-east-1:123453412343:security-configuration/turbottest8434"
  + resource_name = "turbottest8434"
aws_glue_security_configuration.named_test_resource: Creating...
aws_glue_security_configuration.named_test_resource: Creation complete after 2s [id=turbottest8434]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

aws_account = "123453412343"
aws_region = "us-east-1"
database_name = "turbottest8434"
resource_aka = "arn:aws:glue:us-east-1:123453412343:security-configuration/turbottest8434"
resource_name = "turbottest8434"

Running SQL query: test-get-query.sql
[
  {
    "cloud_watch_encryption": {
      "CloudWatchEncryptionMode": "DISABLED",
      "KmsKeyArn": null
    },
    "job_bookmarks_encryption": {
      "JobBookmarksEncryptionMode": "DISABLED",
      "KmsKeyArn": null
    },
    "name": "turbottest8434",
    "s3_encryption": [
      {
        "KmsKeyArn": null,
        "S3EncryptionMode": "SSE-S3"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "cloud_watch_encryption": {
      "CloudWatchEncryptionMode": "DISABLED",
      "KmsKeyArn": null
    },
    "job_bookmarks_encryption": {
      "JobBookmarksEncryptionMode": "DISABLED",
      "KmsKeyArn": null
    },
    "name": "turbottest8434",
    "s3_encryption": [
      {
        "KmsKeyArn": null,
        "S3EncryptionMode": "SSE-S3"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:glue:us-east-1:123453412343:security-configuration/turbottest8434"
    ],
    "name": "turbottest8434",
    "region": "us-east-1",
    "title": "turbottest8434"
  }
]
✔ PASSED

POSTTEST: tests/aws_glue_security_configuration

TEARDOWN: tests/aws_glue_security_configuration

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
  name,
  job_bookmarks_encryption ->> 'JobBookmarksEncryptionMode' as encyption_mode,
  job_bookmarks_encryption ->> 'KmsKeyArn' as kms_key_arn
from
  aws_glue_security_configuration
where
  job_bookmarks_encryption ->> 'JobBookmarksEncryptionMode' != 'DISABLED';
+--------+----------------+-----------------------------------------------------------------------------+
| name   | encyption_mode | kms_key_arn                                                                 |
+--------+----------------+-----------------------------------------------------------------------------+
| test   | CSE-KMS        | arn:aws:kms:us-east-1:123456789012:key/374jdh34-8r7t-2ud4-dd74-82hd7j54fj98 |
+--------+----------------+-----------------------------------------------------------------------------+
```
</details>
