### PR TITLE
feat: install plugin in STEAMPIPE_INSTALL_DIR if set, defaulting to ~/.steampipe. Also, let git ignore .steampipe directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
+STEAMPIPE_INSTALL_DIR?=~/.steampipe
+
 install:
-	go build -o ~/.steampipe/plugins/hub.steampipe.io/plugins/turbot/aws@latest/steampipe-plugin-aws.plugin *.go
+	go build -o $(STEAMPIPE_INSTALL_DIR)/plugins/hub.steampipe.io/plugins/turbot/aws@latest/steampipe-plugin-aws.plugin *.go


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
