### PR TITLE
Add table aws_ecr_registry_scanning_configuration #2083

### DIFF
--- a/aws-test/tests/aws_ecr_registry_scanning_configuration/test-get-expected.json
+++ b/aws-test/tests/aws_ecr_registry_scanning_configuration/test-get-expected.json
@@ -1,0 +1,21 @@
+[
+  {
+    "region": "{{ output.aws_region.value }}",
+    "registry_id": "{{ output.aws_account.value }}",
+    "scanning_configuration": {
+      "Rules": [
+        {
+          "RepositoryFilters": [
+            {
+              "Filter": "example",
+              "FilterType": "WILDCARD"
+            }
+          ],
+          "ScanFrequency": "CONTINUOUS_SCAN"
+        }
+      ],
+      "ScanType": "ENHANCED"
+    },
+    "title": "{{ output.aws_account.value }}"
+  }
+]

--- a/aws-test/tests/aws_ecr_registry_scanning_configuration/test-get-query.sql
+++ b/aws-test/tests/aws_ecr_registry_scanning_configuration/test-get-query.sql
@@ -1,0 +1,3 @@
+select registry_id, scanning_configuration, title, region
+from aws.aws_ecr_registry_scanning_configuration
+where region = '{{ output.aws_region.value }}'

--- a/aws-test/tests/aws_ecr_registry_scanning_configuration/variables.tf
+++ b/aws-test/tests/aws_ecr_registry_scanning_configuration/variables.tf
@@ -1,0 +1,75 @@
+variable "resource_name" {
+  type        = string
+  default     = "turbot-test-20200125-create-update"
+  description = "Name of the resource used throughout the test."
+}
+
+variable "aws_profile" {
+  type        = string
+  default     = "default"
+  description = "AWS credentials profile used for the test. Default is to use the default profile."
+}
+
+variable "aws_region" {
+  type        = string
+  default     = "us-east-1"
+  description = "AWS region used for the test. Does not work with default region in config, so must be defined here."
+}
+
+variable "aws_region_alternate" {
+  type        = string
+  default     = "us-east-2"
+  description = "Alternate AWS region used for tests that require two regions (e.g. DynamoDB global tables)."
+}
+
+provider "aws" {
+  profile = var.aws_profile
+  region  = var.aws_region
+}
+
+provider "aws" {
+  alias   = "alternate"
+  profile = var.aws_profile
+  region  = var.aws_region_alternate
+}
+
+data "aws_partition" "current" {}
+data "aws_caller_identity" "current" {}
+data "aws_region" "primary" {}
+data "aws_region" "alternate" {
+  provider = aws.alternate
+}
+
+data "null_data_source" "resource" {
+  inputs = {
+    scope = "arn:${data.aws_partition.current.partition}:::${data.aws_caller_identity.current.account_id}"
+  }
+}
+
+resource "aws_ecr_registry_scanning_configuration" "configuration" {
+  scan_type = "ENHANCED"
+
+  rule {
+    scan_frequency = "CONTINUOUS_SCAN"
+    repository_filter {
+      filter      = "example"
+      filter_type = "WILDCARD"
+    }
+  }
+}
+
+output "registry_id" {
+  value = aws_ecr_registry_scanning_configuration.configuration.registry_id
+}
+
+output "aws_region" {
+  value = data.aws_region.primary.name
+}
+
+output "aws_partition" {
+  value = data.aws_partition.current.partition
+}
+
+output "aws_account" {
+  value = data.aws_caller_identity.current.account_id
+}

--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -511,6 +511,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_wellarchitected_workload_share":                           tableAwsWellArchitectedWorkloadShare(ctx),
 			"aws_workspaces_directory":                                     tableAwsWorkspacesDirectory(ctx),
 			"aws_workspaces_workspace":                                     tableAwsWorkspace(ctx),
+			"aws_ecr_registry_scanning_configuration":                      tableAwsEcrRegistryScanningConfiguration(ctx),
 		},
 	}
 

