### PR TITLE
Add table `aws_directory_service_log_subscription`. Closes #1824

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -140,6 +140,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_dax_parameter":                                            tableAwsDaxParameter(ctx),
 			"aws_dax_subnet_group":                                         tableAwsDaxSubnetGroup(ctx),
 			"aws_directory_service_directory":                              tableAwsDirectoryServiceDirectory(ctx),
+			"aws_directory_service_log_subscription":                       tableAwsDirectoryServiceLogSubscription(ctx),
 			"aws_dlm_lifecycle_policy":                                     tableAwsDLMLifecyclePolicy(ctx),
 			"aws_dms_replication_instance":                                 tableAwsDmsReplicationInstance(ctx),
 			"aws_docdb_cluster":                                            tableAwsDocDBCluster(ctx),

--- a/aws/table_aws_directory_service_log_subscription.go
+++ b/aws/table_aws_directory_service_log_subscription.go
@@ -89,7 +89,7 @@ func listDirectoryServiceLogSubscription(ctx context.Context, d *plugin.QueryDat
 	}
 	equalQuals := d.EqualsQuals
 	if equalQuals["directory_id"] != nil {
-		if equalQuals["directory_id"].GetStringValue() != "" {
+		if d.EqualsQualString("directory_id") != "" {
 			input.DirectoryId = aws.String(d.EqualsQualString("directory_id"))
 		}
 	}

--- a/aws/table_aws_directory_service_log_subscription.go
+++ b/aws/table_aws_directory_service_log_subscription.go
@@ -48,6 +48,7 @@ func tableAwsDirectoryServiceLogSubscription(_ context.Context) *plugin.Table {
 				Description: "The date and time that the log subscription was created.",
 				Type:        proto.ColumnType_TIMESTAMP,
 			},
+
 			// Steampipe Standard columns
 			{
 				Name:        "title",
@@ -78,9 +79,7 @@ func listDirectoryServiceLogSubscription(ctx context.Context, d *plugin.QueryDat
 	if d.QueryContext.Limit != nil {
 		limit := int32(*d.QueryContext.Limit)
 		if limit < maxLimit {
-			if limit < 1 {
 				maxLimit = limit
-			}
 		}
 	}
 
@@ -91,7 +90,7 @@ func listDirectoryServiceLogSubscription(ctx context.Context, d *plugin.QueryDat
 	equalQuals := d.EqualsQuals
 	if equalQuals["directory_id"] != nil {
 		if equalQuals["directory_id"].GetStringValue() != "" {
-			input.DirectoryId = aws.String(equalQuals["directory_id"].GetStringValue())
+			input.DirectoryId = aws.String(d.EqualsQualString("directory_id"))
 		}
 	}
 

--- a/aws/table_aws_directory_service_log_subscription.go
+++ b/aws/table_aws_directory_service_log_subscription.go
@@ -87,6 +87,7 @@ func listDirectoryServiceLogSubscription(ctx context.Context, d *plugin.QueryDat
 	input := &directoryservice.ListLogSubscriptionsInput{
 		Limit: aws.Int32(maxLimit),
 	}
+	
 	if d.EqualsQualString("directory_id") != "" {
 		input.DirectoryId = aws.String(d.EqualsQualString("directory_id"))
 	}

--- a/aws/table_aws_directory_service_log_subscription.go
+++ b/aws/table_aws_directory_service_log_subscription.go
@@ -87,12 +87,9 @@ func listDirectoryServiceLogSubscription(ctx context.Context, d *plugin.QueryDat
 	input := &directoryservice.ListLogSubscriptionsInput{
 		Limit: aws.Int32(maxLimit),
 	}
-	equalQuals := d.EqualsQuals
-	if equalQuals["directory_id"] != nil {
 		if d.EqualsQualString("directory_id") != "" {
 			input.DirectoryId = aws.String(d.EqualsQualString("directory_id"))
 		}
-	}
 
 	pagesLeft := true
 

--- a/aws/table_aws_directory_service_log_subscription.go
+++ b/aws/table_aws_directory_service_log_subscription.go
@@ -79,7 +79,7 @@ func listDirectoryServiceLogSubscription(ctx context.Context, d *plugin.QueryDat
 	if d.QueryContext.Limit != nil {
 		limit := int32(*d.QueryContext.Limit)
 		if limit < maxLimit {
-				maxLimit = limit
+			maxLimit = limit
 		}
 	}
 
@@ -87,9 +87,9 @@ func listDirectoryServiceLogSubscription(ctx context.Context, d *plugin.QueryDat
 	input := &directoryservice.ListLogSubscriptionsInput{
 		Limit: aws.Int32(maxLimit),
 	}
-		if d.EqualsQualString("directory_id") != "" {
-			input.DirectoryId = aws.String(d.EqualsQualString("directory_id"))
-		}
+	if d.EqualsQualString("directory_id") != "" {
+		input.DirectoryId = aws.String(d.EqualsQualString("directory_id"))
+	}
 
 	pagesLeft := true
 
@@ -118,4 +118,4 @@ func listDirectoryServiceLogSubscription(ctx context.Context, d *plugin.QueryDat
 	}
 
 	return nil, err
-	}
+}

--- a/aws/table_aws_directory_servicelog_subscription.go
+++ b/aws/table_aws_directory_servicelog_subscription.go
@@ -1,0 +1,123 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/directoryservice"
+
+	directoryservicev1 "github.com/aws/aws-sdk-go/service/directoryservice"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableAwsDirectoryServiceLogSubscription(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_directory_service_log_subscription",
+		Description: "AWS Directory Service Log Subscription",
+		List: &plugin.ListConfig{
+			Hydrate: listDirectoryServiceLogSubscription,
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "directory_id",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(directoryservicev1.EndpointsID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "directory_id",
+				Description: "Identifier (ID) of the directory that you want to associate with the log subscription.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "log_group_name",
+				Description: "The name of the log group.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "subscription_created_date_time",
+				Description: "The date and time that the log subscription was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			// Steampipe Standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("LogGroupName"),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listDirectoryServiceLogSubscription(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	// Create Session
+	svc, err := DirectoryServiceClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_directory_service_log_subscription.listDirectoryServiceLogSubscription", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	// Limiting the results
+	maxLimit := int32(1000)
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxLimit {
+			if limit < 1 {
+				maxLimit = limit
+			}
+		}
+
+	// Build the params
+	input := &directoryservice.ListLogSubscriptionsInput{
+		Limit: aws.Int32(maxLimit),
+	}
+
+	// Additonal Filter
+	equalQuals := d.EqualsQuals
+	if equalQuals["directory_id"] != nil {
+		input.DirectoryId = aws.String(d.EqualsQualString("directory_id"))
+	}
+
+	pagesLeft := true
+
+	// List call
+	for pagesLeft {
+		result, err := svc.ListLogSubscriptions(ctx, input)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_directory_service_log_subscription.listDirectoryServiceLogSubscription", "api_error", err)
+			return nil, err
+		}
+
+		for _, subscription := range result.LogSubscriptions {
+			d.StreamListItem(ctx, subscription)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.RowsRemaining(ctx) == 0 {
+				pagesLeft = false
+			}
+		}
+
+		if result.NextToken != nil {
+			input.NextToken = result.NextToken
+		} else {
+			pagesLeft = false
+		}
+	}
+
+	return nil, err
+	}
+	return nil, nil
+}

--- a/docs/tables/aws_directory_servicelog_subscription.md
+++ b/docs/tables/aws_directory_servicelog_subscription.md
@@ -1,0 +1,32 @@
+# Table: aws_directory_service_log_subscription
+
+This forward real-time Directory Service domain controller security logs to the specified Amazon CloudWatch log group in your AWS account.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  log_group_name,
+  partition,
+  subscription_created_date_time,
+  directory_id,
+  title
+from
+  aws_directory_service_log_subscription;
+```
+
+### Get details of the directory associated to the log subscription
+
+```sql
+select
+  s.log_group_name,
+  d.name as directory_name,
+  d.arn as directory_arn,
+  d.directory_id,
+  d.type as directory_type
+from
+  aws_directory_service_log_subscription as s
+  left join aws_directory_service_directory as d on s.directory_id = d.directory_id;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```sql
select * from aws_directory_service_log_subscription
[
 {
  "_ctx": {
   "connection_name": "aws_zero_intg"
  },
  "account_id": "111111111111",
  "directory_id": "d-9f671f1111",
  "log_group_name": "/aws/directoryservice/d-9f671f1111-test.turbot.coom",
  "partition": "aws",
  "region": "ap-south-1",
  "subscription_created_date_time": "2023-07-27T14:31:33+05:30",
  "title": "/aws/directoryservice/d-9f671f1111-test.turbot.coom"
 }
]
```

```sql
select * from aws_directory_service_log_subscription where directory_id = 'd-9f671f8b10'
[
 {
  "_ctx": {
   "connection_name": "aws_zero_intg"
  },
  "account_id": "111111111111",
  "directory_id": "d-9f671f1111",
  "log_group_name": "/aws/directoryservice/d-9f671f1111-test.turbot.coom",
  "partition": "aws",
  "region": "ap-south-1",
  "subscription_created_date_time": "2023-07-27T14:31:33+05:30",
  "title": "/aws/directoryservice/d-9f671f1111-test.turbot.coom"
 }
]
```
</details>
