### PR TITLE
Remove duplicate memoizing of getCommonColumns. Closes #2064

### DIFF
--- a/aws/table_aws_ec2_launch_template.go
+++ b/aws/table_aws_ec2_launch_template.go
@@ -169,8 +169,7 @@ func listEc2LaunchTemplates(ctx context.Context, d *plugin.QueryData, _ *plugin.
 func launchTemplateAkas(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	launchTemplate := h.Item.(types.LaunchTemplate)
 	region := d.EqualsQualString(matrixKeyRegion)
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
-	commonData, err := getCommonColumnsCached(ctx, d, h)
+	commonData, err := getCommonColumns(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ec2_launch_template.launchTemplateAkas", "common_data_error", err)
 		return nil, err

--- a/aws/table_aws_s3_multi_region_access_point.go
+++ b/aws/table_aws_s3_multi_region_access_point.go
@@ -90,8 +90,7 @@ func tableAwsS3MultiRegionAccessPoint(_ context.Context) *plugin.Table {
 
 func listS3MultiRegionAccessPoints(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// Get account details
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
-	commonData, err := getCommonColumnsCached(ctx, d, h)
+	commonData, err := getCommonColumns(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_s3_multi_region_access_point.listS3MultiRegionAccessPoints", "common_data_error", err)
 		return nil, err
@@ -162,8 +161,7 @@ func listS3MultiRegionAccessPoints(ctx context.Context, d *plugin.QueryData, h *
 func getS3MultiRegionAccessPoint(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 
 	// Get account details
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
-	commonData, err := getCommonColumnsCached(ctx, d, h)
+	commonData, err := getCommonColumns(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_s3_multi_region_access_point.getS3MultiRegionAccessPoint", "common_data_error", err)
 		return nil, err
@@ -210,8 +208,7 @@ func getMultiRegionAccessPointArn(ctx context.Context, d *plugin.QueryData, h *p
 	accessPointName := multiRegionAccessPointName(h.Item)
 
 	// Get account details
-	getCommonColumnsCached := plugin.HydrateFunc(getCommonColumns).WithCache()
-	commonData, err := getCommonColumnsCached(ctx, d, h)
+	commonData, err := getCommonColumns(ctx, d, h)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_s3_multi_region_access_point.getMultiRegionAccessPointArn", "common_data_error", err)
 		return nil, err


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Before fix:

steampipe query "select * from aws_ec2_launch_template" 
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
+-------------------------+----------------------+---------------------------+----------------------------------------------------------------------------------------------------+------------------------+-----------------------+----------+-------------------------+--------+------------------------------------------------------------------------------+-----------+------------+--------------+---------------------------------------------------------------+
| launch_template_name    | launch_template_id   | create_time               | created_by                                                                                         | default_version_number | latest_version_number | tags_src | title                   | tags   | akas                                                                         | partition | region     | account_id   | _ctx                                                          |
+-------------------------+----------------------+---------------------------+----------------------------------------------------------------------------------------------------+------------------------+-----------------------+----------+-------------------------+--------+------------------------------------------------------------------------------+-----------+------------+--------------+---------------------------------------------------------------+
| test                    | lt-05e18f2f2c96240c8 | 2021-08-27T19:50:17+05:30 | arn:aws:sts::333333333333:assumed-role/superuser/sourav@hsakjs.com-by2Uc93YidKxTbuj5cf             | 1                      | 4                     | <null>   | test                    | <null> | ["arn:aws:ec2:ap-south-1:333333333333:launch-template/lt-05e18f2f2c96240c8"] | aws       | ap-south-1 | 333333333333 | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
| test-launch-template    | lt-099111138f010488f | 2021-04-15T15:34:58+05:30 | arn:aws:iam::333333333333:user/user-steampipe                                                      | 1                      | 1                     | <null>   | test-launch-template    | <null> | ["arn:aws:ec2:ap-south-1:333333333333:launch-template/lt-099111138f010488f"] | aws       | ap-south-1 | 333333333333 | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
| sp-flow-launch-template | lt-01f7ec4e585e854a7 | 2022-08-03T17:58:51+05:30 | arn:aws:sts::333333333333:assumed-role/AWSReservedSSO_SSO-Admin_73c8b60995c61b0f/binaek@hsakjs.com | 3                      | 3                     | <null>   | sp-flow-launch-template | <null> | ["arn:aws:ec2:us-west-2:333333333333:launch-template/lt-01f7ec4e585e854a7"]  | aws       | us-west-2  | 333333333333 | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
+-------------------------+----------------------+---------------------------+----------------------------------------------------------------------------------------------------+------------------------+-----------------------+----------+-------------------------+--------+------------------------------------------------------------------------------+-----------+------------+--------------+---------------------------------------------------------------+

Time: 6.2s. Rows fetched: 3. Hydrate calls: 6.
➜  aws git:(issue-1831) ✗ steampipe query "select * from aws_ec2_launch_template"
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)

Error: runtime error: invalid memory address or nil pointer dereference (SQLSTATE HV000)

+----------------------+--------------------+-------------+------------+------------------------+-----------------------+----------+-------+------+------+-----------+--------+------------+------+
| launch_template_name | launch_template_id | create_time | created_by | default_version_number | latest_version_number | tags_src | title | tags | akas | partition | region | account_id | _ctx |
+----------------------+--------------------+-------------+------------+------------------------+-----------------------+----------+-------+------+------+-----------+--------+------------+------+
+----------------------+--------------------+-------------+------------+------------------------+-----------------------+----------+-------+------+------+-----------+--------+------------+------+

Time: 59ms. Rows fetched: 0. Hydrate calls: 0.



After fix:

steampipe query "select * from aws_ec2_launch_template"                                      
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
+-------------------------+----------------------+---------------------------+----------------------------------------------------------------------------------------------------+------------------------+-----------------------+----------+-------------------------+--------+------------------------------------------------------------------------------+-----------+------------+--------------+---------------------------------------------------------------+
| launch_template_name    | launch_template_id   | create_time               | created_by                                                                                         | default_version_number | latest_version_number | tags_src | title                   | tags   | akas                                                                         | partition | region     | account_id   | _ctx                                                          |
+-------------------------+----------------------+---------------------------+----------------------------------------------------------------------------------------------------+------------------------+-----------------------+----------+-------------------------+--------+------------------------------------------------------------------------------+-----------+------------+--------------+---------------------------------------------------------------+
| test-launch-template    | lt-099111138f010488f | 2021-04-15T15:34:58+05:30 | arn:aws:iam::333333333333:user/user-steampipe                                                      | 1                      | 1                     | <null>   | test-launch-template    | <null> | ["arn:aws:ec2:ap-south-1:333333333333:launch-template/lt-099111138f010488f"] | aws       | ap-south-1 | 333333333333 | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
| test                    | lt-05e18f2f2c96240c8 | 2021-08-27T19:50:17+05:30 | arn:aws:sts::333333333333:assumed-role/superuser/sourav@hsakjs.com-by2Uc93YidKxTbuj5cf             | 1                      | 4                     | <null>   | test                    | <null> | ["arn:aws:ec2:ap-south-1:333333333333:launch-template/lt-05e18f2f2c96240c8"] | aws       | ap-south-1 | 333333333333 | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
| sp-flow-launch-template | lt-01f7ec4e585e854a7 | 2022-08-03T17:58:51+05:30 | arn:aws:sts::333333333333:assumed-role/AWSReservedSSO_SSO-Admin_73c8b60995c61b0f/binaek@hsakjs.com | 3                      | 3                     | <null>   | sp-flow-launch-template | <null> | ["arn:aws:ec2:us-west-2:333333333333:launch-template/lt-01f7ec4e585e854a7"]  | aws       | us-west-2  | 333333333333 | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
+-------------------------+----------------------+---------------------------+----------------------------------------------------------------------------------------------------+------------------------+-----------------------+----------+-------------------------+--------+------------------------------------------------------------------------------+-----------+------------+--------------+---------------------------------------------------------------+

Time: 5.4s. Rows fetched: 3. Hydrate calls: 6.
➜  aws git:(2064-invalid-memory-address-or-nil-pointer-dereference-querying-aws_ec2_launch_template) ✗ steampipe query "select * from aws_ec2_launch_template"
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
+-------------------------+----------------------+---------------------------+----------------------------------------------------------------------------------------------------+------------------------+-----------------------+----------+-------------------------+--------+------------------------------------------------------------------------------+-----------+------------+--------------+---------------------------------------------------------------+
| launch_template_name    | launch_template_id   | create_time               | created_by                                                                                         | default_version_number | latest_version_number | tags_src | title                   | tags   | akas                                                                         | partition | region     | account_id   | _ctx                                                          |
+-------------------------+----------------------+---------------------------+----------------------------------------------------------------------------------------------------+------------------------+-----------------------+----------+-------------------------+--------+------------------------------------------------------------------------------+-----------+------------+--------------+---------------------------------------------------------------+
| test-launch-template    | lt-099111138f010488f | 2021-04-15T15:34:58+05:30 | arn:aws:iam::333333333333:user/user-steampipe                                                      | 1                      | 1                     | <null>   | test-launch-template    | <null> | ["arn:aws:ec2:ap-south-1:333333333333:launch-template/lt-099111138f010488f"] | aws       | ap-south-1 | 333333333333 | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
| test                    | lt-05e18f2f2c96240c8 | 2021-08-27T19:50:17+05:30 | arn:aws:sts::333333333333:assumed-role/superuser/sourav@hsakjs.com-by2Uc93YidKxTbuj5cf             | 1                      | 4                     | <null>   | test                    | <null> | ["arn:aws:ec2:ap-south-1:333333333333:launch-template/lt-05e18f2f2c96240c8"] | aws       | ap-south-1 | 333333333333 | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
| sp-flow-launch-template | lt-01f7ec4e585e854a7 | 2022-08-03T17:58:51+05:30 | arn:aws:sts::333333333333:assumed-role/AWSReservedSSO_SSO-Admin_73c8b60995c61b0f/binaek@hsakjs.com | 3                      | 3                     | <null>   | sp-flow-launch-template | <null> | ["arn:aws:ec2:us-west-2:333333333333:launch-template/lt-01f7ec4e585e854a7"]  | aws       | us-west-2  | 333333333333 | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
+-------------------------+----------------------+---------------------------+----------------------------------------------------------------------------------------------------+------------------------+-----------------------+----------+-------------------------+--------+------------------------------------------------------------------------------+-----------+------------+--------------+---------------------------------------------------------------+

Time: 72ms. Rows fetched: 3 (cached). Hydrate calls: 0.

```
</details>
