### PR TITLE
Add table aws_ebs_encryption_by_default Closes #1987

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -159,6 +159,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_dynamodb_metric_account_provisioned_write_capacity_util":  tableAwsDynamoDBMetricAccountProvisionedWriteCapacityUtilization(ctx),
 			"aws_dynamodb_table":                                           tableAwsDynamoDBTable(ctx),
 			"aws_dynamodb_table_export":                                    tableAwsDynamoDBTableExport(ctx),
+			"aws_ebs_encryption_by_default":                                tableAwsEBSEncryptionByDefault(ctx),
 			"aws_ebs_snapshot":                                             tableAwsEBSSnapshot(ctx),
 			"aws_ebs_volume":                                               tableAwsEBSVolume(ctx),
 			"aws_ebs_volume_metric_read_ops":                               tableAwsEbsVolumeMetricReadOps(ctx),

--- a/aws/table_aws_ebs_encryption_by_default.go
+++ b/aws/table_aws_ebs_encryption_by_default.go
@@ -1,0 +1,83 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+
+	ec2v1 "github.com/aws/aws-sdk-go/service/ec2"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+func tableAwsEBSEncryptionByDefault(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_ebs_encryption_by_default",
+		Description: "AWS EBS Encryption By Default",
+		List: &plugin.ListConfig{
+			Hydrate: getAwsEBSEncryptionByDefault,
+			Tags:    map[string]string{"service": "ec2", "action": "GetEbsEncryptionByDefault"},
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(ec2v1.EndpointsID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "ebs_encryption_by_default",
+				Description: "Indicates whether encryption by default is enabled.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "ebs_default_kms_key_id",
+				Description: "The Amazon Resource Name (ARN) of the default KMS key for encryption by default.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getAwsEBSDefaultKmsKeyId,
+				Transform:   transform.FromField("KmsKeyId"),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func getAwsEBSEncryptionByDefault(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	// Create session
+	svc, err := EC2Client(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ebs_encryption_by_default.getAwsEBSEncryptionByDefault", "connection_error", err)
+		return nil, err
+	}
+
+	// Build params
+	params := &ec2.GetEbsEncryptionByDefaultInput{}
+
+	resp, err := svc.GetEbsEncryptionByDefault(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ebs_encryption_by_default.getAwsEBSEncryptionByDefault", "api_error", err)
+		return nil, err
+	}
+
+	d.StreamListItem(ctx, resp)
+
+	return nil, nil
+}
+
+func getAwsEBSDefaultKmsKeyId(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	// Create session
+	svc, err := EC2Client(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ebs_encryption_by_default.getAwsEBSDefaultKmsKeyId", "connection_error", err)
+		return nil, err
+	}
+
+	// Build params
+	params := &ec2.GetEbsDefaultKmsKeyIdInput{}
+
+	resp, err := svc.GetEbsDefaultKmsKeyId(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ebs_encryption_by_default.getAwsEBSDefaultKmsKeyId", "api_error", err)
+		return nil, err
+	}
+
+	return resp, nil
+}

--- a/docs/tables/aws_ebs_encryption_by_default.md
+++ b/docs/tables/aws_ebs_encryption_by_default.md
@@ -1,0 +1,29 @@
+# Table: aws_ebs_snapshot
+
+Describes whether EBS encryption by default is enabled for your account in the current Region.
+
+## Examples
+
+### Basic info
+
+```sql
+select
+  ebs_encryption_by_default,
+  ebs_default_kms_key_id,
+  region,
+  account_id
+from
+  aws_ebs_encryption_by_default;
+```
+
+### Get regions with default encryption enabled
+
+```sql
+select
+  ebs_encryption_by_default,
+  ebs_default_kms_key_id,
+  region
+from
+  aws_ebs_encryption_by_default
+where ebs_encryption_by_default;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_ebs_encryption_by_default
+---------------------------+------------------------------------------------------------------------------+-----------+----------------+--------------+---------------------------+
| ebs_encryption_by_default | ebs_default_kms_key_id                                                       | partition | region         | account_id   | _ctx                      |
+---------------------------+------------------------------------------------------------------------------+-----------+----------------+--------------+---------------------------+
| true                      | arn:aws:kms:ap-south-1:33333333333:key/d6c4d4be-2280-483e-9bbf-133c3d2c10af | aws       | ap-south-1     | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | ap-southeast-3 | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | ap-southeast-1 | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | ap-east-1      | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | ap-northeast-1 | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | ap-northeast-3 | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | me-central-1   | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | eu-central-1   | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | eu-north-1     | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | eu-south-1     | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | ap-northeast-2 | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | ap-southeast-2 | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | eu-west-3      | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | eu-west-2      | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | eu-west-1      | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | me-south-1     | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | us-west-1      | 33333333333 | {"connection_name":"aws"} |
| true                      | arn:aws:kms:us-west-2:33333333333:key/b4a97b37-5ac4-4445-aa40-8965e9afb76d  | aws       | us-west-2      | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | us-east-2      | 33333333333 | {"connection_name":"aws"} |
| false                     | arn:aws:kms:us-east-1:33333333333:key/789b57ef-3635-41f5-816e-95c5b33c0c2e  | aws       | us-east-1      | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | af-south-1     | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | ca-central-1   | 33333333333 | {"connection_name":"aws"} |
| false                     | alias/aws/ebs                                                                | aws       | sa-east-1      | 33333333333 | {"connection_name":"aws"} |
+---------------------------+------------------------------------------------------------------------------+-----------+----------------+--------------+---------------------------+
```
</details>