--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -208,6 +208,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_ec2_transit_gateway_vpc_attachment":                       tableAwsEc2TransitGatewayVpcAttachment(ctx),
 			"aws_ecr_image":                                                tableAwsEcrImage(ctx),
 			"aws_ecr_image_scan_finding":                                   tableAwsEcrImageScanFinding(ctx),
+			"aws_ecr_registry_scanning_configuration":                      tableAwsEcrRegistryScanningConfiguration(ctx),
 			"aws_ecr_repository":                                           tableAwsEcrRepository(ctx),
 			"aws_ecrpublic_repository":                                     tableAwsEcrpublicRepository(ctx),
 			"aws_ecs_cluster":                                              tableAwsEcsCluster(ctx),
@@ -511,7 +512,6 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_wellarchitected_workload_share":                           tableAwsWellArchitectedWorkloadShare(ctx),
 			"aws_workspaces_directory":                                     tableAwsWorkspacesDirectory(ctx),
 			"aws_workspaces_workspace":                                     tableAwsWorkspace(ctx),
-			"aws_ecr_registry_scanning_configuration":                      tableAwsEcrRegistryScanningConfiguration(ctx),
 		},
 	}
 

--- a/aws/table_aws_ecr_registry_scanning_configuration.go
+++ b/aws/table_aws_ecr_registry_scanning_configuration.go
@@ -1,0 +1,67 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ecr"
+
+	ecrv1 "github.com/aws/aws-sdk-go/service/ecr"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableAwsEcrRegistryScanningConfiguration(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_ecr_registry_scanning_configuration",
+		Description: "AWS ECR Registry Scanning Configuration",
+		List: &plugin.ListConfig{
+			Hydrate: getEcrRegistryScanningConfiguration,
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(ecrv1.EndpointsID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "registry_id",
+				Description: "The ID of the registry.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "scanning_configuration",
+				Description: "he scanning configuration for the registry.",
+				Type:        proto.ColumnType_JSON,
+			},
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ServerId"),
+			},
+		}),
+	}
+}
+
+func getEcrRegistryScanningConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+
+	// Create Session
+	svc, err := ECRClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ecr_registry_scanning_configuration.getEcrRegistryScanningConfiguration", "connection_error", err)
+		return nil, err
+	}
+
+	params := &ecr.GetRegistryScanningConfigurationInput{}
+
+	op, err := svc.GetRegistryScanningConfiguration(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ecr_registry_scanning_configuration.getEcrRegistryScanningConfiguration", "api_error", err)
+		return nil, err
+	}
+
+	d.StreamListItem(ctx, op)
+
+	return nil, nil
+}

--- a/aws/table_aws_ecr_registry_scanning_configuration.go
+++ b/aws/table_aws_ecr_registry_scanning_configuration.go
@@ -30,7 +30,7 @@ func tableAwsEcrRegistryScanningConfiguration(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "scanning_configuration",
-				Description: "he scanning configuration for the registry.",
+				Description: "The scanning configuration for the registry.",
 				Type:        proto.ColumnType_JSON,
 			},
 			// Steampipe standard columns

--- a/aws/table_aws_ecr_registry_scanning_configuration.go
+++ b/aws/table_aws_ecr_registry_scanning_configuration.go
@@ -38,7 +38,7 @@ func tableAwsEcrRegistryScanningConfiguration(_ context.Context) *plugin.Table {
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
 				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("ServerId"),
+				Transform:   transform.FromField("RegistryId"),
 			},
 		}),
 	}

--- a/docs/tables/aws_ecr_registry_scanning_configuration.md
+++ b/docs/tables/aws_ecr_registry_scanning_configuration.md
@@ -1,11 +1,11 @@
 ---
 title: "Steampipe Table: aws_ecr_registry_scanning_configuration - Query AWS ECR Registry Scanning Configuration using SQL"
