### PR TITLE
Fix arn column in table aws_elastic_beanstalk_environment closes #2105

### DIFF
--- a/aws/table_aws_elastic_beanstalk_environment.go
+++ b/aws/table_aws_elastic_beanstalk_environment.go
@@ -69,6 +69,7 @@ func tableAwsElasticBeanstalkEnvironment(_ context.Context) *plugin.Table {
 				Name:        "arn",
 				Description: "The environment's Amazon Resource Name (ARN).",
 				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("EnvironmentArn"),
 			},
 			{
 				Name:        "description",


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select arn from aws_elastic_beanstalk_environment
+-------------------------------------------------------------------------------+
| arn                                                                           |
+-------------------------------------------------------------------------------+
| arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/TESTNO/TESTNO-env |
| arn:aws:elasticbeanstalk:us-east-1:123456789012:environment/tes5t6/Tes5t6-env |
+-------------------------------------------------------------------------------+

```
</details>
