### PR TITLE
Add repository_scanning_configuration column to aws_ecr_repository table Closes #1716

### DIFF
--- a/aws/table_aws_ecr_repository.go
+++ b/aws/table_aws_ecr_repository.go
@@ -96,6 +96,13 @@ func tableAwsEcrRepository(_ context.Context) *plugin.Table {
 				Transform:   transform.FromValue(),
 			},
 			{
+				Name:        "repository_scanning_configuration",
+				Description: "Gets the scanning configuration for one or more repositories.",
+				Hydrate:     getAwsEcrRepositorieScanningConfiguration,
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromValue(),
+			},
+			{
 				Name:        "image_scanning_configuration",
 				Description: "The image scanning configuration for a repository.",
 				Type:        proto.ColumnType_JSON,
@@ -427,6 +434,29 @@ func getAwsEcrRepositoryLifecyclePolicy(ctx context.Context, d *plugin.QueryData
 			}
 		}
 		plugin.Logger(ctx).Error("aws_ecr_repository.getAwsEcrRepositoryLifecyclePolicy", "api_error", err)
+		return nil, err
+	}
+	return op, nil
+}
+
+func getAwsEcrRepositorieScanningConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+
+	repositoryName := h.Item.(types.Repository).RepositoryName
+
+	// Create Session
+	svc, err := ECRClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ecr_repository.getAwsEcrRepositorieScanningConfiguration", "connection_error", err)
+		return nil, err
+	}
+	// Build the params
+	params := &ecr.BatchGetRepositoryScanningConfigurationInput{
+		RepositoryNames: []string{*repositoryName},
+	}
+	// Get call
+	op, err := svc.BatchGetRepositoryScanningConfiguration(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ecr_repository.getAwsEcrRepositorieScanningConfiguration", "api_error", err)
 		return nil, err
 	}
 	return op, nil

