### PR TITLE
Updated aws_ebs_snapshot should not set maxlimit by default Closes #2081

### DIFF
--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -204,9 +204,10 @@ func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 			limit := int32(*d.QueryContext.Limit)
 			if limit < 5 {
 				input.MaxResults = aws.Int32(5)
-			}
-			if limit > 1000 {
+			} else if limit > 1000 {
 				input.MaxResults = aws.Int32(1000)
+			} else {
+				input.MaxResults = aws.Int32(limit)
 			}
 		}
 	}

--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -193,21 +193,22 @@ func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		return nil, err
 	}
 
+	// It would be more efficient / faster for us to not paginate requests to the DescribeSnapshots API (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSnapshots.html#API_DescribeSnapshots_RequestParameters).
+	// If the user specifies a limit parameter with a value ranging from 5 to 1000, it will be set accordingly. Otherwise, the DescribeSnapshots API will default to retrieving all available snapshots, which is faster than paginating with a value of 1000 per page.
+	input := &ec2.DescribeSnapshotsInput{}
+
 	// Limiting the results
-	maxLimit := int32(1000)
 	if d.QueryContext.Limit != nil {
+		maxLimit := int32(1000)
 		limit := int32(*d.QueryContext.Limit)
 		if limit < maxLimit {
-			if limit < 5 {
+			if limit < 5 && d.EqualsQualString("snapshot_id") == "" { // MaxResults parameter and the snapshot IDs parameter in the same request.
 				maxLimit = 5
-			} else {
-				maxLimit = limit
+				input.MaxResults = &maxLimit
+			} else if limit >= 5 && limit <= 1000 && d.EqualsQualString("snapshot_id") == "" {
+				input.MaxResults = &limit
 			}
 		}
-	}
-
-	input := &ec2.DescribeSnapshotsInput{
-		MaxResults: aws.Int32(maxLimit),
 	}
 
 	// Build filter for ebs snapshot
@@ -215,7 +216,9 @@ func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	input.Filters = filters
 
 	paginator := ec2.NewDescribeSnapshotsPaginator(svc, input, func(o *ec2.DescribeSnapshotsPaginatorOptions) {
-		o.Limit = maxLimit
+		if input.MaxResults != nil {
+			o.Limit = *input.MaxResults
+		}
 		o.StopOnDuplicateToken = true
 	})
 

--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -211,10 +211,6 @@ func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		}
 	}
 
-	if input.MaxResults != nil {
-		plugin.Logger(ctx).Error("Max result input ==>> ", *input.MaxResults)
-	}
-
 	// Build filter for ebs snapshot
 	filters := buildEbsSnapshotFilter(ctx, d, h, d.EqualsQuals, input)
 	input.Filters = filters

--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -193,22 +193,26 @@ func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		return nil, err
 	}
 
-	// It would be more efficient / faster for us to not paginate requests to the DescribeSnapshots API (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSnapshots.html#API_DescribeSnapshots_RequestParameters).
-	// If the user specifies a limit parameter with a value ranging from 5 to 1000, it will be set accordingly. Otherwise, the DescribeSnapshots API will default to retrieving all available snapshots, which is faster than paginating with a value of 1000 per page.
 	input := &ec2.DescribeSnapshotsInput{}
 
 	// Limiting the results
