### PR TITLE
feat: add `aws_cognito_identity_pool` table

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -118,6 +118,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_codedeploy_deployment_config":                             tableAwsCodeDeployDeploymentConfig(ctx),
 			"aws_codedeploy_deployment_group":                              tableAwsCodeDeployDeploymentGroup(ctx),
 			"aws_codepipeline_pipeline":                                    tableAwsCodepipelinePipeline(ctx),
+			"aws_cognito_identity_pool":                                    tableAwsCognitoIdentityPool(ctx),
 			"aws_cognito_identity_provider":                                tableAwsCognitoIdentityProvider(ctx),
 			"aws_cognito_user_pool":                                        tableAwsCognitoUserPool(ctx),
 			"aws_config_aggregate_authorization":                           tableAwsConfigAggregateAuthorization(ctx),

--- a/aws/service.go
+++ b/aws/service.go
@@ -39,6 +39,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/codecommit"
 	"github.com/aws/aws-sdk-go-v2/service/codedeploy"
 	"github.com/aws/aws-sdk-go-v2/service/codepipeline"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity"
 	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
 	"github.com/aws/aws-sdk-go-v2/service/configservice"
 	"github.com/aws/aws-sdk-go-v2/service/costexplorer"
@@ -136,6 +137,7 @@ import (
 	codebuildEndpoint "github.com/aws/aws-sdk-go/service/codebuild"
 	codecommitEndpoint "github.com/aws/aws-sdk-go/service/codecommit"
 	codepipelineEndpoint "github.com/aws/aws-sdk-go/service/codepipeline"
+	cognitoidentityEndpoint "github.com/aws/aws-sdk-go/service/cognitoidentity"
 	cognitoidentityproviderEndpoint "github.com/aws/aws-sdk-go/service/cognitoidentityprovider"
 	daxEndpoint "github.com/aws/aws-sdk-go/service/dax"
 	directoryserviceEndpoint "github.com/aws/aws-sdk-go/service/directoryservice"
@@ -456,6 +458,17 @@ func CodePipelineClient(ctx context.Context, d *plugin.QueryData) (*codepipeline
 		return nil, nil
 	}
 	return codepipeline.NewFromConfig(*cfg), nil
+}
+
+func CognitoIdentityClient(ctx context.Context, d *plugin.QueryData) (*cognitoidentity.Client, error) {
+	cfg, err := getClientForQuerySupportedRegion(ctx, d, cognitoidentityEndpoint.EndpointsID)
+	if err != nil {
+		return nil, err
+	}
+	if cfg == nil {
+		return nil, nil
+	}
+	return cognitoidentity.NewFromConfig(*cfg), nil
 }
 
 func CognitoIdentityProviderClient(ctx context.Context, d *plugin.QueryData) (*cognitoidentityprovider.Client, error) {

--- a/aws/table_aws_cognito_identity_pool.go
+++ b/aws/table_aws_cognito_identity_pool.go
@@ -1,0 +1,213 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentity/types"
+
+	cognitoidentityv1 "github.com/aws/aws-sdk-go/service/cognitoidentity"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableAwsCognitoIdentityPool(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_cognito_identity_pool",
+		Description: "AWS Cognito Identity Pool",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("identity_pool_id"),
+			Hydrate:    getCognitoIdentityPool,
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listCognitoIdentityPools,
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(cognitoidentityv1.EndpointsID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "identity_pool_id",
+				Description: "An identity pool ID in the format REGION:GUID.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "allow_unauthenticated_identities",
+				Description: "TRUE if the identity pool supports unauthenticated logins.",
+				Hydrate:     getCognitoIdentityPool,
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "identity_pool_name",
+				Description: "A string that you provide.",
+				Hydrate:     getCognitoIdentityPool,
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "allow_classic_flow",
+				Description: "Enables or disables the Basic (Classic) authentication flow.",
+				Hydrate:     getCognitoIdentityPool,
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "cognito_identity_providers",
+				Description: "A list representing an Amazon Cognito user pool and its client ID.",
+				Hydrate:     getCognitoIdentityPool,
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "developer_provider_name",
+				Description: "The 'domain' by which Cognito will refer to your users.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "open_id_connect_provider_arns",
+				Description: "The ARNs of the OpenID Connect providers.",
+				Hydrate:     getCognitoIdentityPool,
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "saml_provider_arns",
+				Description: "An array of Amazon Resource Names (ARNs) of the SAML provider for your identity pool.",
+				Hydrate:     getCognitoIdentityPool,
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "supported_login_providers",
+				Description: "Optional key:value pairs mapping provider names to provider app IDs.",
+				Hydrate:     getCognitoIdentityPool,
+				Type:        proto.ColumnType_JSON,
+			},
+			// Steampipe standard columns
+			{
+				Name:        "akas",
+				Description: resourceInterfaceDescription("akas"),
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getCognitoIdentityPool,
+				Transform:   transform.FromField("Arn").Transform(transform.EnsureStringArray),
+			},
+			{
+				Name:        "tags",
+				Description: resourceInterfaceDescription("tags"),
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getCognitoIdentityPool,
+				Transform:   transform.FromField("IdentityPoolTags"),
+			},
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listCognitoIdentityPools(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	// Create session
+	svc, err := CognitoIdentityClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_cognito_identity_pool.listCognitoIdentityPools", "connection_error", err)
+		return nil, err
+	}
+
+	if svc == nil {
+		// Unsupported region check
+		plugin.Logger(ctx).Debug("aws_cognito_identity_pool.listCognitoIdentityPools", "unsupported_region")
+		return nil, nil
+	}
+
+	// Reduce the basic request limit down if the identity has only requested a small number of rows
+	maxLimit := int32(60)
+	limit := d.QueryContext.Limit
+	if d.QueryContext.Limit != nil {
+		if *limit < int64(maxLimit) {
+			if *limit < 1 {
+				maxLimit = 1
+			} else {
+				maxLimit = int32(*limit)
+			}
+		}
+	}
+	input := &cognitoidentity.ListIdentityPoolsInput{
+		MaxResults: maxLimit,
+	}
+	// List call
+	paginator := cognitoidentity.NewListIdentityPoolsPaginator(svc, input, func(o *cognitoidentity.ListIdentityPoolsPaginatorOptions) {
+		o.Limit = maxLimit
+		o.StopOnDuplicateToken = true
+	})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_cognito_identity_pool.listCognitoIdentityPools", "api_error", err)
+			return nil, err
+		}
+		plugin.Logger(ctx).Debug("aws_cognito_identity_pool.listCognitoIdentityPools", "identity_pools", fmt.Sprintf("%#v", output.IdentityPools))
+
+		for _, identityPool := range output.IdentityPools {
+			plugin.Logger(ctx).Debug("aws_cognito_identity_pool.listCognitoIdentityPools", "identity_pool", fmt.Sprintf("%#v", identityPool))
+			d.StreamListItem(ctx, identityPool)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getCognitoIdentityPool(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var identityPoolId string
+	if h.Item != nil {
+		data := h.Item.(types.IdentityPoolShortDescription)
+		if data.IdentityPoolId != nil {
+			identityPoolId = *data.IdentityPoolId
+		}
+	} else {
+		identityPoolId = d.EqualsQualString("identity_pool_id")
+	}
+	plugin.Logger(ctx).Debug("aws_cognito_identity_pool.getCognitoIdentityPool", "identity_pool_id", identityPoolId)
+
+	// check if id is empty
+	if identityPoolId == "" {
+		return nil, nil
+	}
+
+	// Create Session
+	svc, err := CognitoIdentityClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_cognito_identity_pool.getCognitoIdentityPool", "connection_error", err)
+		return nil, err
+	}
+
+	if svc == nil {
+		// Unsupported region check
+		return nil, nil
+	}
+
+	// Build the params
+	params := &cognitoidentity.DescribeIdentityPoolInput{
+		IdentityPoolId: aws.String(identityPoolId),
+	}
+
+	// Get call
+	data, err := svc.DescribeIdentityPool(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_cognito_identity_pool.getCognitoIdentityPool", "api_error", err)
+		return nil, err
+	}
+	plugin.Logger(ctx).Debug("aws_cognito_identity_pool.getCognitoIdentityPool", "identity_pool", fmt.Sprintf("%#v", *data))
+	return *data, nil
+}

--- a/aws/table_aws_cognito_identity_pool.go
+++ b/aws/table_aws_cognito_identity_pool.go
@@ -101,7 +101,7 @@ func tableAwsCognitoIdentityPool(_ context.Context) *plugin.Table {
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Name"),
+				Transform:   transform.FromField("identity_pool_name"),
 			},
 		}),
 	}

