### PR TITLE
Fix capacity_reservation_specification column of aws_ec2_instance table to be of JSON type closes #1894

### DIFF
--- a/aws/table_aws_ec2_instance.go
+++ b/aws/table_aws_ec2_instance.go
@@ -116,7 +116,7 @@ func tableAwsEc2Instance(_ context.Context) *plugin.Table {
 			{
 				Name:        "capacity_reservation_specification",
 				Description: "Information about the Capacity Reservation targeting option.",
-				Type:        proto.ColumnType_STRING,
+				Type:        proto.ColumnType_JSON,
 			},
 			{
 				Name:        "client_token",


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```sql
> select instance_id, arn, capacity_reservation_specification from aws_ec2_instance
[
 {
  "arn": "arn:aws:ec2:us-east-1:111111111111:instance/i-061073b2b90b8a7da",
  "capacity_reservation_specification": {
   "CapacityReservationPreference": "",
   "CapacityReservationTarget": {
    "CapacityReservationId": "cr-022bb8c139a39f1d2",
    "CapacityReservationResourceGroupArn": null
   }
  },
  "instance_id": "i-061073b2b90b8a7da"
 }
]
> 

```
</details>
