### PR TITLE
Add table aws_wellarchitected_lens_review

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -441,6 +441,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_wafv2_regex_pattern_set":                                  tableAwsWafv2RegexPatternSet(ctx),
 			"aws_wafv2_rule_group":                                         tableAwsWafv2RuleGroup(ctx),
 			"aws_wafv2_web_acl":                                            tableAwsWafv2WebAcl(ctx),
+			"aws_wellarchitected_lens_review":                              tableAwsWellArchitectedLensReview(ctx),
 			"aws_wellarchitected_workload":                                 tableAwsWellArchitectedWorkload(ctx),
 			"aws_workspaces_workspace":                                     tableAwsWorkspace(ctx),
 		},

--- a/aws/table_aws_wellarchitected_lens_review.go
+++ b/aws/table_aws_wellarchitected_lens_review.go
@@ -80,7 +80,7 @@ func tableAwsWellArchitectedLensReview(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "updated_at",
-				Description: "The date and time recorded.",
+				Description: "The date and time of the last update.",
 				Type:        proto.ColumnType_TIMESTAMP,
 				Transform:   transform.FromField("LensReview.UpdatedAt"),
 			},

--- a/aws/table_aws_wellarchitected_lens_review.go
+++ b/aws/table_aws_wellarchitected_lens_review.go
@@ -120,9 +120,8 @@ func listWellArchitectedLensReviews(ctx context.Context, d *plugin.QueryData, h 
 	workloadId := h.Item.(types.WorkloadSummary).WorkloadId
 
 	// Reduce number of API call if the workload id has been provided in query parameter.
-	equalQuals := d.EqualsQuals
-	if equalQuals["workload_id"] != nil {
-		if equalQuals["workload_id"].GetStringValue() != *workloadId {
+	if d.EqualsQualString("workload_id") != ""{
+		if d.EqualsQualString("workload_id") != *workloadId {
 			return nil, nil
 		}
 	}

--- a/aws/table_aws_wellarchitected_lens_review.go
+++ b/aws/table_aws_wellarchitected_lens_review.go
@@ -1,0 +1,233 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/wellarchitected"
+	"github.com/aws/aws-sdk-go-v2/service/wellarchitected/types"
+
+	wellarchitectedv1 "github.com/aws/aws-sdk-go/service/wellarchitected"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableAwsWellArchitectedLensReview(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_wellarchitected_lens_review",
+		Description: "AWS Well-Architected Lens Review",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AllColumns([]string{"workload_id", "lens_arn"}),
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ResourceNotFoundException"}),
+			},
+			Hydrate: getWellArchitectedLensReview,
+		},
+		List: &plugin.ListConfig{
+			ParentHydrate: listWellArchitectedWorkloads,
+			Hydrate:       listWellArchitectedLensReviews,
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "workload_id", Require: plugin.Optional},
+			},
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(wellarchitectedv1.EndpointsID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "lens_name",
+				Description: "The full name of the lens.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LensReview.LensName"),
+			},
+			{
+				Name:        "lens_arn",
+				Description: "The ARN for the lens.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LensReview.LensArn"),
+			},
+			{
+				Name:        "lens_alias",
+				Description: "The alias of the lens.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LensReview.LensAlias"),
+			},
+			{
+				Name:        "workload_id",
+				Description: "The ID assigned to the workload.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "lens_status",
+				Description: "The status of the lens.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LensReview.LensStatus"),
+			},
+			{
+				Name:        "lens_version",
+				Description: "The version of the lens.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LensReview.LensVersion"),
+			},
+			{
+				Name:        "notes",
+				Description: "The notes associated with the workload.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getWellArchitectedLensReview,
+				Transform:   transform.FromField("LensReview.Notes"),
+			},
+			{
+				Name:        "updated_at",
+				Description: "The date and time recorded.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("LensReview.UpdatedAt"),
+			},
+			{
+				Name:        "pillar_review_summaries",
+				Description: "A map from risk names to the count of how questions have that rating.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getWellArchitectedLensReview,
+				Transform:   transform.FromField("LensReview.PillarReviewSummaries"),
+			},
+			{
+				Name:        "risk_counts",
+				Description: "A map from risk names to the count of how questions have that rating.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("LensReview.RiskCounts"),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LensName"),
+			},
+		}),
+	}
+}
+
+type LensReviewInfo struct {
+	WorkloadId *string
+	*types.LensReview
+}
+
+//// LIST FUNCTION
+
+func listWellArchitectedLensReviews(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	workloadId := h.Item.(types.WorkloadSummary).WorkloadId
+
+	// Reduce number of API call if the workload id has been provided in query parameter.
+	equalQuals := d.EqualsQuals
+	if equalQuals["workload_id"] != nil {
+		if equalQuals["workload_id"].GetStringValue() != *workloadId {
+			return nil, nil
+		}
+	}
+
+	// Create session
+	svc, err := WellArchitectedClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_wellarchitected_lens_review.listWellArchitectedLensReviews", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	// Limiting the results
+	maxLimit := int32(50)
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxLimit {
+			maxLimit = limit
+		}
+	}
+
+	input := &wellarchitected.ListLensReviewsInput{
+		WorkloadId: workloadId,
+		MaxResults: maxLimit,
+	}
+
+	paginator := wellarchitected.NewListLensReviewsPaginator(svc, input, func(o *wellarchitected.ListLensReviewsPaginatorOptions) {
+		o.Limit = maxLimit
+		o.StopOnDuplicateToken = true
+	})
+
+	// List call
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_wellarchitected_lens_review.listWellArchitectedLensReviews", "api_error", err)
+			return nil, err
+		}
+
+		for _, item := range output.LensReviewSummaries {
+			d.StreamListItem(ctx, LensReviewInfo{
+				WorkloadId: workloadId,
+				LensReview: &types.LensReview{
+					LensAlias:   item.LensAlias,
+					LensArn:     item.LensArn,
+					LensName:    item.LensName,
+					LensStatus:  item.LensStatus,
+					LensVersion: item.LensVersion,
+					RiskCounts:  item.RiskCounts,
+					UpdatedAt:   item.UpdatedAt,
+				},
+			})
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getWellArchitectedLensReview(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var workloadId, lensArn string
+	if h.Item != nil {
+		workloadId = *h.Item.(LensReviewInfo).WorkloadId
+		lensArn = *h.Item.(LensReviewInfo).LensArn
+	} else {
+		quals := d.EqualsQuals
+		workloadId = quals["workload_id"].GetStringValue()
+		lensArn = quals["lens_arn"].GetStringValue()
+	}
+
+	// Empty Check
+	if workloadId == "" || lensArn == "" {
+		return nil, nil
+	}
+
+	// Create Session
+	svc, err := WellArchitectedClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_wellarchitected_lens_review.getWellArchitectedLensReview", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	params := &wellarchitected.GetLensReviewInput{
+		WorkloadId: aws.String(workloadId),
+		LensAlias:  aws.String(lensArn),
+	}
+
+	op, err := svc.GetLensReview(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_wellarchitected_lens_review.getWellArchitectedLensReview", "api_error", err)
+		return nil, err
+	}
+
+	return LensReviewInfo{WorkloadId: &workloadId, LensReview: op.LensReview}, nil
+}

