### PR TITLE
Add column resource_record_set_limit to aws_route53_zone

### DIFF
--- a/aws/table_aws_route53_zone.go
+++ b/aws/table_aws_route53_zone.go
@@ -350,7 +350,7 @@ func getRoute53HostedZoneLimit(ctx context.Context, d *plugin.QueryData, h *plug
 
 	svc, err := Route53Client(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_route53_zone.getHostedZoneLimit", "client_error", err)
+		plugin.Logger(ctx).Error("aws_route53_zone.getRoute53HostedZoneLimit", "client_error", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_route53_zone.go
+++ b/aws/table_aws_route53_zone.go
@@ -132,6 +132,13 @@ func tableAwsRoute53Zone(_ context.Context) *plugin.Table {
 				Hydrate:     getRoute53HostedZoneTurbotAkas,
 				Transform:   transform.FromValue(),
 			},
+			{
+				Name:        "resource_record_set_limit",
+				Description: "The maximum number of resource record sets allowed in the hosted zone.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getRoute53HostedZoneLimit,
+				Transform:   transform.FromField("Limit.Value"),
+			},
 		}),
 	}
 }
@@ -336,6 +343,28 @@ func getRoute53HostedZoneTurbotAkas(ctx context.Context, d *plugin.QueryData, h 
 	akas := []string{"arn:" + commonColumnData.Partition + ":route53:::" + "hostedzone/" + id[2]}
 
 	return akas, nil
+}
+
+func getRoute53HostedZoneLimit(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	hostedZone := h.Item.(HostedZoneResult)
+
+	svc, err := Route53Client(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_route53_zone.getHostedZoneLimit", "client_error", err)
+		return nil, err
+	}
+
+	params := &route53.GetHostedZoneLimitInput{
+		HostedZoneId: hostedZone.Id,
+		Type:         types.HostedZoneLimitTypeMaxRrsetsByZone,
+	}
+
+	resp, err := svc.GetHostedZoneLimit(ctx, params)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 //// TRANSFORM FUNCTIONS

--- a/aws/table_aws_route53_zone.go
+++ b/aws/table_aws_route53_zone.go
@@ -361,6 +361,7 @@ func getRoute53HostedZoneLimit(ctx context.Context, d *plugin.QueryData, h *plug
 
 	resp, err := svc.GetHostedZoneLimit(ctx, params)
 	if err != nil {
+		plugin.Logger(ctx).Error("aws_route53_zone.getRoute53HostedZoneLimit", "api_error", err)
 		return nil, err
 	}
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
SELECT                                                                                                                                                                                                                              
  resource_record_set_limit
from aws_route53_zone
WHERE 
  name not like '%internal%'
LIMIT 1;"
```

```
+---------------------------+
| resource_record_set_limit |
+---------------------------+
| 10000                     |
+---------------------------+
```
</details>
