### PR TITLE
nlbs do not use sec groups

### DIFF
--- a/docs/tables/aws_ec2_network_load_balancer.md
+++ b/docs/tables/aws_ec2_network_load_balancer.md
@@ -4,17 +4,6 @@ AWS Network Load Balancer (NLB) distributes end user traffic across multiple clo
 
 ## Examples
 
-### Security group attached to the network load balancer
-
-```sql
-select
-  name,
-  jsonb_array_elements(security_groups) as attached_security_group
-from
-  aws_ec2_network_load_balancer;
-```
-
-
 ### Count of AZs registered with network load balancers
 
 ```sql


### PR DESCRIPTION

Documentation update, AWS NLBs do not use security group attachments

