### PR TITLE
ACM Certificate tables error out on querying Closes #1815

### DIFF
--- a/aws/table_aws_acm_certificate.go
+++ b/aws/table_aws_acm_certificate.go
@@ -412,7 +412,6 @@ func certificateTurbotTags(_ context.Context, d *transform.TransformData) (inter
 	return turbotTagsMap, nil
 }
 
-
 func certificateArnToTitle(_ context.Context, d *transform.TransformData) (interface{}, error) {
 	item := *d.Value.(*string)
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_acm_certificate []

PRETEST: tests/aws_acm_certificate

TEST: tests/aws_acm_certificate
Running terraform
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 2s [id=222222222222]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_acm_certificate.named_test_resource will be created
  + resource "aws_acm_certificate" "named_test_resource" {
      + arn                       = (known after apply)
      + certificate_body          = (known after apply)
      + domain_name               = (known after apply)
      + domain_validation_options = (known after apply)
      + id                        = (known after apply)
      + key_algorithm             = (known after apply)
      + not_after                 = (known after apply)
      + not_before                = (known after apply)
      + pending_renewal           = (known after apply)
      + private_key               = (sensitive value)
      + renewal_eligibility       = (known after apply)
      + renewal_summary           = (known after apply)
      + status                    = (known after apply)
      + subject_alternative_names = (known after apply)
      + tags                      = {
          + "name" = "turbottest95338"
        }
      + tags_all                  = {
          + "name" = "turbottest95338"
        }
      + type                      = (known after apply)
      + validation_emails         = (known after apply)
      + validation_method         = (known after apply)
    }

  # tls_private_key.example will be created
  + resource "tls_private_key" "example" {
      + algorithm                     = "RSA"
      + ecdsa_curve                   = "P224"
      + id                            = (known after apply)
      + private_key_openssh           = (sensitive value)
      + private_key_pem               = (sensitive value)
      + private_key_pem_pkcs8         = (sensitive value)
      + public_key_fingerprint_md5    = (known after apply)
      + public_key_fingerprint_sha256 = (known after apply)
      + public_key_openssh            = (known after apply)
      + public_key_pem                = (known after apply)
      + rsa_bits                      = 2048
    }

  # tls_self_signed_cert.example will be created
  + resource "tls_self_signed_cert" "example" {
      + allowed_uses          = [
          + "key_encipherment",
          + "digital_signature",
          + "server_auth",
        ]
      + cert_pem              = (known after apply)
      + early_renewal_hours   = 0
      + id                    = (known after apply)
      + is_ca_certificate     = false
      + key_algorithm         = (known after apply)
      + private_key_pem       = (sensitive value)
      + ready_for_renewal     = false
      + set_authority_key_id  = false
      + set_subject_key_id    = false
      + validity_end_time     = (known after apply)
      + validity_period_hours = 12
      + validity_start_time   = (known after apply)

      + subject {
          + common_name  = "turbot.com"
          + organization = "Turbot HQ Pvt. Ltd."
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id       = "222222222222"
  + aws_region       = "us-east-1"
  + certificate_body = (known after apply)
  + resource_aka     = (known after apply)
  + resource_name    = "turbottest95338"
tls_private_key.example: Creating...
tls_private_key.example: Creation complete after 0s [id=e5d01c33e3f7ccc363674d62e19b32ba54b5d7bf]
tls_self_signed_cert.example: Creating...
tls_self_signed_cert.example: Creation complete after 0s [id=329675661499636219381833190269435134305]
aws_acm_certificate.named_test_resource: Creating...
aws_acm_certificate.named_test_resource: Creation complete after 2s [id=arn:aws:acm:us-east-1:222222222222:certificate/7a47185d-2907-4bbe-8b81-e249da94a3b9]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "222222222222"
aws_region = "us-east-1"
certificate_body = "-----BEGIN CERTIFICATE-----\\nMIIDJjCCAg6gAwIBAgIRAPgFOQwotbC1TaOBob6yQWEwDQYJKoZIhvcNAQELBQAw\\nMzEcMBoGA1UEChMTVHVyYm90IEhRIFB2dC4gTHRkLjETMBEGA1UEAxMKdHVyYm90\\nLmNvbTAeFw0yMzA3MTAxMzQxMjRaFw0yMzA3MTEwMTQxMjRaMDMxHDAaBgNVBAoT\\nE1R1cmJvdCBIUSBQdnQuIEx0ZC4xEzARBgNVBAMTCnR1cmJvdC5jb20wggEiMA0G\\nCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCciV8Pghyky855XxTRQnq6qUqw7uRN\\nyMgwkc+6IAzA7MwPYHHiM2JVhf0/jjC9POJQbKAGoaFfnCDQhPgmUEfE9Ruian+y\\n8vR/5sbTIMjX3n8VrPz3AGL+Iu8vDfaXfhVNU59hF0tAsLFHWqlO+EHtCG8IVwD7\\nVRnFiUiGy2Zkdx1O6+otIDVLdDpCu+5ySrPNhrINvbFFHr6CDhOsAL8aQWWCxgfl\\nBJWWRVYYhmS12XmpEz/SclC1oreE7Us9U5XUhbbFtIt2DvBxV6PsQo29Un8jyh3s\\nJfzzvl5nA7qrZiphFppFAx9Xqo5AjQe9v2E0rCSadDk0nQrj2nLTETj5AgMBAAGj\\nNTAzMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMB\\nAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAtPF4blwa9+KiG+5tteXurQwAiiQwt\\nOKG3T0qkJOk3giE+sEWV99ztmnr10Dfdglh3DK9JY7hdtoDQhAKvPnNVheEW0Nhb\\nESZL4wNN/FOsdcYFf1UWHJVVtkxJhIjCa96BgRDOy1h2YFEljbYZhwov/K+27Ez7\\nteUfZGzvn3yC3mHxpK18JNQvWSUu30y6dTSkF+j73khNbM+HayXuq2qRpWJzG0bX\\nx2aQ7u+giFMXcWjus6ifaX6YZpil760WxESOCCDauhTfdVYTAjHarT1ZRSCAYiHx\\nhbjmzkqsA/8aPeglAwliuRi3IPkbHdVQXdFHJPeyPcNn0m/0tZ2jVtrM\\n-----END CERTIFICATE-----\\n"
resource_aka = "arn:aws:acm:us-east-1:222222222222:certificate/7a47185d-2907-4bbe-8b81-e249da94a3b9"
resource_name = "turbottest95338"

Running SQL query: test-get-certificate-chain-query.sql
[
  {
    "certificate": "-----BEGIN CERTIFICATE-----\nMIIDJjCCAg6gAwIBAgIRAPgFOQwotbC1TaOBob6yQWEwDQYJKoZIhvcNAQELBQAw\nMzEcMBoGA1UEChMTVHVyYm90IEhRIFB2dC4gTHRkLjETMBEGA1UEAxMKdHVyYm90\nLmNvbTAeFw0yMzA3MTAxMzQxMjRaFw0yMzA3MTEwMTQxMjRaMDMxHDAaBgNVBAoT\nE1R1cmJvdCBIUSBQdnQuIEx0ZC4xEzARBgNVBAMTCnR1cmJvdC5jb20wggEiMA0G\nCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCciV8Pghyky855XxTRQnq6qUqw7uRN\nyMgwkc+6IAzA7MwPYHHiM2JVhf0/jjC9POJQbKAGoaFfnCDQhPgmUEfE9Ruian+y\n8vR/5sbTIMjX3n8VrPz3AGL+Iu8vDfaXfhVNU59hF0tAsLFHWqlO+EHtCG8IVwD7\nVRnFiUiGy2Zkdx1O6+otIDVLdDpCu+5ySrPNhrINvbFFHr6CDhOsAL8aQWWCxgfl\nBJWWRVYYhmS12XmpEz/SclC1oreE7Us9U5XUhbbFtIt2DvBxV6PsQo29Un8jyh3s\nJfzzvl5nA7qrZiphFppFAx9Xqo5AjQe9v2E0rCSadDk0nQrj2nLTETj5AgMBAAGj\nNTAzMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMB\nAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAtPF4blwa9+KiG+5tteXurQwAiiQwt\nOKG3T0qkJOk3giE+sEWV99ztmnr10Dfdglh3DK9JY7hdtoDQhAKvPnNVheEW0Nhb\nESZL4wNN/FOsdcYFf1UWHJVVtkxJhIjCa96BgRDOy1h2YFEljbYZhwov/K+27Ez7\nteUfZGzvn3yC3mHxpK18JNQvWSUu30y6dTSkF+j73khNbM+HayXuq2qRpWJzG0bX\nx2aQ7u+giFMXcWjus6ifaX6YZpil760WxESOCCDauhTfdVYTAjHarT1ZRSCAYiHx\nhbjmzkqsA/8aPeglAwliuRi3IPkbHdVQXdFHJPeyPcNn0m/0tZ2jVtrM\n-----END CERTIFICATE-----\n",
    "certificate_chain": "-----BEGIN CERTIFICATE-----\nMIIDJjCCAg6gAwIBAgIRAPgFOQwotbC1TaOBob6yQWEwDQYJKoZIhvcNAQELBQAw\nMzEcMBoGA1UEChMTVHVyYm90IEhRIFB2dC4gTHRkLjETMBEGA1UEAxMKdHVyYm90\nLmNvbTAeFw0yMzA3MTAxMzQxMjRaFw0yMzA3MTEwMTQxMjRaMDMxHDAaBgNVBAoT\nE1R1cmJvdCBIUSBQdnQuIEx0ZC4xEzARBgNVBAMTCnR1cmJvdC5jb20wggEiMA0G\nCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQCciV8Pghyky855XxTRQnq6qUqw7uRN\nyMgwkc+6IAzA7MwPYHHiM2JVhf0/jjC9POJQbKAGoaFfnCDQhPgmUEfE9Ruian+y\n8vR/5sbTIMjX3n8VrPz3AGL+Iu8vDfaXfhVNU59hF0tAsLFHWqlO+EHtCG8IVwD7\nVRnFiUiGy2Zkdx1O6+otIDVLdDpCu+5ySrPNhrINvbFFHr6CDhOsAL8aQWWCxgfl\nBJWWRVYYhmS12XmpEz/SclC1oreE7Us9U5XUhbbFtIt2DvBxV6PsQo29Un8jyh3s\nJfzzvl5nA7qrZiphFppFAx9Xqo5AjQe9v2E0rCSadDk0nQrj2nLTETj5AgMBAAGj\nNTAzMA4GA1UdDwEB/wQEAwIFoDATBgNVHSUEDDAKBggrBgEFBQcDATAMBgNVHRMB\nAf8EAjAAMA0GCSqGSIb3DQEBCwUAA4IBAQAtPF4blwa9+KiG+5tteXurQwAiiQwt\nOKG3T0qkJOk3giE+sEWV99ztmnr10Dfdglh3DK9JY7hdtoDQhAKvPnNVheEW0Nhb\nESZL4wNN/FOsdcYFf1UWHJVVtkxJhIjCa96BgRDOy1h2YFEljbYZhwov/K+27Ez7\nteUfZGzvn3yC3mHxpK18JNQvWSUu30y6dTSkF+j73khNbM+HayXuq2qRpWJzG0bX\nx2aQ7u+giFMXcWjus6ifaX6YZpil760WxESOCCDauhTfdVYTAjHarT1ZRSCAYiHx\nhbjmzkqsA/8aPeglAwliuRi3IPkbHdVQXdFHJPeyPcNn0m/0tZ2jVtrM\n-----END CERTIFICATE-----\n"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "certificate_arn": "arn:aws:acm:us-east-1:222222222222:certificate/7a47185d-2907-4bbe-8b81-e249da94a3b9",
    "domain_name": "turbot.com",
    "in_use_by": [],
    "issuer": "Turbot HQ Pvt. Ltd."
  }
]
✔ PASSED

Running SQL query: test-get-tags-query.sql
[
  {
    "tags": {
      "name": "turbottest95338"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:acm:us-east-1:222222222222:certificate/7a47185d-2907-4bbe-8b81-e249da94a3b9"
    ],
    "certificate_arn": "arn:aws:acm:us-east-1:222222222222:certificate/7a47185d-2907-4bbe-8b81-e249da94a3b9",
    "domain_name": "turbot.com",
    "title": "7a47185d-2907-4bbe-8b81-e249da94a3b9"
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
[
  {
    "account_id": "222222222222",
    "akas": [
      "arn:aws:acm:us-east-1:222222222222:certificate/7a47185d-2907-4bbe-8b81-e249da94a3b9"
    ],
    "region": "us-east-1",
    "title": "7a47185d-2907-4bbe-8b81-e249da94a3b9"
  }
]
✔ PASSED

POSTTEST: tests/aws_acm_certificate

TEARDOWN: tests/aws_acm_certificate

SUMMARY:

1/1 passed.


```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_acm_certificate
+--------------------------------------------------------------------------------------+------------------------------------------------------------------+------------------------------------------------------------------+-----------------------+----------------------->
| certificate_arn                                                                      | certificate                                                      | certificate_chain                                                | domain_name           | certificate_transparen>
+--------------------------------------------------------------------------------------+------------------------------------------------------------------+------------------------------------------------------------------+-----------------------+----------------------->
| arn:aws:acm:ap-south-1:222222222222:certificate/c8f72e7f-f6cf-49d1-9c87-a14d4be82b5e | -----BEGIN CERTIFICATE-----                                      | -----BEGIN CERTIFICATE-----                                      | *.test.turbot-dev.com | ENABLED               >
|                                                                                      | MIIFZjCCBE6gAwIBAgIQAQ1yVf+q/86jnQygvA8ChDANBgkqhkiG9w0BAQsFADBG | MIIESTCCAzGgAwIBAgITBn+UV4WH6Kx33rJTMlu8mYtWDTANBgkqhkiG9w0BAQsF |                       |                       >
|                                                                                      | MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRUwEwYDVQQLEwxTZXJ2ZXIg | ADA5MQswCQYDVQQGEwJVUzEPMA0GA1UEChMGQW1hem9uMRkwFwYDVQQDExBBbWF6 |                       |                       >
|                                                                                      | Q0EgMUIxDzANBgNVBAMTBkFtYXpvbjAeFw0yMTAzMjMwMDAwMDBaFw0yMjA0MjEy | b24gUm9vdCBDQSAxMB4XDTE1MTAyMjAwMDAwMFoXDTI1MTAxOTAwMDAwMFowRjEL |                       |                       >

```
</details>
