### PR TITLE
Fixed MaxItems for aws_iam_policy should be 1000, not 100 Closes #2023

### DIFF
--- a/aws/table_aws_iam_policy.go
+++ b/aws/table_aws_iam_policy.go
@@ -165,7 +165,7 @@ func listIamPolicies(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydrate
 	}
 
 	params := buildIamPolicyFilter(d.EqualsQuals, d.Quals)
-	maxItems := int32(100)
+	maxItems := int32(1000)
 
 	// If the requested number of items is less than the paging max limit
 	// set the limit to that instead


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_iam_policy []

PRETEST: tests/aws_iam_policy

TEST: tests/aws_iam_policy
Running terraform
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.alternate: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 1s [id=333333333333]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_iam_policy.named_test_resource will be created
  + resource "aws_iam_policy" "named_test_resource" {
      + arn         = (known after apply)
      + id          = (known after apply)
      + name        = "turbottest16680"
      + name_prefix = (known after apply)
      + path        = "/"
      + policy      = jsonencode(
            {
              + Statement = [
                  + {
                      + Action   = [
                          + "ec2:Describe*",
                        ]
                      + Effect   = "Allow"
                      + Resource = "*"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + policy_id   = (known after apply)
      + tags_all    = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "333333333333"
  + aws_partition = "aws"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest16680"
aws_iam_policy.named_test_resource: Creating...
aws_iam_policy.named_test_resource: Creation complete after 2s [id=arn:aws:iam::333333333333:policy/turbottest16680]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "333333333333"
aws_partition = "aws"
resource_aka = "arn:aws:iam::333333333333:policy/turbottest16680"
resource_id = "arn:aws:iam::333333333333:policy/turbottest16680"
resource_name = "turbottest16680"

Running SQL query: query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "arn": "arn:aws:iam::333333333333:policy/turbottest16680",
    "name": "turbottest16680",
    "policy": {
      "Statement": [
        {
          "Action": [
            "ec2:Describe*"
          ],
          "Effect": "Allow",
          "Resource": "*"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Statement": [
        {
          "Action": [
            "ec2:describe*"
          ],
          "Effect": "Allow",
          "Resource": [
            "*"
          ]
        }
      ],
      "Version": "2012-10-17"
    }
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "arn": "arn:aws:iam::333333333333:policy/turbottest16680",
    "attachment_count": 0,
    "default_version_id": "v1",
    "is_attachable": true,
    "name": "turbottest16680",
    "path": "/",
    "permissions_boundary_usage_count": 0,
    "title": "turbottest16680"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "akas": [
      "arn:aws:iam::333333333333:policy/turbottest16680"
    ],
    "name": "turbottest16680",
    "policy": {
      "Statement": [
        {
          "Action": [
            "ec2:Describe*"
          ],
          "Effect": "Allow",
          "Resource": "*"
        }
      ],
      "Version": "2012-10-17"
    },
    "policy_std": {
      "Statement": [
        {
          "Action": [
            "ec2:describe*"
          ],
          "Effect": "Allow",
          "Resource": [
            "*"
          ]
        }
      ],
      "Version": "2012-10-17"
    }
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "arn": "arn:aws:iam::333333333333:policy/turbottest16680",
    "name": "turbottest16680"
  }
]
✔ PASSED

POSTTEST: tests/aws_iam_policy

TEARDOWN: tests/aws_iam_policy

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_iam_policy
+--------------------------------------------------------------------------------+-----------------------+--------------------+---------------------------------------------------------------------------->
| name                                                                           | policy_id             | path               | arn                                                                        >
+--------------------------------------------------------------------------------+-----------------------+--------------------+---------------------------------------------------------------------------->
| AWSLambdaBasicExecutionRole-bc0e2cb1-5064-4ee7-946a-a67bd21ce60c               | ANPAZGW7IOFIPMPWYN33J | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AWSLambdaBasicExecutionRole-b>
| AWSLambdaBasicExecutionRole-81bb6720-e3c8-4ec3-bfee-da9aebbd5915               | ANPAZGW7IOFIG4KVZOBQV | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AWSLambdaBasicExecutionRole-8>
| snowball_metadata                                                              | ANPAZGW7IOFIK6GXSOXAE | /turbot/           | arn:aws:iam::333333333333:policy/turbot/snowball_metadata                  >
| AwsGlueDataBrewServicePolicyForInputS3-dataquality_test                        | ANPAZGW7IOFIE3OZBRBLR | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AwsGlueDataBrewServicePolicyF>
| SqsPipeSourceTemplate-559fd8e5                                                 | ANPAZGW7IOFIJMMHJQMMC | /service-role/     | arn:aws:iam::333333333333:policy/service-role/SqsPipeSourceTemplate-559fd8e>
| snowball_admin                                                                 | ANPAZGW7IOFIIZKMJR6CG | /turbot/           | arn:aws:iam::333333333333:policy/turbot/snowball_admin                     >
| AmazonSageMaker-ExecutionPolicy-20210611T124331                                | ANPAZGW7IOFIMYN4VEWL7 | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AmazonSageMaker-ExecutionPoli>
| AWSLambdaBasicExecutionRole-6fcdb25e-6250-449d-b8da-2399daca9cab               | ANPAZGW7IOFIE5JBD6KOH | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AWSLambdaBasicExecutionRole-6>
| AllowInvokeApiDestination                                                      | ANPAZGW7IOFIHQVQV7LSG | /                  | arn:aws:iam::333333333333:policy/AllowInvokeApiDestination                 >
| share-ami                                                                      | ANPAZGW7IOFILBUCKSVWV | /                  | arn:aws:iam::333333333333:policy/share-ami                                 >
| AWSLambdaBasicExecutionRole-9a071125-60a4-403c-9f89-4da1200d9531               | ANPAZGW7IOFIK3NUE7FO3 | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AWSLambdaBasicExecutionRole-9>
| AWSLambdaBasicExecutionRole-6503ffbf-8d90-4019-8414-c5c831423863               | ANPAZGW7IOFIKAEPU52T4 | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AWSLambdaBasicExecutionRole-6>
| turbottest37652_1                                                              | ANPAZGW7IOFIMWAJMTMRZ | /                  | arn:aws:iam::333333333333:policy/turbottest37652_1                         >
| AWSLambdaBasicExecutionRole-3abd03b2-390a-444a-a994-b22062699f6a               | ANPAZGW7IOFIN3ADKTILL | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AWSLambdaBasicExecutionRole-3>
| AWSLambdaBasicExecutionRole-b9c30266-c595-4d08-997e-3748fc06abca               | ANPAZGW7IOFIM3ATPTKH2 | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AWSLambdaBasicExecutionRole-b>
| AWSLambdaBasicExecutionRole-4d51f6f8-81cb-43fc-b593-d902079e5bad               | ANPAZGW7IOFIKZOGRSHYB | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AWSLambdaBasicExecutionRole-4>
| AWSLambdaBasicExecutionRole-b28a9c43-eb11-4b68-91c7-8d26e4029ee2               | ANPAZGW7IOFICUURW34LY | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AWSLambdaBasicExecutionRole-b>
| Amazon-GlueServicePolicyForSSM-inspector-inventory-prod-us-east-1-e9ddc5d9789b | ANPAZGW7IOFIAQEZ4O2ZG | /service-role/     | arn:aws:iam::333333333333:policy/service-role/Amazon-GlueServicePolicyForSS>
| AWSLambdaBasicExecutionRole-11153041-dc04-4d59-a85b-0f62efdb5446               | ANPAZGW7IOFIHQD7QRQV2 | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AWSLambdaBasicExecutionRole-1>
| AWSLambdaBasicExecutionRole-aa4edf57-324b-49dc-89d5-5f06e4662fc8               | ANPAZGW7IOFIHH4WZVHBL | /service-role/     | arn:aws:iam::333333333333:policy/service-role/AWSLambdaBasicExecutionRole-a>
| admin                                                                          | ANPAZGW7IOFIKOSBFK6NT | /turbot/           | arn:aws:iam::333333333333:policy/turbot/admin                              >
|                                                                                |                       |                    |                                                                            >
| snowball_readonly                                                              | ANPAZGW7IOFIIQSEUJK3C | /turbot/           | arn:aws:iam::333333333333:policy/turbot/snowball_readonly                  >

```
</details>
