### PR TITLE
Fix aws_route53_record table to use listHostedZones as the ParentHydrate to avoid cross-account access denied errors

### DIFF
--- a/aws/table_aws_route53_record.go
+++ b/aws/table_aws_route53_record.go
@@ -142,7 +142,7 @@ type recordInfo struct {
 //// LIST FUNCTION
 
 func listRoute53Records(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	zone_id := d.EqualsQuals["zone_id"].GetStringValue()
+	zone_id := d.EqualsQualString("zone_id")
 	zone := h.Item.(HostedZoneResult)
 	hostedZoneID := strings.Split(*zone.Id, "/")[2]
 

--- a/docs/tables/aws_route53_record.md
+++ b/docs/tables/aws_route53_record.md
@@ -2,8 +2,6 @@
 
 A Route 53 record contains authoritative DNS information for a specified DNS name. DNS records are most commonly used to map a name to an IP Address
 
-You **_must_** specify a single `zone_id` in a where or join clause in order to use this table.
-
 We recommend specifying the `name` and `type` columns when querying zones with a large number of records to reduce the query time.
 
 ## Examples
@@ -17,9 +15,7 @@ select
   records,
   alias_target
 from
-  aws_route53_record
-where
-  zone_id = 'Z09145482OD83AIAO253B';
+  aws_route53_record;
 ```
 
 ### List all test.com records in a zone
@@ -33,8 +29,7 @@ from
   aws_route53_record,
   jsonb_array_elements_text(records) as record
 where
-  zone_id = 'Z09145482OD83AIAO253B'
-  and name = 'test.com.';
+  name = 'test.com.';
 ```
 
 ### List all NS records in a zone
@@ -48,8 +43,7 @@ from
   aws_route53_record,
   jsonb_array_elements_text(records) as record
 where
-  zone_id = 'Z09145482OD83AIAO253B'
-  and type = 'NS';
+  type = 'NS';
 ```
 
 ### Get test.com NS record in a zone
@@ -63,8 +57,7 @@ from
   aws_route53_record,
   jsonb_array_elements_text(records) as record
 where
-  zone_id = 'Z09145482OD83AIAO253B'
-  and name = 'test.com.'
+  name = 'test.com.'
   and type = 'NS';
 ```
 
@@ -76,8 +69,6 @@ select
   count(*)
 from
   aws_route53_record
-where
-  zone_id = 'Z09145482OD83AIAO253B'
 group by
   type
 order by
@@ -98,8 +89,7 @@ select
 from
   aws_route53_record
 where
-  zone_id = 'Z09145482OD83AIAO253B'
-  and geo_location is not null
+  geo_location is not null
 order by
   name;
 ```
@@ -114,24 +104,7 @@ select
 from
   aws_route53_record
   left join jsonb_array_elements_text(records) as record on true
-where
-  zone_id = 'Z09145482OD83AIAO253B'
 group by
   name,
   type;
-```
-
-### List all records in all zones
-
-```sql
-select
-  r.name,
-  r.type,
-  r.records,
-  r.alias_target
-from
-  aws_route53_zone as z,
-  aws_route53_record as r
-where
-  r.zone_id = z.id ;
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
SETUP: tests/aws_route53_record []

PRETEST: tests/aws_route53_record

TEST: tests/aws_route53_record
Running terraform
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 1s [id=1223243543543]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_eip.named_test_resource will be created
  + resource "aws_eip" "named_test_resource" {
      + allocation_id        = (known after apply)
      + association_id       = (known after apply)
      + carrier_ip           = (known after apply)
      + customer_owned_ip    = (known after apply)
      + domain               = (known after apply)
      + id                   = (known after apply)
      + instance             = (known after apply)
      + network_border_group = (known after apply)
      + network_interface    = (known after apply)
      + private_dns          = (known after apply)
      + private_ip           = (known after apply)
      + public_dns           = (known after apply)
      + public_ip            = (known after apply)
      + public_ipv4_pool     = (known after apply)
      + tags_all             = (known after apply)
      + vpc                  = true
    }

  # aws_route53_record.named_test_resource will be created
  + resource "aws_route53_record" "named_test_resource" {
      + allow_overwrite = (known after apply)
      + fqdn            = (known after apply)
      + id              = (known after apply)
      + name            = "www.turbottest69592.com"
      + records         = (known after apply)
      + set_identifier  = "live"
      + ttl             = 300
      + type            = "A"
      + zone_id         = (known after apply)

      + weighted_routing_policy {
          + weight = 90
        }
    }

  # aws_route53_zone.named_test_resource will be created
  + resource "aws_route53_zone" "named_test_resource" {
      + arn                 = (known after apply)
      + comment             = "Managed by Terraform"
      + force_destroy       = true
      + id                  = (known after apply)
      + name                = "turbottest69592.com"
      + name_servers        = (known after apply)
      + primary_name_server = (known after apply)
      + tags_all            = (known after apply)
      + zone_id             = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "1223243543543"
  + aws_region    = "us-east-1"
  + public_ip     = (known after apply)
  + resource_aka  = (known after apply)
  + resource_name = "turbottest69592"
  + zone_id       = (known after apply)
aws_eip.named_test_resource: Creating...
aws_route53_zone.named_test_resource: Creating...
aws_eip.named_test_resource: Creation complete after 2s [id=eipalloc-05724344e148e58c8]
aws_route53_zone.named_test_resource: Still creating... [10s elapsed]
aws_route53_zone.named_test_resource: Still creating... [20s elapsed]
aws_route53_zone.named_test_resource: Still creating... [30s elapsed]
aws_route53_zone.named_test_resource: Still creating... [40s elapsed]
aws_route53_zone.named_test_resource: Creation complete after 42s [id=Z05661522SJ9PZXXGO8S1]
aws_route53_record.named_test_resource: Creating...
aws_route53_record.named_test_resource: Still creating... [10s elapsed]
aws_route53_record.named_test_resource: Still creating... [20s elapsed]
aws_route53_record.named_test_resource: Still creating... [30s elapsed]
aws_route53_record.named_test_resource: Still creating... [40s elapsed]
aws_route53_record.named_test_resource: Creation complete after 41s [id=Z05661522SJ9PZXXGO8S1_www.turbottest69592.com_A_live]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Warning: Argument is deprecated

  with aws_eip.named_test_resource,
  on variables.tf line 52, in resource "aws_eip" "named_test_resource":
  52:   vpc = true

use domain attribute instead

(and 2 more similar warnings elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "1223243543543"
aws_region = "us-east-1"
public_ip = "44.216.169.1"
resource_aka = "arn:aws:route53:::hostedzone/Z05661522SJ9PZXXGO8S1/recordset/www.turbottest69592.com./A/live"
resource_name = "turbottest69592"
zone_id = "Z05661522SJ9PZXXGO8S1"

Running SQL query: test-list-query.sql
[
  {
    "name": "www.turbottest69592.com.",
    "records": [
      "44.216.169.1"
    ],
    "set_identifier": "live",
    "ttl": "300",
    "type": "A",
    "weight": 90,
    "zone_id": "Z05661522SJ9PZXXGO8S1"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
null
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "akas": [
      "arn:aws:route53:::hostedzone/Z05661522SJ9PZXXGO8S1/recordset/www.turbottest69592.com./A/live"
    ],
    "title": "www.turbottest69592.com."
  }
]
✔ PASSED

POSTTEST: tests/aws_route53_record

TEARDOWN: tests/aws_route53_record

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, type, records, alias_target from aws_route53_record
+-----------------------+-------+-------------------------------------------------------------------------------------------------------+--------------+
| name                  | type  | records                                                                                               | alias_target |
+-----------------------+-------+-------------------------------------------------------------------------------------------------------+--------------+
| test-nag\100test.com. | SOA   | ["ns-1412.awsdns-48.org. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"]                     | <null>       |
| test-nag\100test.com. | NS    | ["ns-1412.awsdns-48.org.","ns-522.awsdns-01.net.","ns-355.awsdns-44.com.","ns-1734.awsdns-24.co.uk."] | <null>       |
| testaab.com.          | NS    | ["ns-1536.awsdns-00.co.uk.","ns-0.awsdns-00.com.","ns-1024.awsdns-00.org.","ns-512.awsdns-00.net."]   | <null>       |
| test1.testaab.com.    | CNAME | ["yahoo.com"]                                                                                         | <null>       |
| testaab.com.          | SOA   | ["ns-1536.awsdns-00.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400"]                   | <null>       |
+-----------------------+-------+-------------------------------------------------------------------------------------------------------+--------------+
```
</details>
