### PR TITLE
feat: add engine_type and endpoints columns to aws_elasticsearch_domain table

### DIFF
--- a/aws/table_aws_elasticsearch_domain.go
+++ b/aws/table_aws_elasticsearch_domain.go
@@ -41,6 +41,11 @@ func tableAwsElasticsearchDomain(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "engine_type",
+				Description: "Specifies the EngineType of the domain.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "domain_id",
 				Description: "The id of the domain.",
 				Type:        proto.ColumnType_STRING,
@@ -63,6 +68,12 @@ func tableAwsElasticsearchDomain(_ context.Context) *plugin.Table {
 				Name:        "endpoint",
 				Description: "The Elasticsearch domain endpoint that use to submit index and search requests.",
 				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsElasticsearchDomain,
+			},
+			{
+				Name:        "endpoints",
+				Description: "Map containing the Elasticsearch domain endpoints used to submit index and search requests.",
+				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsElasticsearchDomain,
 			},
 			{
@@ -237,9 +248,7 @@ func listAwsElasticsearchDomains(ctx context.Context, d *plugin.QueryData, _ *pl
 	}
 
 	for _, domainname := range op.DomainNames {
-		d.StreamListItem(ctx, types.ElasticsearchDomainStatus{
-			DomainName: domainname.DomainName,
-		})
+		d.StreamListItem(ctx, domainname)
 
 		// Context may get cancelled due to manual cancellation or if the limit has been reached
 		if d.RowsRemaining(ctx) == 0 {
@@ -255,7 +264,7 @@ func listAwsElasticsearchDomains(ctx context.Context, d *plugin.QueryData, _ *pl
 func getAwsElasticsearchDomain(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	var domainname string
 	if h.Item != nil {
-		domainname = *h.Item.(types.ElasticsearchDomainStatus).DomainName
+		domainname = *h.Item.(types.DomainInfo).DomainName
 	} else {
 		domainname = d.EqualsQuals["domain_name"].GetStringValue()
 	}

--- a/aws/table_aws_opensearch_domain.go
+++ b/aws/table_aws_opensearch_domain.go
@@ -41,6 +41,11 @@ func tableAwsOpenSearchDomain(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "engine_type",
+				Description: "Specifies the EngineType of the domain.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "domain_id",
 				Description: "The unique identifier for the specified domain.",
 				Type:        proto.ColumnType_STRING,
@@ -240,9 +245,7 @@ func listOpenSearchDomains(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 	}
 
 	for _, domainname := range op.DomainNames {
-		d.StreamListItem(ctx, types.DomainStatus{
-			DomainName: domainname.DomainName,
-		})
+		d.StreamListItem(ctx, domainname)
 
 		// Context may get cancelled due to manual cancellation or if the limit has been reached
 		if d.RowsRemaining(ctx) == 0 {
@@ -258,7 +261,7 @@ func listOpenSearchDomains(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 func getOpenSearchDomain(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	var domainName string
 	if h.Item != nil {
-		domainName = *h.Item.(types.DomainStatus).DomainName
+		domainName = *h.Item.(types.DomainInfo).DomainName
 	} else {
 		domainName = d.EqualsQuals["domain_name"].GetStringValue()
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
