### PR TITLE
Fix aws_cloudfront_function table to remove GetMatrixItemFunc from the table definition. closes #1570

### DIFF
--- a/aws/table_aws_cloudfront_function.go
+++ b/aws/table_aws_cloudfront_function.go
@@ -7,8 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront"
 	"github.com/aws/aws-sdk-go-v2/service/cloudfront/types"
 
-	cloudfrontv1 "github.com/aws/aws-sdk-go/service/cloudfront"
-
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -30,7 +28,6 @@ func tableAwsCloudFrontFunction(_ context.Context) *plugin.Table {
 		List: &plugin.ListConfig{
 			Hydrate: listCloudWatchFunctions,
 		},
-		GetMatrixItemFunc: SupportedRegionMatrix(cloudfrontv1.EndpointsID),
 		Columns: awsRegionalColumns([]*plugin.Column{
 			{
 				Name:        "name",


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_cloudfront_function []

PRETEST: tests/aws_cloudfront_function

TEST: tests/aws_cloudfront_function
Running terraform
data.aws_region.alternate: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 1s [id=123453412343]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_cloudfront_function.named_test_resource will be created
  + resource "aws_cloudfront_function" "named_test_resource" {
      + arn             = (known after apply)
      + code            = <<-EOT
            function handler(event) {
                // NOTE: This example function is for a viewer request event trigger. 
                // Choose viewer request for event trigger when you associate this function with a distribution. 
                var response = {
                    statusCode: 200,
                    statusDescription: 'OK',
                    headers: {
                        'cloudfront-functions': { value: 'generated-by-CloudFront-Functions' }
                    }
                };
                return response;
            }
        EOT
      + comment         = "test function"
      + etag            = (known after apply)
      + id              = (known after apply)
      + live_stage_etag = (known after apply)
      + name            = "turbottest59570"
      + publish         = false
      + runtime         = "cloudfront-js-1.0"
      + status          = (known after apply)
    }

  # time_sleep.wait_30_seconds will be created
  + resource "time_sleep" "wait_30_seconds" {
      + create_duration = "30s"
      + id              = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + id           = (known after apply)
  + resource_aka = (known after apply)
aws_cloudfront_function.named_test_resource: Creating...
aws_cloudfront_function.named_test_resource: Creation complete after 5s [id=turbottest59570]
time_sleep.wait_30_seconds: Creating...
time_sleep.wait_30_seconds: Still creating... [10s elapsed]
time_sleep.wait_30_seconds: Still creating... [20s elapsed]
time_sleep.wait_30_seconds: Creation complete after 30s [id=2023-03-02T11:25:48Z]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

id = "turbottest59570"
resource_aka = "arn:aws:cloudfront::123453412343:function/turbottest59570"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:cloudfront::123453412343:function/turbottest59570",
    "function_config": {
      "Comment": "test function",
      "Runtime": "cloudfront-js-1.0"
    },
    "name": "turbottest59570",
    "status": "UNPUBLISHED"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "arn": "arn:aws:cloudfront::123453412343:function/turbottest59570",
    "function_config": {
      "Comment": "test function",
      "Runtime": "cloudfront-js-1.0"
    },
    "name": "turbottest59570",
    "status": "UNPUBLISHED"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:cloudfront::123453412343:function/turbottest59570"
    ],
    "title": "turbottest59570"
  }
]
✔ PASSED

POSTTEST: tests/aws_cloudfront_function

TEARDOWN: tests/aws_cloudfront_function

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_cloudfront_function where name = 'turbottest58766'
+-----------------+-----------------------------------------------------------+-------------+---------------+-----------------------------------------------------------+---------------------------------------------------------------------------------------------------->
| name            | arn                                                       | status      | e_tag         | function_config                                           | function_metadata                                                                                  >
+-----------------+-----------------------------------------------------------+-------------+---------------+-----------------------------------------------------------+---------------------------------------------------------------------------------------------------->
| turbottest58766 | arn:aws:cloudfront::123453412343:function/turbottest58766 | UNPUBLISHED | ETVPDKIKX0DER | {"Comment":"test function","Runtime":"cloudfront-js-1.0"} | {"CreatedTime":"2023-01-30T12:17:54.774Z","FunctionARN":"arn:aws:cloudfront::123453412343:function/>
+-----------------+-----------------------------------------------------------+-------------+---------------+-----------------------------------------------------------+----------------------------------------------------------------------------------------------------
```
</details>
