### PR TITLE
typo: `aws_sfn_state_machine_*`

### DIFF
--- a/aws/table_aws_sfn_state_machine.go
+++ b/aws/table_aws_sfn_state_machine.go
@@ -25,7 +25,7 @@ func tableAwsStepFunctionsStateMachine(_ context.Context) *plugin.Table {
 			Hydrate: getStepFunctionsStateMachine,
 		},
 		List: &plugin.ListConfig{
-			Hydrate: listStepFunctionsStateManchines,
+			Hydrate: listStepFunctionsStateMachines,
 		},
 		GetMatrixItemFunc: SupportedRegionMatrix(sfnv1.EndpointsID),
 		Columns: awsRegionalColumns([]*plugin.Column{
@@ -114,11 +114,11 @@ func tableAwsStepFunctionsStateMachine(_ context.Context) *plugin.Table {
 
 //// LIST FUNCTION
 
-func listStepFunctionsStateManchines(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+func listStepFunctionsStateMachines(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	// Create session
 	svc, err := StepFunctionsClient(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_sfn_state_machine.listStepFunctionsStateManchines", "connection_error", err)
+		plugin.Logger(ctx).Error("aws_sfn_state_machine.listStepFunctionsStateMachines", "connection_error", err)
 		return nil, err
 	}
 
@@ -147,7 +147,7 @@ func listStepFunctionsStateManchines(ctx context.Context, d *plugin.QueryData, _
 	for paginator.HasMorePages() {
 		output, err := paginator.NextPage(ctx)
 		if err != nil {
-			plugin.Logger(ctx).Error("aws_sfn_state_machine.listStepFunctionsStateManchines", "api_error", err)
+			plugin.Logger(ctx).Error("aws_sfn_state_machine.listStepFunctionsStateMachines", "api_error", err)
 			return nil, err
 		}
 		for _, stateMachine := range output.StateMachines {
@@ -161,7 +161,7 @@ func listStepFunctionsStateManchines(ctx context.Context, d *plugin.QueryData, _
 	}
 
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_sfn_state_machine.listStepFunctionsStateManchines", "api_error", err)
+		plugin.Logger(ctx).Error("aws_sfn_state_machine.listStepFunctionsStateMachines", "api_error", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_sfn_state_machine_execution.go
+++ b/aws/table_aws_sfn_state_machine_execution.go
@@ -129,17 +129,17 @@ func listStepFunctionsStateMachineExecutions(ctx context.Context, d *plugin.Quer
 		return nil, nil
 	}
 
-	arn := h.Item.(types.StateMachineListItem).StateMachineArn
+	stateMachineArn := h.Item.(types.StateMachineListItem).StateMachineArn
 
 	equalQuals := d.EqualsQuals
-	// Minimize the API call with the given layer name
+	// Minimize the API call with the given state machine ARN
 	if equalQuals["state_machine_arn"] != nil {
 		if equalQuals["state_machine_arn"].GetStringValue() != "" {
-			if equalQuals["state_machine_arn"].GetStringValue() != "" && equalQuals["state_machine_arn"].GetStringValue() != *arn {
+			if equalQuals["state_machine_arn"].GetStringValue() != "" && equalQuals["state_machine_arn"].GetStringValue() != *stateMachineArn {
 				return nil, nil
 			}
 		} else if len(getListValues(equalQuals["state_machine_arn"].GetListValue())) > 0 {
-			if !strings.Contains(fmt.Sprint(getListValues(equalQuals["state_machine_arn"].GetListValue())), *arn) {
+			if !strings.Contains(fmt.Sprint(getListValues(equalQuals["state_machine_arn"].GetListValue())), *stateMachineArn) {
 				return nil, nil
 			}
 		}
@@ -155,7 +155,7 @@ func listStepFunctionsStateMachineExecutions(ctx context.Context, d *plugin.Quer
 		}
 	}
 	input := &sfn.ListExecutionsInput{
-		StateMachineArn: arn,
+		StateMachineArn: stateMachineArn,
 		MaxResults:      int32(maxLimit),
 	}
 	if equalQuals["status"] != nil {

--- a/aws/table_aws_sfn_state_machine_execution.go
+++ b/aws/table_aws_sfn_state_machine_execution.go
@@ -28,7 +28,7 @@ func tableAwsStepFunctionsStateMachineExecution(_ context.Context) *plugin.Table
 		},
 		List: &plugin.ListConfig{
 			Hydrate:       listStepFunctionsStateMachineExecutions,
-			ParentHydrate: listStepFunctionsStateManchines,
+			ParentHydrate: listStepFunctionsStateMachines,
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "status", Require: plugin.Optional},
 				{Name: "state_machine_arn", Require: plugin.Optional},

--- a/aws/table_aws_sfn_state_machine_execution_history.go
+++ b/aws/table_aws_sfn_state_machine_execution_history.go
@@ -23,7 +23,7 @@ func tableAwsStepFunctionsStateMachineExecutionHistory(_ context.Context) *plugi
 		Description: "AWS Step Functions State Machine Execution History",
 		List: &plugin.ListConfig{
 			Hydrate:       listStepFunctionsStateMachineExecutionHistories,
-			ParentHydrate: listStepFunctionsStateManchines,
+			ParentHydrate: listStepFunctionsStateMachines,
 		},
 		GetMatrixItemFunc: SupportedRegionMatrix(sfnv1.EndpointsID),
 		Columns: awsRegionalColumns([]*plugin.Column{


### PR DESCRIPTION
- fix: typo
- Rename arn into stateMachineArn for clarity

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
