### PR TITLE
Fixed aws_inspector2_coverage doesn't process regions correctly Closes #1756

### DIFF
--- a/aws/service.go
+++ b/aws/service.go
@@ -147,6 +147,7 @@ import (
 	fsxEndpoint "github.com/aws/aws-sdk-go/service/fsx"
 	glacierEndpoint "github.com/aws/aws-sdk-go/service/glacier"
 	inspectorEndpoint "github.com/aws/aws-sdk-go/service/inspector"
+	inspector2Endpoint "github.com/aws/aws-sdk-go/service/inspector2"
 	kafkaEndpoint "github.com/aws/aws-sdk-go/service/kafka"
 	kinesisanalyticsv2Endpoint "github.com/aws/aws-sdk-go/service/kinesisanalyticsv2"
 	kinesisvideoEndpoint "github.com/aws/aws-sdk-go/service/kinesisvideo"
@@ -784,7 +785,7 @@ func InspectorClient(ctx context.Context, d *plugin.QueryData) (*inspector.Clien
 }
 
 func Inspector2Client(ctx context.Context, d *plugin.QueryData) (*inspector2.Client, error) {
-	cfg, err := getClientForDefaultRegion(ctx, d)
+	cfg, err := getClientForQuerySupportedRegion(ctx, d, inspector2Endpoint.EndpointsID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
  scan_status_reason, region, resource_type,
  count(*)
from
  aws_inspector2_coverage
group by  scan_status_reason, region, resource_type
+--------------------+-----------+---------------+-------+
| scan_status_reason | region    | resource_type | count |
+--------------------+-----------+---------------+-------+
| SUCCESSFUL         | us-east-1 | AWS_ACCOUNT   | 1     |
+--------------------+-----------+---------------+-------+
```
</details>
