### PR TITLE
Fix panic interface conversion error in aws_guardduty_ipset while making a list call. closes #1572

### DIFF
--- a/aws/table_aws_guardduty_ipset.go
+++ b/aws/table_aws_guardduty_ipset.go
@@ -148,7 +148,7 @@ func listAwsGuardDutyIPSets(ctx context.Context, d *plugin.QueryData, h *plugin.
 		}
 
 		for _, item := range output.IpSetIds {
-			d.StreamListItem(ctx, ctx, ipsetInfo{
+			d.StreamListItem(ctx, ipsetInfo{
 				IPSetID:    item,
 				DetectorID: id,
 			})


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_guardduty_ipset []

PRETEST: tests/aws_guardduty_ipset

TEST: tests/aws_guardduty_ipset
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_partition.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 2s [id=123453412343]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_guardduty_detector.primary will be created
  + resource "aws_guardduty_detector" "primary" {
      + account_id                   = (known after apply)
      + arn                          = (known after apply)
      + enable                       = true
      + finding_publishing_frequency = (known after apply)
      + id                           = (known after apply)
      + tags_all                     = (known after apply)

      + datasources {
          + kubernetes {
              + audit_logs {
                  + enable = (known after apply)
                }
            }

          + malware_protection {
              + scan_ec2_instance_with_findings {
                  + ebs_volumes {
                      + enable = (known after apply)
                    }
                }
            }

          + s3_logs {
              + enable = (known after apply)
            }
        }
    }

  # aws_guardduty_ipset.named_test_resource will be created
  + resource "aws_guardduty_ipset" "named_test_resource" {
      + activate    = true
      + arn         = (known after apply)
      + detector_id = (known after apply)
      + format      = "TXT"
      + id          = (known after apply)
      + location    = (known after apply)
      + name        = "turbottest17815"
      + tags_all    = (known after apply)
    }

  # aws_s3_bucket.bucket will be created
  + resource "aws_s3_bucket" "bucket" {
      + acceleration_status         = (known after apply)
      + acl                         = "private"
      + arn                         = (known after apply)
      + bucket                      = (known after apply)
      + bucket_domain_name          = (known after apply)
      + bucket_regional_domain_name = (known after apply)
      + force_destroy               = false
      + hosted_zone_id              = (known after apply)
      + id                          = (known after apply)
      + object_lock_enabled         = (known after apply)
      + policy                      = (known after apply)
      + region                      = (known after apply)
      + request_payer               = (known after apply)
      + tags_all                    = (known after apply)
      + website_domain              = (known after apply)
      + website_endpoint            = (known after apply)

      + cors_rule {
          + allowed_headers = (known after apply)
          + allowed_methods = (known after apply)
          + allowed_origins = (known after apply)
          + expose_headers  = (known after apply)
          + max_age_seconds = (known after apply)
        }

      + grant {
          + id          = (known after apply)
          + permissions = (known after apply)
          + type        = (known after apply)
          + uri         = (known after apply)
        }

      + lifecycle_rule {
          + abort_incomplete_multipart_upload_days = (known after apply)
          + enabled                                = (known after apply)
          + id                                     = (known after apply)
          + prefix                                 = (known after apply)
          + tags                                   = (known after apply)

          + expiration {
              + date                         = (known after apply)
              + days                         = (known after apply)
              + expired_object_delete_marker = (known after apply)
            }

          + noncurrent_version_expiration {
              + days = (known after apply)
            }

          + noncurrent_version_transition {
              + days          = (known after apply)
              + storage_class = (known after apply)
            }

          + transition {
              + date          = (known after apply)
              + days          = (known after apply)
              + storage_class = (known after apply)
            }
        }

      + logging {
          + target_bucket = (known after apply)
          + target_prefix = (known after apply)
        }

      + object_lock_configuration {
          + object_lock_enabled = (known after apply)

          + rule {
              + default_retention {
                  + days  = (known after apply)
                  + mode  = (known after apply)
                  + years = (known after apply)
                }
            }
        }

      + replication_configuration {
          + role = (known after apply)

          + rules {
              + delete_marker_replication_status = (known after apply)
              + id                               = (known after apply)
              + prefix                           = (known after apply)
              + priority                         = (known after apply)
              + status                           = (known after apply)

              + destination {
                  + account_id         = (known after apply)
                  + bucket             = (known after apply)
                  + replica_kms_key_id = (known after apply)
                  + storage_class      = (known after apply)

                  + access_control_translation {
                      + owner = (known after apply)
                    }

                  + metrics {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }

                  + replication_time {
                      + minutes = (known after apply)
                      + status  = (known after apply)
                    }
                }

              + filter {
                  + prefix = (known after apply)
                  + tags   = (known after apply)
                }

              + source_selection_criteria {
                  + sse_kms_encrypted_objects {
                      + enabled = (known after apply)
                    }
                }
            }
        }

      + server_side_encryption_configuration {
          + rule {
              + bucket_key_enabled = (known after apply)

              + apply_server_side_encryption_by_default {
                  + kms_master_key_id = (known after apply)
                  + sse_algorithm     = (known after apply)
                }
            }
        }

      + versioning {
          + enabled    = (known after apply)
          + mfa_delete = (known after apply)
        }

      + website {
          + error_document           = (known after apply)
          + index_document           = (known after apply)
          + redirect_all_requests_to = (known after apply)
          + routing_rules            = (known after apply)
        }
    }

  # aws_s3_bucket_object.MyIPSet will be created
  + resource "aws_s3_bucket_object" "MyIPSet" {
      + acl                    = "private"
      + bucket                 = (known after apply)
      + bucket_key_enabled     = (known after apply)
      + content                = <<-EOT
            10.0.0.0/8
        EOT
      + content_type           = (known after apply)
      + etag                   = (known after apply)
      + force_destroy          = false
      + id                     = (known after apply)
      + key                    = "MyIPSet"
      + kms_key_id             = (known after apply)
      + server_side_encryption = (known after apply)
      + storage_class          = (known after apply)
      + tags_all               = (known after apply)
      + version_id             = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "123453412343"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + detector_id   = (known after apply)
  + ipset_id      = (known after apply)
  + resource_aka  = (known after apply)
  + resource_name = "turbottest17815"
aws_guardduty_detector.primary: Creating...
aws_s3_bucket.bucket: Creating...
aws_guardduty_detector.primary: Creation complete after 2s [id=9cc350fb28d58b3da6bef28182529171]
aws_s3_bucket.bucket: Creation complete after 8s [id=terraform-20230302105518623700000001]
aws_s3_bucket_object.MyIPSet: Creating...
aws_s3_bucket_object.MyIPSet: Creation complete after 1s [id=MyIPSet]
aws_guardduty_ipset.named_test_resource: Creating...
aws_guardduty_ipset.named_test_resource: Still creating... [10s elapsed]
aws_guardduty_ipset.named_test_resource: Creation complete after 19s [id=9cc350fb28d58b3da6bef28182529171:30c350fb395a5fd4da28c91fcaa8acf9]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: Argument is deprecated

  with aws_s3_bucket.bucket,
  on variables.tf line 55, in resource "aws_s3_bucket" "bucket":
  55:   acl = "private"

Use the aws_s3_bucket_acl resource instead

(and 6 more similar warnings elsewhere)

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

account_id = "123453412343"
aws_partition = "aws"
aws_region = "us-east-1"
detector_id = "9cc350fb28d58b3da6bef28182529171"
ipset_id = "30c350fb395a5fd4da28c91fcaa8acf9"
resource_aka = "arn:aws:guardduty:us-east-1:123453412343:detector/9cc350fb28d58b3da6bef28182529171/ipset/30c350fb395a5fd4da28c91fcaa8acf9"
resource_name = "turbottest17815"

Running SQL query: test-get-query.sql
[
  {
    "account_id": "123453412343",
    "format": "TXT",
    "name": "turbottest17815",
    "partition": "aws",
    "region": "us-east-1",
    "title": "turbottest17815"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "account_id": "123453412343",
    "format": "TXT",
    "name": "turbottest17815",
    "partition": "aws",
    "region": "us-east-1",
    "title": "turbottest17815"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "account_id": "123453412343",
    "format": "TXT",
    "name": "turbottest17815",
    "partition": "aws",
    "region": "us-east-1",
    "title": "turbottest17815"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "123453412343",
    "akas": [
      "arn:aws:guardduty:us-east-1:123453412343:detector/9cc350fb28d58b3da6bef28182529171/ipset/30c350fb395a5fd4da28c91fcaa8acf9"
    ],
    "title": "turbottest17815"
  }
]
✔ PASSED

POSTTEST: tests/aws_guardduty_ipset

TEARDOWN: tests/aws_guardduty_ipset

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_guardduty_ipset
+-----------------+----------------------------------+----------------------------------+--------+--------+-----------------------------------------------------------------------+-----------------+------+----------------------------------------------------------------->
| name            | detector_id                      | ipset_id                         | format | status | location                                                              | title           | tags | akas                                                            >
+-----------------+----------------------------------+----------------------------------+--------+--------+-----------------------------------------------------------------------+-----------------+------+----------------------------------------------------------------->
| turbottest17815 | 9cc350fb28d58b3da6bef28182529171 | 30c350fb395a5fd4da28c91fcaa8acf9 | TXT    | ACTIVE | https://s3.amazonaws.com/terraform-20230302105518623700000001/MyIPSet | turbottest17815 | {}   | ["arn:aws:guardduty:us-east-1:123453412343:detector/9cc350fb28d5>
+-----------------+----------------------------------+----------------------------------+--------+--------+-----------------------------------------------------------------------+-----------------+------+-----------------------------------------------------------------
```
</details>
