### PR TITLE
Add checks for supported RDS engines

### DIFF
--- a/aws/table_aws_docdb_cluster.go
+++ b/aws/table_aws_docdb_cluster.go
@@ -317,7 +317,10 @@ func getDocDBCluster(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	}
 
 	if op.DBClusters != nil && len(op.DBClusters) > 0 {
-		return op.DBClusters[0], nil
+		cluster := op.DBClusters[0]
+		if *cluster.Engine == "docdb" {
+			return cluster, nil
+		}
 	}
 	return nil, nil
 }

--- a/aws/table_aws_neptune_db_cluster.go
+++ b/aws/table_aws_neptune_db_cluster.go
@@ -335,7 +335,10 @@ func getNeptuneDBCluster(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		return nil, err
 	}
 	if len(data.DBClusters) > 0 {
-		return data.DBClusters[0], nil
+		cluster := data.DBClusters[0]
+		if *cluster.Engine == "neptune" {
+			return cluster, nil
+		}
 	}
 	return nil, nil
 }

--- a/aws/table_aws_rds_db_cluster.go
+++ b/aws/table_aws_rds_db_cluster.go
@@ -9,8 +9,6 @@ import (
 
 	rdsv1 "github.com/aws/aws-sdk-go/service/rds"
 
-	"github.com/turbot/go-kit/helpers"
-
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -397,18 +395,7 @@ func listRDSDBClusters(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 			// The DescribeDBClusters API returns non-RDS DB clusters as well,
 			// but we only want RDS clusters here, even if the 'engine' qual
 			// isn't passed in.
-			// Current supported RDS engine values as of 2022/08/15 are
-			// "aurora", "aurora-mysql", "aurora-postgresql", "mysql", and "postgres".
-			// https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/RDS.html#createDBCluster-property
-			if helpers.StringSliceContains(
-				[]string{
-					"aurora",
-					"aurora-mysql",
-					"aurora-postgresql",
-					"mysql",
-					"postgres",
-				},
-				*items.Engine) {
+			if isSuppportedRDSEngine(*items.Engine) {
 				d.StreamListItem(ctx, items)
 			}
 
@@ -447,15 +434,7 @@ func getRDSDBCluster(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	if op.DBClusters != nil && len(op.DBClusters) > 0 {
 
 		cluster := op.DBClusters[0]
-		if helpers.StringSliceContains(
-			[]string{
-				"aurora",
-				"aurora-mysql",
-				"aurora-postgresql",
-				"mysql",
-				"postgres",
-			},
-			*cluster.Engine) {
+		if isSuppportedRDSEngine(*cluster.Engine) {
 			return cluster, nil
 		}
 	}

--- a/aws/table_aws_rds_db_cluster_snapshot.go
+++ b/aws/table_aws_rds_db_cluster_snapshot.go
@@ -9,7 +9,6 @@ import (
 
 	rdsv1 "github.com/aws/aws-sdk-go/service/rds"
 
-	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -235,15 +234,7 @@ func listRDSDBClusterSnapshots(ctx context.Context, d *plugin.QueryData, _ *plug
 		}
 
 		for _, items := range output.DBClusterSnapshots {
-			if helpers.StringSliceContains(
-				[]string{
-					"aurora",
-					"aurora-mysql",
-					"aurora-postgresql",
-					"mysql",
-					"postgres",
-				},
-				*items.Engine) {
+			if isSuppportedRDSEngine(*items.Engine) {
 				d.StreamListItem(ctx, items)
 			}
 
@@ -281,15 +272,7 @@ func getRDSDBClusterSnapshot(ctx context.Context, d *plugin.QueryData, _ *plugin
 
 	if op.DBClusterSnapshots != nil && len(op.DBClusterSnapshots) > 0 {
 		snapshot := op.DBClusterSnapshots[0]
-		if helpers.StringSliceContains(
-			[]string{
-				"aurora",
-				"aurora-mysql",
-				"aurora-postgresql",
-				"mysql",
-				"postgres",
-			},
-			*snapshot.Engine) {
+		if isSuppportedRDSEngine(*snapshot.Engine) {
 			return snapshot, nil
 		}
 	}

--- a/aws/table_aws_rds_db_instance.go
+++ b/aws/table_aws_rds_db_instance.go
@@ -9,7 +9,6 @@ import (
 
 	rdsv1 "github.com/aws/aws-sdk-go/service/rds"
 
-	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -488,15 +487,7 @@ func listRDSDBInstances(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		}
 
 		for _, items := range output.DBInstances {
-			if helpers.StringSliceContains(
-				[]string{
-					"aurora",
-					"aurora-mysql",
-					"aurora-postgresql",
-					"mysql",
-					"postgres",
-				},
-				*items.Engine) {
+			if isSuppportedRDSEngine(*items.Engine) {
 				d.StreamListItem(ctx, items)
 			}
 
@@ -534,15 +525,7 @@ func getRDSDBInstance(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 
 	if op.DBInstances != nil && len(op.DBInstances) > 0 {
 		instance := op.DBInstances[0]
-		if helpers.StringSliceContains(
-			[]string{
-				"aurora",
-				"aurora-mysql",
-				"aurora-postgresql",
-				"mysql",
-				"postgres",
-			},
-			*instance.Engine) {
+		if isSuppportedRDSEngine(*instance.Engine) {
 			return instance, nil
 		}
 	}

--- a/aws/table_aws_rds_db_snapshot.go
+++ b/aws/table_aws_rds_db_snapshot.go
@@ -9,7 +9,6 @@ import (
 
 	rdsv1 "github.com/aws/aws-sdk-go/service/rds"
 
-	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -270,15 +269,7 @@ func listRDSDBSnapshots(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		}
 
 		for _, items := range output.DBSnapshots {
-			if helpers.StringSliceContains(
-				[]string{
-					"aurora",
-					"aurora-mysql",
-					"aurora-postgresql",
-					"mysql",
-					"postgres",
-				},
-				*items.Engine) {
+			if isSuppportedRDSEngine(*items.Engine) {
 				d.StreamListItem(ctx, items)
 			}
 
@@ -316,15 +307,7 @@ func getRDSDBSnapshot(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrat
 
 	if op.DBSnapshots != nil && len(op.DBSnapshots) > 0 {
 		snapshot := op.DBSnapshots[0]
-		if helpers.StringSliceContains(
-			[]string{
-				"aurora",
-				"aurora-mysql",
-				"aurora-postgresql",
-				"mysql",
-				"postgres",
-			},
-			*snapshot.Engine) {
+		if isSuppportedRDSEngine(*snapshot.Engine) {
 			return snapshot, nil
 		}
 	}

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -13,6 +13,7 @@ import (
 	"unicode/utf8"
 
 	sagemakerTypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
+	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/go-kit/types"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -202,4 +203,31 @@ func isAWSARN(s string) bool {
 
 	// Test if the string matches the ARN pattern
 	return regex.MatchString(s)
+}
+
+// The function ensures that the given engine is is not of type `docdb` or `neptune`
+// You can get the available engines list from - https://docs.aws.amazon.com/cli/latest/reference/rds/describe-db-engine-versions.html
+// Current supported RDS engine values as of 2023/08/07
+func isSuppportedRDSEngine(engine string) bool {
+	supportedEngines := []string{
+		"aurora",
+		"aurora-mysql",
+		"aurora-postgresql",
+		"custom-sqlserver-ee",
+		"custom-sqlserver-se",
+		"custom-sqlserver-web",
+		"mariadb",
+		"mysql",
+		"oracle-ee",
+		"oracle-ee-cdb",
+		"oracle-se2",
+		"oracle-se2-cdb",
+		"postgres",
+		"sqlserver-ee",
+		"sqlserver-ex",
+		"sqlserver-se",
+		"sqlserver-web",
+	}
+
+	return helpers.StringSliceContains(supportedEngines, engine)
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
  arn,
  db_cluster_identifier,
  deletion_protection,
  engine,
  status,
  region
from
  aws_docdb_cluster where db_cluster_identifier = 'docdb-2023-08-08-06-20-43';
+----------------------------------------------------------------------+---------------------------+---------------------+--------+-----------+-----------+
| arn                                                                  | db_cluster_identifier     | deletion_protection | engine | status    | region    |
+----------------------------------------------------------------------+---------------------------+---------------------+--------+-----------+-----------+
| arn:aws:rds:us-east-1:123123123495:cluster:docdb-2023-08-08-06-20-43 | docdb-2023-08-08-06-20-43 | true                | docdb  | available | us-east-1 |
+----------------------------------------------------------------------+---------------------------+---------------------+--------+-----------+-----------+

> select
  arn,
  db_cluster_identifier,
  deletion_protection,
  engine,
  status,
  region 
from 
  aws_neptune_db_cluster where db_cluster_identifier = 'database-1'
+-------------------------------------------------------+-----------------------+---------------------+---------+-----------+-----------+
| arn                                                   | db_cluster_identifier | deletion_protection | engine  | status    | region    |
+-------------------------------------------------------+-----------------------+---------------------+---------+-----------+-----------+
| arn:aws:rds:us-east-1:123123123495:cluster:database-1 | database-1            | false               | neptune | available | us-east-1 |
+-------------------------------------------------------+-----------------------+---------------------+---------+-----------+-----------+

> select
  db_instance_identifier,
  class,
  engine,
  engine_version,
  publicly_accessible
from
  aws_rds_db_instance
+------------------------+-------------+-----------+------------------------------------+---------------------+
| db_instance_identifier | class       | engine    | engine_version                     | publicly_accessible |
+------------------------+-------------+-----------+------------------------------------+---------------------+
| database-1             | db.t3.small | oracle-ee | 19.0.0.0.ru-2023-04.rur-2023-04.r1 | false               |
+------------------------+-------------+-----------+------------------------------------+---------------------+
| database-2             | db.t2.micro | mariadb   | 10.6.14                            | false               |
+------------------------+-------------+-----------+------------------------------------+---------------------+
```
</details>
