### PR TITLE
Fixed the tags column data type for the tables aws_securitylake_data_lake and aws_simspaceweaver_simulation closes #1682

### DIFF
--- a/aws/table_aws_securitylake_data_lake.go
+++ b/aws/table_aws_securitylake_data_lake.go
@@ -58,7 +58,7 @@ func tableAwsSecurityLakeDataLake(_ context.Context) *plugin.Table {
 			{
 				Name:        "tags",
 				Description: resourceInterfaceDescription("tags"),
-				Type:        proto.ColumnType_STRING,
+				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("TagsMap"),
 			},
 		}),

--- a/aws/table_aws_simspaceweaver_simulation.go
+++ b/aws/table_aws_simspaceweaver_simulation.go
@@ -110,7 +110,7 @@ func tableAwsSimSpaceWeaverSimulation(_ context.Context) *plugin.Table {
 			{
 				Name:        "tags",
 				Description: resourceInterfaceDescription("tags"),
-				Type:        proto.ColumnType_STRING,
+				Type:        proto.ColumnType_JSON,
 				Hydrate:     listAwsSimSpaceWeaverSimulationTags,
 			},
 			{


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select encryption_key, replication_role_arn, tags from aws_securitylake_data_lake
+----------------+-------------------------------------------------------------------------+--------+
| encryption_key | replication_role_arn                                                    | tags   |
+----------------+-------------------------------------------------------------------------+--------+
| S3_MANAGED_KEY | arn:aws:iam::123456789009:role/SecurityLake_S3ReplicationRole_us_east_1 | <null> |
| S3_MANAGED_KEY | <null>                                                                  | <null> |
| S3_MANAGED_KEY | <null>                                                                  | <null> |
| S3_MANAGED_KEY | <null>                                                                  | <null> |
| S3_MANAGED_KEY | <null>                                                                  | <null> |
| S3_MANAGED_KEY | <null>                                                                  | <null> |
| S3_MANAGED_KEY | <null>                                                                  | <null> |
| S3_MANAGED_KEY | <null>                                                                  | <null> |
+----------------+-------------------------------------------------------------------------+--------+

Time: 8.8s. Rows fetched: 49. Hydrate calls: 0.
> select name, tags from aws_simspaceweaver_simulation;
+--------+---------------+
| name   | tags          |
+--------+---------------+
| test23 | {"foo":"bar"} |
+--------+---------------+
```
</details>
