### PR TITLE
Add column user_data in the table aws_ec2_launch_template_version Closes #1791

### DIFF
--- a/aws/table_aws_ec2_launch_template_version.go
+++ b/aws/table_aws_ec2_launch_template_version.go
@@ -166,6 +166,12 @@ func tableAwsEc2LaunchTemplateVersion(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_INT,
 			},
 			{
+				Name:        "user_data",
+				Description: "The user data of the launch template.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LaunchTemplateData.UserData").Transform(base64DecodedData),
+			},
+			{
 				Name:        "launch_template_data",
 				Description: "Information about the launch template.",
 				Type:        proto.ColumnType_JSON,


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_launch_template_version []

PRETEST: tests/aws_ec2_launch_template_version

TEST: tests/aws_ec2_launch_template_version
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 2s [id=222222222222]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_launch_template.named_test_resource will be created
  + resource "aws_launch_template" "named_test_resource" {
      + arn                                  = (known after apply)
      + default_version                      = (known after apply)
      + disable_api_stop                     = true
      + disable_api_termination              = true
      + ebs_optimized                        = "true"
      + id                                   = (known after apply)
      + instance_initiated_shutdown_behavior = "terminate"
      + instance_type                        = "t2.micro"
      + latest_version                       = (known after apply)
      + name                                 = "turbottest22059"
      + name_prefix                          = (known after apply)
      + tags                                 = {
          + "Name" = "turbottest22059"
        }
      + tags_all                             = {
          + "Name" = "turbottest22059"
        }

      + block_device_mappings {
          + device_name = "/dev/sda1"

          + ebs {
              + iops        = (known after apply)
              + throughput  = (known after apply)
              + volume_size = 20
              + volume_type = (known after apply)
            }
        }

      + capacity_reservation_specification {
          + capacity_reservation_preference = "open"
        }

      + cpu_options {
          + core_count       = 4
          + threads_per_core = 2
        }

      + credit_specification {
          + cpu_credits = "standard"
        }

      + elastic_gpu_specifications {
          + type = "test"
        }

      + elastic_inference_accelerator {
          + type = "eia1.medium"
        }

      + instance_market_options {
          + market_type = "spot"
        }

      + license_specification {
          + license_configuration_arn = (known after apply)
        }

      + metadata_options {
          + http_endpoint               = "enabled"
          + http_protocol_ipv6          = (known after apply)
          + http_put_response_hop_limit = 1
          + http_tokens                 = "required"
          + instance_metadata_tags      = "enabled"
        }

      + monitoring {
          + enabled = true
        }

      + network_interfaces {
          + associate_public_ip_address = "true"
        }

      + placement {
          + availability_zone = "us-west-2a"
        }

      + tag_specifications {
          + resource_type = "instance"
          + tags          = {
              + "Name" = "turbottest22059"
            }
        }
    }

  # aws_licensemanager_license_configuration.named_test_resource will be created
  + resource "aws_licensemanager_license_configuration" "named_test_resource" {
      + arn                      = (known after apply)
      + description              = "Testing"
      + id                       = (known after apply)
      + license_count            = 10
      + license_count_hard_limit = true
      + license_counting_type    = "Socket"
      + license_rules            = [
          + "#minimumSockets=2",
        ]
      + name                     = "turbottest22059"
      + owner_account_id         = (known after apply)
      + tags_all                 = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "222222222222"
  + aws_partition = "aws"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest22059"
aws_licensemanager_license_configuration.named_test_resource: Creating...
aws_licensemanager_license_configuration.named_test_resource: Creation complete after 2s [id=arn:aws:license-manager:us-east-1:222222222222:license-configuration:lic-c6c4715ccafa29b5473068b906dcdd87]
aws_launch_template.named_test_resource: Creating...
aws_launch_template.named_test_resource: Creation complete after 4s [id=lt-06bc3d6c8c19a19c7]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

account_id = "222222222222"
aws_partition = "aws"
resource_aka = "arn:aws:ec2:us-east-1:222222222222:launch-template/lt-06bc3d6c8c19a19c7"
resource_id = "lt-06bc3d6c8c19a19c7"
resource_name = "turbottest22059"

Running SQL query: test-get-query.sql
[
  {
    "launch_template_id": "lt-06bc3d6c8c19a19c7",
    "launch_template_name": "turbottest22059",
    "version_number": 1
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "launch_template_name": "turbottest22059",
    "version_number": 1
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_launch_template_version

TEARDOWN: tests/aws_ec2_launch_template_version

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select launch_template_name, user_data from aws_ec2_launch_template_version
+-------------------------+------------------+
| launch_template_name    | user_data        |
+-------------------------+------------------+
| test                    |                  |
| test                    | echo "hello...." |
| test-launch-template    |                  |
| test                    |                  |
| test                    |                  |
| sp-flow-launch-template |                  |
+-------------------------+------------------+
```
</details>
