### PR TITLE
Limit API calls for `aws_sfn_state_machine_execution_history` and ignore `ExecutionDoesNotExist` errors

### DIFF
--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -869,15 +869,3 @@ func buildEc2InstanceFilter(equalQuals plugin.KeyColumnEqualsQualMap) []types.Fi
 	}
 	return filters
 }
-
-func getListValues(listValue *proto.QualValueList) []*string {
-	values := make([]*string, 0)
-	if listValue != nil {
-		for _, value := range listValue.Values {
-			if value.GetStringValue() != "" {
-				values = append(values, aws.String(value.GetStringValue()))
-			}
-		}
-	}
-	return values
-}

--- a/aws/table_aws_sfn_state_machine_execution.go
+++ b/aws/table_aws_sfn_state_machine_execution.go
@@ -8,6 +8,7 @@ import (
 
 	sfnv1 "github.com/aws/aws-sdk-go/service/sfn"
 
+	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -135,7 +136,7 @@ func listStepFunctionsStateMachineExecutions(ctx context.Context, d *plugin.Quer
 		if stateMachineArnQualsStr, ok := stateMachineArnQuals.(string); ok && stateMachineArnQualsStr != "" && stateMachineArnQualsStr != *stateMachineArn {
 			return nil, nil
 		}
-	} else if stateMachineArnQualsStr, ok := stateMachineArnQuals.([]string); ok && len(stateMachineArnQualsStr) > 0 && !stringListContains(stateMachineArnQualsStr, *stateMachineArn) {
+	} else if stateMachineArnQualsStr, ok := stateMachineArnQuals.([]string); ok && len(stateMachineArnQualsStr) > 0 && !helpers.StringSliceContains(stateMachineArnQualsStr, *stateMachineArn) {
 		return nil, nil
 
 	}

--- a/aws/table_aws_sfn_state_machine_execution.go
+++ b/aws/table_aws_sfn_state_machine_execution.go
@@ -46,7 +46,7 @@ func tableAwsStepFunctionsStateMachineExecution(_ context.Context) *plugin.Table
 			},
 			{
 				Name:        "status",
-				Description: "The current status of the execution.",
+				Description: "The current status of the execution (valid values are `RUNNING`, `SUCCEEDED`, `FAILED`, `TIMED_OUT`, `ABORTED`).",
 				Type:        proto.ColumnType_STRING,
 			},
 			{

--- a/aws/table_aws_sfn_state_machine_execution.go
+++ b/aws/table_aws_sfn_state_machine_execution.go
@@ -131,14 +131,13 @@ func listStepFunctionsStateMachineExecutions(ctx context.Context, d *plugin.Quer
 	stateMachineArn := h.Item.(types.StateMachineListItem).StateMachineArn
 
 	// Minimize the API call with the given state machine ARN
-	stateMachineArnQuals := getQualsValueByColumn(d.Quals, "state_machine_arn", "string")
+	stateMachineArnQuals := getQualsValueByColumn(d.Quals, "state_machine_arn", "string") // FIXME: this does not filter on operators at all, so issues with other operators than `=` or `in` would occur, e.g. with `like`
 	if stateMachineArnQuals != nil {
 		if stateMachineArnQualsStr, ok := stateMachineArnQuals.(string); ok && stateMachineArnQualsStr != "" && stateMachineArnQualsStr != *stateMachineArn {
 			return nil, nil
 		}
 	} else if stateMachineArnQualsStr, ok := stateMachineArnQuals.([]string); ok && len(stateMachineArnQualsStr) > 0 && !helpers.StringSliceContains(stateMachineArnQualsStr, *stateMachineArn) {
 		return nil, nil
-
 	}
 
 	maxLimit := int32(1000)

--- a/aws/table_aws_sfn_state_machine_execution.go
+++ b/aws/table_aws_sfn_state_machine_execution.go
@@ -46,7 +46,7 @@ func tableAwsStepFunctionsStateMachineExecution(_ context.Context) *plugin.Table
 			},
 			{
 				Name:        "status",
-				Description: "The current status of the execution (valid values are `RUNNING`, `SUCCEEDED`, `FAILED`, `TIMED_OUT`, `ABORTED`).",
+				Description: "The current status of the execution (RUNNING | SUCCEEDED | FAILED | TIMED_OUT | ABORTED).",
 				Type:        proto.ColumnType_STRING,
 			},
 			{

--- a/aws/table_aws_sfn_state_machine_execution.go
+++ b/aws/table_aws_sfn_state_machine_execution.go
@@ -144,7 +144,7 @@ func listStepFunctionsStateMachineExecutions(ctx context.Context, d *plugin.Quer
 	// If the requested number of items is less than the paging max limit
 	// set the limit to that instead
 	limit := d.QueryContext.Limit
-	if d.QueryContext.Limit != nil {
+	if limit != nil {
 		if *limit < int64(maxLimit) {
 			maxLimit = int32(*limit)
 		}

--- a/aws/table_aws_sfn_state_machine_execution_history.go
+++ b/aws/table_aws_sfn_state_machine_execution_history.go
@@ -15,6 +15,7 @@ import (
 
 	sfnv1 "github.com/aws/aws-sdk-go/service/sfn"
 
+	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -304,7 +305,7 @@ func listStepFunctionsStateMachineExecutionHistories(ctx context.Context, d *plu
 			if executionArnQualsStr, ok := executionArnQuals.(string); ok && executionArnQualsStr != "" && executionArnQualsStr != *item.ExecutionArn {
 				continue
 
-			} else if executionArnQualsList, ok := executionArnQuals.([]string); ok && len(executionArnQualsList) > 0 && !stringListContains(executionArnQualsList, *item.ExecutionArn) {
+			} else if executionArnQualsList, ok := executionArnQuals.([]string); ok && len(executionArnQualsList) > 0 && !helpers.StringSliceContains(executionArnQualsList, *item.ExecutionArn) {
 				continue
 			}
 		}

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -11,8 +11,10 @@ import (
 	"time"
 	"unicode/utf8"
 
+	"github.com/aws/aws-sdk-go-v2/aws"
 	sagemakerTypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/turbot/go-kit/types"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 )
@@ -117,9 +119,21 @@ func sageMakerTurbotTags(_ context.Context, d *transform.TransformData) (interfa
 	return nil, nil
 }
 
-func getQualsValueByColumn(equalQuals plugin.KeyColumnQualMap, columnName string, dataType string) interface{} {
+func getListValues(listValue *proto.QualValueList) []*string {
+	values := make([]*string, 0)
+	if listValue != nil {
+		for _, value := range listValue.Values {
+			if value.GetStringValue() != "" {
+				values = append(values, aws.String(value.GetStringValue()))
+			}
+		}
+	}
+	return values
+}
+
+func getQualsValueByColumn(quals plugin.KeyColumnQualMap, columnName string, dataType string) interface{} {
 	var value interface{}
-	for _, q := range equalQuals[columnName].Quals {
+	for _, q := range quals[columnName].Quals {
 		if dataType == "string" {
 			if q.Value.GetStringValue() != "" {
 				value = q.Value.GetStringValue()

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -132,6 +132,9 @@ func getListValues(listValue *proto.QualValueList) []*string {
 }
 
 func getQualsValueByColumn(quals plugin.KeyColumnQualMap, columnName string, dataType string) interface{} {
+	if quals[columnName] == nil {
+		return nil
+	}
 	var value interface{}
 	for _, q := range quals[columnName].Quals {
 		if dataType == "string" {

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -119,16 +119,6 @@ func sageMakerTurbotTags(_ context.Context, d *transform.TransformData) (interfa
 	return nil, nil
 }
 
-func stringListContains(list []string, value string) bool {
-	for _, item := range list {
-		if item == value {
-			return true
-		}
-	}
-
-	return false
-}
-
 func getListValues(listValue *proto.QualValueList) []*string {
 	values := make([]*string, 0)
 	if listValue != nil {

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -119,6 +119,16 @@ func sageMakerTurbotTags(_ context.Context, d *transform.TransformData) (interfa
 	return nil, nil
 }
 
+func stringListContains(list []string, value string) bool {
+	for _, item := range list {
+		if item == value {
+			return true
+		}
+	}
+
+	return false
+}
+
 func getListValues(listValue *proto.QualValueList) []*string {
 	values := make([]*string, 0)
 	if listValue != nil {


### PR DESCRIPTION
In its current state, the [aws_sfn_state_machine_execution_history](https://hub.steampipe.io/plugins/turbot/aws/tables/aws_sfn_state_machine_execution_history) table is unusable for us not matter what criteria are used in queries because it tries to load all execution events from all executions of all state machines, including expired executions, which results in errors, e.g.:
```
2023-04-06 10:21:11.816 UTC [ERROR] steampipe-plugin-aws.plugin: [ERROR] 1680776471843: aws_sfn_state_machine_execution_history.getRowDataForExecutionHistory: api_error="operation error SFN: GetExecutionHistory, https response error StatusCode: 400, RequestID: d118ab6d-033c-453c-abdc-6e52142cac74, ExecutionDoesNotExist: Execution Does Not Exist: 'arn:aws:states:eu-west-3:****:execution:mysfn:eb3a80d6-7efe-4900-8ae8-fce10c75e52d'"
```

This PR:
* ignores expired executions for which history is no longer available
* reduces AWS API calls made by `aws_sfn_state_machine_execution_history` by filtering on `execution_arn`


Ideally, the list hydrate function of the `aws_sfn_state_machine_execution_history` table should depend on the the list hydrate function of the `aws_sfn_state_machine_execution` table instead of the one of the `aws_sfn_state_machine` table, but `ParentHydrate` functions [cannot be chained across more than two tables right now](https://github.com/turbot/steampipe-plugin-sdk/issues/394).

Slack thread: https://steampipe.slack.com/archives/C044P668806/p1680791390660499?thread_ts=1680791226.554809&cid=C044P668806

TODO:
- [x] rebase on main once #1686 is merged
- [x] support having `execution_arn` used in `in` queries with `getListValues()`, e.g.:

```sql
with constants (r, s_arn, e_arn) as (
    values (
            'eu-west-3',
            'arn:aws:states:eu-west-3:123456789012:stateMachine:mysfn',
            'arn:aws:states:eu-west-3:123456789012:execution:mysfn:map-%'
        )
)
select id,
    execution_arn,
    execution_failed_event_details
from aws_sfn_state_machine_execution_history,
    constants
where region = r
    and execution_arn in (
        select execution_arn
        from aws_sfn_state_machine_execution,
            constants
        where region = r
            and state_machine_arn = s_arn
            and execution_arn like e_arn
    )
    and execution_failed_event_details is not null;
```

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