-description: "Allows users to query AWS ECR Registry Scanning Configuration at the private registry level on a per-Region basis."
+description: "Allows users to query AWS ECR Registry Scanning Configuration at the private registry level on a per-region basis."
 ---
 
 # Table: aws_ecr_registry_scanning_configuration - Query AWS ECR Registry Scanning Configuration using SQL
 
-The AWS ECR Registry Scanning Configurations are defined at the private registry level on a per-Region basis. These refers to the settings and policies that govern how Amazon ECR scans your container images for vulnerabilities. Amazon ECR integrates with the Amazon ECR image scanning feature, which automatically scans your Docker and OCI images for software vulnerabilities.
+The AWS ECR Registry Scanning Configurations are defined at the private registry level on a per-region basis. These refer to the settings and policies that govern how Amazon ECR scans your container images for vulnerabilities. Amazon ECR integrates with the Amazon ECR image scanning feature, which automatically scans your Docker and OCI images for software vulnerabilities.
 
 ## Table Usage Guide
 
@@ -34,9 +34,8 @@ from
   aws_ecr_registry_scanning_configuration;
 ```
 
-
 ### Configuration info for a particular region
-Determine scanning configuration of container images for a specific region. This query is beneficial for understanding the scanning configuration of your container images in that particular region.
+Determine the scanning configuration of container images for a specific region. This query is beneficial for understanding the scanning configuration of your container images in that particular region.
 
 ```sql+postgres
 select
@@ -62,7 +61,7 @@ where
 
 
 ### List the regions where enhanced scanning is enabled
