### PR TITLE
Adding source_account_id column to aws_securityhub_finding table

### DIFF
--- a/aws/table_aws_securityhub_finding.go
+++ b/aws/table_aws_securityhub_finding.go
@@ -43,7 +43,7 @@ func tableAwsSecurityHubFinding(_ context.Context) *plugin.Table {
 				{Name: "verification_state", Require: plugin.Optional, Operators: []string{"=", "<>"}},
 				{Name: "workflow_state", Require: plugin.Optional, Operators: []string{"=", "<>"}},
 				{Name: "workflow_status", Require: plugin.Optional, Operators: []string{"=", "<>"}},
-				{Name: "affected_account_id", Require: plugin.Optional, Operators: []string{"=", "<>"}},
+				{Name: "source_account_id", Require: plugin.Optional, Operators: []string{"=", "<>"}},
 			},
 			IgnoreConfig: &plugin.IgnoreConfig{
 				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"InvalidAccessException"}),
@@ -246,7 +246,7 @@ func tableAwsSecurityHubFinding(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
-				Name:        "affected_account_id",
+				Name:        "source_account_id",
 				Description: "The account id where the affected resource lives.",
 				Type:        proto.ColumnType_STRING,
 			},
@@ -382,7 +382,7 @@ func buildListFindingsParam(quals plugin.KeyColumnQualMap) *types.AwsSecurityFin
 	securityFindingsFilter := &types.AwsSecurityFindingFilters{}
 	strFilter := types.StringFilter{}
 
-	strColumns := []string{"company_name", "compliance_status", "generator_id", "product_arn", "product_name", "record_state", "title", "verification_state", "workflow_state", "workflow_status", "affected_account_id"}
+	strColumns := []string{"company_name", "compliance_status", "generator_id", "product_arn", "product_name", "record_state", "title", "verification_state", "workflow_state", "workflow_status", "source_account_id"}
 
 	for _, s := range strColumns {
 		if quals[s] == nil {
@@ -432,7 +432,7 @@ func buildListFindingsParam(quals plugin.KeyColumnQualMap) *types.AwsSecurityFin
 			case "workflow_status":
 				strFilter.Value = aws.String(value)
 				securityFindingsFilter.WorkflowStatus = append(securityFindingsFilter.WorkflowStatus, strFilter)
-			case "affected_account_id":
+			case "source_account_id":
 				strFilter.Value = aws.String(value)
 				securityFindingsFilter.WorkflowStatus = append(securityFindingsFilter.AwsAccountId, strFilter)
 			}

--- a/aws/table_aws_securityhub_finding.go
+++ b/aws/table_aws_securityhub_finding.go
@@ -43,6 +43,7 @@ func tableAwsSecurityHubFinding(_ context.Context) *plugin.Table {
 				{Name: "verification_state", Require: plugin.Optional, Operators: []string{"=", "<>"}},
 				{Name: "workflow_state", Require: plugin.Optional, Operators: []string{"=", "<>"}},
 				{Name: "workflow_status", Require: plugin.Optional, Operators: []string{"=", "<>"}},
+				{Name: "affected_account_id", Require: plugin.Optional, Operators: []string{"=", "<>"}},
 			},
 			IgnoreConfig: &plugin.IgnoreConfig{
 				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"InvalidAccessException"}),
@@ -244,7 +245,11 @@ func tableAwsSecurityHubFinding(_ context.Context) *plugin.Table {
 				Description: "Provides a list of vulnerabilities associated with the findings.",
 				Type:        proto.ColumnType_JSON,
 			},
-
+			{
+				Name:        "affected_account_id",
+				Description: "The account id where the affected resource lives."
+				Type:        proto.ColumnType_STRING,
+			},
 			/// Steampipe standard columns
 			{
 				Name:        "title",
@@ -377,7 +382,7 @@ func buildListFindingsParam(quals plugin.KeyColumnQualMap) *types.AwsSecurityFin
 	securityFindingsFilter := &types.AwsSecurityFindingFilters{}
 	strFilter := types.StringFilter{}
 
-	strColumns := []string{"company_name", "compliance_status", "generator_id", "product_arn", "product_name", "record_state", "title", "verification_state", "workflow_state", "workflow_status"}
+	strColumns := []string{"company_name", "compliance_status", "generator_id", "product_arn", "product_name", "record_state", "title", "verification_state", "workflow_state", "workflow_status", "affected_account_id"}
 
 	for _, s := range strColumns {
 		if quals[s] == nil {
@@ -427,6 +432,9 @@ func buildListFindingsParam(quals plugin.KeyColumnQualMap) *types.AwsSecurityFin
 			case "workflow_status":
 				strFilter.Value = aws.String(value)
 				securityFindingsFilter.WorkflowStatus = append(securityFindingsFilter.WorkflowStatus, strFilter)
+			case "affected_account_id":
+				strFilter.Value = aws.String(value)
+				securityFindingsFilter.WorkflowStatus = append(securityFindingsFilter.AwsAccountId, strFilter)
 			}
 
 		}

--- a/aws/table_aws_securityhub_finding.go
+++ b/aws/table_aws_securityhub_finding.go
@@ -247,7 +247,7 @@ func tableAwsSecurityHubFinding(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "affected_account_id",
-				Description: "The account id where the affected resource lives."
+				Description: "The account id where the affected resource lives.",
 				Type:        proto.ColumnType_STRING,
 			},
 			/// Steampipe standard columns

--- a/docs/tables/aws_securityhub_finding.md
+++ b/docs/tables/aws_securityhub_finding.md
@@ -334,3 +334,33 @@ group by
 order by
   count desc;
 ```
+
+### List all findings for affected account 0123456789012
+
+```sql
+select
+  SELECT
+    title,
+    f.severity ->> 'Original' as severity,
+    r ->> 'Type' as resource_type,
+    affected_account_id
+  FROM
+    aws_securityhub_finding,
+    jsonb_array_elements(resources) r
+  WHERE
+    affected_account_id = '0123456789012';
+```
+
+### Count the number of findings by affected account
+
+```sql
+select
+  affected_account_id,
+  count(*) as finding_count
+from
+  aws_securityhub_finding
+group by
+  affected_account_id
+order by
+  affected_account_id;
+```

--- a/docs/tables/aws_securityhub_finding.md
+++ b/docs/tables/aws_securityhub_finding.md
@@ -343,24 +343,24 @@ select
     title,
     f.severity ->> 'Original' as severity,
     r ->> 'Type' as resource_type,
-    affected_account_id
+    source_account_id
   FROM
     aws_securityhub_finding,
     jsonb_array_elements(resources) r
   WHERE
-    affected_account_id = '0123456789012';
+    source_account_id = '0123456789012';
 ```
 
 ### Count the number of findings by affected account
 
 ```sql
 select
-  affected_account_id,
+  source_account_id,
   count(*) as finding_count
 from
   aws_securityhub_finding
 group by
-  affected_account_id
+  source_account_id
 order by
-  affected_account_id;
+  source_account_id;
 ```


### PR DESCRIPTION
The table `aws_securityhub_finding` exposes a column `account_id` which based on this document: https://hub.steampipe.io/plugins/turbot/aws/tables/aws_securityhub_finding is "The AWS Account ID in which the resource is located.". This can be very confusing, in this case, account_id is where security hub is running, not where the affected resource by a security hub finding is running. When you are aggregating findings from different accounts, is important to understand or been able to filter by the affected account: where the affected resource lives.

That's why i'm adding the column `affected_account_id`
