### PR TITLE
Add new column auto_minor_version_upgrade in table aws_rds_db_cluster closes #2108

### DIFF
--- a/aws/table_aws_rds_db_cluster.go
+++ b/aws/table_aws_rds_db_cluster.go
@@ -100,7 +100,7 @@ func tableAwsRDSDBCluster(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "auto_minor_version_upgrade",
-				Description: 	"A value that indicates that minor version patches are applied automatically. This setting is only for non-Aurora Multi-AZ DB clusters.",
+				Description: "A value that indicates that minor version patches are applied automatically. This setting is only for non-Aurora Multi-AZ DB clusters.",
 				Type:        proto.ColumnType_BOOL,
 			},
 			{

--- a/aws/table_aws_rds_db_cluster.go
+++ b/aws/table_aws_rds_db_cluster.go
@@ -99,6 +99,11 @@ func tableAwsRDSDBCluster(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_INT,
 			},
 			{
+				Name:        "auto_minor_version_upgrade",
+				Description: 	"A value that indicates that minor version patches are applied automatically. This setting is only for non-Aurora Multi-AZ DB clusters.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
 				Name:        "backtrack_consumed_change_records",
 				Description: "The number of change records stored for Backtrack.",
 				Type:        proto.ColumnType_INT,


### PR DESCRIPTION
… 

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select title, auto_minor_version_upgrade from aws_rds_db_cluster
+------------+----------------------------+
| title      | auto_minor_version_upgrade |
+------------+----------------------------+
| database-1 | true                       |
+------------+----------------------------+

```
</details>
