### PR TITLE
Fixed aws_ssm_document queries fail when querying multiple regions with the same document name Closes #1715

### DIFF
--- a/aws-test/tests/aws_ssm_document/test-get-query.sql
+++ b/aws-test/tests/aws_ssm_document/test-get-query.sql
@@ -1,3 +1,3 @@
 select name, tags, title, akas
 from aws.aws_ssm_document
-where name = '{{ resourceName }}';
+where arn = '{{ output.resource_aka.value }}';

--- a/aws-test/tests/aws_ssm_document/test-list-query.sql
+++ b/aws-test/tests/aws_ssm_document/test-list-query.sql
@@ -7,6 +7,5 @@ select
 from
   aws.aws_ssm_document
 where
-  owner = 'Self'
-  and akas::text = '["{{ output.resource_aka.value }}"]';
+  akas::text = '["{{ output.resource_aka.value }}"]';
 

--- a/docs/tables/aws_ssm_document.md
+++ b/docs/tables/aws_ssm_document.md
@@ -68,7 +68,7 @@ where
   and account_ids :: jsonb ? 'all';
 ```
 
-### Get a document by region
+### Get a specific document
 
 ```sql
 select
@@ -80,7 +80,5 @@ select
 from
   aws_ssm_document
 where
-  arn = 'arn:aws:ssm:ap-south-1:112233445566:document/AWS-ASGEnterStandby'
-and
-  region = 'ap-south-1';
+  arn = 'arn:aws:ssm:ap-south-1:112233445566:document/AWS-ASGEnterStandby';
 ```

--- a/docs/tables/aws_ssm_document.md
+++ b/docs/tables/aws_ssm_document.md
@@ -67,3 +67,20 @@ where
   owner_type = 'Self'
   and account_ids :: jsonb ? 'all';
 ```
+
+### Get a document by region
+
+```sql
+select
+  name,
+  arn,
+  approved_version,
+  created_date,
+  document_type
+from
+  aws_ssm_document
+where
+  arn = 'arn:aws:ssm:ap-south-1:112233445566:document/AWS-ASGEnterStandby'
+and
+  region = 'ap-south-1';
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ssm_document []

PRETEST: tests/aws_ssm_document

TEST: tests/aws_ssm_document
Running terraform
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 2s [id=112233445566]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ssm_document.named_test_resource will be created
  + resource "aws_ssm_document" "named_test_resource" {
      + arn              = (known after apply)
      + content          = <<-EOT
            schemaVersion: '1.2'
            description: Check ip configuration of a Linux instance.
            parameters: {}
            runtimeConfig:
              'aws:runShellScript':
                properties:
                  - id: '0.aws:runShellScript'
                    runCommand:
                      - ifconfig
        EOT
      + created_date     = (known after apply)
      + default_version  = (known after apply)
      + description      = (known after apply)
      + document_format  = "YAML"
      + document_type    = "Command"
      + document_version = (known after apply)
      + hash             = (known after apply)
      + hash_type        = (known after apply)
      + id               = (known after apply)
      + latest_version   = (known after apply)
      + name             = "turbottest50436"
      + owner            = (known after apply)
      + parameter        = (known after apply)
      + platform_types   = (known after apply)
      + schema_version   = (known after apply)
      + status           = (known after apply)
      + tags             = {
          + "name" = "turbottest50436"
        }
      + tags_all         = {
          + "name" = "turbottest50436"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest50436"
aws_ssm_document.named_test_resource: Creating...
aws_ssm_document.named_test_resource: Creation complete after 3s [id=turbottest50436]

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:ssm:us-east-1:112233445566:document/turbottest50436"
resource_name = "turbottest50436"

Running SQL query: test-get-query.sql
[
  {
    "akas": [
      "arn:aws:ssm:us-east-1:112233445566:document/turbottest50436"
    ],
    "name": "turbottest50436",
    "tags": {
      "name": "turbottest50436"
    },
    "title": "turbottest50436"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ssm:us-east-1:112233445566:document/turbottest50436"
    ],
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest50436"
      }
    ],
    "title": "turbottest50436"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "document_format": "YAML",
    "document_type": "Command",
    "document_version": "1",
    "name": "turbottest50436",
    "partition": "aws",
    "region": "us-east-1",
    "tags": {
      "name": "turbottest50436"
    },
    "title": "turbottest50436"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:ssm:us-east-1:112233445566:document/turbottest50436"
    ],
    "name": "turbottest50436",
    "region": "us-east-1",
    "tags": {
      "name": "turbottest50436"
    },
    "title": "turbottest50436"
  }
]
✔ PASSED

POSTTEST: tests/aws_ssm_document

TEARDOWN: tests/aws_ssm_document

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, arn from aws_ssm_document where arn = 'arn:aws:ssm:ap-south-1:112233445566:document/AWS-ASGEnterStandby'
+---------------------+------------------------------------------------------------------+
| name                | arn                                                              |
+---------------------+------------------------------------------------------------------+
| AWS-ASGEnterStandby | arn:aws:ssm:ap-south-1:112233445566:document/AWS-ASGEnterStandby |
+---------------------+------------------------------------------------------------------+

> select name, arn from aws_ssm_document where arn = ''
+------+-----+
| name | arn |
+------+-----+
+------+-----+

Time: 3.8s.

> select name, arn from aws_ssm_document where arn = 'fdsdss:fdgs'
+------+-----+
| name | arn |
+------+-----+
+------+-----+

Time: 64ms.

```
</details>
