### PR TITLE
Support tags for aws_backup_vault and aws_backup_recovery_point Closes #2031

### DIFF
--- a/aws/table_aws_backup_recovery_point.go
+++ b/aws/table_aws_backup_recovery_point.go
@@ -2,12 +2,15 @@ package aws
 
 import (
 	"context"
+	"errors"
+	"regexp"
 	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/arn"
 	"github.com/aws/aws-sdk-go-v2/service/backup"
 	"github.com/aws/aws-sdk-go-v2/service/backup/types"
+	"github.com/aws/smithy-go"
 
 	backupv1 "github.com/aws/aws-sdk-go/service/backup"
 
@@ -150,10 +153,16 @@ func tableAwsBackupRecoveryPoint(_ context.Context) *plugin.Table {
 
 			// Steampipe standard columns
 			{
+				Name:        "tags",
+				Description: resourceInterfaceDescription("tags"),
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsBackupRecoveryPointTags,
+			},
+			{
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("ResourceArn").Transform(arnToAkas),
+				Transform:   transform.FromField("ResourceArn").Transform(transform.EnsureStringArray),
 			},
 		}),
 	}
@@ -287,4 +296,63 @@ func getAwsBackupRecoveryPoint(ctx context.Context, d *plugin.QueryData, h *plug
 	}
 
 	return detail, nil
+}
+
+func getAwsBackupRecoveryPointTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	arn := recoveryPointArn(h.Item)
+
+	// Define the regex pattern for the recovery point ARN
+	pattern := `arn:aws:backup:[a-z0-9\-]+:[0-9]{12}:recovery-point:*`
+
+	// Create a regular expression object
+	re := regexp.MustCompile(pattern)
+
+	// Only return the tags associated with the resovery point
+	if !re.MatchString(arn) {
+		return nil, nil
+	}
+
+	// Create Session
+	svc, err := BackupClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_backup_recovery_point.getAwsBackupRecoveryPointTags", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	params := &backup.ListTagsInput{
+		ResourceArn: aws.String(arn),
+	}
+
+	op, err := svc.ListTags(ctx, params)
+	if err != nil {
+
+		var ae smithy.APIError
+		if errors.As(err, &ae) {
+			if ae.ErrorCode() == "ResourceNotFoundException" {
+				return &backup.GetBackupVaultNotificationsOutput{}, nil
+			}
+		}
+		plugin.Logger(ctx).Error("aws_backup_recovery_point.getAwsBackupRecoveryPointTags", "api_error", err)
+		return nil, err
+	}
+
+	if op.Tags == nil {
+		return nil, nil
+	}
+	
+	return op, nil
+}
+
+func recoveryPointArn(item interface{}) string {
+	switch item := item.(type) {
+	case types.RecoveryPointByBackupVault:
+		return *item.RecoveryPointArn
+	case *backup.DescribeRecoveryPointOutput:
+		return *item.RecoveryPointArn
+	}
+	return ""
 }

--- a/aws/table_aws_backup_recovery_point.go
+++ b/aws/table_aws_backup_recovery_point.go
@@ -52,6 +52,12 @@ func tableAwsBackupRecoveryPoint(_ context.Context) *plugin.Table {
 				},
 			},
 		},
