### PR TITLE
Add table aws_directory_service_certificate Closes #1835

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -136,6 +136,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_dax_parameter_group":                                      tableAwsDaxParameterGroup(ctx),
 			"aws_dax_parameter":                                            tableAwsDaxParameter(ctx),
 			"aws_dax_subnet_group":                                         tableAwsDaxSubnetGroup(ctx),
+			"aws_directory_service_certificate":                            tableAwsDirectoryServiceCertificate(ctx),
 			"aws_directory_service_directory":                              tableAwsDirectoryServiceDirectory(ctx),
 			"aws_dlm_lifecycle_policy":                                     tableAwsDLMLifecyclePolicy(ctx),
 			"aws_dms_replication_instance":                                 tableAwsDmsReplicationInstance(ctx),

--- a/aws/table_aws_directory_service_certificate.go
+++ b/aws/table_aws_directory_service_certificate.go
@@ -159,8 +159,7 @@ func listDirectoryServiceCertificates(ctx context.Context, d *plugin.QueryData, 
 	for pagesLeft {
 		result, err := svc.ListCertificates(ctx, input)
 		if err != nil {
-			// Should we ignore this error?
-			// In the case of parent hydrate the ignore config is not sesms to be working fine. So we need handle it manually
+			// In the case of parent hydrate the ignore config seems to not work fine. So we need to handle it manually```
 			// operation error Directory Service: ListCertificates, https response error StatusCode: 400, RequestID: 6238d084-f28d-42a7-876a-684b0ec0d999, UnsupportedOperationException: LDAPS operations are not supported for this Directory Type. : RequestId: 6238d084-f28d-42a7-876a-684b0ec0d999
 			var ae smithy.APIError
 			if errors.As(err, &ae) {

--- a/aws/table_aws_directory_service_certificate.go
+++ b/aws/table_aws_directory_service_certificate.go
@@ -1,0 +1,253 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/directoryservice"
+	"github.com/aws/aws-sdk-go-v2/service/directoryservice/types"
+	"github.com/aws/smithy-go"
+
+	directoryservicev1 "github.com/aws/aws-sdk-go/service/directoryservice"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableAwsDirectoryServiceCertificate(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_directory_service_certificate",
+		Description: "AWS Directory Service Certificate",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AllColumns([]string{"directory_id", "certificate_id"}),
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"CertificateDoesNotExistException", "DirectoryDoesNotExistException", "InvalidParameterException"}),
+			},
+			Hydrate: getDirectoryServiceCertificate,
+		},
+		List: &plugin.ListConfig{
+			ParentHydrate: listDirectoryServiceDirectories,
+			Hydrate:       listDirectoryServiceCertificates,
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "directory_id",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(directoryservicev1.EndpointsID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "directory_id",
+				Description: "The directory identifier.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "certificate_id",
+				Description: "The identifier of the certificate.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "common_name",
+				Description: "The common name for the certificate.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "type",
+				Description: "The function that the registered certificate performs. Valid values include ClientLDAPS or ClientCertAuth. The default value is ClientLDAPS.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "state",
+				Description: "The state of the certificate. Valid values: Registering | Registered | RegisterFailed | Deregistering | Deregistered | DeregisterFailed.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "expiry_date_time",
+				Description: "The date and time when the certificate will expire.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "registered_date_time",
+				Description: "The date and time that the certificate was registered.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Hydrate:     getDirectoryServiceCertificate,
+			},
+			{
+				Name:        "state_reason",
+				Description: "Describes a state change for the certificate.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getDirectoryServiceCertificate,
+			},
+			{
+				Name:        "client_cert_auth_settings",
+				Description: "A ClientCertAuthSettings object that contains client certificate authentication settings.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getDirectoryServiceCertificate,
+			},
+
+			// Steampipe Standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("CertificateId"),
+			},
+		}),
+	}
+}
+
+type CertInfo struct {
+	DirectoryId            *string
+	CertificateId          *string
+	ClientCertAuthSettings *types.ClientCertAuthSettings
+	CommonName             *string
+	ExpiryDateTime         *time.Time
+	RegisteredDateTime     *time.Time
+	State                  types.CertificateState
+	StateReason            *string
+	Type                   types.CertificateType
+}
+
+//// LIST FUNCTION
+
+func listDirectoryServiceCertificates(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	directory := h.Item.(types.DirectoryDescription)
+
+	// Restrict the API call for other certificates.
+	if d.EqualsQualString("directory_id") != "" && d.EqualsQualString("directory_id") != *directory.DirectoryId {
+		return nil, nil
+	}
+
+	// Create Session
+	svc, err := DirectoryServiceClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_directory_service_certificate.listDirectoryServiceCertificates", "connection_error", err)
+		return nil, err
+	}
+
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	// Limiting the results
+	maxLimit := int32(50)
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxLimit {
+			maxLimit = limit
+		}
+	}
+
+	// Build the params
+	input := &directoryservice.ListCertificatesInput{
+		DirectoryId: directory.DirectoryId,
+		Limit:       aws.Int32(maxLimit),
+	}
+
+	pagesLeft := true
+	// List call
+	for pagesLeft {
+		result, err := svc.ListCertificates(ctx, input)
+		if err != nil {
+			// Should we ignore this error?
+			// In the case of parent hydrate the ignore config is not sesms to be working fine. So we need handle it manually
+			// operation error Directory Service: ListCertificates, https response error StatusCode: 400, RequestID: 6238d084-f28d-42a7-876a-684b0ec0d999, UnsupportedOperationException: LDAPS operations are not supported for this Directory Type. : RequestId: 6238d084-f28d-42a7-876a-684b0ec0d999
+			var ae smithy.APIError
+		if errors.As(err, &ae) {
+			if ae.ErrorCode() == "UnsupportedOperationException" {
+				return nil, nil
+			}
+		}
+			plugin.Logger(ctx).Error("aws_directory_service_certificate.listDirectoryServiceCertificates", "api_error", err)
+			return nil, err
+		}
+
+		for _, cert := range result.CertificatesInfo {
+
+			d.StreamListItem(ctx, CertInfo{
+				DirectoryId:    directory.DirectoryId,
+				CertificateId:  cert.CertificateId,
+				CommonName:     cert.CommonName,
+				ExpiryDateTime: cert.ExpiryDateTime,
+				State:          cert.State,
+				Type:           cert.Type,
+			})
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.RowsRemaining(ctx) == 0 {
+				pagesLeft = false
+			}
+		}
+
+		if result.NextToken != nil {
+			input.NextToken = result.NextToken
+		} else {
+			pagesLeft = false
+		}
+	}
+
+	return nil, err
+}
+
+//// HYDRATE FUNCTIONS
+
+func getDirectoryServiceCertificate(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var directoryID, certID string
+
+	if h.Item != nil {
+		data := h.Item.(CertInfo)
+		directoryID = *data.DirectoryId
+		certID = *data.CertificateId
+	} else {
+		directoryID = d.EqualsQualString("directory_id")
+		certID = d.EqualsQualString("certificate_id")
+	}
+
+	if directoryID == "" || certID == "" {
+		return nil, nil
+	}
+
+	// Create service
+	svc, err := DirectoryServiceClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_directory_service_certificate.getDirectoryServiceCertificate", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	params := &directoryservice.DescribeCertificateInput{
+		DirectoryId:   &directoryID,
+		CertificateId: &certID,
+	}
+
+	op, err := svc.DescribeCertificate(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_directory_service_certificate.getDirectoryServiceCertificate", "api_error", err)
+		return nil, err
+	}
+
+	if op.Certificate != nil {
+		return CertInfo{
+			DirectoryId:            &directoryID,
+			CertificateId:          &certID,
+			ClientCertAuthSettings: op.Certificate.ClientCertAuthSettings,
+			CommonName:             op.Certificate.CommonName,
+			ExpiryDateTime:         op.Certificate.ExpiryDateTime,
+			RegisteredDateTime:     op.Certificate.RegisteredDateTime,
+			State:                  op.Certificate.State,
+			StateReason:            op.Certificate.StateReason,
+			Type:                   op.Certificate.Type,
+		}, nil
+	}
+	return nil, nil
+}

