### PR TITLE
Fixed Interface Conversion Error When Querying aws.aws_health_affected_entity Closes #2069

### DIFF
--- a/aws/table_aws_health_affected_entity.go
+++ b/aws/table_aws_health_affected_entity.go
@@ -87,7 +87,7 @@ func tableAwsHealthAffectedEntity(_ context.Context) *plugin.Table {
 
 func listHealthAffectedEntities(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// Create Session
-	event := h.Item.(*types.Event)
+	event := h.Item.(types.Event)
 
 	// Limiting the results
 	maxLimit := int32(100)
@@ -150,7 +150,7 @@ func listHealthAffectedEntities(ctx context.Context, d *plugin.QueryData, h *plu
 	return nil, err
 }
 
-// / UTILITY FUNCTION
+//// UTILITY FUNCTION
 // Build health affected entity list call input filter
 func buildHealthAffectedEntityFilter(d *plugin.QueryData) *types.EntityFilter {
 	filter := &types.EntityFilter{}


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
