### PR TITLE
Remove example query `List managed actions for each environment` aws_elastic_beanstalk_environment table doc Closes # 1632

### DIFF
--- a/docs/tables/aws_elastic_beanstalk_environment.md
+++ b/docs/tables/aws_elastic_beanstalk_environment.md
@@ -57,18 +57,3 @@ from
 where
   health_status = 'Suspended';
 ```
-
-### List managed actions for each environment
-
-```sql
-select
-  environment_name,
-  a ->> 'ActionDescription' as action_description,
-  a ->> 'ActionId' as action_id,
-  a ->> 'ActionType' as action_type,
-  a ->> 'Status' as action_status,
-  a ->> 'WindowStartTime' as action_window_start_time
-from
-  aws_elastic_beanstalk_environment,
-  jsonb_array_elements(managed_actions) as a;
-```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
