### PR TITLE
Add table `aws_workspaces_directory`. Closes #1819

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -494,6 +494,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_wellarchitected_workload":                                 tableAwsWellArchitectedWorkload(ctx),
 			"aws_wellarchitected_workload_share":                           tableAwsWellArchitectedWorkloadShare(ctx),
 			"aws_workspaces_workspace":                                     tableAwsWorkspace(ctx),
+			"aws_workspaces_directory":                                     tableAwsWorkspacesDirectory(ctx),
 		},
 	}
 

--- a/aws/table_aws_workspaces_directory.go
+++ b/aws/table_aws_workspaces_directory.go
@@ -1,0 +1,324 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/workspaces"
+	"github.com/aws/aws-sdk-go-v2/service/workspaces/types"
+
+	workspacesv1 "github.com/aws/aws-sdk-go/service/workspaces"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableAwsWorkspacesDirectory(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_workspaces_directory",
+		Description: "AWS Workspaces Directory",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("directory_id"),
+			IgnoreConfig: &plugin.IgnoreConfig{
+				 ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ValidationException"}),
+			},
+			Hydrate: getWorkspacesDirectory,
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listWorkspacesDirectories,
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(workspacesv1.EndpointsID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "directory_id",
+				Description: "The directory identifier.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "name",
+				Description: "The name of the directory.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DirectoryName"),
+			},
+			{
+				Name:        "arn",
+				Description: "The arn of the directory.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getWorkspaceDirectoryArn,
+				Transform:   transform.FromValue(),
+			},
+			{
+				Name:        "alias",
+				Description: "The directory alias.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "certificate_based_auth_properties",
+				Description: "The certificate-based authentication properties used to authenticate SAML 2.0 Identity Provider (IdP) user identities to Active Directory for WorkSpaces login.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "customer_user_name",
+				Description: "The user name for the service account.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "directory_type",
+				Description: "The directory type.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "dns_ip_addresses",
+				Description: "The IP addresses of the DNS servers for the directory.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "iam_role_id",
+				Description: "The identifier of the IAM role. This is the role that allows Amazon WorkSpaces to make calls to other services, such as Amazon EC2, on your behalf.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "ip_group_ids",
+				Description: "The identifiers of the IP access control groups associated with the directory.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "registration_code",
+				Description: "The registration code for the directory. This is the code that users enter in their Amazon WorkSpaces client application to connect to the directory.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "saml_properties",
+				Description: "Describes the enablement status, user access URL, and relay state parameter name that are used for configuring federation with an SAML 2.0 identity provider.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "selfservice_permissions",
+				Description: "The default self-service permissions for WorkSpaces in the directory.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "state",
+				Description: "The state of the directory's registration with Amazon WorkSpaces.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "subnet_ids",
+				Description: "The identifiers of the subnets used with the directory.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "tenancy",
+				Description: "Specifies whether the directory is dedicated or shared.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "workspace_access_properties",
+				Description: "The devices and operating systems that users can use to access WorkSpaces.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "workspace_creation_properties",
+				Description: "The default creation properties for all WorkSpaces in the directory.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "workspace_security_group_id",
+				Description: "The identifier of the security group that is assigned to new WorkSpaces.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("WorkspaceSecurityGroupId"),
+			},
+			{
+				Name:        "tags_src",
+				Description: "The list of tags for the directory.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     listWorkspacesDirectoriesTags,
+				Transform:   transform.FromValue(),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DirectoryName"),
+			},
+			{
+				Name:        "tags",
+				Description: resourceInterfaceDescription("tags"),
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     listWorkspacesDirectoriesTags,
+				Transform:   transform.From(workspaceDirectoryTurbotTags),
+			},
+			{
+				Name:        "akas",
+				Description: resourceInterfaceDescription("akas"),
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getWorkspaceDirectoryArn,
+				Transform:   transform.FromValue().Transform(transform.EnsureStringArray),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listWorkspacesDirectories(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+
+	// Create Session
+	svc, err := WorkspacesClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_workspaces_directory.listWorkspacesDirectories", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	// Limiting the results
+	maxLimit := int32(25)
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxLimit {
+			if limit < 1 {
+				maxLimit = 1
+			} else {
+				maxLimit = limit
+			}
+		}
+	}
+
+	input := &workspaces.DescribeWorkspaceDirectoriesInput{
+		Limit: aws.Int32(maxLimit),
+	}
+
+	paginator := workspaces.NewDescribeWorkspaceDirectoriesPaginator(svc, input, func(o *workspaces.DescribeWorkspaceDirectoriesPaginatorOptions) {
+		o.StopOnDuplicateToken = true
+	})
+
+	// List call
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_workspaces_directory.listWorkspacesDirectories", "api_error", err)
+			return nil, err
+		}
+
+		for _, items := range output.Directories {
+			d.StreamListItem(ctx, items)
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getWorkspacesDirectory(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	DirectoryId := d.EqualsQualString("directory_id")
+
+	// check if workspace id is empty
+	if DirectoryId == "" {
+		return nil, nil
+	}
+
+	// Create Session
+	svc, err := WorkspacesClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_workspaces_directory.getWorkspacesDirectory", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	// Build the params
+	params := &workspaces.DescribeWorkspaceDirectoriesInput{
+		DirectoryIds: []string{DirectoryId},
+	}
+
+	// Get call
+	data, err := svc.DescribeWorkspaceDirectories(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_workspaces_directory.getWorkspacesDirectory", "api_error", err)
+		return nil, err
+	}
+
+	if len(data.Directories) > 0 {
+		return data.Directories[0], nil
+	}
+
+	return nil, nil
+}
+
+func listWorkspacesDirectoriesTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	DirectoryId := h.Item.(types.WorkspaceDirectory).DirectoryId
+
+	// Create Session
+	svc, err := WorkspacesClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_workspaces_directory.listWorkspacesDirectoriesTags", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	// Build the params
+	params := &workspaces.DescribeTagsInput{
+		ResourceId: DirectoryId,
+	}
+
+	tags, err := svc.DescribeTags(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_workspaces_directory.listWorkspacesDirectoriesTags", "api_error", err)
+		return nil, err
+	}
+
+	return tags, nil
+}
+
+// https://docs.aws.amazon.com/workspaces/latest/adminguide/workspaces-access-control.html
+func getWorkspaceDirectoryArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	plugin.Logger(ctx).Trace("getDirectoryArn")
+	region := d.EqualsQualString(matrixKeyRegion)
+	DirectoryId := h.Item.(types.WorkspaceDirectory).DirectoryId
+
+	commonData, err := getCommonColumns(ctx, d, h)
+	if err != nil {
+		return nil, err
+	}
+
+	commonColumnData := commonData.(*awsCommonColumnData)
+	arn := "arn:" + commonColumnData.Partition + ":workspaces:" + region + ":" + commonColumnData.AccountId + ":directory/" + *DirectoryId
+
+	return arn, nil
+}
+
+//// TRANSFORM FUNCTION
+
+// Transform function for workspaces resources tags
+func workspaceDirectoryTurbotTags(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	tags := d.HydrateItem.(*workspaces.DescribeTagsOutput)
+
+	if tags.TagList != nil {
+		turbotTagsMap := map[string]string{}
+		for _, i := range tags.TagList {
+			turbotTagsMap[*i.Key] = *i.Value
+		}
+		return turbotTagsMap, nil
+	}
+
+	return nil, nil
+}

