### PR TITLE
Add columns `dkim_attributes` and `identity_mail_from_domain_attributes` to aws_ses_domain_identity table. closes #1564

### DIFF
--- a/aws/table_aws_ses_domain_identity.go
+++ b/aws/table_aws_ses_domain_identity.go
@@ -58,7 +58,7 @@ func tableAwsSESDomainIdentity(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "identity_mail_from_domain_attributes",
-				Description: "A map of identities to custom MAIL FROM attributes.",
+				Description: "The custom MAIL FROM attributes for a list of identities.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getSESDomainIdentityMailFromDomainAttributes,
 				Transform:   transform.FromValue(),


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select identity, dkim_attributes, identity_mail_from_domain_attributes from aws_ses_domain_identity;
+------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------->
| identity   | dkim_attributes                                                                                                                                                                                | identity_mail_from_domain_attributes                         >
+------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------->
| test32.com | {"test32.com":{"DkimEnabled":true,"DkimTokens":["ahl3wybzhdgys5ibgfsn557p66u6cmed","eaq4ca4vzcbc4gegcztulcskiiz6lvl5","spejsbsgqth5tryzub3yqtbkzocef6rm"],"DkimVerificationStatus":"Pending"}} | {"test32.com":{"BehaviorOnMXFailure":"UseDefaultValue","MailF>
+------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------
```
</details>
