### PR TITLE
Fixed aws_rds_db_instance_metric_write_iops_daily displays "ReadIOPS" instead of "WriteIOPS" Closes #2075

### DIFF
--- a/aws/table_aws_rds_db_instance_metric_write_iops_daily.go
+++ b/aws/table_aws_rds_db_instance_metric_write_iops_daily.go
@@ -35,5 +35,5 @@ func tableAwsRdsInstanceMetricWriteIopsDaily(_ context.Context) *plugin.Table {
 
 func listRdsInstanceMetricWriteIopsDaily(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	instance := h.Item.(types.DBInstance)
-	return listCWMetricStatistics(ctx, d, "DAILY", "AWS/RDS", "ReadIOPS", "DBInstanceIdentifier", *instance.DBInstanceIdentifier)
+	return listCWMetricStatistics(ctx, d, "DAILY", "AWS/RDS", "WriteIOPS", "DBInstanceIdentifier", *instance.DBInstanceIdentifier)
 }


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs herN/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Before Fix:

 > select * from aws_silverwater.aws_rds_db_instance_metric_write_iops_daily
+------------------------+-------------+-----------+---------------------+--------------------+----------------------+--------------+--------------------+--------------+---------------------------+-----------+----------------+--------------+---------------------------->
| db_instance_identifier | metric_name | namespace | average             | maximum            | minimum              | sample_count | sum                | unit         | timestamp                 | partition | region         | account_id   | _ctx                       >
+------------------------+-------------+-----------+---------------------+--------------------+----------------------+--------------+--------------------+--------------+---------------------------+-----------+----------------+--------------+---------------------------->
| helix-toh              | ReadIOPS    | AWS/RDS   | 0.41062909479385584 | 22.104965294538676 | 0                    | 1440         | 591.3058965031524  | Count/Second | 2023-03-17T15:30:00+05:30 | aws       | ap-southeast-1 | 333333333333 | {"connection_name":"aws_sil>
| helix-toh              | ReadIOPS    | AWS/RDS   | 0.4139584668526824  | 3.7164808426245353 | 0                    | 1440         | 596.1001922678627  | Count/Second | 2023-06-20T15:30:00+05:30 | aws       | ap-southeast-1 | 333333333333 | {"connection_name":"aws_sil>
| helix-toh              | ReadIOPS    | AWS/RDS   | 0.3921754574418799  | 3.675553411944717  | 0                    | 1440         | 564.7326587163071  | Count/Second | 2023-02-28T15:30:00+05:30 | aws       | ap-southeast-1 | 333333333333 | {"connection_name":"aws_sil>

After Fix:

> select * from aws_silverwater.aws_rds_db_instance_metric_write_iops_daily
+------------------------+-------------+-----------+--------------------+--------------------+---------------------+--------------+--------------------+--------------+---------------------------+-----------+----------------+--------------+------------------------------>
| db_instance_identifier | metric_name | namespace | average            | maximum            | minimum             | sample_count | sum                | unit         | timestamp                 | partition | region         | account_id   | _ctx                         >
+------------------------+-------------+-----------+--------------------+--------------------+---------------------+--------------+--------------------+--------------+---------------------------+-----------+----------------+--------------+------------------------------>
| helix-toh              | WriteIOPS   | AWS/RDS   | 6.502521977259377  | 30.22376247521618  | 1.4992254002098915  | 1440         | 9363.631647253504  | Count/Second | 2023-07-17T15:30:00+05:30 | aws       | ap-southeast-1 | 333333333333 | {"connection_name":"aws_silve>
| helix-toh              | WriteIOPS   | AWS/RDS   | 6.164296771395731  | 24.506034569222024 | 1.3994169096209912  | 1440         | 8876.587350809852  | Count/Second | 2023-04-03T15:30:00+05:30 | aws       | ap-southeast-1 | 333333333333 | {"connection_name":"aws_silve>
| helix-toh              | WriteIOPS   | AWS/RDS   | 6.621809725886396  | 23.85911128142755  | 1.6683906703593714  | 1440         | 9535.40600527641   | Count/Second | 2023-09-22T15:30:00+05:30 | aws       | ap-southeast-1 | 333333333333 | {"connection_name":"aws_silve>


```
</details>
