### PR TITLE
Fix aws_acm_certificate table to return certificates of all type of key_algorithms Closes #1794

### DIFF
--- a/aws/table_aws_acm_certificate.go
+++ b/aws/table_aws_acm_certificate.go
@@ -334,7 +334,7 @@ func getAwsAcmCertificateAttributes(ctx context.Context, d *plugin.QueryData, h 
 		return nil, err
 	}
 
-	// The API DOC https://docs.aws.amazon.com/acm/latest/APIReference/API_CertificateSummary.html#ACM-Type-CertificateSummary-KeyAlgorithm the API should return the responce by providing "_" between the algorithm key. but it is returning with "-".
+	// The API documentation (https://docs.aws.amazon.com/acm/latest/APIReference/API_CertificateSummary.html#ACM-Type-CertificateSummary-KeyAlgorithm) specifies that the API should return the response with a separator "_" between the algorithm keys. However, we have observed that it is returning the response with a "-" separator instead.
 	if detail != nil && detail.Certificate != nil {
 		detail.Certificate.KeyAlgorithm = types.KeyAlgorithm(strings.ReplaceAll(fmt.Sprint(detail.Certificate.KeyAlgorithm), "-", "_"))
 	}

--- a/aws/table_aws_acm_certificate.go
+++ b/aws/table_aws_acm_certificate.go
@@ -62,7 +62,6 @@ func tableAwsAcmCertificate(_ context.Context) *plugin.Table {
 				Name:        "domain_name",
 				Description: "Fully qualified domain name (FQDN), such as www.example.com or example.com, for the certificate",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "certificate_transparency_logging_preference",
@@ -75,7 +74,6 @@ func tableAwsAcmCertificate(_ context.Context) *plugin.Table {
 				Name:        "created_at",
 				Description: "The time at which the certificate was requested. This value exists only when the certificate type is AMAZON_ISSUED",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "subject",
@@ -87,7 +85,6 @@ func tableAwsAcmCertificate(_ context.Context) *plugin.Table {
 				Name:        "imported_at",
 				Description: "The name of the certificate authority that issued and signed the certificate",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "issuer",
@@ -123,19 +120,16 @@ func tableAwsAcmCertificate(_ context.Context) *plugin.Table {
 				Name:        "status",
 				Description: "The status of the certificate",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "key_algorithm",
 				Description: "The algorithm that was used to generate the public-private key pair",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "not_after",
 				Description: "The time after which the certificate is not valid",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "not_before",
@@ -147,7 +141,6 @@ func tableAwsAcmCertificate(_ context.Context) *plugin.Table {
 				Name:        "renewal_eligibility",
 				Description: "Specifies whether the certificate is eligible for renewal.",
 				Type:        proto.ColumnType_STRING,
-				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "revocation_reason",
@@ -159,7 +152,6 @@ func tableAwsAcmCertificate(_ context.Context) *plugin.Table {
 				Name:        "revoked_at",
 				Description: "The time at which the certificate was revoked. This value exists only when the certificate status is REVOKED",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Hydrate:     getAwsAcmCertificateAttributes,
 			},
 			{
 				Name:        "serial",


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_acm_certificate []

PRETEST: tests/aws_acm_certificate

TEST: tests/aws_acm_certificate
Running terraform
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 2s [id=222222222222]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_acm_certificate.named_test_resource will be created
  + resource "aws_acm_certificate" "named_test_resource" {
      + arn                       = (known after apply)
      + certificate_body          = (known after apply)
      + domain_name               = (known after apply)
      + domain_validation_options = (known after apply)
      + id                        = (known after apply)
      + key_algorithm             = (known after apply)
      + not_after                 = (known after apply)
      + not_before                = (known after apply)
      + pending_renewal           = (known after apply)
      + private_key               = (sensitive value)
      + renewal_eligibility       = (known after apply)
      + renewal_summary           = (known after apply)
      + status                    = (known after apply)
      + subject_alternative_names = (known after apply)
      + tags                      = {
          + "name" = "turbottest67709"
        }
      + tags_all                  = {
          + "name" = "turbottest67709"
        }
      + type                      = (known after apply)
      + validation_emails         = (known after apply)
      + validation_method         = (known after apply)
    }

  # tls_private_key.example will be created
  + resource "tls_private_key" "example" {
      + algorithm                     = "RSA"
      + ecdsa_curve                   = "P224"
      + id                            = (known after apply)
      + private_key_openssh           = (sensitive value)
      + private_key_pem               = (sensitive value)
      + private_key_pem_pkcs8         = (sensitive value)
      + public_key_fingerprint_md5    = (known after apply)
      + public_key_fingerprint_sha256 = (known after apply)
      + public_key_openssh            = (known after apply)
      + public_key_pem                = (known after apply)
      + rsa_bits                      = 2048
    }

  # tls_self_signed_cert.example will be created
  + resource "tls_self_signed_cert" "example" {
      + allowed_uses          = [
          + "key_encipherment",
          + "digital_signature",
          + "server_auth",
        ]
      + cert_pem              = (known after apply)
      + early_renewal_hours   = 0
      + id                    = (known after apply)
      + is_ca_certificate     = false
      + key_algorithm         = (known after apply)
      + private_key_pem       = (sensitive value)
      + ready_for_renewal     = false
      + set_authority_key_id  = false
      + set_subject_key_id    = false
      + validity_end_time     = (known after apply)
      + validity_period_hours = 12
      + validity_start_time   = (known after apply)

      + subject {
          + common_name  = "turbot.com"
          + organization = "Turbot HQ Pvt. Ltd."
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id       = "222222222222"
  + aws_region       = "us-east-1"
  + certificate_body = (known after apply)
  + resource_aka     = (known after apply)
  + resource_name    = "turbottest67709"
tls_private_key.example: Creating...
tls_private_key.example: Creation complete after 0s [id=7463cbd56dcfa5758085473e06e5d530d35a507a]
tls_self_signed_cert.example: Creating...
tls_self_signed_cert.example: Creation complete after 0s [id=39275443238600060525518510107392325662]
aws_acm_certificate.named_test_resource: Creating...
aws_acm_certificate.named_test_resource: Creation complete after 2s [id=arn:aws:acm:us-east-1:222222222222:certificate/9c5ef98b-374f-400f-9a9b-285cf4049eaa]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "222222222222"
aws_region = "us-east-1"
certificate_body = "-----BEGIN CERTIFICATE-----\\nMIIDJTCCAg2gAwIBAgIQHYws20xs3f0NZsgcSSW4HjANBgkqhkiG9w0BAQsFADAz\\nMRwwGgYDVQQKExNUdXJib3QgSFEgUHZ0LiBMdGQuMRMwEQYDVQQDEwp0dXJib3Qu\\nY29tMB4XDTIzMDYyNjA2MTU1MVoXDTIzMDYyNjE4MTU1MVowMzEcMBoGA1UEChMT\\nVHVyYm90IEhRIFB2dC4gTHRkLjETMBEGA1UEAxMKdHVyYm90LmNvbTCCASIwDQYJ\\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBALlLBiiDT1frNWU2ECg8boc8DC4m4mXH\\n3dLsSqIdmb6tqo/EotT04NqqBLEgGK0Rii5vVP+ybTkBpEj5WOkpYfm8GZBo/glh\\nPzbp9QONsz4oBWqxjf5/mg/E/8SS1WVPjiZBef5J1uLHx8l4fktCj6Gcsl+95FN1\\n9/Y+3ct/1EScstpWM1aOBIW/u9fYLAJXrmUUPYgEYAcISibGv0b4i5Z9j2/1T9Oc\\nSv7ldugDAsxZXs9o4/a8WPaFlZyYnql7tgggygVQHiWsnU3Wba0ZW1aKZ2qzfGfi\\nza3eWUGEQ3inRBBZlCa5ystze0pfPf0CPxz03jp+NLu4lCvmIwMce0cCAwEAAaM1\\nMDMwDgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMBMAwGA1UdEwEB\\n/wQCMAAwDQYJKoZIhvcNAQELBQADggEBAFcSQwcgMWaYBhnW2bhAxT2J5g0+BWwt\\n40ocFF9u9qifVEc+vpIagJ7X5/tG7l6xwQPC0BpNeIVNhpeOhHFRnNcCoNvViWR1\\nmrK/ytanJ4K+qBVB33rLY3Bqxxvr4ND3IoY6yInEcSEP7JwAm3cFGp/SBoz3ICwe\\nmfDTGSIOMPcauH4U/39PXjIcYc7OwiQX83h53dFnKcMus3XQanjBUgkEfk8s7yU5\\nnTe6i/yYlTiqXmq3pCl+mLHrTcywTYQgDBZMNcq6N1MeinUk9jZ72CXMPmZj8TPU\\nGEPC1xxvrqz+M9iU4f1p4nWN7XWtajygSqIcxn6mVGQZYiZU9OFxA0E=\\n-----END CERTIFICATE-----\\n"
resource_aka = "arn:aws:acm:us-east-1:222222222222:certificate/9c5ef98b-374f-400f-9a9b-285cf4049eaa"
resource_name = "turbottest67709"

Running SQL query: test-get-certificate-chain-query.sql
[
  {
    "certificate": "-----BEGIN CERTIFICATE-----\nMIIDJTCCAg2gAwIBAgIQHYws20xs3f0NZsgcSSW4HjANBgkqhkiG9w0BAQsFADAz\nMRwwGgYDVQQKExNUdXJib3QgSFEgUHZ0LiBMdGQuMRMwEQYDVQQDEwp0dXJib3Qu\nY29tMB4XDTIzMDYyNjA2MTU1MVoXDTIzMDYyNjE4MTU1MVowMzEcMBoGA1UEChMT\nVHVyYm90IEhRIFB2dC4gTHRkLjETMBEGA1UEAxMKdHVyYm90LmNvbTCCASIwDQYJ\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBALlLBiiDT1frNWU2ECg8boc8DC4m4mXH\n3dLsSqIdmb6tqo/EotT04NqqBLEgGK0Rii5vVP+ybTkBpEj5WOkpYfm8GZBo/glh\nPzbp9QONsz4oBWqxjf5/mg/E/8SS1WVPjiZBef5J1uLHx8l4fktCj6Gcsl+95FN1\n9/Y+3ct/1EScstpWM1aOBIW/u9fYLAJXrmUUPYgEYAcISibGv0b4i5Z9j2/1T9Oc\nSv7ldugDAsxZXs9o4/a8WPaFlZyYnql7tgggygVQHiWsnU3Wba0ZW1aKZ2qzfGfi\nza3eWUGEQ3inRBBZlCa5ystze0pfPf0CPxz03jp+NLu4lCvmIwMce0cCAwEAAaM1\nMDMwDgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMBMAwGA1UdEwEB\n/wQCMAAwDQYJKoZIhvcNAQELBQADggEBAFcSQwcgMWaYBhnW2bhAxT2J5g0+BWwt\n40ocFF9u9qifVEc+vpIagJ7X5/tG7l6xwQPC0BpNeIVNhpeOhHFRnNcCoNvViWR1\nmrK/ytanJ4K+qBVB33rLY3Bqxxvr4ND3IoY6yInEcSEP7JwAm3cFGp/SBoz3ICwe\nmfDTGSIOMPcauH4U/39PXjIcYc7OwiQX83h53dFnKcMus3XQanjBUgkEfk8s7yU5\nnTe6i/yYlTiqXmq3pCl+mLHrTcywTYQgDBZMNcq6N1MeinUk9jZ72CXMPmZj8TPU\nGEPC1xxvrqz+M9iU4f1p4nWN7XWtajygSqIcxn6mVGQZYiZU9OFxA0E=\n-----END CERTIFICATE-----\n",
    "certificate_chain": "-----BEGIN CERTIFICATE-----\nMIIDJTCCAg2gAwIBAgIQHYws20xs3f0NZsgcSSW4HjANBgkqhkiG9w0BAQsFADAz\nMRwwGgYDVQQKExNUdXJib3QgSFEgUHZ0LiBMdGQuMRMwEQYDVQQDEwp0dXJib3Qu\nY29tMB4XDTIzMDYyNjA2MTU1MVoXDTIzMDYyNjE4MTU1MVowMzEcMBoGA1UEChMT\nVHVyYm90IEhRIFB2dC4gTHRkLjETMBEGA1UEAxMKdHVyYm90LmNvbTCCASIwDQYJ\nKoZIhvcNAQEBBQADggEPADCCAQoCggEBALlLBiiDT1frNWU2ECg8boc8DC4m4mXH\n3dLsSqIdmb6tqo/EotT04NqqBLEgGK0Rii5vVP+ybTkBpEj5WOkpYfm8GZBo/glh\nPzbp9QONsz4oBWqxjf5/mg/E/8SS1WVPjiZBef5J1uLHx8l4fktCj6Gcsl+95FN1\n9/Y+3ct/1EScstpWM1aOBIW/u9fYLAJXrmUUPYgEYAcISibGv0b4i5Z9j2/1T9Oc\nSv7ldugDAsxZXs9o4/a8WPaFlZyYnql7tgggygVQHiWsnU3Wba0ZW1aKZ2qzfGfi\nza3eWUGEQ3inRBBZlCa5ystze0pfPf0CPxz03jp+NLu4lCvmIwMce0cCAwEAAaM1\nMDMwDgYDVR0PAQH/BAQDAgWgMBMGA1UdJQQMMAoGCCsGAQUFBwMBMAwGA1UdEwEB\n/wQCMAAwDQYJKoZIhvcNAQELBQADggEBAFcSQwcgMWaYBhnW2bhAxT2J5g0+BWwt\n40ocFF9u9qifVEc+vpIagJ7X5/tG7l6xwQPC0BpNeIVNhpeOhHFRnNcCoNvViWR1\nmrK/ytanJ4K+qBVB33rLY3Bqxxvr4ND3IoY6yInEcSEP7JwAm3cFGp/SBoz3ICwe\nmfDTGSIOMPcauH4U/39PXjIcYc7OwiQX83h53dFnKcMus3XQanjBUgkEfk8s7yU5\nnTe6i/yYlTiqXmq3pCl+mLHrTcywTYQgDBZMNcq6N1MeinUk9jZ72CXMPmZj8TPU\nGEPC1xxvrqz+M9iU4f1p4nWN7XWtajygSqIcxn6mVGQZYiZU9OFxA0E=\n-----END CERTIFICATE-----\n"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "certificate_arn": "arn:aws:acm:us-east-1:222222222222:certificate/9c5ef98b-374f-400f-9a9b-285cf4049eaa",
    "domain_name": "turbot.com",
    "in_use_by": [],
    "issuer": "Turbot HQ Pvt. Ltd."
  }
]
✔ PASSED

Running SQL query: test-get-tags-query.sql
[
  {
    "tags": {
      "name": "turbottest67709"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:acm:us-east-1:222222222222:certificate/9c5ef98b-374f-400f-9a9b-285cf4049eaa"
    ],
    "certificate_arn": "arn:aws:acm:us-east-1:222222222222:certificate/9c5ef98b-374f-400f-9a9b-285cf4049eaa",
    "domain_name": "turbot.com",
    "title": "9c5ef98b-374f-400f-9a9b-285cf4049eaa"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "222222222222",
    "akas": [
      "arn:aws:acm:us-east-1:222222222222:certificate/9c5ef98b-374f-400f-9a9b-285cf4049eaa"
    ],
    "region": "us-east-1",
    "title": "9c5ef98b-374f-400f-9a9b-285cf4049eaa"
  }
]
✔ PASSED

POSTTEST: tests/aws_acm_certificate

TEARDOWN: tests/aws_acm_certificate

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```



> select certificate_arn, key_algorithm from aws_acm_certificate
+--------------------------------------------------------------------------------------+---------------+
| certificate_arn                                                                      | key_algorithm |
+--------------------------------------------------------------------------------------+---------------+
| arn:aws:acm:ap-south-1:222222222222:certificate/c8f72e7f-f6cf-49d1-9c87-a14d4be82b5e | RSA_2048      |
| arn:aws:acm:us-west-2:222222222222:certificate/83dc500f-49dd-4b58-a55f-03514f67bad2  | RSA_2048      |
| arn:aws:acm:us-east-2:222222222222:certificate/75ba26fc-131b-48ae-9ce0-1da155237d58  | RSA_2048      |
| arn:aws:acm:us-east-2:222222222222:certificate/cc2672df-2d55-4e13-8733-53454a3a3d61  | RSA_2048      |
| arn:aws:acm:us-east-1:222222222222:certificate/7dec6bad-5220-4a8c-8ad6-213703a5808b  | RSA_2048      |
| arn:aws:acm:us-east-1:222222222222:certificate/71a2afa2-6fd3-4815-88f4-e7ff498800a5  | RSA_2048      |
+--------------------------------------------------------------------------------------+---------------+

Time: 5.8s. Rows fetched: 6. Hydrate calls: 6.

> select certificate_arn, key_algorithm from aws_acm_certificate where key_algorithm = 'RSA_2048'
+--------------------------------------------------------------------------------------+---------------+
| certificate_arn                                                                      | key_algorithm |
+--------------------------------------------------------------------------------------+---------------+
| arn:aws:acm:ap-south-1:222222222222:certificate/c8f72e7f-f6cf-49d1-9c87-a14d4be82b5e | RSA_2048      |
| arn:aws:acm:us-west-2:222222222222:certificate/83dc500f-49dd-4b58-a55f-03514f67bad2  | RSA_2048      |
| arn:aws:acm:us-east-2:222222222222:certificate/75ba26fc-131b-48ae-9ce0-1da155237d58  | RSA_2048      |
| arn:aws:acm:us-east-1:222222222222:certificate/7dec6bad-5220-4a8c-8ad6-213703a5808b  | RSA_2048      |
| arn:aws:acm:us-east-2:222222222222:certificate/cc2672df-2d55-4e13-8733-53454a3a3d61  | RSA_2048      |
| arn:aws:acm:us-east-1:222222222222:certificate/71a2afa2-6fd3-4815-88f4-e7ff498800a5  | RSA_2048      |
+--------------------------------------------------------------------------------------+---------------+
```
</details>
