### PR TITLE
feat(aws_pricing_product): add OfferingClass field

### DIFF
--- a/aws/table_aws_pricing_product.go
+++ b/aws/table_aws_pricing_product.go
@@ -33,7 +33,7 @@ func tableAwsPricingProduct(_ context.Context) *plugin.Table {
 			{Name: "term", Description: "Whether your AWS usage is Reserved or On-Demand.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.Term")},
 			{Name: "purchase_option", Description: "How you chose to pay for this line item (All Upfront, Partial Upfront, No Upfront).", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.TermAttributes.PurchaseOption")},
 			{Name: "lease_contract_length", Description: "The length of time that your RI is reserved for.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.TermAttributes.LeaseContractLength")},
-			{Name: "offering_class", Description: "The type of RI (Standard or Convertible)", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.TermAttributes.OfferingClass")},
+			{Name: "offering_class", Description: "The type of RI (Standard or Convertible).", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.TermAttributes.OfferingClass")},
 			{Name: "description", Description: "Description for a product / offer / pricing-tier combination.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.Description")},
 			{Name: "begin_range", Description: "Start of billing range, by unit", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.BeginRange")},
 			{Name: "end_range", Description: "Enf of billing range, by unit", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.EndRange")},

--- a/aws/table_aws_pricing_product.go
+++ b/aws/table_aws_pricing_product.go
@@ -33,6 +33,7 @@ func tableAwsPricingProduct(_ context.Context) *plugin.Table {
 			{Name: "term", Description: "Whether your AWS usage is Reserved or On-Demand.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.Term")},
 			{Name: "purchase_option", Description: "How you chose to pay for this line item (All Upfront, Partial Upfront, No Upfront).", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.TermAttributes.PurchaseOption")},
 			{Name: "lease_contract_length", Description: "The length of time that your RI is reserved for.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.TermAttributes.LeaseContractLength")},
+			{Name: "offering_class", Description: "The type of RI (Standard or Convertible)", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.TermAttributes.OfferingClass")},
 			{Name: "description", Description: "Description for a product / offer / pricing-tier combination.", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.Description")},
 			{Name: "begin_range", Description: "Start of billing range, by unit", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.BeginRange")},
 			{Name: "end_range", Description: "Enf of billing range, by unit", Type: proto.ColumnType_STRING, Transform: transform.FromField("Offer.PriceDimension.EndRange")},
@@ -73,6 +74,7 @@ type TermAttributes struct {
 	_                   struct{} `type:"structure"`
 	PurchaseOption      *string
 	LeaseContractLength *string
+	OfferingClass       *string
 }
 
 type Offer struct {


### PR DESCRIPTION
# Description
Hey folks 👋 

I made that little PR that should solve the issue #1862 
Actually the `OfferingClass` field is not in the regular attributes of the product but after some investigation I figure it out that it is in the `TermAttributes`


# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
select
attributes ->> 'tenancy' as tenancy,
attributes ->> 'regionCode' as region,
offering_class,
term, unit,
price_per_unit,
purchase_option,
lease_contract_length
from aws_fix.aws_pricing_product where service_code='AmazonEC2' and filters='{"regionCode": "eu-west-1", "tenancy": "Shared", "operatingSystem":"Linux", "operation":"RunInstances", "instanceType": "m5.large"}' :: jsonb and term = 'Reserved'
+---------+-----------+----------------+----------+----------+----------------+-----------------+-----------------------+
| tenancy | region    | offering_class | term     | unit     | price_per_unit | purchase_option | lease_contract_length |
+---------+-----------+----------------+----------+----------+----------------+-----------------+-----------------------+
| Shared  | eu-west-1 | convertible    | Reserved | Hrs      | 0.0000000000   | All Upfront     | 1yr                   |
| Shared  | eu-west-1 | convertible    | Reserved | Hrs      | 0.0860000000   | No Upfront      | 1yr                   |
| Shared  | eu-west-1 | convertible    | Reserved | Quantity | 743            | Partial Upfront | 3yr                   |
| Shared  | eu-west-1 | convertible    | Reserved | Quantity | 1457           | All Upfront     | 3yr                   |
| Shared  | eu-west-1 | standard       | Reserved | Quantity | 562            | Partial Upfront | 3yr                   |
| Shared  | eu-west-1 | convertible    | Reserved | Hrs      | 0.0000000000   | All Upfront     | 3yr                   |
| Shared  | eu-west-1 | standard       | Reserved | Hrs      | 0.0670000000   | No Upfront      | 1yr                   |
| Shared  | eu-west-1 | convertible    | Reserved | Hrs      | 0.0610000000   | No Upfront      | 3yr                   |
| Shared  | eu-west-1 | convertible    | Reserved | Quantity | 360            | Partial Upfront | 1yr                   |
| Shared  | eu-west-1 | standard       | Reserved | Quantity | 551            | All Upfront     | 1yr                   |
| Shared  | eu-west-1 | convertible    | Reserved | Hrs      | 0.0280000000   | Partial Upfront | 3yr                   |
| Shared  | eu-west-1 | convertible    | Reserved | Quantity | 706            | All Upfront     | 1yr                   |
| Shared  | eu-west-1 | standard       | Reserved | Quantity | 281            | Partial Upfront | 1yr                   |
| Shared  | eu-west-1 | standard       | Reserved | Hrs      | 0.0000000000   | All Upfront     | 1yr                   |
| Shared  | eu-west-1 | standard       | Reserved | Hrs      | 0.0210000000   | Partial Upfront | 3yr                   |
| Shared  | eu-west-1 | standard       | Reserved | Hrs      | 0.0460000000   | No Upfront      | 3yr                   |
| Shared  | eu-west-1 | standard       | Reserved | Quantity | 1057           | All Upfront     | 3yr                   |
| Shared  | eu-west-1 | convertible    | Reserved | Hrs      | 0.0410000000   | Partial Upfront | 1yr                   |
| Shared  | eu-west-1 | standard       | Reserved | Hrs      | 0.0000000000   | All Upfront     | 3yr                   |
| Shared  | eu-west-1 | standard       | Reserved | Hrs      | 0.0320000000   | Partial Upfront | 1yr                   |
+---------+-----------+----------------+----------+----------+----------------+-----------------+-----------------------+
```

</details>
