### PR TITLE
Populate 'processor_features' Column When Default Value Is Set Closes #2018

### DIFF
--- a/aws/table_aws_rds_db_instance.go
+++ b/aws/table_aws_rds_db_instance.go
@@ -47,7 +47,7 @@ func tableAwsRDSDBInstance(_ context.Context) *plugin.Table {
 				Tags: map[string]string{"service": "rds", "action": "DescribeCertificates"},
 			},
 			{
-				Func: getRDSDBInstanceprocessFeatures,
+				Func: getRDSDBInstanceProcessorFeatures,
 				Tags: map[string]string{"service": "rds", "action": "DescribeOrderableDBInstanceOptions"},
 			},
 		},

--- a/aws/table_aws_rds_db_instance.go
+++ b/aws/table_aws_rds_db_instance.go
@@ -632,7 +632,7 @@ func getRDSDBInstanceprocessFeatures(ctx context.Context, d *plugin.QueryData, h
 
 	op, err := svc.DescribeOrderableDBInstanceOptions(ctx, params)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_rds_db_instance.getRDSDBInstanceCertificate", "api_error", err)
+		plugin.Logger(ctx).Error("aws_rds_db_instance.getRDSDBInstanceprocessFeatures", "api_error", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_rds_db_instance.go
+++ b/aws/table_aws_rds_db_instance.go
@@ -46,6 +46,10 @@ func tableAwsRDSDBInstance(_ context.Context) *plugin.Table {
 				Func: getRDSDBInstanceCertificate,
 				Tags: map[string]string{"service": "rds", "action": "DescribeCertificates"},
 			},
+			{
+				Func: getRDSDBInstanceprocessFeatures,
+				Tags: map[string]string{"service": "rds", "action": "DescribeOrderableDBInstanceOptions"},
+			},
 		},
 		GetMatrixItemFunc: SupportedRegionMatrix(rdsv1.EndpointsID),
 		Columns: awsRegionalColumns([]*plugin.Column{


### PR DESCRIPTION
Note: This PR contains the fix if the `ProcessorFeatures` value has been set to the default configuration, then we should get the default value for the particular DB Instance.

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select db_instance_identifier, engine,engine_version, availability_zone, class, processor_features from aws_rds_db_instance;
+------------------------+-----------+------------------------------------+-------------------+--------------+--------------------------------------------------------------------------+
| db_instance_identifier | engine    | engine_version                     | availability_zone | class        | processor_features                                                       |
+------------------------+-----------+------------------------------------+-------------------+--------------+--------------------------------------------------------------------------+
| database-2             | oracle-ee | 19.0.0.0.ru-2023-10.rur-2023-10.r1 | us-east-1b        | db.m5d.large | [{"Name":"threadsPerCore","Value":"2"},{"Name":"coreCount","Value":"1"}] |
| database-1             | mysql     | 8.0.33                             | us-east-1b        | db.t3.micro  | <null>                                                                   |
+------------------------+-----------+------------------------------------+-------------------+--------------+--------------------------------------------------------------------------+

```
</details>
