### PR TITLE
Added column vpc_endpoint_type in table aws_vpc_endpoint Closes #2001

### DIFF
--- a/aws/table_aws_vpc_endpoint.go
+++ b/aws/table_aws_vpc_endpoint.go
@@ -58,6 +58,11 @@ func tableAwsVpcEndpoint(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "vpc_endpoint_type",
+				Description: "The type of endpoint.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "state",
 				Description: "The state of the VPC endpoint.",
 				Type:        proto.ColumnType_STRING,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_vpc_endpoint []

PRETEST: tests/aws_vpc_endpoint

TEST: tests/aws_vpc_endpoint
Running terraform
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 1s [id=333333333333]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_vpc.main will be created
  + resource "aws_vpc" "main" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags                                 = {
          + "name" = "turbottest63070"
        }
      + tags_all                             = {
          + "name" = "turbottest63070"
        }
    }

  # aws_vpc_endpoint.named_test_resource will be created
  + resource "aws_vpc_endpoint" "named_test_resource" {
      + arn                   = (known after apply)
      + cidr_blocks           = (known after apply)
      + dns_entry             = (known after apply)
      + id                    = (known after apply)
      + ip_address_type       = (known after apply)
      + network_interface_ids = (known after apply)
      + owner_id              = (known after apply)
      + policy                = (known after apply)
      + prefix_list_id        = (known after apply)
      + private_dns_enabled   = false
      + requester_managed     = (known after apply)
      + route_table_ids       = (known after apply)
      + security_group_ids    = (known after apply)
      + service_name          = "com.amazonaws.us-east-1.s3"
      + state                 = (known after apply)
      + subnet_ids            = (known after apply)
      + tags                  = {
          + "Name" = "turbottest63070"
        }
      + tags_all              = {
          + "Name" = "turbottest63070"
        }
      + vpc_endpoint_type     = "Gateway"
      + vpc_id                = (known after apply)
    }

Plan: 2 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "333333333333"
  + aws_region    = "us-east-1"
  + partition     = "aws"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest63070"
  + vpc_id        = (known after apply)
aws_vpc.main: Creating...
aws_vpc.main: Creation complete after 5s [id=vpc-0917e37b4f46eca5a]
aws_vpc_endpoint.named_test_resource: Creating...
aws_vpc_endpoint.named_test_resource: Creation complete after 9s [id=vpce-029abc7900c6a5131]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 0 destroyed.

Outputs:

account_id = "333333333333"
aws_region = "us-east-1"
partition = "aws"
resource_aka = "arn:aws:ec2:us-east-1:333333333333:vpc-endpoint/vpce-029abc7900c6a5131"
resource_id = "vpce-029abc7900c6a5131"
resource_name = "turbottest63070"
vpc_id = "vpc-0917e37b4f46eca5a"

Running SQL query: test-get-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:333333333333:vpc-endpoint/vpce-029abc7900c6a5131"
    ],
    "tags": {
      "Name": "turbottest63070"
    },
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest63070"
      }
    ],
    "title": "turbottest63070",
    "vpc_endpoint_id": "vpce-029abc7900c6a5131"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:333333333333:vpc-endpoint/vpce-029abc7900c6a5131"
    ],
    "tags": {
      "Name": "turbottest63070"
    },
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest63070"
      }
    ],
    "title": "turbottest63070",
    "vpc_endpoint_id": "vpce-029abc7900c6a5131",
    "vpc_id": "vpc-0917e37b4f46eca5a"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
null
✔ PASSED

Running SQL query: test-turbot-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "account_id": "333333333333",
    "akas": [
      "arn:aws:ec2:us-east-1:333333333333:vpc-endpoint/vpce-029abc7900c6a5131"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "tags": {
      "Name": "turbottest63070"
    },
    "title": "turbottest63070"
  }
]
✔ PASSED

POSTTEST: tests/aws_vpc_endpoint

TEARDOWN: tests/aws_vpc_endpoint

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select vpc_endpoint_id, service_name, vpc_endpoint_type, vpc_id from aws_aab.aws_vpc_endpoint

+------------------------+---------------------------------+-------------------+-----------------------+
| vpc_endpoint_id        | service_name                    | vpc_endpoint_type | vpc_id                |
+------------------------+---------------------------------+-------------------+-----------------------+
| vpce-0386b6412d0fa00f4 | com.amazonaws.ap-south-1.s3     | Gateway           | vpc-0e6e5565b44c7f8e1 |
| vpce-04f53df54e1c52675 | com.amazonaws.ap-south-1.sqs    | Interface         | vpc-0cde9775d4cb9e4a6 |
| vpce-0009e48de303f3d1f | com.amazonaws.ap-southeast-1.s3 | Gateway           | vpc-0a6a3d993546b5860 |
| vpce-0cc1b35f001a9d412 | com.amazonaws.eu-west-3.s3      | Gateway           | vpc-0739d92f76f494e26 |
| vpce-08b415b2df02db958 | com.amazonaws.us-east-2.s3      | Gateway           | vpc-0a93262e0a9f10dda |
| vpce-05016773df71b616b | com.amazonaws.us-east-1.s3      | Gateway           | vpc-0528c7162bd8edfa4 |
+------------------------+---------------------------------+-------------------+-----------------------+

Time: 4.8s. Rows fetched: 6. Hydrate calls: 0.
```
</details>
