### PR TITLE
Add table aws_vpc_nat_gateway_metric_bytes_out_to_destination

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -444,6 +444,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_vpc_flow_log_event":                                       tableAwsVpcFlowLogEvent(ctx),
 			"aws_vpc_flow_log":                                             tableAwsVpcFlowlog(ctx),
 			"aws_vpc_internet_gateway":                                     tableAwsVpcInternetGateway(ctx),
+			"aws_vpc_nat_gateway_metric_bytes_out_to_destination":          tableAwsVpcNatGatewayMetricBytesOutToDestination(ctx),
 			"aws_vpc_nat_gateway":                                          tableAwsVpcNatGateway(ctx),
 			"aws_vpc_network_acl":                                          tableAwsVpcNetworkACL(ctx),
 			"aws_vpc_peering_connection":                                   tableAwsVpcPeeringConnection(ctx),

--- a/aws/table_aws_vpc_nat_gateway_metric_bytes_out_to_destination.go
+++ b/aws/table_aws_vpc_nat_gateway_metric_bytes_out_to_destination.go
@@ -1,0 +1,38 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableAwsVpcNatGatewayMetricBytesOutToDestination(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_vpc_nat_gateway_metric_bytes_out_to_destination",
+		Description: "AWS VPC Nat Gateway Cloudwatch Metrics - BytesOutToDestination",
+		List: &plugin.ListConfig{
+			ParentHydrate: listVpcNatGateways,
+			Hydrate:       listVpcNatGatewayMetricBytesOutToDestination,
+		},
+		GetMatrixItemFunc: CloudWatchRegionsMatrix,
+		Columns: awsRegionalColumns(cwMetricColumns(
+			[]*plugin.Column{
+				{
+					Name:        "nat_gateway_id",
+					Description: "The ID of the NAT gateway.",
+					Type:        proto.ColumnType_STRING,
+					Transform:   transform.FromField("DimensionValue"),
+				},
+			})),
+	}
+}
+
+func listVpcNatGatewayMetricBytesOutToDestination(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	natGateway := h.Item.(types.NatGateway)
+	return listCWMetricStatistics(ctx, d, "5_MIN", "AWS/VPC", "BytesOutToDestination", "NatGatewayId", *natGateway.NatGatewayId)
+}

--- a/aws/table_aws_vpc_nat_gateway_metric_bytes_out_to_destination.go
+++ b/aws/table_aws_vpc_nat_gateway_metric_bytes_out_to_destination.go
@@ -34,5 +34,5 @@ func tableAwsVpcNatGatewayMetricBytesOutToDestination(_ context.Context) *plugin
 
 func listVpcNatGatewayMetricBytesOutToDestination(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	natGateway := h.Item.(types.NatGateway)
-	return listCWMetricStatistics(ctx, d, "5_MIN", "AWS/VPC", "BytesOutToDestination", "NatGatewayId", *natGateway.NatGatewayId)
+	return listCWMetricStatistics(ctx, d, "5_MIN", "AWS/NATGateway", "BytesOutToDestination", "NatGatewayId", *natGateway.NatGatewayId)
 }

--- a/docs/tables/aws_vpc_nat_gateway_metric_bytes_out_to_destination.md
+++ b/docs/tables/aws_vpc_nat_gateway_metric_bytes_out_to_destination.md
@@ -25,15 +25,17 @@ order by
 
 ```sql
 select
-  nat_gateway_id,
+  g.nat_gateway_id,
   vpc_id,
   subnet_id
 from
   aws_vpc_nat_gateway as g
-  left join aws_vpc_nat_gateway_metric_bytes_out_to_destination as d,
+  left join aws_vpc_nat_gateway_metric_bytes_out_to_destination as d
   on g.nat_gateway_id = d.nat_gateway_id
-where
-  minimum = 0
-order by
-  nat_gateway_id;
+group by
+  g.nat_gateway_id,
+  vpc_id,
+  subnet_id
+having
+  sum(average) = 0;
 ```

--- a/docs/tables/aws_vpc_nat_gateway_metric_bytes_out_to_destination.md
+++ b/docs/tables/aws_vpc_nat_gateway_metric_bytes_out_to_destination.md
@@ -21,7 +21,7 @@ order by
   timestamp;
 ```
 
-### Show unused nat gateways
+### Show unused NAT gateways
 
 ```sql
 select

--- a/docs/tables/aws_vpc_nat_gateway_metric_bytes_out_to_destination.md
+++ b/docs/tables/aws_vpc_nat_gateway_metric_bytes_out_to_destination.md
@@ -1,0 +1,39 @@
+# Table: aws_vpc_nat_gateway_metric_bytes_out_to_destination
+
+Amazon CloudWatch Metrics provide data about the performance of your systems. The `aws_vpc_nat_gateway_metric_bytes_out_to_destination` table provides metric statistics at 5 minute intervals for the most recent 5 days.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  nat_gateway_id,
+  timestamp,
+  minimum,
+  maximum,
+  average,
+  sample_count
+from
+  aws_vpc_nat_gateway_metric_bytes_out_to_destination
+order by
+  nat_gateway_id,
+  timestamp;
+```
+
+### Show unused nat gateways
+
+```sql
+select
+  nat_gateway_id,
+  vpc_id,
+  subnet_id
+from
+  aws_vpc_nat_gateway as g
+  left join aws_vpc_nat_gateway_metric_bytes_out_to_destination as d,
+  on g.nat_gateway_id = d.nat_gateway_id
+where
+  minimum = 0
+order by
+  nat_gateway_id;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
select
  g.nat_gateway_id,
  vpc_id,
  subnet_id
from
  aws_vpc_nat_gateway as g
  left join aws_vpc_nat_gateway_metric_bytes_out_to_destination as d
  on g.nat_gateway_id = d.nat_gateway_id
group by
  g.nat_gateway_id,
  vpc_id,
  subnet_id
having
  sum(average) <> 0;
+-----------------------+-----------------------+--------------------------+
| nat_gateway_id        | vpc_id                | subnet_id                |
+-----------------------+-----------------------+--------------------------+
| nat-0601e5792805b2571 | vpc-0e6e5565b44c7f8e1 | subnet-0160eb88cc3f8b7bd |
+-----------------------+-----------------------+--------------------------+
```
</details>
