### PR TITLE
Fixed aws_organizations_policy table returns duplicate data closes #1680

### DIFF
--- a/aws/table_aws_organizations_policy.go
+++ b/aws/table_aws_organizations_policy.go
@@ -138,8 +138,15 @@ func listOrganizationsPolicies(ctx context.Context, d *plugin.QueryData, _ *plug
 		}
 
 		for _, policy := range output.Policies {
-			d.StreamListItem(ctx, &types.Policy{
-				PolicySummary: &policy,
+			d.StreamListItem(ctx, types.Policy{
+				PolicySummary: &types.PolicySummary{
+					Arn:         policy.Arn,
+					AwsManaged:  policy.AwsManaged,
+					Description: policy.Description,
+					Id:          policy.Id,
+					Name:        policy.Name,
+					Type:        policy.Type,
+				},
 			})
 
 			// Context may get cancelled due to manual cancellation or if the limit has been reached
@@ -158,7 +165,7 @@ func getOrganizationsPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.
 	var policyId string
 
 	if h.Item != nil {
-		policyId = *h.Item.(*types.Policy).PolicySummary.Id
+		policyId = *h.Item.(types.Policy).PolicySummary.Id
 	} else {
 		policyId = d.EqualsQuals["id"].GetStringValue()
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, id, type,region from aws_org.aws_organizations_policy WHERE type = 'SERVICE_CONTROL_POLICY'
+-----------------------+-----------------+------------------------+--------+
| name                  | id              | type                   | region |
+-----------------------+-----------------+------------------------+--------+
| FullAWSAccess         | p-FullAWSAccess | SERVICE_CONTROL_POLICY | global |
| aws-guardrails-fTtSzn | p-det6slxu      | SERVICE_CONTROL_POLICY | global |
| aws-guardrails-wjGhoX | p-n322wdtl      | SERVICE_CONTROL_POLICY | global |
+-----------------------+-----------------+------------------------+--------+

> select name, id, type,region from aws_org.aws_organizations_policy WHERE id = 'p-det6slxu'
+-----------------------+------------+------------------------+--------+
| name                  | id         | type                   | region |
+-----------------------+------------+------------------------+--------+
| aws-guardrails-fTtSzn | p-det6slxu | SERVICE_CONTROL_POLICY | global |
+-----------------------+------------+------------------------+--------+
```
</details>
