### PR TITLE
Add table aws_organizations_organizational_unit back to the table list

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -334,7 +334,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_oam_sink":                                                 tableAwsOAMSink(ctx),
 			"aws_opensearch_domain":                                        tableAwsOpenSearchDomain(ctx),
 			"aws_organizations_account":                                    tableAwsOrganizationsAccount(ctx),
-			// "aws_organizations_organizational_unit":                        tableAwsOrganizationsOrganizationalUnit(ctx),
+			"aws_organizations_organizational_unit":                        tableAwsOrganizationsOrganizationalUnit(ctx),
 			"aws_organizations_policy":                                     tableAwsOrganizationsPolicy(ctx),
 			"aws_organizations_policy_target":                              tableAwsOrganizationsPolicyTarget(ctx),
 			"aws_organizations_root":                                       tableAwsOrganizationsRoot(ctx),

--- a/docs/tables/aws_organizations_organizational_unit.md
+++ b/docs/tables/aws_organizations_organizational_unit.md
@@ -1,0 +1,187 @@
+# Table: aws_organizations_organizational_unit
+
+A container for accounts within a root. An OU also can contain other OUs, enabling you to create a hierarchy that resembles an upside-down tree, with a root at the top and branches of OUs that reach down, ending in accounts that are the leaves of the tree. When you attach a policy to one of the nodes in the hierarchy, it flows down and affects all the branches (OUs) and leaves (accounts) beneath it. An OU can have exactly one parent, and currently each account can be a member of exactly one OU.
+
+To represent the hierarchical structure, the table includes a `path` column. This column is crucial for understanding the relationship between different OUs in the hierarchy. Due to compatibility issues with the ltree type, which is typically used for representing tree-like structures in PostgreSQL, the standard hyphen (-) in the path values has been replaced with an underscore (\_). This modification ensures proper functionality of the ltree operations and queries.
+
+By default, querying the table without any specific filters will return all OUs from the root of the hierarchy. Users have the option to query the table using a specific `parent_id`. This allows for the retrieval of all direct child OUs under the specified parent.
+
+## Examples
+
+### Basic info
+This query helps AWS administrators and cloud architects to efficiently manage, audit, and report on the structure and composition of their AWS Organizations.
+
+```sql+postgres
+select
+  name,
+  id,
+  arn,
+  parent_id,
+  title,
+  akas
+from
+  aws_organizations_organizational_unit;
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  arn,
+  parent_id,
+  title,
+  akas
+from
+  aws_organizations_organizational_unit;
+```
+
+### Find a specific organizational unit and all its descendants
+By filtering OUs based on their path, the query efficiently retrieves information about a specific subset of your organization's structure, which is particularly useful for large organizations with complex hierarchies.
+
+```sql+postgres
+select
+  name,
+  id,
+  parent_id,
+  path
+from
+  aws_organizations_organizational_unit
+where
+  path <@ 'r_wxnb.ou_wxnb_m8l8t123';
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  parent_id,
+  path
+from
+  aws_organizations_organizational_unit
+where
+  path like 'r_wxnb.ou_wxnb_m8l8t123%'
+```
+
+### Select all organizational units at a certain level in the hierarchy
+Retrieving a list of organizational units (OUs) from a structured hierarchy, specifically those that exist at a particular level. In the context of a database or a management system like AWS Organizations, this involves using a query to filter and display only the OUs that are positioned at the same depth or stage in the hierarchical structure.
+
+```sql+postgres
+select
+  name,
+  id,
+  parent_id,
+  path
+from
+  aws_organizations_organizational_unit
+where
+  nlevel(path) = 3;
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  parent_id,
+  path
+from
+  aws_organizations_organizational_unit
+where
+  (length(path) - length(replace(path, '.', ''))) = 2;
+```
+
+### Get all ancestors of a given organizational unit
+Ancestors are the units in the hierarchy that precede the given OU. An ancestor can be a direct parent (the immediate higher-level unit), or it can be any higher-level unit up to the root of the hierarchy.
+
+```sql+postgres
+select
+  name,
+  id,
+  parent_id,
+  path
+from
+  aws_organizations_organizational_unit
+where
+  'r_wxnb.ou_wxnb_m8l123aq.ou_wxnb_5gri123b' @> path;
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  parent_id,
+  path
+from
+  aws_organizations_organizational_unit
+where
+  path like 'r_wxnb.ou_wxnb_m8l123aq.ou_wxnb_5gri123b%';
+```
+
+### Retrieve all siblings of a specific organizational unit
+The query is useful for retrieving information about sibling organizational units corresponding to a specified organizational unit.
+
+```sql+postgres
+select
+  name,
+  id,
+  parent_id,
+  path
+from
+  aws_organizations_organizational_unit
+where
+  parent_id =
+  (
+    select
+      parent_id
+    from
+      aws_organizations_organizational_unit
+    where
+      name = 'Punisher'
+  );
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  parent_id,
+  path
+from
+  aws_organizations_organizational_unit
+where
+  parent_id =
+  (
+    select
+      parent_id
+    from
+      aws_organizations_organizational_unit
+    where
+      name = 'Punisher'
+  );
+```
+
+### Select organizational units with a path that matches a specific pattern
+This query is designed to retrieve organizational units that have a specific hierarchical path pattern within an AWS (Amazon Web Services) organization's structure.
+
+```sql+postgres
+select
+  name,
+  id,
+  parent_id,
+  path
+from
+  aws_organizations_organizational_unit
+where
+  path ~ 'r_wxnb.*.ou_wxnb_m81234aq.*';
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  parent_id,
+  path
+from
+  aws_organizations_organizational_unit
+where
+  path like 'r_wxnb%ou_wxnb_m81234aq%';
+```

