### PR TITLE
Updated tables as per EC2 package version updated

### DIFF
--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -212,7 +212,9 @@ func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 
 	// Build filter for ebs snapshot
 	filters := buildEbsSnapshotFilter(ctx, d, h, d.EqualsQuals, input)
-	input.Filters = filters
+	if len(filters) > 0 {
+		input.Filters = filters
+	}
 
 	paginator := ec2.NewDescribeSnapshotsPaginator(svc, input, func(o *ec2.DescribeSnapshotsPaginatorOptions) {
 		o.Limit = maxLimit

--- a/aws/table_aws_ec2_instance_availability.go
+++ b/aws/table_aws_ec2_instance_availability.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
+	"github.com/turbot/steampipe-plugin-sdk/v5/query_cache"
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -28,8 +29,9 @@ func tableAwsInstanceAvailability(_ context.Context) *plugin.Table {
 					Require: plugin.Optional,
 				},
 				{
-					Name:    "location_type",
-					Require: plugin.Optional,
+					Name:       "location_type",
+					Require:    plugin.Optional,
+					CacheMatch: query_cache.CacheMatchExact,
 				},
 			},
 		},

--- a/aws/table_aws_ec2_instance_type.go
+++ b/aws/table_aws_ec2_instance_type.go
@@ -87,6 +87,18 @@ func tableAwsInstanceType(_ context.Context) *plugin.Table {
 				Hydrate:     describeInstanceType,
 			},
 			{
+				Name:        "nitro_enclaves_support",
+				Description: "Indicates whether instance storage is supported.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     describeInstanceType,
+			},
+			{
+				Name:        "nitro_tpm_support",
+				Description: "Indicates whether NitroTPM is supported.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     describeInstanceType,
+			},
+			{
 				Name:        "hypervisor",
 				Description: "The hypervisor for the instance type.",
 				Type:        proto.ColumnType_STRING,
@@ -156,6 +168,30 @@ func tableAwsInstanceType(_ context.Context) *plugin.Table {
 			{
 				Name:        "gpu_info",
 				Description: "Describes the GPU accelerator settings for the instance type.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     describeInstanceType,
+			},
+			{
+				Name:        "fpga_info",
+				Description: "Describes the FPGA accelerator settings for the instance type.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     describeInstanceType,
+			},
+			{
+				Name:        "inference_accelerator_info",
+				Description: "Describes the Inference accelerator settings for the instance type.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     describeInstanceType,
+			},
+			{
+				Name:        "nitro_tpm_info",
+				Description: "Describes the supported NitroTPM versions for the instance type.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     describeInstanceType,
+			},
+			{
+				Name:        "supported_boot_modes",
+				Description: "The supported boot modes.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     describeInstanceType,
 			},


### PR DESCRIPTION
_**Note:**_ I have tested all the tables utilizing the EC2 package and found no breaking changes. The data from the current EC2 package in the main branch and the new EC2 package featured in [this PR](https://github.com/turbot/steampipe-plugin-aws/pull/2077) were compared, revealing identical results.

# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```

> select * from aws_ec2_instance_availability limit 1
+---------------+-----------+---------------+-------------+------------------------------------------------------+---------------------------------------------------------------+
| instance_type | location  | location_type | title       | akas                                                 | _ctx                                                          |
+---------------+-----------+---------------+-------------+------------------------------------------------------+---------------------------------------------------------------+
| c7gd.medium   | us-east-1 | region        | c7gd.medium | ["arn:aws:ec2:us-east-1::instance-type/c7gd.medium"] | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
+---------------+-----------+---------------+-------------+------------------------------------------------------+---------------------------------------------------------------+

Time: 3.8s. Rows fetched: 1. Hydrate calls: 1.
> select * from aws_ec2_instance_availability where location_type = 'region'limit 1
+---------------+------------+---------------+--------------+--------------------------------------------------------+---------------------------------------------------------------+
| instance_type | location   | location_type | title        | akas                                                   | _ctx                                                          |
+---------------+------------+---------------+--------------+--------------------------------------------------------+---------------------------------------------------------------+
| i4i.16xlarge  | ap-south-1 | region        | i4i.16xlarge | ["arn:aws:ec2:ap-south-1::instance-type/i4i.16xlarge"] | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
+---------------+------------+---------------+--------------+--------------------------------------------------------+---------------------------------------------------------------+

Time: 304ms. Rows fetched: 1. Hydrate calls: 1.
> select * from aws_ec2_instance_availability where location_type = 'availability-zone' limit 1
+---------------+-------------+-------------------+--------------+---------------------------------------------------------+---------------------------------------------------------------+
| instance_type | location    | location_type     | title        | akas                                                    | _ctx                                                          |
+---------------+-------------+-------------------+--------------+---------------------------------------------------------+---------------------------------------------------------------+
| m5a.16xlarge  | ap-south-1a | availability-zone | m5a.16xlarge | ["arn:aws:ec2:ap-south-1a::instance-type/m5a.16xlarge"] | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
+---------------+-------------+-------------------+--------------+---------------------------------------------------------+---------------------------------------------------------------+

Time: 252ms. Rows fetched: 1. Hydrate calls: 1.
> select * from aws_ec2_instance_availability where location_type = 'availability-zone-id' limit 1
+---------------+----------+----------------------+--------------+------------------------------------------------------+---------------------------------------------------------------+
| instance_type | location | location_type        | title        | akas                                                 | _ctx                                                          |
+---------------+----------+----------------------+--------------+------------------------------------------------------+---------------------------------------------------------------+
| m5a.16xlarge  | aps1-az1 | availability-zone-id | m5a.16xlarge | ["arn:aws:ec2:aps1-az1::instance-type/m5a.16xlarge"] | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
+---------------+----------+----------------------+--------------+------------------------------------------------------+---------------------------------------------------------------+

Time: 247ms. Rows fetched: 1. Hydrate calls: 1.
> select * from aws_ec2_instance_availability where location_type = 'outpost' limit 1
+---------------+----------+---------------+-------+------+------+
| instance_type | location | location_type | title | akas | _ctx |
+---------------+----------+---------------+-------+------+------+
+---------------+----------+---------------+-------+------+------+

Time: 0.9s. Rows fetched: 0. Hydrate calls: 0.
> select * from aws_ec2_instance_type limit 1
+---------------+-------------------------+------------+---------------------------------+--------------------+---------------------------+--------------------+-----------------------+------------------------+-------------------+------------+--------------------------->
| instance_type | auto_recovery_supported | bare_metal | burstable_performance_supported | current_generation | dedicated_hosts_supported | free_tier_eligible | hibernation_supported | nitro_enclaves_support | nitro_tpm_support | hypervisor | instance_storage_supported>
+---------------+-------------------------+------------+---------------------------------+--------------------+---------------------------+--------------------+-----------------------+------------------------+-------------------+------------+--------------------------->
| r7a.2xlarge   | true                    | false      | false                           | true               | true                      | false              | true                  | unsupported            | supported         | nitro      | false                     >
+---------------+-------------------------+------------+---------------------------------+--------------------+---------------------------+--------------------+-----------------------+------------------------+-------------------+------------+--------------------------->

Time: 0.9s. Rows fetched: 1. Hydrate calls: 2.
> 
```
</details>