--- a/aws/table_aws_cognito_identity_pool.go
+++ b/aws/table_aws_cognito_identity_pool.go
@@ -62,6 +62,7 @@ func tableAwsCognitoIdentityPool(_ context.Context) *plugin.Table {
 			{
 				Name:        "developer_provider_name",
 				Description: "The 'domain' by which Cognito will refer to your users.",
+				Hydrate:     getCognitoIdentityPool,
 				Type:        proto.ColumnType_STRING,
 			},
 			{

--- a/aws/table_aws_cognito_identity_provider.go
+++ b/aws/table_aws_cognito_identity_provider.go
@@ -245,7 +245,7 @@ func getCognitoIdentityProviderTurbotAkas(ctx context.Context, d *plugin.QueryDa
 	commonColumnData := c.(*awsCommonColumnData)
 
 	// Get data for turbot defined properties
-	//arn:aws:cognito-idp::<account-id>:userpool/<id>/provider/<name>
+	//arn:aws:cognito-idp:<region>:<account-id>:userpool/<id>/provider/<name>
 	arn := "arn:" + commonColumnData.Partition + ":cognito-idp:" + region + ":" + commonColumnData.AccountId + ":userpool/" + userPoolId + "/provider/" + *data.ProviderName
 
 	return []string{arn}, nil

--- a/docs/tables/aws_cognito_identity_pool.md
+++ b/docs/tables/aws_cognito_identity_pool.md
@@ -1,0 +1,31 @@
+# Table: aws_cognito_identity_pool
+
+An Amazon Cognito identity pool is a store of user identity information that is specific to your AWS account.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  identity_pool_id,
+  identity_pool_name,
+  tags,
+  region,
+  account_id
+from
+  aws_cognito_identity_pool;
+```
+
+### List identity pools with classic flow enabled
+
+```sql
+select
+  identity_pool_id,
+  identity_pool_name,
+  allow_classic_flow
+from
+  aws_cognito_identity_pool
+where
+  allow_classic_flow = true;
+```

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/codecommit v1.14.0
 	github.com/aws/aws-sdk-go-v2/service/codedeploy v1.16.1
 	github.com/aws/aws-sdk-go-v2/service/codepipeline v1.14.0
+	github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.15.14
 	github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/configservice v1.29.1
 	github.com/aws/aws-sdk-go-v2/service/costexplorer v1.25.0
@@ -116,7 +117,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.24.2
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.20.1
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.28.0
-	github.com/aws/smithy-go v1.13.5
+	github.com/aws/smithy-go v1.14.1
 	github.com/gocarina/gocsv v0.0.0-20201208093247-67c824bc04d4
 	github.com/golang/protobuf v1.5.2
 	github.com/turbot/go-kit v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/aws/aws-sdk-go-v2/service/codedeploy v1.16.1 h1:IfpSUYyAAnf1bIiQXdaEI
 github.com/aws/aws-sdk-go-v2/service/codedeploy v1.16.1/go.mod h1:a6V2kjEeGO21QyOLbNDcHq4PaASn4K+kKbJ0WI+MgbE=
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.14.0 h1:vuUng/+gXtRZ0LhMpgPy1D/yOcIo58hCQuukZhLFIEI=
 github.com/aws/aws-sdk-go-v2/service/codepipeline v1.14.0/go.mod h1:CZzLW6TnEwqFDs9BcgSVB7lbUe4KGuspzmMHGAwBTow=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.15.14 h1:xvHxtLFQXzpb84cadYdZs7D7yqJeKGdvWvEqc/UeiHA=
+github.com/aws/aws-sdk-go-v2/service/cognitoidentity v1.15.14/go.mod h1:K/70M7G9PybGy0HExz/ICmaKuCd2fea7+8Jw+5ugde4=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.23.0 h1:duuTZRVQHwQZsH4TnK2q3Gr/y2S2zqil0Itkg69QvHQ=
 github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider v1.23.0/go.mod h1:1ObmNic2RK0BZg20466bTpGNXjauAlNsX+0px/DSlDU=
 github.com/aws/aws-sdk-go-v2/service/configservice v1.29.1 h1:xUaQ7NhFtJ5q7Iq6R0r1njb+Rq+vpwYWb3VDMaFKKjs=
@@ -471,8 +473,9 @@ github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.20.1 h1:8ID/qag72lWZQ5yT
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.20.1/go.mod h1:Hb9paYQ+u2HHObVp/jp4BWlgnsf2FORBwm8+MRU29e4=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.28.0 h1:sjfoG4ahd0yE77sKiBokTlZHd9pk1k+vPGNJo6ct2QQ=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.28.0/go.mod h1:oudvE1/KOdqMDrq9PG1QjLpvQb8S5R3y2Fci+Vuc6To=
-github.com/aws/smithy-go v1.13.5 h1:hgz0X/DX0dGqTYpGALqXJoRKRj5oQ7150i5FdTePzO8=
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aws/smithy-go v1.14.1 h1:EFKMUmH/iHMqLiwoEDx2rRjRQpI1YCn5jTysoaDujFs=
+github.com/aws/smithy-go v1.14.1/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=


### PR DESCRIPTION
This PR adds the `aws_cognito_identity_pool` table.

~Marked as draft as it is based on the branch of #1854, will rebase on `main` once that one is merged.~

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
  identity_pool_id,
  identity_pool_name,
  tags,
  region,
  account_id
from
  aws_cognito_identity_pool;
+------------------------------------------------+---------------------------+------+-----------+--------------+
| identity_pool_id                               | identity_pool_name        | tags | region    | account_id   |
+------------------------------------------------+---------------------------+------+-----------+--------------+
| eu-west-3:e96205bf-1ef2-4fe6-a748-65e948673960 | test-pdecat-identity-pool | {}   | eu-west-3 | 012345678901 |
+------------------------------------------------+---------------------------+------+-----------+--------------+

> select
  identity_pool_id,
  identity_pool_name,
  allow_classic_flow
from
  aws_cognito_identity_pool
where
  allow_classic_flow = true;
+------------------------------------------------+---------------------------+--------------------+
| identity_pool_id                               | identity_pool_name        | allow_classic_flow |
+------------------------------------------------+---------------------------+--------------------+
| eu-west-3:e96205bf-1ef2-4fe6-a748-65e948673960 | test-pdecat-identity-pool | true               |
+------------------------------------------------+---------------------------+--------------------+
```
</details>
