### PR TITLE
Fixed a typo in the description of a column

### DIFF
--- a/aws/table_aws_organizations_account.go
+++ b/aws/table_aws_organizations_account.go
@@ -36,7 +36,7 @@ func tableAwsOrganizationsAccount(_ context.Context) *plugin.Table {
 		Columns: awsGlobalRegionColumns([]*plugin.Column{
 			{
 				Name:        "name",
-				Description: "The name of the member account.",
+				Description: "The friendly name of the account.",
 				Type:        proto.ColumnType_STRING,
 			},
 			// This description has added text for better clarification on ID type

--- a/aws/table_aws_organizations_account.go
+++ b/aws/table_aws_organizations_account.go
@@ -36,7 +36,7 @@ func tableAwsOrganizationsAccount(_ context.Context) *plugin.Table {
 		Columns: awsGlobalRegionColumns([]*plugin.Column{
 			{
 				Name:        "name",
-				Description: "The description of the permission set.",
+				Description: "The name of the member account.",
 				Type:        proto.ColumnType_STRING,
 			},
 			// This description has added text for better clarification on ID type


### PR DESCRIPTION
This is a minor fix to the `.inspect aws_organizations_account` command; the text currently refers to a permission set, but should refer to an AWS account. This PR corrects the text in the description.

Current output:
```
> .inspect aws_organizations_account
+------------------+--------------------------+----------------------------------------------------------------------------------+
| column           | type                     | description                                                                      |
+------------------+--------------------------+----------------------------------------------------------------------------------+
| _ctx             | jsonb                    | Steampipe context in JSON form, e.g. connection_name.                            |
| account_id       | text                     | The AWS Account ID in which the resource is located.                             |
| akas             | jsonb                    | Array of globally unique identifier strings (also known as) for the resource.    |
| arn              | text                     | The Amazon Resource Name (ARN) of the account.                                   |
| email            | text                     | The email address associated with the AWS account.                               |
| id               | text                     | The unique identifier (account ID) of the member account.                        |
| joined_method    | text                     | The method by which the account joined the organization.                         |
| joined_timestamp | timestamp with time zone | The date the account became a part of the organization.                          |
| name             | text                     | The description of the permission set.                                           |
| partition        | text                     | The AWS partition in which the resource is located (aws, aws-cn, or aws-us-gov). |
| region           | text                     | The AWS Region in which the resource is located.                                 |
| status           | text                     | The status of the account in the organization.                                   |
| tags             | jsonb                    | A map of tags for the resource.                                                  |
| tags_src         | jsonb                    |                                                                                  |
| title            | text                     | Title of the resource.                                                           |
+------------------+--------------------------+----------------------------------------------------------------------------------+
```

Correct output should be 
```
| name             | text                     |  The name of the member account.                                         |
```

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
