### PR TITLE
Fixed the table aws_dynamodb_backup returns error BackupNotFoundException closes #1913

### DIFF
--- a/aws/table_aws_dynamodb_backup.go
+++ b/aws/table_aws_dynamodb_backup.go
@@ -21,7 +21,7 @@ func tableAwsDynamoDBBackup(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("arn"),
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ValidationException"}),
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ValidationException", "BackupNotFoundException"}),
 			},
 			Hydrate: getDynamodbBackup,
 		},


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_aab.aws_dynamodb_backup where arn = 'arn:aws:dynamodb:us-east-1:123457632432:table/table-delete/backup/01678793340962-cc4bfb86'
+---------------------------------------+-------------------------------------------------------------------------------------------+--------------+------------------------------------------------------->
| name                                  | arn                                                                                       | table_name   | table_arn                                             >
+---------------------------------------+-------------------------------------------------------------------------------------------+--------------+------------------------------------------------------->
| table-delete_2023-03-14T11.29.00.852Z | arn:aws:dynamodb:us-east-1:123457632432:table/table-delete/backup/01678793340962-cc4bfb86 | table-delete | arn:aws:dynamodb:us-east-1:123457632432:table/table-de>
+---------------------------------------+-------------------------------------------------------------------------------------------+--------------+------------------------------------------------------->

```
</details>