--- a/docs/tables/aws_organizations_organizational_unit.md
+++ b/docs/tables/aws_organizations_organizational_unit.md
@@ -1,8 +1,15 @@
+---
+title: "Steampipe Table: aws_organizations_organizational_unit - Query AWS Organizations Organizational Units using SQL"
+description: "Allows users to query AWS Organizations Organizational Units and provides information about each OUs."
+---
+
 # Table: aws_organizations_organizational_unit
 
 A container for accounts within a root. An OU also can contain other OUs, enabling you to create a hierarchy that resembles an upside-down tree, with a root at the top and branches of OUs that reach down, ending in accounts that are the leaves of the tree. When you attach a policy to one of the nodes in the hierarchy, it flows down and affects all the branches (OUs) and leaves (accounts) beneath it. An OU can have exactly one parent, and currently each account can be a member of exactly one OU.
 
-To represent the hierarchical structure, the table includes a `path` column. This column is crucial for understanding the relationship between different OUs in the hierarchy. Due to compatibility issues with the ltree type, which is typically used for representing tree-like structures in PostgreSQL, the standard hyphen (-) in the path values has been replaced with an underscore (\_). This modification ensures proper functionality of the ltree operations and queries.
+## Table Usage Guide
+
+The `aws_organizations_organizational_unit` table in Steampipe provides you with information about  the hierarchical structure, the table includes a `path` column. This column is crucial for understanding the relationship between different OUs in the hierarchy. Due to compatibility issues with the ltree type, which is typically used for representing tree-like structures in PostgreSQL, the standard hyphen (-) in the path values has been replaced with an underscore (\_). This modification ensures proper functionality of the ltree operations and queries.
 
 By default, querying the table without any specific filters will return all OUs from the root of the hierarchy. Users have the option to query the table using a specific `parent_id`. This allows for the retrieval of all direct child OUs under the specified parent.
 

--- a/docs/tables/aws_organizations_organizational_unit.md
+++ b/docs/tables/aws_organizations_organizational_unit.md
@@ -1,6 +1,6 @@
 ---
 title: "Steampipe Table: aws_organizations_organizational_unit - Query AWS Organizations Organizational Units using SQL"
-description: "Allows users to query AWS Organizations Organizational Units and provides information about each OUs."
+description: "Allows users to query AWS Organizations Organizational Units and provides information about each OU."
 ---
 
 # Table: aws_organizations_organizational_unit
@@ -9,7 +9,7 @@ A container for accounts within a root. An OU also can contain other OUs, enabli
 
 ## Table Usage Guide
 
-The `aws_organizations_organizational_unit` table in Steampipe provides you with information about  the hierarchical structure, the table includes a `path` column. This column is crucial for understanding the relationship between different OUs in the hierarchy. Due to compatibility issues with the ltree type, which is typically used for representing tree-like structures in PostgreSQL, the standard hyphen (-) in the path values has been replaced with an underscore (\_). This modification ensures proper functionality of the ltree operations and queries.
+The `aws_organizations_organizational_unit` table in Steampipe provides you with information about  the hierarchical structure, the table includes a `path` column. This column is crucial for understanding the relationship between different OUs in the hierarchy. Due to compatibility issues with the `ltree` type, which is typically used for representing tree-like structures in PostgreSQL, the standard hyphen (-) in the path values has been replaced with an underscore (\_). This modification ensures proper functionality of the `ltree` operations and queries.
 
 By default, querying the table without any specific filters will return all OUs from the root of the hierarchy. Users have the option to query the table using a specific `parent_id`. This allows for the retrieval of all direct child OUs under the specified parent.
 


### PR DESCRIPTION
**Note:** This table is compatible with Steampipe CLI version `v0.21.4` and later.

# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
  name,
  id,
  parent_id,
  title, path
from
  aws_organizations_organizational_unit;
