### PR TITLE
Update the table aws_sns_topic_subscription to use ListSubscriptionsByTopic API instead of ListSubscriptions

### DIFF
--- a/docs/tables/aws_sns_topic_subscription.md
+++ b/docs/tables/aws_sns_topic_subscription.md
@@ -36,7 +36,6 @@ where
   redrive_policy is null;
 ```
 
-
 ### List of subscriptions which are not configured to filter messages
 Determine the areas in which subscriptions are not set up to filter messages. This is beneficial for identifying potential inefficiencies or areas of improvement within your notification system.
 
@@ -59,7 +58,6 @@ from
 where
   filter_policy is null;
 ```
-
 
 ### Subscription count by topic arn
 Determine the areas in which your AWS SNS topics are gaining the most traction by analyzing the number of subscriptions each topic has. This can help prioritize content creation and resource allocation for popular topics.


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```

No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_sns_topic_subscription []

PRETEST: tests/aws_sns_topic_subscription

TEST: tests/aws_sns_topic_subscription
Running terraform
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 0s [id=345644333333]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_sns_topic.aws_sns_subscription will be created
  + resource "aws_sns_topic" "aws_sns_subscription" {
      + arn                         = (known after apply)
      + beginning_archive_time      = (known after apply)
      + content_based_deduplication = false
      + fifo_topic                  = false
      + id                          = (known after apply)
      + name                        = "turbottest40512"
      + name_prefix                 = (known after apply)
      + owner                       = (known after apply)
      + policy                      = (known after apply)
      + signature_version           = (known after apply)
      + tags_all                    = (known after apply)
      + tracing_config              = (known after apply)
    }

  # aws_sns_topic_subscription.named_test_resource will be created
  + resource "aws_sns_topic_subscription" "named_test_resource" {
      + arn                             = (known after apply)
      + confirmation_timeout_in_minutes = 1
      + confirmation_was_authenticated  = (known after apply)
      + endpoint                        = (known after apply)
      + endpoint_auto_confirms          = false
      + filter_policy_scope             = (known after apply)
      + id                              = (known after apply)
      + owner_id                        = (known after apply)
      + pending_confirmation            = (known after apply)
      + protocol                        = "sqs"
      + raw_message_delivery            = false
      + topic_arn                       = (known after apply)
    }

  # aws_sqs_queue.aws_sns_subscription will be created
  + resource "aws_sqs_queue" "aws_sns_subscription" {
      + arn                               = (known after apply)
      + content_based_deduplication       = false
      + deduplication_scope               = (known after apply)
      + delay_seconds                     = 0
      + fifo_queue                        = false
      + fifo_throughput_limit             = (known after apply)
      + id                                = (known after apply)
      + kms_data_key_reuse_period_seconds = (known after apply)
      + max_message_size                  = 262144
      + message_retention_seconds         = 345600
      + name                              = "turbottest40512"
      + name_prefix                       = (known after apply)
      + policy                            = (known after apply)
      + receive_wait_time_seconds         = 0
      + redrive_allow_policy              = (known after apply)
      + redrive_policy                    = (known after apply)
      + sqs_managed_sse_enabled           = (known after apply)
      + tags_all                          = (known after apply)
      + url                               = (known after apply)
      + visibility_timeout_seconds        = 30
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "345644333333"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + endpoint      = (known after apply)
  + resource_aka  = (known after apply)
  + resource_name = "turbottest40512"
  + topic_arn     = (known after apply)
aws_sqs_queue.aws_sns_subscription: Creating...
aws_sns_topic.aws_sns_subscription: Creating...
aws_sns_topic.aws_sns_subscription: Creation complete after 4s [id=arn:aws:sns:us-east-1:345644333333:turbottest40512]
aws_sqs_queue.aws_sns_subscription: Still creating... [10s elapsed]
aws_sqs_queue.aws_sns_subscription: Still creating... [20s elapsed]
aws_sqs_queue.aws_sns_subscription: Still creating... [30s elapsed]
aws_sqs_queue.aws_sns_subscription: Creation complete after 30s [id=https://sqs.us-east-1.amazonaws.com/345644333333/turbottest40512]
aws_sns_topic_subscription.named_test_resource: Creating...
aws_sns_topic_subscription.named_test_resource: Creation complete after 5s [id=arn:aws:sns:us-east-1:345644333333:turbottest40512:cb9ae652-92c7-40d3-9af5-4ddbed8e7168]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "345644333333"
aws_partition = "aws"
aws_region = "us-east-1"
endpoint = "arn:aws:sqs:us-east-1:345644333333:turbottest40512"
resource_aka = "arn:aws:sns:us-east-1:345644333333:turbottest40512:cb9ae652-92c7-40d3-9af5-4ddbed8e7168"
resource_name = "turbottest40512"
topic_arn = "arn:aws:sns:us-east-1:345644333333:turbottest40512"

Running SQL query: test-get-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "endpoint": "arn:aws:sqs:us-east-1:345644333333:turbottest40512",
    "protocol": "sqs",
    "topic_arn": "arn:aws:sns:us-east-1:345644333333:turbottest40512"
  }
]
✔ PASSED

Running SQL query: test-get-subscription-attributes-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "confirmation_was_authenticated": true,
    "delivery_policy": null,
    "effective_delivery_policy": null,
    "filter_policy": null,
    "pending_confirmation": false,
    "raw_message_delivery": false,
    "redrive_policy": null
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "endpoint": "arn:aws:sqs:us-east-1:345644333333:turbottest40512",
    "owner": "345644333333",
    "protocol": "sqs",
    "subscription_arn": "arn:aws:sns:us-east-1:345644333333:turbottest40512:cb9ae652-92c7-40d3-9af5-4ddbed8e7168",
    "topic_arn": "arn:aws:sns:us-east-1:345644333333:turbottest40512"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[]
✔ PASSED

Running SQL query: test-turbot-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "account_id": "345644333333",
    "akas": [
      "arn:aws:sns:us-east-1:345644333333:turbottest40512:cb9ae652-92c7-40d3-9af5-4ddbed8e7168"
    ],
    "partition": "aws",
    "region": "us-east-1",
    "title": "cb9ae652-92c7-40d3-9af5-4ddbed8e7168"
  }
]
✔ PASSED

POSTTEST: tests/aws_sns_topic_subscription

TEARDOWN: tests/aws_sns_topic_subscription

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_sns_topic_subscription
+----------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------+--------------+----------+------------------------------------------------------------------->
| subscription_arn                                                                                         | topic_arn                                                           | owner        | protocol | endpoint                                                          >
+----------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------+--------------+----------+------------------------------------------------------------------->
| arn:aws:sns:ap-south-1:345644333333:Default_CloudWatch_Alarms_Topic:a5f6943c-ef6d-4632-baae-04270fd50506 | arn:aws:sns:ap-south-1:345644333333:Default_CloudWatch_Alarms_Topic | 345644333333 | email    | debabrat@turbot.com                                               >
| arn:aws:sns:ap-south-1:345644333333:topic-public:0add4eaa-880f-47ca-ba1d-1105e0019320                    | arn:aws:sns:ap-south-1:345644333333:topic-public                    | 345644333333 | email    | debabrat@turbot.com                                               >
| arn:aws:sns:ap-southeast-1:345644333333:turbot_aws_api_handler:befe33df-048e-4b9a-b88f-f5f523a35d57      | arn:aws:sns:ap-southeast-1:345644333333:turbot_aws_api_handler      | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
| arn:aws:sns:ap-northeast-2:345644333333:turbot_aws_api_handler:320975b1-b30f-4f0f-a476-6290fd4a2fd8      | arn:aws:sns:ap-northeast-2:345644333333:turbot_aws_api_handler      | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
| arn:aws:sns:ap-northeast-1:345644333333:turbot_aws_api_handler:0719a028-2719-4fec-a940-a4f954d2c90b      | arn:aws:sns:ap-northeast-1:345644333333:turbot_aws_api_handler      | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
| arn:aws:sns:eu-west-1:345644333333:turbot_aws_api_handler:cd13b6a3-84d5-43be-8c1c-d86f13c615a9           | arn:aws:sns:eu-west-1:345644333333:turbot_aws_api_handler           | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
| arn:aws:sns:eu-central-1:345644333333:turbot_aws_api_handler:c6523074-4f8e-4e70-bc0e-0aae47c5baf1        | arn:aws:sns:eu-central-1:345644333333:turbot_aws_api_handler        | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
| arn:aws:sns:eu-west-2:345644333333:turbot_aws_api_handler:85578808-943e-4b54-a7ce-2147897a56ca           | arn:aws:sns:eu-west-2:345644333333:turbot_aws_api_handler           | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
| arn:aws:sns:eu-west-3:345644333333:turbot_aws_api_handler:18989fb2-5339-4498-af81-19c15f8948d0           | arn:aws:sns:eu-west-3:345644333333:turbot_aws_api_handler           | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
| arn:aws:sns:eu-north-1:345644333333:turbot_aws_api_handler:452fc4a8-ab57-4feb-af46-68f2cce6fae8          | arn:aws:sns:eu-north-1:345644333333:turbot_aws_api_handler          | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
| arn:aws:sns:us-east-2:345644333333:turbot_aws_api_handler:5b754223-7037-40b4-a7c4-0bd229391425           | arn:aws:sns:us-east-2:345644333333:turbot_aws_api_handler           | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
| arn:aws:sns:ca-central-1:345644333333:turbot_aws_api_handler:1ea22619-28bc-46b3-8761-8dcdaa8f2727        | arn:aws:sns:ca-central-1:345644333333:turbot_aws_api_handler        | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
| arn:aws:sns:us-west-1:345644333333:turbot_aws_api_handler:ebdf2eae-bb47-41cf-b50a-51b6c5445c9b           | arn:aws:sns:us-west-1:345644333333:turbot_aws_api_handler           | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
| arn:aws:sns:us-east-1:345644333333:turbot_aws_api_handler:1fb041bf-319d-4f82-b02b-d8162db57abe           | arn:aws:sns:us-east-1:345644333333:turbot_aws_api_handler           | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
| arn:aws:sns:sa-east-1:345644333333:turbot_aws_api_handler:7ab3a8a5-dc76-4031-961a-3218af8916cb           | arn:aws:sns:sa-east-1:345644333333:turbot_aws_api_handler           | 345644333333 | https    | https://nagraj-turbot.cloud.turbot-dev.com/api/v5/events/raw?token>
+----------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------+--------------+----------+------------------------------------------------------------------->

Time: 6.0s. Rows fetched: 15. Hydrate calls: 30.

> select * from aws_sns_topic_subscription where subscription_arn = 'arn:aws:sns:ap-south-1:345644333333:topic-public:0add4eaa-880f-47ca-ba1d-1105e0019320'
+---------------------------------------------------------------------------------------+--------------------------------------------------+--------------+----------+---------------------+--------------------------------+----------------------+----------------------+---->
| subscription_arn                                                                      | topic_arn                                        | owner        | protocol | endpoint            | confirmation_was_authenticated | pending_confirmation | raw_message_delivery | del>
+---------------------------------------------------------------------------------------+--------------------------------------------------+--------------+----------+---------------------+--------------------------------+----------------------+----------------------+---->
| arn:aws:sns:ap-south-1:345644333333:topic-public:0add4eaa-880f-47ca-ba1d-1105e0019320 | arn:aws:sns:ap-south-1:345644333333:topic-public | 345644333333 | email    | debabrat@turbot.com | false                          | false                | false                | <nu>
+---------------------------------------------------------------------------------------+--------------------------------------------------+--------------+----------+---------------------+--------------------------------+----------------------+----------------------+---->

Time: 2.8s. Rows fetched: 1. Hydrate calls: 1.

```
</details>
