### PR TITLE
Fix source_account_id optional qual column in aws_security_hub_finding table 

### DIFF
--- a/aws/table_aws_securityhub_finding.go
+++ b/aws/table_aws_securityhub_finding.go
@@ -434,7 +434,7 @@ func buildListFindingsParam(quals plugin.KeyColumnQualMap) *types.AwsSecurityFin
 				securityFindingsFilter.WorkflowStatus = append(securityFindingsFilter.WorkflowStatus, strFilter)
 			case "source_account_id":
 				strFilter.Value = aws.String(value)
-				securityFindingsFilter.WorkflowStatus = append(securityFindingsFilter.AwsAccountId, strFilter)
+				securityFindingsFilter.AwsAccountId = append(securityFindingsFilter.AwsAccountId, strFilter)
 			}
 
 		}


### PR DESCRIPTION
Field source_account_id was incorrectly defined, fixed. 
