### PR TITLE
Add deletion_protection_enabled column to aws_dynamodb_table table

### DIFF
--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -196,7 +196,6 @@ func tableAwsDynamoDBTable(_ context.Context) *plugin.Table {
 				Description: "Indicates whether deletion protection is enabled (true) or disabled (false) on the table.",
 				Type:        proto.ColumnType_BOOL,
 				Hydrate:     getDynamoDBTable,
-				Transform:   transform.FromField("DeletionProtectionEnabled"),
 			},
 			{
 				Name:        "continuous_backups_status",

--- a/aws/table_aws_dynamodb_table.go
+++ b/aws/table_aws_dynamodb_table.go
@@ -192,6 +192,13 @@ func tableAwsDynamoDBTable(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("SSEDescription"),
 			},
 			{
+				Name:        "deletion_protection_enabled",
+				Description: "Indicates whether deletion protection is enabled (true) or disabled (false) on the table.",
+				Type:        proto.ColumnType_BOOL,
+				Hydrate:     getDynamoDBTable,
+				Transform:   transform.FromField("DeletionProtectionEnabled"),
+			},
+			{
 				Name:        "continuous_backups_status",
 				Description: "The continuous backups status of the table. ContinuousBackupsStatus can be one of the following states: ENABLED, DISABLED.",
 				Type:        proto.ColumnType_STRING,

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/appconfig v1.15.1
 	github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.17.1
 	github.com/aws/aws-sdk-go-v2/service/appstream v1.20.5
+	github.com/aws/aws-sdk-go-v2/service/appsync v1.22.5
 	github.com/aws/aws-sdk-go-v2/service/athena v1.23.1
 	github.com/aws/aws-sdk-go-v2/service/auditmanager v1.23.0
 	github.com/aws/aws-sdk-go-v2/service/autoscaling v1.26.1
@@ -42,7 +43,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/dlm v1.15.6
 	github.com/aws/aws-sdk-go-v2/service/docdb v1.20.1
 	github.com/aws/aws-sdk-go-v2/service/drs v1.10.0
-	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.18.1
+	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.19.0
 	github.com/aws/aws-sdk-go-v2/service/ec2 v1.81.0
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.18.1
 	github.com/aws/aws-sdk-go-v2/service/ecrpublic v1.15.0
@@ -123,8 +124,10 @@ require (
 	github.com/aws/smithy-go v1.19.0
 	github.com/gocarina/gocsv v0.0.0-20201208093247-67c824bc04d4
 	github.com/golang/protobuf v1.5.3
+	github.com/rs/dnscache v0.0.0-20230804202142-fc85eb664529
 	github.com/turbot/go-kit v0.9.0-rc.1
 	github.com/turbot/steampipe-plugin-sdk/v5 v5.8.0
+	golang.org/x/sync v0.5.0
 	golang.org/x/text v0.13.0
 )
 
@@ -144,10 +147,9 @@ require (
 	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.35 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.28 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.0.18 // indirect
-	github.com/aws/aws-sdk-go-v2/service/appsync v1.22.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.9.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.22 // indirect
-	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.21 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.23 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.21 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.12.0 // indirect
@@ -205,7 +207,6 @@ require (
 	github.com/prometheus/common v0.37.0 // indirect
 	github.com/prometheus/procfs v0.8.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
-	github.com/rs/dnscache v0.0.0-20230804202142-fc85eb664529 // indirect
 	github.com/sethvargo/go-retry v0.2.4 // indirect
 	github.com/stevenle/topsort v0.2.0 // indirect
 	github.com/tkrajina/go-reflector v0.5.6 // indirect
@@ -225,7 +226,6 @@ require (
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/net v0.17.0 // indirect
 	golang.org/x/oauth2 v0.11.0 // indirect
-	golang.org/x/sync v0.5.0 // indirect
 	golang.org/x/sys v0.14.0 // indirect
 	golang.org/x/time v0.5.0 // indirect
 	golang.org/x/xerrors v0.0.0-20220907171357-04be3eba64a2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -325,6 +325,8 @@ github.com/aws/aws-sdk-go-v2/service/drs v1.10.0 h1:7JQlmAKx339YQEImt6dK2xViu9t1
 github.com/aws/aws-sdk-go-v2/service/drs v1.10.0/go.mod h1:+rdKQi9kdwiJXEAR8Yyl++lLbZhVql61xSPdC44YqTs=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.18.1 h1:xmKa+GjQxvzK5xZNzrcybXuPOvjYX9JDWNkXF7fNr5c=
 github.com/aws/aws-sdk-go-v2/service/dynamodb v1.18.1/go.mod h1:uP2wpt43//qh6NqMFslaRu53A2YbnFStkV4Wn1Ldels=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.19.0 h1:1AlVHOQPNyAxRkujCxmy5gKH7RrO53Z/bFBt1W0sHuM=
+github.com/aws/aws-sdk-go-v2/service/dynamodb v1.19.0/go.mod h1:njGV8YOTBFbXQGuoei1SU+rQO32F01qvBQ9oUIR+SSY=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.81.0 h1:FuCLk1Qm2elBD1MLEM0IujYQLfklBRoOleE91Hy8qPU=
 github.com/aws/aws-sdk-go-v2/service/ec2 v1.81.0/go.mod h1:mV0E7631M1eXdB+tlGFIw6JxfsC7Pz7+7Aw15oLVhZw=
 github.com/aws/aws-sdk-go-v2/service/ecr v1.18.1 h1:fZNQcqqyAcb34XZ6uNuDlmKIaZKRGdoXYfK5WLRjBbQ=
@@ -381,6 +383,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.22 h1:kv5vRAl00tozRx
 github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.1.22/go.mod h1:Od+GU5+Yx41gryN/ZGZzAJMZ9R1yn6lgA0fD5Lo5SkQ=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.21 h1:UYhcXvg66FBsZKRpXtNc4w+2rwaTHzST/zhpQBxzhPo=
 github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.21/go.mod h1:NXJls8x8f9zVSaf+EKKoonqaahWK69MUWm6w6ob0FHs=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.23 h1:5AwQnYQT3ZX/N7hPTAx4ClWyucaiqr2esQRMNbJIby0=
+github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.7.23/go.mod h1:s8OUYECPoPpevQHmRmMBemFIx6Oc91iapsw56KiXIMY=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.21 h1:5C6XgTViSb0bunmU57b3CT+MhxULqHH2721FVA+/kDM=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.21/go.mod h1:lRToEJsn+DRA9lW4O9L9+/3hjTkUzlzyzHqn8MTds5k=
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.13.21 h1:vY5siRXvW5TrOKm2qKEf9tliBfdLxdfy0i02LOcmqUo=


### PR DESCRIPTION
Please see https://github.com/aws/aws-sdk-go-v2/commit/5799416de4970748df37d556db57a88e050d99c9#diff-5bff2101cfda3ee73930b662b6d8c0498792c94dae3d4f403f703fe3f8e4e342R1

# Integration test logs
<details>
  <summary>Logs</summary>

N/A
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select arn, deletion_protection_enabled from aws_dynamodb_table;
+-------------------------------------------------------------------------------------+-----------------------------+
| arn                                                                                 | deletion_protection_enabled |
+-------------------------------------------------------------------------------------+-----------------------------+
| arn:aws:dynamodb:eu-central-1:123456789012:table/prod-foobar                        | true                       |
| arn:aws:dynamodb:eu-central-1:123456789012:table/dev-foobar                         | false                       |
| arn:aws:dynamodb:eu-central-1:123456789012:table/staging-foobar                     | false                       |
+-------------------------------------------------------------------------------------+-----------------------------+
```
</details>
