### PR TITLE
Fix the aws_cloudtrail_lookup_event input param to pass correctly end time as input param

### DIFF
--- a/aws/table_aws_cloudtrail_lookup_event.go
+++ b/aws/table_aws_cloudtrail_lookup_event.go
@@ -212,7 +212,7 @@ func buildCloudtrailLookupEventFilter(ctx context.Context, quals plugin.KeyColum
 	}
 	if quals["end_time"] != nil {
 		value := getQualsValueByColumn(quals, "end_time", "time")
-		input.StartTime = aws.Time(value.(time.Time))
+		input.EndTime = aws.Time(value.(time.Time))
 	}
 
 	return input

--- a/docs/tables/aws_cloudtrail_lookup_event.md
+++ b/docs/tables/aws_cloudtrail_lookup_event.md
@@ -40,8 +40,8 @@ select
 from
   aws_cloudtrail_lookup_event
 where
-  start_time = now()
-  and end_time = now() - interval '5 minutes';
+  start_time = now() - interval '5 minutes'
+  and end_time = now();
 ```
 
 ```sql+sqlite
@@ -54,8 +54,8 @@ select
 from
   aws_cloudtrail_lookup_event
 where
-  start_time = datetime('now')
-  and end_time = datetime('now', '-5 minutes');
+  start_time = datetime('now', '-5 minutes')
+  and end_time = datetime('now');
 ```
 
 ### List all action events, i.e., not ReadOnly that occurred over the last hour


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
  event_name,
  event_source, start_time, end_time,
  event_time,
  username,
  jsonb_pretty(cloud_trail_event) as cloud_trail_event
from
  aws_cloudtrail_lookup_event
where
  start_time = '2024-03-08T09:30:00Z'
  and end_time = '2024-03-08T09:40:00Z'
+-----------------------------------+-------------------------------+---------------------------+---------------------------+---------------------------+---------------------->
| event_name                        | event_source                  | start_time                | end_time                  | event_time                | username             >
+-----------------------------------+-------------------------------+---------------------------+---------------------------+---------------------------+---------------------->
| ListUserPools                     | cognito-idp.amazonaws.com     | 2024-03-08T15:00:00+05:30 | 2024-03-08T15:10:00+05:30 | 2024-03-08T15:00:48+05:30 | resource-explorer-2  >
|                                   |                               |                           |                           |                           |                      >
|                                   |                               |                           |                           |                           |                      >
|                                   |                               |                           |                           |                           |                      >
|                                   |                               |                           |                           |                           |                      >
|                                   |                               |                           |                           |                           |                      >
|                                   |                               |                           |                           |                           |                      >

```
</details>