-Identify regions where the enhanced scanning is enabled for container image. This is helpful for determining whether enhanced vulnerability scanning features are available through integrations with AWS services or third-party tools.
+Identify regions where the enhanced scanning is enabled for container images. This helps determine whether enhanced vulnerability scanning features are available through integrations with AWS services or third-party tools.
 
 ```sql+postgres
 select

--- a/docs/tables/aws_ecr_registry_scanning_configuration.md
+++ b/docs/tables/aws_ecr_registry_scanning_configuration.md
@@ -1,0 +1,85 @@
+---
+title: "Steampipe Table: aws_ecr_registry_scanning_configuration - Query AWS ECR Registry Scanning Configuration using SQL"
+description: "Allows users to query AWS ECR Registry Scanning Configuration at the private registry level on a per-Region basis."
+---
+
+# Table: aws_ecr_registry_scanning_configuration - Query AWS ECR Registry Scanning Configuration using SQL
+
+The AWS ECR Registry Scanning Configurations are defined at the private registry level on a per-Region basis. These refers to the settings and policies that govern how Amazon ECR scans your container images for vulnerabilities. Amazon ECR integrates with the Amazon ECR image scanning feature, which automatically scans your Docker and OCI images for software vulnerabilities.
+
+## Table Usage Guide
+
+The `aws_ecr_registry_scanning_configuration` table in Steampipe provides you with information about the scanning configurations of Amazon Elastic Container Registry (ECR). This table allows you, as a cloud administrator, security team member, or developer, to query the scanning rules associated with the registry. You can utilize this table to gather insights on scanning configurations, such as the rules, the repository filters, and the region name. The schema outlines the various attributes of the scanning configurations for you, including the region, rules, repository filters, scan type and scan frequency.
+
+## Examples
+
+### Basic configuration info
+Analyze the configuration to understand that Amazon ECR scans your container images for vulnerabilities. This is essential for several reasons, primarily centered around security, compliance, and operational efficiency in managing container images.
+
+```sql+postgres
+select
+  registry_id,
+  jsonb_pretty(scanning_configuration),
+  region
+from
+  aws_ecr_registry_scanning_configuration;
+```
+
+```sql+sqlite
+select
+  registry_id,
+  scanning_configuration,
+  region
+from
+  aws_ecr_registry_scanning_configuration;
+```
+
+
+### Configuration info for a particular region
+Determine scanning configuration of container images for a specific region. This query is beneficial for understanding the scanning configuration of your container images in that particular region.
+
+```sql+postgres
+select
+  registry_id,
+  jsonb_pretty(scanning_configuration),
+  region
+from
+  aws_ecr_registry_scanning_configuration
+where
+  region = 'ap-south-1';
+```
+
+```sql+sqlite
+select
+  registry_id,
+  scanning_configuration,
+  region
+from
+  aws_ecr_registry_scanning_configuration
+where
+  region = 'ap-south-1';
+```
+
+
+### List the regions where enhanced scanning is enabled
+Identify regions where the enhanced scanning is enabled for container image. This is helpful for determining whether enhanced vulnerability scanning features are available through integrations with AWS services or third-party tools.
+
+```sql+postgres
+select
+  registry_id,
+  region
+from
+  aws_ecr_registry_scanning_configuration
+where
+  scanning_configuration ->> 'ScanType' = 'ENHANCED'
+```
+
+```sql+sqlite
+select
+  registry_id,
+  region
+from
+  aws_ecr_registry_scanning_configuration
+where
+  json_extract(scanning_configuration, '$.ScanType') = 'ENHANCED';
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```

SETUP: tests/aws_ecr_registry_scanning_configuration []

PRETEST: tests/aws_ecr_registry_scanning_configuration

TEST: tests/aws_ecr_registry_scanning_configuration
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 0s [id=12345678910]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ecr_registry_scanning_configuration.configuration will be created
  + resource "aws_ecr_registry_scanning_configuration" "configuration" {
      + id          = (known after apply)
      + registry_id = (known after apply)
      + scan_type   = "ENHANCED"

      + rule {
          + scan_frequency = "CONTINUOUS_SCAN"

          + repository_filter {
              + filter      = "example"
              + filter_type = "WILDCARD"
            }
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + aws_account   = "12345678910"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + registry_id   = (known after apply)
aws_ecr_registry_scanning_configuration.configuration: Creating...
aws_ecr_registry_scanning_configuration.configuration: Creation complete after 2s [id=12345678910]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

aws_account = "12345678910"
aws_partition = "aws"
aws_region = "us-east-1"
registry_id = "12345678910"

Running SQL query: test-get-query.sql
[
  {
    "region": "us-east-1",
    "registry_id": "12345678910",
    "scanning_configuration": {
      "Rules": [
        {
          "RepositoryFilters": [
            {
              "Filter": "example",
              "FilterType": "WILDCARD"
            }
          ],
          "ScanFrequency": "CONTINUOUS_SCAN"
        }
      ],
      "ScanType": "ENHANCED"
    },
    "title": "12345678910"
  }
]
✔ PASSED

POSTTEST: tests/aws_ecr_registry_scanning_configuration

TEARDOWN: tests/aws_ecr_registry_scanning_configuration

SUMMARY:

1/1 passed
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
+--------------+------------------------------------------------------------------------------------------------------------------------------------+--------------+-----------+----------------+--------------+---------------------------------------------------------------+
| registry_id  | scanning_configuration                                                                                                             | title        | partition | region         | account_id   | _ctx                                                          |
+--------------+------------------------------------------------------------------------------------------------------------------------------------+--------------+-----------+----------------+--------------+---------------------------------------------------------------+
| 12345678910 | {"Rules":[{"RepositoryFilters":[{"Filter":"*","FilterType":"WILDCARD"}],"ScanFrequency":"CONTINUOUS_SCAN"}],"ScanType":"ENHANCED"} | 12345678910 | aws       | ap-south-1     | 12345678910 | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
| 12345678910 | {"Rules":[],"ScanType":"BASIC"}                                                                                                    | 12345678910 | aws       | ap-southeast-1 | 12345678910 | {"connection_name":"aws","steampipe":{"sdk_version":"5.8.0"}} |
+--------------+------------------------------------------------------------------------------------------------------------------------------------+--------------+-----------+----------------+--------------+---------------------------------------------------------------+
```
</details>