--- a/aws/table_aws_directory_service_certificate.go
+++ b/aws/table_aws_directory_service_certificate.go
@@ -99,7 +99,7 @@ func tableAwsDirectoryServiceCertificate(_ context.Context) *plugin.Table {
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("CertificateId"),
+				Transform:   transform.FromField("CommonName"),
 			},
 		}),
 	}

--- a/aws/table_aws_directory_service_certificate.go
+++ b/aws/table_aws_directory_service_certificate.go
@@ -159,7 +159,7 @@ func listDirectoryServiceCertificates(ctx context.Context, d *plugin.QueryData, 
 	for pagesLeft {
 		result, err := svc.ListCertificates(ctx, input)
 		if err != nil {
-			// In the case of parent hydrate the ignore config seems to not work fine. So we need to handle it manually```
+			// In the case of parent hydrate the ignore config seems to not work fine. So we need to handle it manually
 			// operation error Directory Service: ListCertificates, https response error StatusCode: 400, RequestID: 6238d084-f28d-42a7-876a-684b0ec0d999, UnsupportedOperationException: LDAPS operations are not supported for this Directory Type. : RequestId: 6238d084-f28d-42a7-876a-684b0ec0d999
 			var ae smithy.APIError
 			if errors.As(err, &ae) {

--- a/docs/tables/aws_directory_service_certificate.md
+++ b/docs/tables/aws_directory_service_certificate.md
@@ -22,7 +22,7 @@ from
   aws_directory_service_certificate;
 ```
 
-### List MicrosoftAD type directories
+### List 'MicrosoftAD' type directories
 
 ```sql
 select

--- a/docs/tables/aws_directory_service_certificate.md
+++ b/docs/tables/aws_directory_service_certificate.md
@@ -53,7 +53,7 @@ where
   state = 'Deregistered';
 ```
 
-### List certificates that are expired in the last 30 days
+### List certificates that will expire in the coming 7 days
 
 ```sql
 select
@@ -66,7 +66,7 @@ select
 from
   aws_directory_service_certificate
 where
-  expiry_date_time >= time() - interval '30' day;
+  expiry_date_time >= now() + interval '7' day;
 ```
 
 ### Get client certificate auth settings of each certificate

--- a/docs/tables/aws_directory_service_certificate.md
+++ b/docs/tables/aws_directory_service_certificate.md
@@ -1,0 +1,81 @@
+# Table: aws_directory_service_certificate
+
+AWS Directory Service is a managed service provided by Amazon Web Services (AWS) that allows you to connect and integrate your AWS resources with an existing on-premises Microsoft Active Directory (AD) or establish a new, standalone directory in the AWS Cloud.
+
+When setting up AWS Directory Service, you have the option to use Secure Sockets Layer (SSL) certificates to secure the communication between your on-premises directory and the AWS Cloud. This is especially important if you have a hybrid environment where you need to establish a secure connection between your on-premises AD and the AWS Cloud.
+
+The AWS Directory Service certificate refers to the SSL certificate that is used to secure the communication between your on-premises AD and AWS. This certificate is typically issued by a trusted certificate authority (CA) and ensures that the communication is encrypted and secure.
+
+## Examples
+
+### Basic Info
+
+```sql
+select
+  directory_id,
+  certificate_id,
+  common_name,
+  type,
+  state,
+  expiry_date_time
+from
+  aws_directory_service_certificate;
+```
+
+### List MicrosoftAD type directories
+
+```sql
+select
+  c.certificate_id,
+  c.common_name,
+  c.directory_id,
+  c.type as certificate_type,
+  d.name as directory_name,
+  d.type as directory_type
+from
+  aws_directory_service_certificate c,
+  aws_directory_service_directory d
+where
+  d.type = 'MicrosoftAD';
+```
+
+### List certificates that are deregistered
+
+```sql
+select
+  name,
+  directory_id,
+  type,
+  state
+from
+  aws_directory_service_certificate
+where
+  state = 'Deregistered';
+```
+
+### List certificates that are expired in the last 30 days
+
+```sql
+select
+  directory_id,
+  certificate_id,
+  common_name,
+  type,
+  state,
+  expiry_date_time
+from
+  aws_directory_service_certificate
+where
+  expiry_date_time >= time() - interval '30' day;
+```
+
+### Get client certificate auth settings of each certificate
+
+```sql
+select
+  directory_id,
+  certificate_id,
+  client_cert_auth_settings -> 'OCSPUrl' as ocsp_url
+from
+  aws_directory_service_certificate;
+```

--- a/docs/tables/aws_directory_service_certificate.md
+++ b/docs/tables/aws_directory_service_certificate.md
@@ -117,6 +117,6 @@ select
 from
   aws_directory_service_certificate
 order by
-  partition ,
+  partition,
   registered_date_time desc;
 ```

--- a/docs/tables/aws_directory_service_certificate.md
+++ b/docs/tables/aws_directory_service_certificate.md
@@ -43,7 +43,7 @@ where
 
 ```sql
 select
-  name,
+  common_name,
   directory_id,
   type,
   state

--- a/docs/tables/aws_directory_service_certificate.md
+++ b/docs/tables/aws_directory_service_certificate.md
@@ -75,6 +75,7 @@ where
 select
   directory_id,
   certificate_id,
+  common_name,
   client_cert_auth_settings -> 'OCSPUrl' as ocsp_url
 from
   aws_directory_service_certificate;

--- a/docs/tables/aws_directory_service_certificate.md
+++ b/docs/tables/aws_directory_service_certificate.md
@@ -80,3 +80,43 @@ select
 from
   aws_directory_service_certificate;
 ```
+
+### Retrieve the number of certificates registered in each directory
+
+```sql
+select
+  directory_id,
+  count(*) as certificate_count
+from
+  aws_directory_service_certificate
+group by
+  directory_id;
+```
+
+### List all certificates that were registered more than a year ago and have not been deregistered
+
+```sql
+select
+  common_name,
+  directory_id,
+  type,
+  state
+from
+  aws_directory_service_certificate
+where
+  registered_date_time <= now() - interval '1 year'
+  and state not like 'Deregister%';
+```
+
+### Find the certificate with the latest registration date in each AWS partition
+
+```sql
+select
+  distinct partition,
+  registered_date_time
+from
+  aws_directory_service_certificate
+order by
+  partition ,
+  registered_date_time desc;
+```

--- a/docs/tables/aws_directory_service_certificate.md
+++ b/docs/tables/aws_directory_service_certificate.md
@@ -39,7 +39,7 @@ where
   d.type = 'MicrosoftAD';
 ```
 
-### List certificates that are deregistered
+### List deregistered certificates
 
 ```sql
 select


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_aab.aws_directory_service_certificate
+--------------+----------------+-------------+-------------+------------+---------------------------+---------------------------+--------------------------------------+---------------------------+------>
| directory_id | certificate_id | common_name | type        | state      | expiry_date_time          | registered_date_time      | state_reason                         | client_cert_auth_settings | title>
+--------------+----------------+-------------+-------------+------------+---------------------------+---------------------------+--------------------------------------+---------------------------+------>
| d-90679c9511 | c-9067387b7a   | unused      | ClientLDAPS | Registered | 2024-05-16T14:07:09+05:30 | 2023-07-18T13:22:51+05:30 | Certificate registered successfully. | <null>                    | c-906>
+--------------+----------------+-------------+-------------+------------+---------------------------+---------------------------+--------------------------------------+---------------------------+-----
```
</details>
