### PR TITLE
Add table aws_ssm_document_permission. closes #1669

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -385,6 +385,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_sqs_queue":                                                tableAwsSqsQueue(ctx),
 			"aws_ssm_association":                                          tableAwsSSMAssociation(ctx),
 			"aws_ssm_document":                                             tableAwsSSMDocument(ctx),
+			"aws_ssm_document_permission":                                  tableAwsSSMDocumentPermission(ctx),
 			"aws_ssm_inventory":                                            tableAwsSSMInventory(ctx),
 			"aws_ssm_maintenance_window":                                   tableAwsSSMMaintenanceWindow(ctx),
 			"aws_ssm_managed_instance_compliance":                          tableAwsSSMManagedInstanceCompliance(ctx),

--- a/aws/table_aws_ssm_document.go
+++ b/aws/table_aws_ssm_document.go
@@ -42,13 +42,13 @@ func tableAwsSSMDocument(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "account_ids",
-				Description: "The account IDs that have permission to use this document.The ID can be either an AWS account or All.",
+				Description: "[DEPRECATED] The account IDs that have permission to use this document.The ID can be either an AWS account or All.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsSSMDocumentPermissionDetail,
 			},
 			{
 				Name:        "account_sharing_info_list",
-				Description: "A list of AWS accounts where the current document is shared and the version shared with each account.",
+				Description: "[DEPRECATED] A list of AWS accounts where the current document is shared and the version shared with each account.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsSSMDocumentPermissionDetail,
 			},

--- a/aws/table_aws_ssm_document_permission.go
+++ b/aws/table_aws_ssm_document_permission.go
@@ -1,0 +1,133 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	"github.com/aws/aws-sdk-go-v2/service/ssm/types"
+
+	ssmv1 "github.com/aws/aws-sdk-go/service/ssm"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+func tableAwsSSMDocumentPermission(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_ssm_document_permission",
+		Description: "AWS SSM Document Permission",
+		List: &plugin.ListConfig{
+			Hydrate: listAwsSSMDocumentPermissions,
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "document_name", Require: plugin.Required},
+			},
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(ssmv1.EndpointsID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "document_name",
+				Description: "The name of the Systems Manager document.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "shared_account_id",
+				Description: "The Amazon Web Services account ID where the current document is shared.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("AccountSharingInfo.AccountId"),
+			},
+			{
+				Name:        "shared_document_version",
+				Description: "The version of the current document shared with the account.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("AccountSharingInfo.SharedDocumentVersion"),
+			},
+			{
+				Name:        "account_ids",
+				Description: "The account IDs that have permission to use this document.The ID can be either an AWS account or All.",
+				Type:        proto.ColumnType_JSON,
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("AccountSharingInfo.SharedDocumentVersion"),
+			},
+		}),
+	}
+}
+
+type PermissionInfo struct {
+	DocumentName       string
+	AccountIds         []string
+	AccountSharingInfo types.AccountSharingInfo
+}
+
+//// LIST FUNCTION
+
+func listAwsSSMDocumentPermissions(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	documentName := d.EqualsQualString("document_name")
+
+	// Empty check
+	if documentName == "" {
+		return nil, nil
+	}
+
+	// Create session
+	svc, err := SSMClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ssm_document_permission.listAwsSSMDocumentPermissions", "client_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region check
+		return nil, nil
+	}
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	maxItems := int32(200)
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxItems {
+			maxItems = int32(limit)
+		}
+	}
+
+	input := &ssm.DescribeDocumentPermissionInput{
+		MaxResults:     &maxItems,
+		Name:           &documentName,
+		PermissionType: types.DocumentPermissionType("Share"),
+	}
+
+	// API doesn't support aws-sdk-go-v2 paginator as of date
+	pagesLeft := true
+	for pagesLeft {
+		response, err := svc.DescribeDocumentPermission(ctx, input)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_ssm_document_permission.listAwsSSMDocumentPermissions", "api_error", err)
+			return nil, err
+		}
+		for _, item := range response.AccountSharingInfoList {
+			d.StreamListItem(ctx, &PermissionInfo{
+				DocumentName:       documentName,
+				AccountIds:         response.AccountIds,
+				AccountSharingInfo: item,
+			})
+
+			// Context may get cancelled due to manual cancellation or if the limit has been reached
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+		if response.NextToken != nil {
+			pagesLeft = true
+			input.NextToken = response.NextToken
+		} else {
+			pagesLeft = false
+		}
+	}
+
+	return nil, nil
+}

--- a/aws/table_aws_ssm_document_permission.go
+++ b/aws/table_aws_ssm_document_permission.go
@@ -44,7 +44,7 @@ func tableAwsSSMDocumentPermission(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "account_ids",
-				Description: "The account IDs that have permission to use this document.The ID can be either an AWS account or All.",
+				Description: "The account IDs that have permission to use this document. The ID can be either an AWS account or All.",
 				Type:        proto.ColumnType_JSON,
 			},
 

--- a/docs/tables/aws_ssm_document_permission.md
+++ b/docs/tables/aws_ssm_document_permission.md
@@ -1,0 +1,40 @@
+# Table: aws_ssm_document_permission
+
+Describes the permissions for a AWS Systems Manager document (SSM document). If you created the document, you are the owner. If a document is shared, it can either be shared privately (by specifying a user's AWS account ID) or publicly (All).
+
+**Note**: `document_name` is required in query parameter to get the permission details of the document.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  document_name,
+  shared_account_id,
+  shared_document_version,
+  account_ids,
+  title
+from
+  aws_ssm_document_permission
+where
+  document_name = 'test';
+```
+
+### Get document details for the permissions
+
+```sql
+select
+  p.document_name,
+  p.shared_account_id,
+  p.shared_document_version,
+  d.approved_version,
+  d.attachments_information,
+  d.created_date,
+  d.default_version
+from
+  aws_ssm_document_permission as p,
+  aws_ssm_document as d
+where
+  p.document_name = 'test';
+```

--- a/docs/tables/aws_ssm_document_permission.md
+++ b/docs/tables/aws_ssm_document_permission.md
@@ -18,7 +18,7 @@ select
 from
   aws_ssm_document_permission
 where
-  document_name = 'test';
+  document_name = 'ConfigureS3BucketLogging';
 ```
 
 ### Get document details for the permissions
@@ -36,5 +36,5 @@ from
   aws_ssm_document_permission as p,
   aws_ssm_document as d
 where
-  p.document_name = 'test';
+  p.document_name = 'ConfigureS3BucketLogging';
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_ssm_document_permission where document_name = 'test';
+---------------+-------------------+-------------------------+---------------------------------+----------+-----------+-----------+--------------+---------------------------+
| document_name | shared_account_id | shared_document_version | account_ids                     | title    | partition | region    | account_id   | _ctx                      |
+---------------+-------------------+-------------------------+---------------------------------+----------+-----------+-----------+--------------+---------------------------+
| test          | 321321312412      | $DEFAULT                | ["123456789012","321321312412"] | $DEFAULT | aws       | us-east-1 | 367493749284 | {"connection_name":"aws"} |
| test          | 123456789012      | $DEFAULT                | ["123456789012","321321312412"] | $DEFAULT | aws       | us-east-1 | 367493749284 | {"connection_name":"aws"} |
+---------------+-------------------+-------------------------+---------------------------------+----------+-----------+-----------+--------------+---------------------------+
```
</details>