--- a/docs/tables/aws_wellarchitected_lens_review.md
+++ b/docs/tables/aws_wellarchitected_lens_review.md
@@ -1,0 +1,62 @@
+# Table: aws_wellarchitected_lens_review
+
+Review the state of your applications and workloads against architectural best practices, identify opportunities for improvement, and track progress over time
+
+## Examples
+
+## Basic info
+
+```sql
+select
+  lens_name,
+  workload_id,
+  lens_arn,
+  lens_alias,
+  lens_version,
+  updated_at
+from
+  aws_wellarchitected_lens_review;
+```
+
+## List reviews for deprecated lenses
+
+```sql
+select
+  lens_name,
+  workload_id,
+  lens_alias,
+  lens_status
+from
+  aws_wellarchitected_lens_review
+where
+  lens_status = 'DEPRECATED';
+```
+
+## Get high risk issue counts for each review
+
+```sql
+select
+  lens_name,
+  workload_id,
+  risk_counts -> 'HIGH' as high_risk_counts
+from
+  aws_wellarchitected_lens_review;
+```
+
+## Get workload details for each lwns review
+
+```sql
+select
+  r.lens_name,
+  r.workload_id,
+  r.lens_status,
+  r.lens_version,
+  w.architectural_design,
+  w.environment,
+  w.review_restriction_date
+from
+  aws_wellarchitected_lens_review as r,
+  aws_wellarchitected_workload as w
+where
+  r.workload_id = w.workload_id;
+```

