### PR TITLE
Fixed MaxItems for aws_iam_policy_attachment should be 1000, not 100 Closes #2022

### DIFF
--- a/aws/table_aws_iam_policy_attachment.go
+++ b/aws/table_aws_iam_policy_attachment.go
@@ -75,7 +75,7 @@ func listIamPolicyAttachments(ctx context.Context, d *plugin.QueryData, h *plugi
 		return nil, err
 	}
 	policy := h.Item.(types.Policy)
-	maxItems := int32(100)
+	maxItems := int32(1000)
 
 	// If the requested number of items is less than the paging max limit
 	// set the limit to that instead


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_iam_policy_attachment
+------------------------------------------------------------------------------------------------------------------------------+-------------+----------------------------------------------------------------------+-------------------------------------------------------->
| policy_arn                                                                                                                   | is_attached | policy_groups                                                        | policy_roles                                           >
+------------------------------------------------------------------------------------------------------------------------------+-------------+----------------------------------------------------------------------+-------------------------------------------------------->
| arn:aws:iam::aws:policy/AWSImportExportFullAccess                                                                            | false       | []                                                                   | []                                                     >
| arn:aws:iam::333333333333:policy/service-role/AccessAnalyzerMonitorServicePolicy_FRTK4LTDCR                                  | true        | []                                                                   | [{"RoleId":"AROAZGW7IOFIJLBOWOZ6J","RoleName":"AccessAn>
| arn:aws:iam::333333333333:policy/service-role/s3crr_for_capcha7.2_968eea                                                     | true        | []                                                                   | [{"RoleId":"AROAZGW7IOFIKDTWEDOCT","RoleName":"s3crr_ro>
| arn:aws:iam::333333333333:policy/service-role/AWSLambdaBasicExecutionRole-e9a282bc-bcea-4190-8fa1-cff1224d4bb3               | false       | []                                                                   | []                                                     >
| arn:aws:iam::333333333333:policy/service-role/CodeBuildBasePolicy-test-us-east-2                                             | true        | []                                                                   | [{"RoleId":"AROAZGW7IOFIAM23RLPN6","RoleName":"codebuil>
| arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role                                                        | true        | []                                                                   | [{"RoleId":"AROAZGW7IOFII6TZCJIXR","RoleName":"EMR_EC2_>
| arn:aws:iam::333333333333:policy/service-role/KinesisFirehoseServicePolicy-aws-waf-logs-web-acl-us-east-1                    | true        | []                                                                   | [{"RoleId":"AROAZGW7IOFIORQQE2LZS","RoleName":"KinesisF>
| arn:aws:iam::aws:policy/CloudSearchFullAccess                                                                                | false       | []                                                                   | []                                                     >
| arn:aws:iam::aws:policy/AmazonSESFullAccess                                                                                  | false       | []                                                                   | []                                                     >
| arn:aws:iam::333333333333:policy/turbot/xray_admin                                                                           | true        | []                                                                   | [{"RoleId":"AROAZGW7IOFIDYQVIKJXW","RoleName":"ta_xray_>
| arn:aws:iam::333333333333:policy/turbot/iam_operator                                                                         | true        | []                                                                   | [{"RoleId":"AROAZGW7IOFIHLLLCXOQJ","RoleName":"ta_iam_o>


```
</details>
