### PR TITLE
fix(sfn): handle pagination and ignore errors for expired executions history

### DIFF
--- a/aws/table_aws_sfn_state_machine_execution_history.go
+++ b/aws/table_aws_sfn_state_machine_execution_history.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"strconv"
 	"strings"
 	"sync"
@@ -9,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sfn"
 	"github.com/aws/aws-sdk-go-v2/service/sfn/types"
+	"github.com/aws/smithy-go"
 
 	sfnv1 "github.com/aws/aws-sdk-go/service/sfn"
 
@@ -346,20 +348,47 @@ func getRowDataForExecutionHistory(ctx context.Context, d *plugin.QueryData, arn
 		return nil, nil
 	}
 
-	params := &sfn.GetExecutionHistoryInput{
-		ExecutionArn: aws.String(arn),
+	maxLimit := int32(1000)
+	// If the requested number of items is less than the paging max limit
+	// set the limit to that instead
+	limit := d.QueryContext.Limit
+	if limit != nil {
+		if *limit < int64(maxLimit) {
+			maxLimit = int32(*limit)
+		}
 	}
 
 	var items []historyInfo
 
-	listHistory, err := svc.GetExecutionHistory(ctx, params)
-	if err != nil {
-		plugin.Logger(ctx).Error("aws_sfn_state_machine_execution_history.getRowDataForExecutionHistory", "api_error", err)
-		return nil, err
+	input := &sfn.GetExecutionHistoryInput{
+		MaxResults:   maxLimit,
+		ExecutionArn: aws.String(arn),
 	}
+	paginator := sfn.NewGetExecutionHistoryPaginator(svc, input, func(o *sfn.GetExecutionHistoryPaginatorOptions) {
+		o.Limit = maxLimit
+		o.StopOnDuplicateToken = true
+	})
+	// List call
+	for paginator.HasMorePages() {
+		plugin.Logger(ctx).Trace("aws_sfn_state_machine_execution_history.getRowDataForExecutionHistory", "api_call GetExecutionHistory", arn)
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			var apiErr smithy.APIError
+			if errors.As(err, &apiErr) {
+				switch apiErr.(type) {
+				case *types.ExecutionDoesNotExist:
+					// Ignore expired executions for which history is no longer available
+					plugin.Logger(ctx).Trace("aws_sfn_state_machine_execution_history.getRowDataForExecutionHistory", "api_error ignore_expired", err)
+					return nil, nil
+				}
+			}
+			plugin.Logger(ctx).Error("aws_sfn_state_machine_execution_history.getRowDataForExecutionHistory", "api_error", err)
+			return nil, err
+		}
 
-	for _, event := range listHistory.Events {
-		items = append(items, historyInfo{event, arn})
+		for _, event := range output.Events {
+			items = append(items, historyInfo{event, arn})
+		}
 	}
 
 	return items, nil

--- a/aws/table_aws_sfn_state_machine_execution_history.go
+++ b/aws/table_aws_sfn_state_machine_execution_history.go
@@ -373,6 +373,7 @@ func getRowDataForExecutionHistory(ctx context.Context, d *plugin.QueryData, arn
 		plugin.Logger(ctx).Trace("aws_sfn_state_machine_execution_history.getRowDataForExecutionHistory", "api_call GetExecutionHistory", arn)
 		output, err := paginator.NextPage(ctx)
 		if err != nil {
+			// Note: IgnoreConfig doesn't work when a ParentHydrate is used https://github.com/turbot/steampipe-plugin-sdk/issues/544
 			var apiErr smithy.APIError
 			if errors.As(err, &apiErr) {
 				switch apiErr.(type) {


### PR DESCRIPTION
This PR updates  the `aws_sfn_state_machine_execution_history` table to implement pagination and ignore errors for expired executions history, [which are only preserved for a maximum of 90 days](https://docs.aws.amazon.com/step-functions/latest/dg/limits-overview.html#service-limits-state-machine-executions).

Without this latter change, one would get errors like this one:
```
Error: operation error SFN: GetExecutionHistory, https response error StatusCode: 400, RequestID: 68dacbfc-af53-42f5-985e-a019c51b679f, ExecutionDoesNotExist: Execution Does Not Exist: 'arn:aw
s:states:eu-west-3:012345678901:execution:sfn-test-012345678901:b1b58243-1276-4195-863a-e83bed3dd603' (SQLSTATE HV000)

```

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