-	if d.QueryContext.Limit != nil {
-		maxLimit := int32(1000)
-		limit := int32(*d.QueryContext.Limit)
-		if limit < maxLimit {
-			if limit < 5 && d.EqualsQualString("snapshot_id") == "" { // MaxResults parameter and the snapshot IDs parameter in the same request.
-				maxLimit = 5
-				input.MaxResults = &maxLimit
-			} else if limit >= 5 && limit <= 1000 && d.EqualsQualString("snapshot_id") == "" {
-				input.MaxResults = &limit
+	// You cannot specify this parameter and the snapshot IDs parameter in the same request.
+	// It would be more efficient / faster for us to not paginate requests to the DescribeSnapshots API (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSnapshots.html#API_DescribeSnapshots_RequestParameters).
+	// If the user specifies a limit parameter with a value ranging from 5 to 1000, it will be set accordingly. Otherwise, the DescribeSnapshots API will default to retrieving all available snapshots, which is faster than paginating with a value of 1000 per page.
+	if d.EqualsQualString("snapshot_id") == "" {
+		if d.QueryContext.Limit != nil {
+			limit := int32(*d.QueryContext.Limit)
+			if limit < 5 {
+				input.MaxResults = aws.Int32(5)
+			}
+			if limit > 1000 {
+				input.MaxResults = aws.Int32(1000)
 			}
 		}
+	}
+
+	if input.MaxResults != nil {
+		plugin.Logger(ctx).Error("Max result input ==>> ", *input.MaxResults)
 	}
 
 	// Build filter for ebs snapshot

--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -196,7 +196,7 @@ func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	input := &ec2.DescribeSnapshotsInput{}
 
 	// Limiting the results
-	// You cannot specify this parameter and the snapshot IDs parameter in the same request.
+	// You cannot specify limit and the snapshot ID in the same request.
 	// It would be more efficient / faster for us to not paginate requests to the DescribeSnapshots API (https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSnapshots.html#API_DescribeSnapshots_RequestParameters).
 	// If the user specifies a limit parameter with a value ranging from 5 to 1000, it will be set accordingly. Otherwise, the DescribeSnapshots API will default to retrieving all available snapshots, which is faster than paginating with a value of 1000 per page.
 	if d.EqualsQualString("snapshot_id") == "" {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ebs_snapshot []

PRETEST: tests/aws_ebs_snapshot

TEST: tests/aws_ebs_snapshot
Running terraform
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 0s [id=333333333333]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ebs_snapshot.named_test_resource will be created
  + resource "aws_ebs_snapshot" "named_test_resource" {
      + arn                    = (known after apply)
      + data_encryption_key_id = (known after apply)
      + description            = "Test snapshot"
      + encrypted              = (known after apply)
      + id                     = (known after apply)
      + kms_key_id             = (known after apply)
      + owner_alias            = (known after apply)
      + owner_id               = (known after apply)
      + storage_tier           = (known after apply)
      + tags                   = {
          + "Name" = "turbottest43535"
        }
      + tags_all               = {
          + "Name" = "turbottest43535"
        }
      + volume_id              = (known after apply)
      + volume_size            = (known after apply)
    }

  # aws_ebs_volume.test_volume will be created
  + resource "aws_ebs_volume" "test_volume" {
      + arn               = (known after apply)
      + availability_zone = "us-east-1a"
      + encrypted         = (known after apply)
      + final_snapshot    = false
      + id                = (known after apply)
      + iops              = (known after apply)
      + kms_key_id        = (known after apply)
      + size              = 1
      + snapshot_id       = (known after apply)
      + tags_all          = (known after apply)
      + throughput        = (known after apply)
      + type              = (known after apply)
    }

  # aws_snapshot_create_volume_permission.example_perm will be created
  + resource "aws_snapshot_create_volume_permission" "example_perm" {
      + account_id  = "388460667113"
      + id          = (known after apply)
      + snapshot_id = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "333333333333"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest43535"
  + snapshot_id   = (known after apply)
  + volume_id     = (known after apply)
aws_ebs_volume.test_volume: Creating...
aws_ebs_volume.test_volume: Still creating... [10s elapsed]
aws_ebs_volume.test_volume: Creation complete after 14s [id=vol-0f102d289d9dbe7aa]
aws_ebs_snapshot.named_test_resource: Creating...
aws_ebs_snapshot.named_test_resource: Still creating... [10s elapsed]
aws_ebs_snapshot.named_test_resource: Creation complete after 18s [id=snap-016bcbd67da0306f9]
aws_snapshot_create_volume_permission.example_perm: Creating...
aws_snapshot_create_volume_permission.example_perm: Creation complete after 1s [id=snap-016bcbd67da0306f9-388460667113]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "333333333333"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:ec2:us-east-1::snapshot/snap-016bcbd67da0306f9"
resource_name = "turbottest43535"
snapshot_id = "snap-016bcbd67da0306f9"
volume_id = "vol-0f102d289d9dbe7aa"

Running SQL query: test-get-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "description": "Test snapshot",
    "encrypted": false,
    "owner_id": "333333333333",
    "snapshot_id": "snap-016bcbd67da0306f9",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest43535"
      }
    ],
    "volume_id": "vol-0f102d289d9dbe7aa",
    "volume_size": 1
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:333333333333:snapshot/snap-016bcbd67da0306f9"
    ],
    "create_volume_permissions": [
      {
        "Group": "",
        "UserId": "388460667113"
      }
    ],
    "snapshot_id": "snap-016bcbd67da0306f9",
    "tags": {
      "Name": "turbottest43535"
    },
    "title": "snap-016bcbd67da0306f9"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "snapshot_id": "snap-016bcbd67da0306f9",
    "volume_id": "vol-0f102d289d9dbe7aa"
  }
]
✔ PASSED

