### PR TITLE
Fixed associated_resources column of aws_wafv2_web_acl table to return associated CF distributions Closes #1762

### DIFF
--- a/aws/table_aws_wafv2_web_acl.go
+++ b/aws/table_aws_wafv2_web_acl.go
@@ -377,6 +377,10 @@ func listAssociatedResources(ctx context.Context, d *plugin.QueryData, h *plugin
 			return nil, nil
 		}
 
+		// Doc(https://docs.aws.amazon.com/cloudfront/latest/APIReference/API_ListDistributionsByWebACLId.html) says
+		// We need to pass the Web ACL ID to get the associated distrubutions with it but it doesn't.
+		// By passing the Web ACL ARN we are getting the associated disctributions with it.
+		// The AWS CLI behaves the same way as the API is behaving.
 		// Build param
 		param := &cloudfront.ListDistributionsByWebACLIdInput{
 			WebACLId: aws.String(data["Arn"]),

--- a/aws/table_aws_wafv2_web_acl.go
+++ b/aws/table_aws_wafv2_web_acl.go
@@ -366,6 +366,7 @@ func listAssociatedResources(ctx context.Context, d *plugin.QueryData, h *plugin
 
 	// Create session
 	if locationType == "global" {
+
 		svc, err := CloudFrontClient(ctx, d)
 		if err != nil {
 			plugin.Logger(ctx).Error("aws_wafv2_web_acl.listAssociatedResources", "connection_error", err)
@@ -375,9 +376,10 @@ func listAssociatedResources(ctx context.Context, d *plugin.QueryData, h *plugin
 			// unsupported region check
 			return nil, nil
 		}
+
 		// Build param
 		param := &cloudfront.ListDistributionsByWebACLIdInput{
-			WebACLId: aws.String(data["ID"]),
+			WebACLId: aws.String(data["Arn"]),
 		}
 
 		op, err := svc.ListDistributionsByWebACLId(ctx, param)
@@ -391,9 +393,15 @@ func listAssociatedResources(ctx context.Context, d *plugin.QueryData, h *plugin
 			}
 			return nil, err
 		}
+
 		var ARNs []string
-		for i := 0; i < len(op.DistributionList.Items); i++ {
-			ARNs[i] = *op.DistributionList.Items[i].ARN
+
+		if op.DistributionList != nil {
+			if len(op.DistributionList.Items) > 0 {
+				for _, item := range op.DistributionList.Items {
+					ARNs = append(ARNs, *item.ARN)
+				}
+			}
 		}
 		return ARNs, nil
 	} else {

--- a/aws/table_aws_wafv2_web_acl.go
+++ b/aws/table_aws_wafv2_web_acl.go
@@ -395,7 +395,6 @@ func listAssociatedResources(ctx context.Context, d *plugin.QueryData, h *plugin
 		}
 
 		var ARNs []string
-
 		if op.DistributionList != nil {
 			if len(op.DistributionList.Items) > 0 {
 				for _, item := range op.DistributionList.Items {


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, region, associated_resources from aws_wafv2_web_acl
+-----------------+-----------+----------------------------------------------------------------------------+
| name            | region    | associated_resources                                                       |
+-----------------+-----------+----------------------------------------------------------------------------+
| test-cloudfront | global    | ["arn:aws:cloudfront::112233445566:distribution/E3SVMR2TLS0Z8S"]           |
| test-regional   | us-east-2 | ["arn:aws:appsync:us-east-2:112233445566:apis/2z2iik2jt5dyblbxwsozdpzqwy"] |
+-----------------+-----------+----------------------------------------------------------------------------+
```
</details>
