### PR TITLE
Add columns event_topics and snapshot_limit  in the table aws_directory_service_directory Closes #1825

### DIFF
--- a/aws/table_aws_directory_service_directory.go
+++ b/aws/table_aws_directory_service_directory.go
@@ -147,8 +147,22 @@ func tableAwsDirectoryServiceDirectory(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "dns_ip_addrs",
-				Description: "he IP addresses of the DNS servers for the directory.",
+				Description: "The IP addresses of the DNS servers for the directory.",
 				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "event_topics",
+				Description: "Amazon SNS topic names that receive status messages from the specified Directory ID.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getDirectoryServiceEventTopics,
+				Transform:   transform.FromValue(),
+			},
+			{
+				Name:        "snapshot_limit",
+				Description: "Obtains the manual snapshot limits for a directory.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getDirectoryServiceSnapshotLimit,
+				Transform:   transform.FromValue(),
 			},
 			{
 				Name:        "owner_directory_description",
@@ -309,6 +323,68 @@ func getDirectoryServiceDirectory(ctx context.Context, d *plugin.QueryData, _ *p
 	if op.DirectoryDescriptions != nil && len(op.DirectoryDescriptions) > 0 {
 		return op.DirectoryDescriptions[0], nil
 	}
+	return nil, nil
+}
+
+func getDirectoryServiceEventTopics(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	directory := h.Item.(types.DirectoryDescription)
+
+	// Create service
+	svc, err := DirectoryServiceClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_directory_service_directory.getDirectoryServiceEventTopics", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	params := &directoryservice.DescribeEventTopicsInput{
+		DirectoryId: directory.DirectoryId,
+	}
+
+	op, err := svc.DescribeEventTopics(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_directory_service_directory.getDirectoryServiceEventTopics", "api_error", err)
+		return nil, err
+	}
+
+	if op != nil {
+		return op.EventTopics, nil
+	}
+
+	return nil, nil
+}
+
+func getDirectoryServiceSnapshotLimit(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	directory := h.Item.(types.DirectoryDescription)
+
+	// Create service
+	svc, err := DirectoryServiceClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_directory_service_directory.getDirectoryServiceSnapshotLimit", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	params := &directoryservice.GetSnapshotLimitsInput{
+		DirectoryId: directory.DirectoryId,
+	}
+
+	op, err := svc.GetSnapshotLimits(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_directory_service_directory.getDirectoryServiceSnapshotLimit", "api_error", err)
+		return nil, err
+	}
+
+	if op != nil {
+		return op.SnapshotLimits, nil
+	}
+
 	return nil, nil
 }
 

--- a/docs/tables/aws_directory_service_directory.md
+++ b/docs/tables/aws_directory_service_directory.md
@@ -15,7 +15,7 @@ from
   aws_directory_service_directory;
 ```
 
-### List MicrosoftAD type directories 
+### List MicrosoftAD type directories
 
 ```sql
 select
@@ -25,7 +25,7 @@ select
   type
 from
   aws_directory_service_directory
-where 
+where
   type = 'MicrosoftAD';
 ```
 
@@ -42,4 +42,32 @@ select
 from
   aws_directory_service_directory,
   jsonb_array_elements(shared_directories) sd;
+```
+
+### Get snapshot limit details of each directory
+
+```sql
+select
+  name,
+  directory_id,
+  snapshot_limit ->> 'ManualSnapshotsCurrentCount' as manual_snapshots_current_count,
+  snapshot_limit ->> 'ManualSnapshotsLimit' as manual_snapshots_limit,
+  snapshot_limit ->> 'ManualSnapshotsLimitReached' as manual_snapshots_limit_reached
+from
+  aws_directory_service_directory;
+```
+
+### Get topic details of each directory
+
+```sql
+select
+  name,
+  directory_id,
+  e ->> 'CreatedDateTime' as topic_created_date_time,
+  e ->> 'Status' as topic_status,
+  e ->> 'TopicArn' as topic_arn,
+  e ->> 'TopicName' as topic_name
+from
+  aws_directory_service_directory,
+  jsonb_array_elements(event_topics) as e;
 ```

--- a/docs/tables/aws_directory_service_directory.md
+++ b/docs/tables/aws_directory_service_directory.md
@@ -57,7 +57,7 @@ from
   aws_directory_service_directory;
 ```
 
-### Get topic details of each directory
+### Get SNS topic details of each directory
 
 ```sql
 select


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_directory_service_directory []

