### PR TITLE
Fix the type of `sms_configuration_failure` in `aws_cognito_user_pool`. Closes #1888

### DIFF
--- a/aws/table_aws_cognito_user_pool.go
+++ b/aws/table_aws_cognito_user_pool.go
@@ -155,7 +155,7 @@ func tableAwsCognitoUserPool(_ context.Context) *plugin.Table {
 				Name:        "sms_configuration_failure",
 				Description: "The reason why the SMS configuration can't send the messages to your users.",
 				Hydrate:     getCognitoUserPool,
-				Type:        proto.ColumnType_JSON,
+				Type:        proto.ColumnType_STRING,
 			},
 			{
 				Name:        "status",


### PR DESCRIPTION
From `json` to `string`.
The [official documentation](https://docs.aws.amazon.com/cognito-user-identity-pools/latest/APIReference/API_DescribeUserPool.html) confirms this as well.

# Example query results
<details>
  <summary>Results</summary>

```
> select sms_configuration_failure from aws.aws_cognito_user_pool;
+---------------------------+
| sms_configuration_failure |
+---------------------------+
| <null>                    |
| <null>                    |
| <null>                    |
| SNSSandbox                |
| SNSSandbox                |
+---------------------------+
```
</details>
