### PR TITLE
added example for query instance with their subnet information

### DIFF
--- a/docs/tables/aws_ec2_instance.md
+++ b/docs/tables/aws_ec2_instance.md
@@ -195,3 +195,18 @@ select
 from
   aws_ec2_instance;
 ```
+
+### Get instance with their subnet information
+
+```sql
+select 
+  i.instance_id, 
+  i.vpc_id, 
+  i.subnet_id, 
+  s.tags ->> 'Name' 
+from 
+  aws_ec2_instance as i, 
+  aws_vpc_subnet as s 
+where 
+  i.subnet_id = s.subnet_id;
+```

--- a/docs/tables/aws_ec2_instance.md
+++ b/docs/tables/aws_ec2_instance.md
@@ -203,7 +203,7 @@ select
   i.instance_id, 
   i.vpc_id, 
   i.subnet_id, 
-  s.tags ->> 'Name' 
+  s.tags ->> 'Name' as name
 from 
   aws_ec2_instance as i, 
   aws_vpc_subnet as s 

--- a/docs/tables/aws_ec2_instance.md
+++ b/docs/tables/aws_ec2_instance.md
@@ -203,7 +203,7 @@ select
   i.instance_id, 
   i.vpc_id, 
   i.subnet_id, 
-  s.tags ->> 'Name' as name
+  s.tags ->> 'Name' as subnet_name
 from 
   aws_ec2_instance as i, 
   aws_vpc_subnet as s 

--- a/docs/tables/aws_ec2_instance.md
+++ b/docs/tables/aws_ec2_instance.md
@@ -196,7 +196,7 @@ from
   aws_ec2_instance;
 ```
 
-### Get instance with their subnet information
+### Get subnet details for each instance
 
 ```sql
 select 


### PR DESCRIPTION
Hi, In this PR i have added example to query aws ec2 instance with their subnet information.
### Issue This PR fix #1555 
Example i added

### Get instance with their subnet information

```sql
select 
  i.instance_id, 
  i.vpc_id, 
  i.subnet_id, 
  s.tags ->> 'Name'  as subnet_name
from 
  aws_ec2_instance as i, 
  aws_vpc_subnet as s 
where 
  i.subnet_id = s.subnet_id;
```