POSTTEST: tests/aws_ebs_snapshot

TEARDOWN: tests/aws_ebs_snapshot

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_ebs_snapshot limit 1001
+------------------------+--------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+---------------------------+------------------>
| snapshot_id            | arn                                                                | state     | volume_size | volume_id             | encrypted | start_time                | description      >
+------------------------+--------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+---------------------------+------------------>
| snap-0e4020f22ea51ce02 | arn:aws:ec2:us-east-1:333333333333:snapshot/snap-0e4020f22ea51ce02 | completed | 8           | vol-0b74a7c71a8d290b5 | false     | 2024-02-16T12:37:01+05:30 | Created by Create>
| snap-0aa97f0d110df2170 | arn:aws:ec2:us-west-2:333333333333:snapshot/snap-0aa97f0d110df2170 | completed | 8           | vol-ffffffff          | true      | 2022-08-10T19:16:59+05:30 | Copied for Destin>
| snap-0347b5f7028f17c4d | arn:aws:ec2:us-east-1:333333333333:snapshot/snap-0347b5f7028f17c4d | completed | 65          | vol-03dfbff108e201832 | true      | 2024-02-16T13:36:32+05:30 | Created by Create>
| snap-0218dafac05aa26df | arn:aws:ec2:us-west-2:333333333333:snapshot/snap-0218dafac05aa26df | completed | 8           | vol-0154f6cab9c391b5c | true      | 2022-08-05T16:34:29+05:30 |                  >
| snap-06ff60334c460fcd7 | arn:aws:ec2:us-east-1:333333333333:snapshot/snap-06ff60334c460fcd7 | completed | 8           | vol-0510d750c3666945f | false     | 2023-07-12T18:06:34+05:30 | This snapshot is >
| snap-097deed7e68c51be7 | arn:aws:ec2:us-east-1:333333333333:snapshot/snap-097deed7e68c51be7 | completed | 65          | vol-03dfbff108e201832 | true      | 2024-02-16T13:54:36+05:30 | Created by Create>
| snap-0cf8bb375c199cba6 | arn:aws:ec2:us-east-1:333333333333:snapshot/snap-0cf8bb375c199cba6 | completed | 65          | vol-0d6296e7e555d1f08 | false     | 2024-02-16T12:53:52+05:30 | Created by Create>
+------------------------+--------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+---------------------------+------------------>

Time: 2.0s. Rows fetched: 7. Hydrate calls: 21.

> select * from aws_ebs_snapshot where snapshot_id = 'snap-0e4020f22ea51ce02' limit 1001
+------------------------+--------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+---------------------------+------------------>
| snapshot_id            | arn                                                                | state     | volume_size | volume_id             | encrypted | start_time                | description      >
+------------------------+--------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+---------------------------+------------------>
| snap-0e4020f22ea51ce02 | arn:aws:ec2:us-east-1:333333333333:snapshot/snap-0e4020f22ea51ce02 | completed | 8           | vol-0b74a7c71a8d290b5 | false     | 2024-02-16T12:37:01+05:30 | Created by Create>
+------------------------+--------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+---------------------------+------------------>

Time: 0.9s. Rows fetched: 1. Hydrate calls: 3.

> select * from aws_ebs_snapshot where snapshot_id = 'snap-0e4020f22ea51ce02' limit 6
+------------------------+--------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+---------------------------+------------------>
| snapshot_id            | arn                                                                | state     | volume_size | volume_id             | encrypted | start_time                | description      >
+------------------------+--------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+---------------------------+------------------>
| snap-0e4020f22ea51ce02 | arn:aws:ec2:us-east-1:333333333333:snapshot/snap-0e4020f22ea51ce02 | completed | 8           | vol-0b74a7c71a8d290b5 | false     | 2024-02-16T12:37:01+05:30 | Created by Create>
+------------------------+--------------------------------------------------------------------+-----------+-------------+-----------------------+-----------+---------------------------+------------------>

Time: 5.2s. Rows fetched: 1. Hydrate calls: 3.

```
</details>