+		HydrateConfig: []plugin.HydrateConfig{
+			{
+				Func: getAwsBackupRecoveryPoint,
+				Tags: map[string]string{"service": "backup", "action": "DescribeRecoveryPoint"},
+			},
+		},
 		GetMatrixItemFunc: SupportedRegionMatrix(backupv1.EndpointsID),
 		Columns: awsRegionalColumns([]*plugin.Column{
 			{

--- a/aws/table_aws_backup_recovery_point.go
+++ b/aws/table_aws_backup_recovery_point.go
@@ -302,7 +302,7 @@ func getAwsBackupRecoveryPointTags(ctx context.Context, d *plugin.QueryData, h *
 	arn := recoveryPointArn(h.Item)
 
 	// Define the regex pattern for the recovery point ARN
-	pattern := `arn:aws:backup:[a-z0-9\-]+:[0-9]{12}:recovery-point:*`
+	pattern := `arn:aws:backup:[a-z0-9\-]+:[0-9]{12}:recovery-point:.*`
 
 	// Create a regular expression object
 	re := regexp.MustCompile(pattern)
@@ -343,7 +343,7 @@ func getAwsBackupRecoveryPointTags(ctx context.Context, d *plugin.QueryData, h *
 	if op.Tags == nil {
 		return nil, nil
 	}
-	
+
 	return op, nil
 }
 

--- a/aws/table_aws_backup_vault.go
+++ b/aws/table_aws_backup_vault.go
@@ -257,7 +257,6 @@ func getAwsBackupVaultNotification(ctx context.Context, d *plugin.QueryData, h *
 
 	op, err := svc.GetBackupVaultNotifications(ctx, params)
 	if err != nil {
-		plugin.Logger(ctx).Error("Error ====>>>>>", err.Error())
 		if strings.Contains(err.Error(), "Failed reading notifications from database for Backup vault") {
 			return &backup.GetBackupVaultNotificationsOutput{}, nil
 		}

--- a/aws/table_aws_backup_vault.go
+++ b/aws/table_aws_backup_vault.go
@@ -298,7 +298,7 @@ func getAwsBackupVaultTags(ctx context.Context, d *plugin.QueryData, h *plugin.H
 		var ae smithy.APIError
 		if errors.As(err, &ae) {
 			if ae.ErrorCode() == "ResourceNotFoundException" {
-				return &backup.GetBackupVaultNotificationsOutput{}, nil
+				return &backup.ListTagsOutput{}, nil
 			}
 		}
 		plugin.Logger(ctx).Error("aws_backup_vault.getAwsBackupVaultTags", "api_error", err)
@@ -330,7 +330,7 @@ func getAwsBackupVaultAccessPolicy(ctx context.Context, d *plugin.QueryData, h *
 		var ae smithy.APIError
 		if errors.As(err, &ae) {
 			if ae.ErrorCode() == "ResourceNotFoundException" || ae.ErrorCode() == "InvalidParameter" {
-				return backup.GetBackupVaultNotificationsOutput{}, nil
+				return backup.GetBackupVaultAccessPolicyOutput{}, nil
 			}
 		}
 		return nil, err

--- a/aws/table_aws_backup_vault.go
+++ b/aws/table_aws_backup_vault.go
@@ -257,8 +257,8 @@ func getAwsBackupVaultNotification(ctx context.Context, d *plugin.QueryData, h *
 
 	op, err := svc.GetBackupVaultNotifications(ctx, params)
 	if err != nil {
-
-		if strings.Contains(err.Error(), "Failed reading notifications from database for Backup vault ") {
+		plugin.Logger(ctx).Error("Error ====>>>>>", err.Error())
+		if strings.Contains(err.Error(), "Failed reading notifications from database for Backup vault") {
 			return &backup.GetBackupVaultNotificationsOutput{}, nil
 		}
 
@@ -326,13 +326,13 @@ func getAwsBackupVaultAccessPolicy(ctx context.Context, d *plugin.QueryData, h *
 
 	op, err := svc.GetBackupVaultAccessPolicy(ctx, params)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_backup_vault.getAwsBackupVaultAccessPolicy", "api_error", err)
 		var ae smithy.APIError
 		if errors.As(err, &ae) {
 			if ae.ErrorCode() == "ResourceNotFoundException" || ae.ErrorCode() == "InvalidParameter" {
 				return backup.GetBackupVaultAccessPolicyOutput{}, nil
 			}
 		}
+		plugin.Logger(ctx).Error("aws_backup_vault.getAwsBackupVaultAccessPolicy", "api_error", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_backup_vault.go
+++ b/aws/table_aws_backup_vault.go
@@ -286,11 +286,6 @@ func getAwsBackupVaultTags(ctx context.Context, d *plugin.QueryData, h *plugin.H
 		return nil, nil
 	}
 
-	if svc == nil {
-		// Unsupported region, return no data
-		return nil, nil
-	}
-
 	arn := vaultArn(h.Item)
 
 	params := &backup.ListTagsInput{

--- a/docs/tables/aws_backup_recovery_point.md
+++ b/docs/tables/aws_backup_recovery_point.md
@@ -109,7 +109,7 @@ select
       select tags from aws_ec2_ami where image_id = substr(r.recovery_point_arn, instr(r.recovery_point_arn, '::image/') + 8)
     )
     when r.resource_type in ('S3', 'EFS') then r.tags
-  end as target_resource_tags,
+  end as tags,
   r.region,
   r.account_id
 from

--- a/docs/tables/aws_backup_recovery_point.md
+++ b/docs/tables/aws_backup_recovery_point.md
@@ -11,6 +11,11 @@ The AWS Backup Recovery Point is a component of AWS Backup, a fully managed back
 
 The `aws_backup_recovery_point` table in Steampipe provides you with information about each recovery point within an AWS Backup vault. This table allows you, as a DevOps engineer or system administrator, to query recovery point-specific details, including the backup vault where the recovery point is stored, the source of the backup, the state of the recovery point, and associated metadata. You can utilize this table to gather insights on recovery points, such as identifying unencrypted recovery points, verifying backup completion status, and more. The schema outlines the various attributes of the recovery point for you, including the recovery point ARN, creation date, backup size, and associated tags.
 
+Note: The value in the `tags` column will be populated under the following conditions:
+- The resource ARN corresponds to a Recovery Point resource ARN.
+- The resource ARN matches the specified pattern: `arn:aws:backup:[a-z0-9\-]+:[0-9]{12}:recovery-point:*`.
+- Tags are associated with the Recovery Point.
+
 ## Examples
 
 ### Basic Info
@@ -63,4 +68,57 @@ from
   aws_backup_recovery_point
 where
   is_encrypted = 1;
+```
+
+### Get associated tags for the targeted Recovery Points EC2, EBS and S3 resource types
+Retrieving metadata, in the form of tags, for recovery points associated with three resource types - EC2 instances, EBS volumes, and S3 buckets. Tags are key-value pairs that provide valuable information about AWS resources.
+
+```sql+postgres
+select
+  r.backup_vault_name as backup_vault_name,
+  r.recovery_point_arn as recovery_point_arn,
+  r.resource_type as resource_type,
+case
+    when r.resource_type = 'EBS' then (
+      select tags from aws_ebs_snapshot where arn = concat(
+        (string_to_array(r.recovery_point_arn, '::'))[1],
+        ':',
+        r.account_id,
+        ':',
+        (string_to_array(r.recovery_point_arn, '::'))[2]
+      )
+    )
+    when r.resource_type = 'EC2' then (
+      select tags from aws_ec2_ami where image_id = (string_to_array(r.recovery_point_arn, '::image/'))[2]
+    )
+    when r.resource_type = 'S3' then (
+      select tags from aws_s3_bucket where arn = r.recovery_point_arn
+    )
+end as target_resource_tags,
+  r.region,
+  r.account_id
+from
+  aws_backup_recovery_point as r;
+```
+
+```sql+sqlite
+select
+  r.backup_vault_name as backup_vault_name,
+  r.recovery_point_arn as recovery_point_arn,
+  r.resource_type as resource_type,
+  case
+    when r.resource_type = 'EBS' then (
+      select tags from aws_ebs_snapshot where arn = substr(r.recovery_point_arn, instr(r.recovery_point_arn, '::') + 2)
+    )
+    when r.resource_type = 'EC2' then (
+      select tags from aws_ec2_ami where image_id = substr(r.recovery_point_arn, instr(r.recovery_point_arn, '::image/') + 8)
+    )
+    when r.resource_type = 'S3' then (
+      select tags from aws_s3_bucket where arn = r.recovery_point_arn
+    )
+  end as target_resource_tags,
+  r.region,
+  r.account_id
+from
+  aws_backup_recovery_point as r;
 ```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, tags from aws_backup_vault
+--------------------------------+---------------+
| name                           | tags          |
+--------------------------------+---------------+
| Default                        | {}            |
| aws/efs/automatic-backup-vault | {}            |
| Default                        | {"foo":"bar"} |
| Default                        | {}            |
| Default                        | {}            |
| aws/efs/automatic-backup-vault | {}            |
+--------------------------------+---------------+
```
</details>
