### PR TITLE
Fixed aws_ssm_maintenance_window fails if ScheduleTimezone is not UTC Closes #2114

### DIFF
--- a/aws/table_aws_ssm_maintenance_window.go
+++ b/aws/table_aws_ssm_maintenance_window.go
@@ -155,10 +155,11 @@ func tableAwsSSMMaintenanceWindow(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_TIMESTAMP,
 				Hydrate:     getAwsSSMMaintenanceWindow,
 			},
+			// The value of NextExecutionTime is influenced by the timezone set by the user. Due to uncertainty regarding the date string's format, attempts to parse it into the time.RFC3339 format result in errors when the timezone isn't UTC. Consequently, we have designated the column type as a string.
 			{
 				Name:        "next_execution_time",
 				Description: "The next time the maintenance window will actually run, taking into account any specified times for the Maintenance Window to become active or inactive.",
-				Type:        proto.ColumnType_TIMESTAMP,
+				Type:        proto.ColumnType_STRING,
 			},
 
 			/// Standard columns for all tables


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ssm_maintenance_window []

PRETEST: tests/aws_ssm_maintenance_window

TEST: tests/aws_ssm_maintenance_window
Running terraform
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 1s [id=478932174913]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ssm_maintenance_window.named_test_resource will be created
  + resource "aws_ssm_maintenance_window" "named_test_resource" {
      + allow_unassociated_targets = false
      + cutoff                     = 1
      + duration                   = 3
      + enabled                    = true
      + id                         = (known after apply)
      + name                       = "turbottest21306"
      + schedule                   = "cron(0 16 ? * TUE *)"
      + tags                       = {
          + "name" = "turbottest21306"
        }
      + tags_all                   = {
          + "name" = "turbottest21306"
        }
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "478932174913"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest21306"
aws_ssm_maintenance_window.named_test_resource: Creating...
aws_ssm_maintenance_window.named_test_resource: Creation complete after 3s [id=mw-04c74110c3938a448]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 1 added, 0 changed, 0 destroyed.

Outputs:

account_id = "478932174913"
aws_region = "us-east-1"
resource_aka = "arn:aws:ssm:us-east-1:478932174913:maintenancewindow/mw-04c74110c3938a448"
resource_id = "mw-04c74110c3938a448"
resource_name = "turbottest21306"

Running SQL query: test-get-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "akas": [
      "arn:aws:ssm:us-east-1:478932174913:maintenancewindow/mw-04c74110c3938a448"
    ],
    "name": "turbottest21306",
    "tags": {
      "name": "turbottest21306"
    },
    "title": "turbottest21306"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "name": "turbottest21306",
    "partition": "aws",
    "region": "us-east-1",
    "tags": {
      "name": "turbottest21306"
    },
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest21306"
      }
    ],
    "targets": [],
    "tasks": [],
    "window_id": "mw-04c74110c3938a448"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[]
✔ PASSED

Running SQL query: test-turbot-query.sql
Warning: terminal options has been deprecated and will be removed in a future version of Steampipe.
These can now be set in a steampipe workspace.
(/Users/parthas/.steampipe/config/default.spc:34,20-42,2)
[
  {
    "account_id": "478932174913",
    "akas": [
      "arn:aws:ssm:us-east-1:478932174913:maintenancewindow/mw-04c74110c3938a448"
    ],
    "region": "us-east-1",
    "tags": {
      "name": "turbottest21306"
    },
    "title": "turbottest21306"
  }
]
✔ PASSED

TEARDOWN: tests/aws_ssm_maintenance_window

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, window_id, next_execution_time, schedule_timezone from aws_ssm_maintenance_window
+----------------+----------------------+------------------------+-------------------+
| name           | window_id            | next_execution_time    | schedule_timezone |
+----------------+----------------------+------------------------+-------------------+
| test53         | mw-097381b8933477677 | 2024-03-12T10:30-11:00 | Etc/GMT+11        |
| test43         | mw-0ed96845774cec670 | 2024-03-12T11:29Z      | <null>            |
| teriuyqwtyiuqw | mw-08691312d3d4701c2 | 2024-03-12T10:30+02:00 | Israel            |
+----------------+----------------------+------------------------+-------------------+
```
</details>