--- a/docs/tables/aws_wellarchitected_lens_review.md
+++ b/docs/tables/aws_wellarchitected_lens_review.md
@@ -1,6 +1,6 @@
 # Table: aws_wellarchitected_lens_review
 
-Review the state of your applications and workloads against architectural best practices, identify opportunities for improvement, and track progress over time
+Review the state of your applications and workloads against architectural best practices, identify opportunities for improvement, and track progress over time.
 
 ## Examples
 

--- a/docs/tables/aws_wellarchitected_lens_review.md
+++ b/docs/tables/aws_wellarchitected_lens_review.md
@@ -4,7 +4,7 @@ Review the state of your applications and workloads against architectural best p
 
 ## Examples
 
-## Basic info
+### Basic info
 
 ```sql
 select

--- a/docs/tables/aws_wellarchitected_lens_review.md
+++ b/docs/tables/aws_wellarchitected_lens_review.md
@@ -18,7 +18,7 @@ from
   aws_wellarchitected_lens_review;
 ```
 
-## List reviews for deprecated lenses
+### List reviews of deprecated lenses
 
 ```sql
 select

--- a/docs/tables/aws_wellarchitected_lens_review.md
+++ b/docs/tables/aws_wellarchitected_lens_review.md
@@ -32,7 +32,7 @@ where
   lens_status = 'DEPRECATED';
 ```
 
-## Get high risk issue counts for each review
+### Get high-risk issue counts for each review
 
 ```sql
 select

--- a/docs/tables/aws_wellarchitected_lens_review.md
+++ b/docs/tables/aws_wellarchitected_lens_review.md
@@ -60,3 +60,29 @@ from
 where
   r.workload_id = w.workload_id;
 ```
+
+### Get the pillar review summary of lens reviews
+
+```sql
+select
+  lens_name,
+  lens_arn,
+  s ->> 'Notes' as pillar_review_summary_note,
+  s ->> 'PillarId' as pillar_id,
+  s ->> 'PillarName' as pillar_name,
+  s ->> 'RiskCounts' as RiskCounts
+from
+  aws_wellarchitected_lens_review,
+  jsonb_array_elements(pillar_review_summaries) as s;
+```
+
+### Get risk count details of the lens review
+
+```sql
+select
+  lens_name,
+  lens_arn,
+  jsonb_pretty(risk_counts) as risk_counts
+from
+  aws_wellarchitected_lens_review;
+```

--- a/docs/tables/aws_wellarchitected_lens_review.md
+++ b/docs/tables/aws_wellarchitected_lens_review.md
@@ -43,7 +43,7 @@ from
   aws_wellarchitected_lens_review;
 ```
 
-## Get workload details for each lwns review
+### Get workload details of each lens review
 
 ```sql
 select


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
  lens_name,
  workload_id,
  lens_arn,
  lens_alias,
  lens_version,
  updated_at
from
  aws_wellarchitected_lens_review;