+--------------------------+------------------+------------------+--------------------------+------------------------------------------+
| name                     | id               | parent_id        | title                    | path                                     |
+--------------------------+------------------+------------------+--------------------------+------------------------------------------+
| account creation testing | ou-wxnb-feyv7riq | r-wxnb           | account creation testing | r_wxnb.ou_wxnb_feyv7riq                  |
| Devgov                   | ou-wxnb-bijhomqq | r-wxnb           | Devgov                   | r_wxnb.ou_wxnb_bijhomqq                  |
| Turbot SaaS Staging      | ou-wxnb-wofu2g1q | r-wxnb           | Turbot SaaS Staging      | r_wxnb.ou_wxnb_wofu2g1q                  |
| Zaphod                   | ou-wxnb-9fwb3vkp | ou-wxnb-wofu2g1q | Zaphod                   | r_wxnb.ou_wxnb_wofu2g1q.ou_wxnb_9fwb3vkp |
| Babelfish                | ou-wxnb-xsjjyp4l | ou-wxnb-wofu2g1q | Babelfish                | r_wxnb.ou_wxnb_wofu2g1q.ou_wxnb_xsjjyp4l |
| Turbot SaaS Dev          | ou-wxnb-m8l8tpaq | r-wxnb           | Turbot SaaS Dev          | r_wxnb.ou_wxnb_m8l8tpaq                  |
| Parker                   | ou-wxnb-v9prfpcr | ou-wxnb-m8l8tpaq | Parker                   | r_wxnb.ou_wxnb_m8l8tpaq.ou_wxnb_v9prfpcr |
| Demo                     | ou-wxnb-t4tmxsge | ou-wxnb-m8l8tpaq | Demo                     | r_wxnb.ou_wxnb_m8l8tpaq.ou_wxnb_t4tmxsge |
| Howard the Duck          | ou-wxnb-ysd8ytz1 | ou-wxnb-m8l8tpaq | Howard the Duck          | r_wxnb.ou_wxnb_m8l8tpaq.ou_wxnb_ysd8ytz1 |
| Stacy                    | ou-wxnb-d2piz569 | ou-wxnb-m8l8tpaq | Stacy                    | r_wxnb.ou_wxnb_m8l8tpaq.ou_wxnb_d2piz569 |
| Nagraj                   | ou-wxnb-ztidbw0m | ou-wxnb-m8l8tpaq | Nagraj                   | r_wxnb.ou_wxnb_m8l8tpaq.ou_wxnb_ztidbw0m |
| Hawkeye                  | ou-wxnb-etrw8nse | ou-wxnb-m8l8tpaq | Hawkeye                  | r_wxnb.ou_wxnb_m8l8tpaq.ou_wxnb_etrw8nse |
| Punisher                 | ou-wxnb-5grilgkb | ou-wxnb-m8l8tpaq | Punisher                 | r_wxnb.ou_wxnb_m8l8tpaq.ou_wxnb_5grilgkb |
| Shaktiman                | ou-wxnb-hf7lyl45 | ou-wxnb-m8l8tpaq | Shaktiman                | r_wxnb.ou_wxnb_m8l8tpaq.ou_wxnb_hf7lyl45 |
| Morales                  | ou-wxnb-cxfxoe75 | ou-wxnb-m8l8tpaq | Morales                  | r_wxnb.ou_wxnb_m8l8tpaq.ou_wxnb_cxfxoe75 |
| Osborn                   | ou-wxnb-5tlr34nv | ou-wxnb-m8l8tpaq | Osborn                   | r_wxnb.ou_wxnb_m8l8tpaq.ou_wxnb_5tlr34nv |
| Turbot SaaS Prod         | ou-wxnb-5rbvg65u | r-wxnb           | Turbot SaaS Prod         | r_wxnb.ou_wxnb_5rbvg65u                  |
| www                      | ou-wxnb-vch85tma | r-wxnb           | www                      | r_wxnb.ou_wxnb_vch85tma                  |
| Sales                    | ou-wxnb-drzvknhj | ou-wxnb-5rbvg65u | Sales                    | r_wxnb.ou_wxnb_5rbvg65u.ou_wxnb_drzvknhj |
| Primeval                 | ou-wxnb-w048ykj6 | ou-wxnb-5rbvg65u | Primeval                 | r_wxnb.ou_wxnb_5rbvg65u.ou_wxnb_w048ykj6 |
| Rocketeer                | ou-wxnb-9enu98k8 | ou-wxnb-5rbvg65u | Rocketeer                | r_wxnb.ou_wxnb_5rbvg65u.ou_wxnb_9enu98k8 |
| Personal Sandbox         | ou-wxnb-joldicj7 | r-wxnb           | Personal Sandbox         | r_wxnb.ou_wxnb_joldicj7                  |
| Silverwater              | ou-wxnb-v66c90u3 | r-wxnb           | Silverwater              | r_wxnb.ou_wxnb_v66c90u3                  |
| Rex                      | ou-wxnb-52uc2fbu | r-wxnb           | Rex                      | r_wxnb.ou_wxnb_52uc2fbu                  |
| Jamal                    | ou-wxnb-05v0c1hg | r-wxnb           | Jamal                    | r_wxnb.ou_wxnb_05v0c1hg                  |
+--------------------------+------------------+------------------+--------------------------+------------------------------------------+

Time: 14.8s. Rows fetched: 25. Hydrate calls: 25.
```
</details>