PRETEST: tests/aws_directory_service_directory

TEST: tests/aws_directory_service_directory
Running terraform
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 2s [id=222222222222]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_directory_service_directory.named_test_resource will be created
  + resource "aws_directory_service_directory" "named_test_resource" {
      + access_url                           = (known after apply)
      + alias                                = (known after apply)
      + desired_number_of_domain_controllers = (known after apply)
      + dns_ip_addresses                     = (known after apply)
      + edition                              = (known after apply)
      + enable_sso                           = false
      + id                                   = (known after apply)
      + name                                 = "turbottest2106.com"
      + password                             = (sensitive value)
      + security_group_id                    = (known after apply)
      + short_name                           = (known after apply)
      + size                                 = "Small"
      + tags                                 = {
          + "Name" = "turbottest2106"
        }
      + tags_all                             = {
          + "Name" = "turbottest2106"
        }
      + type                                 = "SimpleAD"

      + vpc_settings {
          + availability_zones = (known after apply)
          + subnet_ids         = (known after apply)
          + vpc_id             = (known after apply)
        }
    }

  # aws_iam_role.my_role will be created
  + resource "aws_iam_role" "my_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "dax.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest2106"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)
    }

  # aws_subnet.my_subnet1 will be created
  + resource "aws_subnet" "my_subnet1" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.1.1.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_subnet.my_subnet2 will be created
  + resource "aws_subnet" "my_subnet2" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.1.2.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.my_vpc will be created
  + resource "aws_vpc" "my_vpc" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.1.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags_all                             = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "222222222222"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest2106"
aws_iam_role.my_role: Creating...
aws_vpc.my_vpc: Creating...
aws_iam_role.my_role: Creation complete after 3s [id=turbottest2106]
aws_vpc.my_vpc: Creation complete after 6s [id=vpc-01349a3cfb51809ff]
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet1: Creation complete after 2s [id=subnet-05aec27bebda00367]
aws_subnet.my_subnet2: Creation complete after 2s [id=subnet-03654c75f95acff40]
aws_directory_service_directory.named_test_resource: Creating...
aws_directory_service_directory.named_test_resource: Still creating... [10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [7m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [7m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [7m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [7m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [7m40s elapsed]
aws_directory_service_directory.named_test_resource: Creation complete after 7m48s [id=d-90679d4a66]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "222222222222"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:ds:us-east-1:222222222222:directory/d-90679d4a66"
resource_id = "d-90679d4a66"
resource_name = "turbottest2106"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:ds:us-east-1:222222222222:directory/d-90679d4a66",
    "directory_id": "d-90679d4a66",
    "name": "turbottest2106.com"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ds:us-east-1:222222222222:directory/d-90679d4a66"
    ],
    "name": "turbottest2106.com",
    "tags": {
      "Name": "turbottest2106"
    },
    "title": "turbottest2106.com"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:ds:us-east-1:222222222222:directory/d-90679d4a66"
    ],
    "name": "turbottest2106.com",
    "title": "turbottest2106.com"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
null
✔ PASSED

TEARDOWN: tests/aws_directory_service_directory

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, directory_id, event_topics, snapshot_limit from aws_directory_service_directory where directory_id = 'd-90679d45e9'
+------------+--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>
| name       | directory_id | event_topics                                                                                                                                                                 >
+------------+--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>
| test23.com | d-90679d45e9 | [{"CreatedDateTime":"2023-07-11T08:04:08.593Z","DirectoryId":"d-90679d45e9","Status":"Registered","TopicArn":"arn:aws:sns:us-east-1:222222222222:test23","TopicName":"test23">
+------------+--------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------>

> select name, directory_id, event_topics, snapshot_limit from aws_directory_service_directory where directory_id = 'd-90679d45e9'
+------------+--------------+--------------+------------------------------------------------------------------------------------------------+
| name       | directory_id | event_topics | snapshot_limit                                                                                 |
+------------+--------------+--------------+------------------------------------------------------------------------------------------------+
| test23.com | d-90679d45e9 | []           | {"ManualSnapshotsCurrentCount":0,"ManualSnapshotsLimit":5,"ManualSnapshotsLimitReached":false} |
+------------+--------------+--------------+------------------------------------------------------------------------------------------------+
```
</details>