--- a/aws/table_aws_ecr_repository.go
+++ b/aws/table_aws_ecr_repository.go
@@ -98,7 +98,7 @@ func tableAwsEcrRepository(_ context.Context) *plugin.Table {
 			{
 				Name:        "repository_scanning_configuration",
 				Description: "Gets the scanning configuration for one or more repositories.",
-				Hydrate:     getAwsEcrRepositorieScanningConfiguration,
+				Hydrate:     getAwsEcrRepositoryScanningConfiguration,
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromValue(),
 			},
@@ -439,14 +439,14 @@ func getAwsEcrRepositoryLifecyclePolicy(ctx context.Context, d *plugin.QueryData
 	return op, nil
 }
 
-func getAwsEcrRepositorieScanningConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+func getAwsEcrRepositoryScanningConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 
 	repositoryName := h.Item.(types.Repository).RepositoryName
 
 	// Create Session
 	svc, err := ECRClient(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_ecr_repository.getAwsEcrRepositorieScanningConfiguration", "connection_error", err)
+		plugin.Logger(ctx).Error("aws_ecr_repository.getAwsEcrRepositoryScanningConfiguration", "connection_error", err)
 		return nil, err
 	}
 	// Build the params
@@ -456,7 +456,7 @@ func getAwsEcrRepositorieScanningConfiguration(ctx context.Context, d *plugin.Qu
 	// Get call
 	op, err := svc.BatchGetRepositoryScanningConfiguration(ctx, params)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_ecr_repository.getAwsEcrRepositorieScanningConfiguration", "api_error", err)
+		plugin.Logger(ctx).Error("aws_ecr_repository.getAwsEcrRepositoryScanningConfiguration", "api_error", err)
 		return nil, err
 	}
 	return op, nil

--- a/docs/tables/aws_ecr_repository.md
+++ b/docs/tables/aws_ecr_repository.md
@@ -127,3 +127,49 @@ where
   s ->> 'Effect' = 'Allow'
   and a in ('*', 'ecr:*');
 ```
+
+### List repository scanning configuration settings
+
+```sql
+select
+  repository_name,
+  r ->> 'AppliedScanFilters' as applied_scan_filters,
+  r ->> 'RepositoryArn' as repo_arn,
+  r ->> 'RepositoryName' as repo_name,
+  r ->> 'ScanFrequency' as scan_frequency,
+  r ->> 'ScanOnPush' as scan_push
+from
+  aws_ecr_repository,
+  jsonb_array_elements(repository_scanning_configuration -> 'ScanningConfigurations') as r
+
+```
+
+### List repository scan frequency is set to manual
+
+```sql
+select
+  repository_name,
+  r ->> 'RepositoryArn' as repo_arn,
+  r ->> 'RepositoryName' as repo_name,
+  r ->> 'ScanFrequency' as scan_frequency
+from
+  aws_ecr_repository,
+  jsonb_array_elements(repository_scanning_configuration -> 'ScanningConfigurations') as r
+where
+  r ->> 'ScanFrequency' = 'MANUAL'
+```
+
+### List repositories with scan-on-push is disabled
+
+```sql
+select
+  repository_name,
+  r ->> 'RepositoryArn' as repo_arn,
+  r ->> 'RepositoryName' as repo_name,
+  r ->> 'ScanOnPush' as scan_push
+from
+  aws_ecr_repository,
+  jsonb_array_elements(repository_scanning_configuration -> 'ScanningConfigurations') as r
+where
+ r ->> 'ScanOnPush' = 'false'
+```

--- a/docs/tables/aws_ecr_repository.md
+++ b/docs/tables/aws_ecr_repository.md
@@ -139,7 +139,7 @@ select
   r ->> 'ScanOnPush' as scan_push
 from
   aws_ecr_repository,
-  jsonb_array_elements(repository_scanning_configuration -> 'ScanningConfigurations') as r
+  jsonb_array_elements(repository_scanning_configuration -> 'ScanningConfigurations') as r;
 
 ```
 
@@ -154,7 +154,7 @@ from
   aws_ecr_repository,
   jsonb_array_elements(repository_scanning_configuration -> 'ScanningConfigurations') as r
 where
-  r ->> 'ScanFrequency' = 'MANUAL'
+  r ->> 'ScanFrequency' = 'MANUAL';
 ```
 
 ### List repositories with scan-on-push is disabled
@@ -168,5 +168,5 @@ from
   aws_ecr_repository,
   jsonb_array_elements(repository_scanning_configuration -> 'ScanningConfigurations') as r
 where
- r ->> 'ScanOnPush' = 'false'
+ r ->> 'ScanOnPush' = 'false';
 ```

--- a/docs/tables/aws_ecr_repository.md
+++ b/docs/tables/aws_ecr_repository.md
@@ -134,9 +134,9 @@ where
 select
   repository_name,
   r ->> 'AppliedScanFilters' as applied_scan_filters,
-  r ->> 'RepositoryArn' as repo_arn,
+  r ->> 'RepositoryArn' as repository_arn,
   r ->> 'ScanFrequency' as scan_frequency,
-  r ->> 'ScanOnPush' as scan_push
+  r ->> 'ScanOnPush' as scan_on_push
 from
   aws_ecr_repository,
   jsonb_array_elements(repository_scanning_configuration -> 'ScanningConfigurations') as r;

--- a/docs/tables/aws_ecr_repository.md
+++ b/docs/tables/aws_ecr_repository.md
@@ -135,7 +135,6 @@ select
   repository_name,
   r ->> 'AppliedScanFilters' as applied_scan_filters,
   r ->> 'RepositoryArn' as repo_arn,
-  r ->> 'RepositoryName' as repo_name,
   r ->> 'ScanFrequency' as scan_frequency,
   r ->> 'ScanOnPush' as scan_push
 from
@@ -144,13 +143,12 @@ from
 
 ```
 
-### List repository scan frequency is set to manual
+### List repositories where the scanning frequency is set to manual
 
 ```sql
 select
   repository_name,
-  r ->> 'RepositoryArn' as repo_arn,
-  r ->> 'RepositoryName' as repo_name,
+  r ->> 'RepositoryArn' as repository_arn,
   r ->> 'ScanFrequency' as scan_frequency
 from
   aws_ecr_repository,
@@ -164,9 +162,8 @@ where
 ```sql
 select
   repository_name,
-  r ->> 'RepositoryArn' as repo_arn,
-  r ->> 'RepositoryName' as repo_name,
-  r ->> 'ScanOnPush' as scan_push
+  r ->> 'RepositoryArn' as repository_arn,
+  r ->> 'ScanOnPush' as scan_on_push
 from
   aws_ecr_repository,
   jsonb_array_elements(repository_scanning_configuration -> 'ScanningConfigurations') as r


### PR DESCRIPTION
…ns using batch-get-repository-scanning-configuration method Closes #1716

# Integration test logs
<details>
  <summary>Logs</summary>

```
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select title, repository_scanning_configuration,image_scanning_configuration from aws_ecr_repository
[
 {
  "image_scanning_configuration": {
   "ScanOnPush": false
  },
  "repository_scanning_configuration": {
   "Failures": [],
   "ResultMetadata": {},
   "ScanningConfigurations": [
    {
     "AppliedScanFilters": [],
     "RepositoryArn": "arn:aws:ecr:us-east-1:698112345678:repository/demo",
     "RepositoryName": "demo",
     "ScanFrequency": "MANUAL",
     "ScanOnPush": false
    }
   ]
  },
  "title": "demo"
 }
]
```
</details>
