### PR TITLE
Fix `aws_cloudformation_stack_resource` returns empty if not provided with `stack_name`. Closes #1765

### DIFF
--- a/aws/table_aws_cloudformation_stack_resource.go
+++ b/aws/table_aws_cloudformation_stack_resource.go
@@ -119,7 +119,7 @@ func listCloudFormationStackResources(ctx context.Context, d *plugin.QueryData, 
 	stackName := d.EqualsQualString("stack_name")
 
 	// If a stack name is specified in optional quals, the user is not allowed to perform API calls for other stacks.
-	if stackName == "" || stackName != *stack.StackName {
+	if d.EqualsQuals["stack_name"] != nil && stackName != *stack.StackName {
 		return nil, nil
 	}
 
@@ -140,11 +140,6 @@ func listCloudFormationStackResources(ctx context.Context, d *plugin.QueryData, 
 		StackName: stack.StackName,
 	}
 
-	// Additonal Filter
-	equalQuals := d.EqualsQuals
-	if equalQuals["stack_name"] != nil {
-		input.StackName = aws.String(equalQuals["stack_name"].GetStringValue())
-	}
 	paginator := cloudformation.NewListStackResourcesPaginator(svc, input, func(o *cloudformation.ListStackResourcesPaginatorOptions) {
 		o.StopOnDuplicateToken = true
 	})


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select logical_resource_id, stack_name, stack_id from aws_cloudformation_stack_resource limit 4
+---------------------------+------------------------------------+------------------------------------------------------------------------------------------------------------------------------+
| logical_resource_id       | stack_name                         | stack_id                                                                                                                     |
+---------------------------+------------------------------------+------------------------------------------------------------------------------------------------------------------------------+
| APSO1BucketPolicy20150107 | aab                                | arn:aws:cloudformation:ap-south-1:123793682495:stack/aab/2a025e00-2b01-11e8-8023-50faf0e43cae                                |
| EcsInstanceAsg            | EC2ContainerService-test-graph     | arn:aws:cloudformation:ap-south-1:123793682495:stack/EC2ContainerService-test-graph/ec5bc7b0-6b35-11ed-92da-0a4f3d521d4c     |
| APSO1                     | aab                                | arn:aws:cloudformation:ap-south-1:123793682495:stack/aab/2a025e00-2b01-11e8-8023-50faf0e43cae                                |
| CWCrossAccountSharingRole | CloudWatch-CrossAccountSharingRole | arn:aws:cloudformation:ap-south-1:123793682495:stack/CloudWatch-CrossAccountSharingRole/48b9e5a0-b2e9-11ed-8792-06eea6981f12 |
+---------------------------+------------------------------------+------------------------------------------------------------------------------------------------------------------------------+

Time: 0.9s. Rows fetched: 4. Hydrate calls: 4.
> select logical_resource_id, stack_name, stack_id from aws_cloudformation_stack_resource where stack_name = 'EC2ContainerService-test-graph'
+---------------------+--------------------------------+--------------------------------------------------------------------------------------------------------------------------+
| logical_resource_id | stack_name                     | stack_id                                                                                                                 |
+---------------------+--------------------------------+--------------------------------------------------------------------------------------------------------------------------+
| EcsInstanceAsg      | EC2ContainerService-test-graph | arn:aws:cloudformation:ap-south-1:123793682495:stack/EC2ContainerService-test-graph/ec5bc7b0-6b35-11ed-92da-0a4f3d521d4c |
| EcsInstanceLc       | EC2ContainerService-test-graph | arn:aws:cloudformation:ap-south-1:123793682495:stack/EC2ContainerService-test-graph/ec5bc7b0-6b35-11ed-92da-0a4f3d521d4c |
+---------------------+--------------------------------+--------------------------------------------------------------------------------------------------------------------------+

Time: 1.6s. Rows fetched: 2. Hydrate calls: 2.
> select logical_resource_id, stack_name, stack_id from aws_cloudformation_stack_resource where stack_name = ''
+---------------------+------------+----------+
| logical_resource_id | stack_name | stack_id |
+---------------------+------------+----------+
+---------------------+------------+----------+

Time: 1.6s.
```
</details>
