### PR TITLE
Fix aws_ecr_image_scan_finding table to return an empty row instead of an error when image scanning is in progress

### DIFF
--- a/aws/table_aws_ecr_image_scan_finding.go
+++ b/aws/table_aws_ecr_image_scan_finding.go
@@ -166,7 +166,8 @@ func listAwsEcrImageScanFindings(ctx context.Context, d *plugin.QueryData, _ *pl
 			return nil, err
 		}
 
-		if output.ImageScanFindings == nil || output.ImageScanFindings.Findings == nil {
+		// If the scan is in progress and no findings are available yet, ImageScanFindings is nil
+		if output.ImageScanFindings == nil {
 			return nil, nil
 		}
 

--- a/aws/table_aws_ecr_image_scan_finding.go
+++ b/aws/table_aws_ecr_image_scan_finding.go
@@ -166,6 +166,10 @@ func listAwsEcrImageScanFindings(ctx context.Context, d *plugin.QueryData, _ *pl
 			return nil, err
 		}
 
+		if output.ImageScanFindings == nil || output.ImageScanFindings.Findings == nil {
+			return nil, nil
+		}
+
 		for _, finding := range output.ImageScanFindings.Findings {
 			result := &ImageScanFindingsOutput{
 				ImageDigest:      output.ImageId.ImageDigest,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