+--------------------------------+----------------------------------+---------------------------------------------------+-----------------+--------------+---------------------------+
| lens_name                      | workload_id                      | lens_arn                                          | lens_alias      | lens_version | updated_at                |
+--------------------------------+----------------------------------+---------------------------------------------------+-----------------+--------------+---------------------------+
| AWS Well-Architected Framework | c1b83ac60f9e6ff4f7bed73e182176ba | arn:aws:wellarchitected::aws:lens/wellarchitected | wellarchitected | 2022-03-31   | 2023-02-01T16:41:49+05:30 |
| AWS Well-Architected Framework | 4fca39b680a31bb118be6bc0d177849d | arn:aws:wellarchitected::aws:lens/wellarchitected | wellarchitected | 2022-03-31   | 2023-04-10T16:36:40+05:30 |
| AWS Well-Architected Framework | 986971c59cebcd4612f1f858bf75566f | arn:aws:wellarchitected::aws:lens/wellarchitected | wellarchitected | 2022-03-31   | 2023-02-01T16:43:21+05:30 |
| AWS Well-Architected Framework | efaeef4856e23ae4722d248fe00aabda | arn:aws:wellarchitected::aws:lens/wellarchitected | wellarchitected | 2022-03-31   | 2023-01-30T22:45:09+05:30 |
+--------------------------------+----------------------------------+---------------------------------------------------+-----------------+--------------+---------------------------+

> select
  lens_name,
  workload_id,
  lens_alias,
  lens_status
from
  aws_wellarchitected_lens_review
where
  lens_status = 'DEPRECATED';
+-----------+-------------+------------+-------------+
| lens_name | workload_id | lens_alias | lens_status |
+-----------+-------------+------------+-------------+
+-----------+-------------+------------+-------------+

Time: 16ms. Rows fetched: 4 (cached). Hydrate calls: 0.
> select
  lens_name,
  workload_id,
  risk_counts -> 'HIGH' as high_risk_counts
from
  aws_wellarchitected_lens_review;
+--------------------------------+----------------------------------+------------------+
| lens_name                      | workload_id                      | high_risk_counts |
+--------------------------------+----------------------------------+------------------+
| AWS Well-Architected Framework | c1b83ac60f9e6ff4f7bed73e182176ba | 0                |
| AWS Well-Architected Framework | 4fca39b680a31bb118be6bc0d177849d | 0                |
| AWS Well-Architected Framework | 986971c59cebcd4612f1f858bf75566f | 0                |
| AWS Well-Architected Framework | efaeef4856e23ae4722d248fe00aabda | 0                |
+--------------------------------+----------------------------------+------------------+

Time: 19ms. Rows fetched: 4 (cached). Hydrate calls: 0.
> select
  r.lens_name,
  r.workload_id,
  r.lens_status,
  r.lens_version,
  w.architectural_design,
  w.environment,
  w.review_restriction_date
from
  aws_wellarchitected_lens_review as r,
  aws_wellarchitected_workload as w
where
  r.workload_id = w.workload_id;
+--------------------------------+----------------------------------+-------------+--------------+----------------------+---------------+-------------------------+
| lens_name                      | workload_id                      | lens_status | lens_version | architectural_design | environment   | review_restriction_date |
+--------------------------------+----------------------------------+-------------+--------------+----------------------+---------------+-------------------------+
| AWS Well-Architected Framework | efaeef4856e23ae4722d248fe00aabda | CURRENT     | 2022-03-31   | <null>               | PREPRODUCTION | <null>                  |
| AWS Well-Architected Framework | 986971c59cebcd4612f1f858bf75566f | CURRENT     | 2022-03-31   | <null>               | PREPRODUCTION | <null>                  |
| AWS Well-Architected Framework | c1b83ac60f9e6ff4f7bed73e182176ba | CURRENT     | 2022-03-31   | <null>               | PREPRODUCTION | <null>                  |
| AWS Well-Architected Framework | 4fca39b680a31bb118be6bc0d177849d | CURRENT     | 2022-03-31   | <null>               | PREPRODUCTION | <null>                  |
+--------------------------------+----------------------------------+-------------+--------------+----------------------+---------------+-------------------------+

```
</details>