--- a/aws/table_aws_workspaces_directory.go
+++ b/aws/table_aws_workspaces_directory.go
@@ -23,7 +23,7 @@ func tableAwsWorkspacesDirectory(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("directory_id"),
 			IgnoreConfig: &plugin.IgnoreConfig{
-				 ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ValidationException"}),
+				 ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ValidationException", "InvalidParameterValuesException"}),
 			},
 			Hydrate: getWorkspacesDirectory,
 		},
@@ -184,11 +184,7 @@ func listWorkspacesDirectories(ctx context.Context, d *plugin.QueryData, h *plug
 	if d.QueryContext.Limit != nil {
 		limit := int32(*d.QueryContext.Limit)
 		if limit < maxLimit {
-			if limit < 1 {
-				maxLimit = 1
-			} else {
 				maxLimit = limit
-			}
 		}
 	}
 
@@ -291,7 +287,7 @@ func listWorkspacesDirectoriesTags(ctx context.Context, d *plugin.QueryData, h *
 
 // https://docs.aws.amazon.com/workspaces/latest/adminguide/workspaces-access-control.html
 func getWorkspaceDirectoryArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	plugin.Logger(ctx).Trace("getDirectoryArn")
+	plugin.Logger(ctx).Debug("getDirectoryArn")
 	region := d.EqualsQualString(matrixKeyRegion)
 	DirectoryId := h.Item.(types.WorkspaceDirectory).DirectoryId
 
@@ -301,6 +297,7 @@ func getWorkspaceDirectoryArn(ctx context.Context, d *plugin.QueryData, h *plugi
 	}
 
 	commonColumnData := commonData.(*awsCommonColumnData)
+	// The format used in arn can be taken reference from (https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonworkspaces.html#amazonworkspaces-resources-for-iam-policies)
 	arn := "arn:" + commonColumnData.Partition + ":workspaces:" + region + ":" + commonColumnData.AccountId + ":directory/" + *DirectoryId
 
 	return arn, nil

--- a/docs/tables/aws_workspaces_directory.md
+++ b/docs/tables/aws_workspaces_directory.md
@@ -1,0 +1,145 @@
+# Table: aws_workspaces_directory
+
+Amazon WorkSpaces Directory refers to the service that manages user identities and access control for Amazon WorkSpaces. Amazon WorkSpaces is a cloud-based desktop computing service that allows users to access virtual desktops from anywhere, on any device. The directory in Amazon WorkSpaces serves as the central source for user authentication and management. It can be thought of as the repository of user accounts and permissions that control who can access and use WorkSpaces instances.
+
+## Examples
+
+## Basic info
+
+```sql
+select
+  name,
+  directory_id,
+  arn,
+  alias,
+  customer_user_name,
+  directory_type,
+  state
+from
+  aws_workspaces_directory;
+```
+
+### List directories that have certificate authority arn enabled
+
+```sql
+select
+  name,
+  directory_id,
+  arn,
+  alias,
+  customer_user_name,
+  directory_type,
+  state
+from
+  aws_workspaces_directory
+where
+  certificate_based_auth_properties ->> 'Status' = 'ENABLED';
+```
+
+### List directories that are of a particular type
+
+```sql
+select
+  name,
+  directory_id,
+  arn,
+  alias,
+  customer_user_name,
+  directory_type,
+  state
+from
+  aws_workspaces_directory
+where
+  directory_type = 'SIMPLE_AD';
+```
+
+### Get the SAML properties of a particular directory
+
+```sql
+select
+  name,
+  directory_id,
+  arn,
+  saml_properties ->> 'RelayStateParameterName' as saml_relay_state_parameter_name,
+  saml_properties ->> 'Status' as saml_status,
+  saml_properties ->> 'UserAccessUrl' as saml_user_access_url
+from
+  aws_workspaces_directory
+where
+  directory_id = 'd-96676995ea';
+```
+
+### List the directories that have Switch Running Mode enabled
+
+```sql
+select
+  name,
+  directory_id,
+  arn,
+  alias,
+  customer_user_name,
+  directory_type,
+  state,
+  selfservice_permissions ->> 'SwitchRunningMode' as switch_running_mode
+from
+  aws_workspaces_directory
+where
+  selfservice_permissions ->> 'SwitchRunningMode' = 'ENABLED';
+```
+
+### Get the workspace creation properties of a particular directory
+
+```sql
+select
+  name,
+  directory_id,
+  arn,
+  workspace_creation_properties ->> 'CustomSecurityGroupId' as custom_security_group_id,
+  workspace_creation_properties ->> 'DefaultOu' as default_ou,
+  workspace_creation_properties ->> 'EnableInternetAccess' as enable_internet_access,
+  workspace_creation_properties ->> 'EnableMaintenanceMode' as enable_maintenance_mode,
+  workspace_creation_properties ->> 'EnableWorkDocs' as enable_work_docs,
+  workspace_creation_properties ->> 'UserEnabledAsLocalAdministrator' as user_enabled_as_local_administrator
+from
+  aws_workspaces_directory
+where
+  directory_id = 'd-96676995ea';
+```
+
+### List all registered directories
+
+```sql
+select
+  name,
+  directory_id,
+  arn,
+  alias,
+  customer_user_name,
+  directory_type,
+  state
+from
+  aws_workspaces_directory
+where
+  state = 'REGISTERED';
+```
+
+### Get the workspace access properties of a particular directory
+
+```sql
+select
+  name,
+  directory_id,
+  arn,
+  workspace_access_properties ->> 'DeviceTypeAndroid' as device_type_android,
+  workspace_access_properties ->> 'DeviceTypeChromeOs' as device_type_chrome_os,
+  workspace_access_properties ->> 'DeviceTypeIos' as device_type_ios,
+  workspace_access_properties ->> 'DeviceTypeLinux' as device_type_linux,
+  workspace_access_properties ->> 'DeviceTypeOsx' as device_type_osx,
+  workspace_access_properties ->> 'DeviceTypeWeb' as device_type_web,
+  workspace_access_properties ->> 'DeviceTypeWindows' as device_type_windows,
+  workspace_access_properties ->> 'DeviceTypeZeroClient' as device_type_zero_client
+from
+  aws_workspaces_directory
+where
+  directory_id = 'd-96676995ea';
+```

--- a/docs/tables/aws_workspaces_directory.md
+++ b/docs/tables/aws_workspaces_directory.md
@@ -19,7 +19,7 @@ from
   aws_workspaces_directory;
 ```
 
-### List directories that have certificate authority arn enabled
+### List directories that have certificate authority ARN enabled
 
 ```sql
 select
@@ -36,7 +36,7 @@ where
   certificate_based_auth_properties ->> 'Status' = 'ENABLED';
 ```
 
-### List directories that are of a particular type
+### List directories of a particular type
 
 ```sql
 select


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```sql
select
  name,
  directory_id,
  arn,
  alias,
  customer_user_name,
  directory_type,
  state
from
  aws_workspaces_directory;
+------------+--------------+-----------------------------------------------------------------------+----------+--------------------+----------------+------------+
| name       | directory_id | arn                                                                   | alias    | customer_user_name | directory_type | state      |
+------------+--------------+-----------------------------------------------------------------------+----------+--------------------+----------------+------------+
| turbot.com | d-9667699578 | arn:aws:workspaces:ap-southeast-1:111111111111:directory/d-9667699578 | turbot   | Administrator      | SIMPLE_AD      | REGISTERED |
| turbot.com | d-96676995ea | arn:aws:workspaces:ap-southeast-1:111111111111:directory/d-96676995ea | turbottt | Administrator      | SIMPLE_AD      | REGISTERED |
+------------+--------------+-----------------------------------------------------------------------+----------+--------------------+----------------+------------+
```

```sql
select
  name,
  directory_id,
  arn,
  alias,
  customer_user_name,
  directory_type,
  state
from
  aws_workspaces_directory 
where 
  directory_id = 'd-96676995ea';
+------------+--------------+-----------------------------------------------------------------------+----------+--------------------+----------------+------------+
| name       | directory_id | arn                                                                   | alias    | customer_user_name | directory_type | state      |
+------------+--------------+-----------------------------------------------------------------------+----------+--------------------+----------------+------------+
| turbot.com | d-96676995ea | arn:aws:workspaces:ap-southeast-1:111111111111:directory/d-96676995ea | turbottt | Administrator      | SIMPLE_AD      | REGISTERED |
+------------+--------------+-----------------------------------------------------------------------+----------+--------------------+----------------+------------+
```
</details>
