### PR TITLE
Add OpenZFSFileSystemConfiguration in table aws_fsx_file_system Closes #2112

### DIFF
--- a/aws/table_aws_fsx_file_system.go
+++ b/aws/table_aws_fsx_file_system.go
@@ -122,6 +122,12 @@ func tableAwsFsxFileSystem(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 			},
 			{
+				Name:        "open_zfs_configuration",
+				Description: "The configuration for this FSx for NetApp ONTAP file system.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("OpenZFSConfiguration"),
+			},
+			{
 				Name:        "subnet_ids",
 				Description: "Specifies the IDs of the subnets that the file system is accessible from.",
 				Type:        proto.ColumnType_JSON,


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_fsx_file_system []

PRETEST: tests/aws_fsx_file_system

TEST: tests/aws_fsx_file_system
Running terraform
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 0s [id=434553143433]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_fsx_lustre_file_system.named_test_resource will be created
  + resource "aws_fsx_lustre_file_system" "named_test_resource" {
      + arn                               = (known after apply)
      + auto_import_policy                = (known after apply)
      + automatic_backup_retention_days   = (known after apply)
      + copy_tags_to_backups              = false
      + daily_automatic_backup_start_time = (known after apply)
      + data_compression_type             = "NONE"
      + deployment_type                   = "SCRATCH_1"
      + dns_name                          = (known after apply)
      + export_path                       = (known after apply)
      + file_system_type_version          = (known after apply)
      + id                                = (known after apply)
      + imported_file_chunk_size          = (known after apply)
      + kms_key_id                        = (known after apply)
      + mount_name                        = (known after apply)
      + network_interface_ids             = (known after apply)
      + owner_id                          = (known after apply)
      + storage_capacity                  = 1200
      + storage_type                      = "SSD"
      + subnet_ids                        = (known after apply)
      + tags                              = {
          + "foo" = "turbottest70280"
        }
      + tags_all                          = {
          + "foo" = "turbottest70280"
        }
      + vpc_id                            = (known after apply)
      + weekly_maintenance_start_time     = (known after apply)
    }

  # aws_subnet.my_subnet will be created
  + resource "aws_subnet" "my_subnet" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = (known after apply)
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.1.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.my_vpc will be created
  + resource "aws_vpc" "my_vpc" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags_all                             = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest70280"
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Creation complete after 6s [id=vpc-0e5f4a386ea75b978]
aws_subnet.my_subnet: Creating...
aws_subnet.my_subnet: Creation complete after 3s [id=subnet-0c11fd181f8b63531]
aws_fsx_lustre_file_system.named_test_resource: Creating...
aws_fsx_lustre_file_system.named_test_resource: Still creating... [10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [30s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [40s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [50s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [1m0s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [1m10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [1m20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [1m30s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [1m40s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [1m50s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [2m0s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [2m10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [2m20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [2m30s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [2m40s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [2m50s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [3m0s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [3m10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [3m20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [3m30s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [3m40s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [3m50s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [4m0s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [4m10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [4m20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [4m30s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [4m40s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [4m50s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [5m0s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [5m10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [5m20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [5m30s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [5m40s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [5m50s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [6m0s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [6m10s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Still creating... [6m20s elapsed]
aws_fsx_lustre_file_system.named_test_resource: Creation complete after 6m22s [id=fs-0de22a77c12a49ffc]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

resource_aka = "arn:aws:fsx:us-east-1:434553143433:file-system/fs-0de22a77c12a49ffc"
resource_id = "fs-0de22a77c12a49ffc"
resource_name = "turbottest70280"

Running SQL query: test-get-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "arn": "arn:aws:fsx:us-east-1:434553143433:file-system/fs-0de22a77c12a49ffc",
    "file_system_id": "fs-0de22a77c12a49ffc"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "akas": [
      "arn:aws:fsx:us-east-1:434553143433:file-system/fs-0de22a77c12a49ffc"
    ],
    "file_system_id": "fs-0de22a77c12a49ffc",
    "title": "fs-0de22a77c12a49ffc"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "file_system_id": "fs-0de22a77c12a49ffc",
    "title": "fs-0de22a77c12a49ffc"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[]
✔ PASSED

POSTTEST: tests/aws_fsx_file_system

TEARDOWN: tests/aws_fsx_file_system

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select file_system_id, jsonb_pretty(open_zfs_configuration) as open_zfs_configuration from aws_fsx_file_system;
+----------------------+------------------------------------------------+
| file_system_id       | open_zfs_configuration                         |
+----------------------+------------------------------------------------+
| fs-0d39c8625d62239b4 | {                                              |
|                      |     "RootVolumeId": "fsvol-0e5f74462caacd8d1", |
|                      |     "DeploymentType": "MULTI_AZ_1",            |
|                      |     "CopyTagsToBackups": false,                |
|                      |     "CopyTagsToVolumes": false,                |
|                      |     "ThroughputCapacity": 160,                 |
|                      |     "DiskIopsConfiguration": {                 |
|                      |         "Iops": 192,                           |
|                      |         "Mode": "AUTOMATIC"                    |
|                      |     },                                         |
|                      |     "WeeklyMaintenanceStartTime": "1:03:30",   |
|                      |     "AutomaticBackupRetentionDays": 30,        |
|                      |     "DailyAutomaticBackupStartTime": "03:00"   |
|                      | }                                              |
+----------------------+------------------------------------------------+

Time: 142ms. Rows fetched: 1 (cached). Hydrate calls: 0.
```
</details>
