### PR TITLE
Fixed aws_cloudwatch_log_group table for the error key column is not globally unique Closes #1975

### DIFF
--- a/aws-test/tests/aws_cloudwatch_log_group/test-get-query.sql
+++ b/aws-test/tests/aws_cloudwatch_log_group/test-get-query.sql
@@ -1,3 +1,3 @@
 select name
 from aws.aws_cloudwatch_log_group
-where name = '{{ resourceName }}'
+where name = '{{ resourceName }}' and region = '{{ output.region_name.value }}'

--- a/aws/table_aws_cloudwatch_log_group.go
+++ b/aws/table_aws_cloudwatch_log_group.go
@@ -191,16 +191,16 @@ func listCloudwatchLogGroups(ctx context.Context, d *plugin.QueryData, _ *plugin
 func getCloudwatchLogGroup(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
 	name := d.EqualsQualString("name")
 
+	// check if name is empty
+	if strings.TrimSpace(name) == "" {
+		return nil, nil
+	}
+
 	// Get client
 	svc, err := CloudWatchLogsClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_cloudwatch_log_group.getCloudwatchLogGroup", "client_error", err)
 		return nil, err
-	}
-
-	// check if name is empty
-	if strings.TrimSpace(name) == "" {
-		return nil, nil
 	}
 
 	params := &cloudwatchlogs.DescribeLogGroupsInput{


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_cloudwatch_log_group []

PRETEST: tests/aws_cloudwatch_log_group

TEST: tests/aws_cloudwatch_log_group
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 0s [id=333333333333]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_cloudwatch_log_group.named_test_resource will be created
  + resource "aws_cloudwatch_log_group" "named_test_resource" {
      + arn               = (known after apply)
      + id                = (known after apply)
      + name              = "turbottest1235"
      + name_prefix       = (known after apply)
      + retention_in_days = 0
      + skip_destroy      = false
      + tags              = {
          + "name" = "turbottest1235"
        }
      + tags_all          = {
          + "name" = "turbottest1235"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "333333333333"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest1235"
aws_cloudwatch_log_group.named_test_resource: Creating...
aws_cloudwatch_log_group.named_test_resource: Creation complete after 3s [id=turbottest1235]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "333333333333"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:logs:us-east-1:333333333333:log-group:turbottest1235"
resource_name = "turbottest1235"

Running SQL query: test-get-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "name": "turbottest1235"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "tags": {
      "name": "turbottest1235"
    }
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "arn": "arn:aws:logs:us-east-1:333333333333:log-group:turbottest1235:*",
    "metric_filter_count": 0,
    "name": "turbottest1235",
    "retention_in_days": null,
    "stored_bytes": 0
  }
]
✔ PASSED

Running SQL query: test-turbot-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "account_id": "333333333333",
    "akas": [
      "arn:aws:logs:us-east-1:333333333333:log-group:turbottest1235:*"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "tags": {
      "name": "turbottest1235"
    },
    "title": "turbottest1235"
  }
]
✔ PASSED

POSTTEST: tests/aws_cloudwatch_log_group

TEARDOWN: tests/aws_cloudwatch_log_group

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_aab.aws_cloudwatch_log_group where name = 'test'
+------+------------------------------------------------------+---------------------------+------------+---------------------+-------------------+--------------+----------------------------------------------------------------------------------------------+------------->
| name | arn                                                  | creation_time             | kms_key_id | metric_filter_count | retention_in_days | stored_bytes | data_protection                                                                              | data_protect>
+------+------------------------------------------------------+---------------------------+------------+---------------------+-------------------+--------------+----------------------------------------------------------------------------------------------+------------->
| test | arn:aws:logs:us-east-1:333333333333:log-group:test:* | 2023-11-17T22:34:26+05:30 | <null>     | 0                   | <null>            | 0            | {"LastUpdatedTime":null,"LogGroupIdentifier":null,"PolicyDocument":null,"ResultMetadata":{}} | <null>      >
| test | arn:aws:logs:us-east-2:333333333333:log-group:test:* | 2023-10-09T21:31:24+05:30 | <null>     | 0                   | 3                 | 0            | {"LastUpdatedTime":null,"LogGroupIdentifier":null,"PolicyDocument":null,"ResultMetadata":{}} | <null>      >
+------+------------------------------------------------------+---------------------------+------------+---------------------+-------------------+--------------+----------------------------------------------------------------------------------------------+------------->

Time: 7.8s. Rows fetched: 3. Hydrate calls: 9.

> select * from aws_aab.aws_cloudwatch_log_group where name = 'test' and region = 'us-east-1'
+------+------------------------------------------------------+---------------------------+------------+---------------------+-------------------+--------------+----------------------------------------------------------------------------------------------+------------->
| name | arn                                                  | creation_time             | kms_key_id | metric_filter_count | retention_in_days | stored_bytes | data_protection                                                                              | data_protect>
+------+------------------------------------------------------+---------------------------+------------+---------------------+-------------------+--------------+----------------------------------------------------------------------------------------------+------------->
| test | arn:aws:logs:us-east-1:333333333333:log-group:test:* | 2023-11-17T22:34:26+05:30 | <null>     | 0                   | <null>            | 0            | {"LastUpdatedTime":null,"LogGroupIdentifier":null,"PolicyDocument":null,"ResultMetadata":{}} | <null>      >
+------+------------------------------------------------------+---------------------------+------------+---------------------+-------------------+--------------+----------------------------------------------------------------------------------------------+------------->

Time: 3.3s. Rows fetched: 1. Hydrate calls: 3.
> select * from aws_aab.aws_cloudwatch_log_group where name = 'test' and region = 'us-east-4'
+------+-----+---------------+------------+---------------------+-------------------+--------------+-----------------+------------------------+-------+------+------+-----------+--------+------------+------+
| name | arn | creation_time | kms_key_id | metric_filter_count | retention_in_days | stored_bytes | data_protection | data_protection_policy | title | tags | akas | partition | region | account_id | _ctx |
+------+-----+---------------+------------+---------------------+-------------------+--------------+-----------------+------------------------+-------+------+------+-----------+--------+------------+------+
+------+-----+---------------+------------+---------------------+-------------------+--------------+-----------------+------------------------+-------+------+------+-----------+--------+------------+------+

Time: 93ms.

```
</details>
