### PR TITLE
Fix `aws_wafv2_web_acl` not returning `CLOUDFRONT` resources closes #1747

### DIFF
--- a/aws/service.go
+++ b/aws/service.go
@@ -1445,6 +1445,10 @@ func getClientForQuerySupportedRegionWithExclusions(ctx context.Context, d *plug
 		return nil, fmt.Errorf("getClientForQuerySupportedRegion called without a region in QueryData")
 	}
 
+	if region == "global" {
+		region = "us-east-1"
+	}
+
 	// Work out which regions are valid for this service
 	validRegions, err := listRegionsForService(ctx, d, serviceID)
 	if err != nil {

--- a/aws/service.go
+++ b/aws/service.go
@@ -1394,7 +1394,16 @@ func WAFRegionalClient(ctx context.Context, d *plugin.QueryData) (*wafregional.C
 }
 
 func WAFV2Client(ctx context.Context, d *plugin.QueryData, region string) (*wafv2.Client, error) {
-	cfg, err := getClientForQuerySupportedRegion(ctx, d, wafv2Endpoint.EndpointsID)
+	var cfg *aws.Config
+	var err error
+	// For WAFv2 resources of type CloudFront, we are building the region metrix including a region value 'global'.
+	// We need to pass the the region value 'us-east-1' to get the cloudfront resource types.
+	// getClientForQuerySupportedRegion function removes the invalid region(global) while building the client for which we need the below check
+	if region == "global" {
+		cfg, err = getClient(ctx, d, "us-east-1")
+	} else {
+		cfg, err = getClientForQuerySupportedRegion(ctx, d, wafv2Endpoint.EndpointsID)
+	}
 	if err != nil {
 		return nil, err
 	}
@@ -1443,11 +1452,6 @@ func getClientForQuerySupportedRegionWithExclusions(ctx context.Context, d *plug
 	region := d.EqualsQualString(matrixKeyRegion)
 	if region == "" {
 		return nil, fmt.Errorf("getClientForQuerySupportedRegion called without a region in QueryData")
-	}
-
-	// Region "global" is a special case for wafv2 cloudfront resources
-	if region == "global" {
-		region = "us-east-1"
 	}
 
 	// Work out which regions are valid for this service

--- a/aws/service.go
+++ b/aws/service.go
@@ -1445,6 +1445,7 @@ func getClientForQuerySupportedRegionWithExclusions(ctx context.Context, d *plug
 		return nil, fmt.Errorf("getClientForQuerySupportedRegion called without a region in QueryData")
 	}
 
+	// Region "global" is a special case for wafv2 cloudfront resources
 	if region == "global" {
 		region = "us-east-1"
 	}

--- a/aws/table_aws_wafv2_ip_set.go
+++ b/aws/table_aws_wafv2_ip_set.go
@@ -253,15 +253,7 @@ func getAwsWafv2IpSet(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 func listTagsForAwsWafv2IpSet(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.EqualsQualString(matrixKeyRegion)
 
-	if region == "global" {
-		region = "us-east-1"
-	}
 	data := ipSetData(h.Item)
-	locationType := strings.Split(strings.Split(string(data["Arn"]), ":")[5], "/")[0]
-	// To work with CloudFront, you must specify the Region US East (N. Virginia)
-	if locationType == "global" && region != "us-east-1" {
-		return nil, nil
-	}
 
 	// Create session
 	svc, err := WAFV2Client(ctx, d, region)

--- a/aws/table_aws_wafv2_ip_set.go
+++ b/aws/table_aws_wafv2_ip_set.go
@@ -122,7 +122,6 @@ func listAwsWafv2IpSets(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	scope := types.ScopeRegional
 
 	if region == "global" {
-		region = "us-east-1"
 		scope = types.ScopeCloudfront
 	}
 
@@ -220,10 +219,6 @@ func getAwsWafv2IpSet(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 	if strings.ToLower(scope) == "cloudfront" && region != "global" {
 		return nil, nil
-	}
-
-	if region == "global" {
-		region = "us-east-1"
 	}
 
 	// Create Session

--- a/aws/table_aws_wafv2_regex_pattern_set.go
+++ b/aws/table_aws_wafv2_regex_pattern_set.go
@@ -120,7 +120,6 @@ func listAwsWafv2RegexPatternSets(ctx context.Context, d *plugin.QueryData, _ *p
 	scope := types.ScopeRegional
 
 	if region == "global" {
-		region = "us-east-1"
 		scope = types.ScopeCloudfront
 	}
 	// Create session
@@ -217,10 +216,6 @@ func getAwsWafv2RegexPatternSet(ctx context.Context, d *plugin.QueryData, h *plu
 
 	if strings.ToLower(scope) == "cloudfront" && region != "global" {
 		return nil, nil
-	}
-
-	if region == "global" {
-		region = "us-east-1"
 	}
 
 	// Create Session

--- a/aws/table_aws_wafv2_regex_pattern_set.go
+++ b/aws/table_aws_wafv2_regex_pattern_set.go
@@ -251,16 +251,7 @@ func listTagsForAwsWafv2RegexPatternSet(ctx context.Context, d *plugin.QueryData
 
 	region := d.EqualsQualString(matrixKeyRegion)
 
-	if region == "global" {
-		region = "us-east-1"
-	}
 	data := regexPatternSetData(h.Item)
-	locationType := strings.Split(strings.Split(string(data["Arn"]), ":")[5], "/")[0]
-
-	// To work with CloudFront, you must specify the Region US East (N. Virginia)
-	if locationType == "global" && region != "us-east-1" {
-		return nil, nil
-	}
 
 	// Create session
 	svc, err := WAFV2Client(ctx, d, region)

--- a/aws/table_aws_wafv2_rule_group.go
+++ b/aws/table_aws_wafv2_rule_group.go
@@ -268,12 +268,6 @@ func listTagsForAwsWafv2RuleGroup(ctx context.Context, d *plugin.QueryData, h *p
 	region := d.EqualsQualString(matrixKeyRegion)
 
 	data := ruleGroupData(h.Item)
-	locationType := strings.Split(strings.Split(string(data["Arn"]), ":")[5], "/")[0]
-
-	// To work with CloudFront, you must specify the Region US East (N. Virginia)
-	if locationType == "global" && region != "us-east-1" {
-		return nil, nil
-	}
 
 	// Create session
 	svc, err := WAFV2Client(ctx, d, region)

--- a/aws/table_aws_wafv2_rule_group.go
+++ b/aws/table_aws_wafv2_rule_group.go
@@ -134,7 +134,6 @@ func listAwsWafv2RuleGroups(ctx context.Context, d *plugin.QueryData, _ *plugin.
 	scope := types.ScopeRegional
 
 	if region == "global" {
-		region = "us-east-1"
 		scope = types.ScopeCloudfront
 	}
 
@@ -235,10 +234,6 @@ func getAwsWafv2RuleGroup(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		return nil, nil
 	}
 
-	if region == "global" {
-		region = "us-east-1"
-	}
-
 	// Create Session
 	svc, err := WAFV2Client(ctx, d, region)
 	if err != nil {
@@ -272,9 +267,6 @@ func getAwsWafv2RuleGroup(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 func listTagsForAwsWafv2RuleGroup(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.EqualsQualString(matrixKeyRegion)
 
-	if region == "global" {
-		region = "us-east-1"
-	}
 	data := ruleGroupData(h.Item)
 	locationType := strings.Split(strings.Split(string(data["Arn"]), ":")[5], "/")[0]
 

--- a/aws/table_aws_wafv2_web_acl.go
+++ b/aws/table_aws_wafv2_web_acl.go
@@ -298,12 +298,6 @@ func listTagsForAwsWafv2WebAcl(ctx context.Context, d *plugin.QueryData, h *plug
 	region := d.EqualsQualString(matrixKeyRegion)
 
 	data := webAclData(h.Item)
-	locationType := strings.Split(strings.Split(string(data["Arn"]), ":")[5], "/")[0]
-
-	// To work with CloudFront, you must specify the Region US East (N. Virginia)
-	if locationType == "global" && region != "us-east-1" {
-		return nil, nil
-	}
 
 	// Create session
 	svc, err := WAFV2Client(ctx, d, region)
@@ -333,12 +327,6 @@ func getLoggingConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin
 	region := d.EqualsQualString(matrixKeyRegion)
 
 	data := webAclData(h.Item)
-	locationType := strings.Split(strings.Split(string(data["Arn"]), ":")[5], "/")[0]
-
-	// To work with CloudFront, you must specify the Region US East (N. Virginia)
-	if locationType == "global" && region != "us-east-1" {
-		return nil, nil
-	}
 
 	// Create session
 	svc, err := WAFV2Client(ctx, d, region)

--- a/aws/table_aws_wafv2_web_acl.go
+++ b/aws/table_aws_wafv2_web_acl.go
@@ -168,7 +168,6 @@ func listAwsWafv2WebAcls(ctx context.Context, d *plugin.QueryData, _ *plugin.Hyd
 	scope := types.ScopeRegional
 
 	if region == "global" {
-		region = "us-east-1"
 		scope = types.ScopeCloudfront
 	}
 
@@ -267,10 +266,6 @@ func getAwsWafv2WebAcl(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 		return nil, nil
 	}
 
-	if region == "global" {
-		region = "us-east-1"
-	}
-
 	// Create Session
 	svc, err := WAFV2Client(ctx, d, region)
 	if err != nil {
@@ -302,9 +297,6 @@ func getAwsWafv2WebAcl(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 func listTagsForAwsWafv2WebAcl(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.EqualsQualString(matrixKeyRegion)
 
-	if region == "global" {
-		region = "us-east-1"
-	}
 	data := webAclData(h.Item)
 	locationType := strings.Split(strings.Split(string(data["Arn"]), ":")[5], "/")[0]
 
@@ -340,9 +332,6 @@ func listTagsForAwsWafv2WebAcl(ctx context.Context, d *plugin.QueryData, h *plug
 func getLoggingConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	region := d.EqualsQualString(matrixKeyRegion)
 
-	if region == "global" {
-		region = "us-east-1"
-	}
 	data := webAclData(h.Item)
 	locationType := strings.Split(strings.Split(string(data["Arn"]), ":")[5], "/")[0]
 
@@ -384,9 +373,6 @@ func listAssociatedResources(ctx context.Context, d *plugin.QueryData, h *plugin
 
 	region := d.EqualsQualString(matrixKeyRegion)
 
-	if region == "global" {
-		region = "us-east-1"
-	}
 	data := webAclData(h.Item)
 	locationType := strings.Split(strings.Split(string(data["Arn"]), ":")[5], "/")[0]
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
  name,
  id,
  scope,
  description,
  capacity,
  managed_by_firewall_manager
from
  aws_wafv2_web_acl;
+---------------------+--------------------------------------+------------+-------------------+----------+-----------------------------+
| name                | id                                   | scope      | description       | capacity | managed_by_firewall_manager |
+---------------------+--------------------------------------+------------+-------------------+----------+-----------------------------+
| test-waf-acl-global | 73c9276d-be09-4a0d-9b67-83c87862e9e5 | CLOUDFRONT | test-waf-acl      | 0        | false                       |
| test-waf-acl-use1   | f473a3fe-360a-4087-9cee-e1a9ecd1dfad | REGIONAL   | test-waf-acl-use1 | 0        | false                       |
+---------------------+--------------------------------------+------------+-------------------+----------+-----------------------------+
```
</details>
