### PR TITLE
Fixed aws_vpc_eip produce nil pointer error Closes #2124

### DIFF
--- a/aws/table_aws_api_gateway_stage.go
+++ b/aws/table_aws_api_gateway_stage.go
@@ -183,6 +183,7 @@ func listAPIGatewayStage(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 	// Create Session
 	svc, err := APIGatewayClient(ctx, d)
 	if err != nil {
+		plugin.Logger(ctx).Error("aws_api_gateway_stage.listAPIGatewayStage", "service_client_error", err)
 		return nil, err
 	}
 
@@ -192,6 +193,7 @@ func listAPIGatewayStage(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 
 	op, err := svc.GetStages(ctx, params)
 	if err != nil {
+		plugin.Logger(ctx).Error("aws_api_gateway_stage.listAPIGatewayStage", "api_error", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_vpc_eip.go
+++ b/aws/table_aws_vpc_eip.go
@@ -183,6 +183,7 @@ func listVpcEips(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData
 	resp, err := svc.DescribeAddresses(ctx, input)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_eip.listVpcEips", "api_error", err)
+		return nil, err
 	}
 	for _, address := range resp.Addresses {
 		d.StreamListItem(ctx, address)

--- a/aws/table_aws_vpc_vpn_connection.go
+++ b/aws/table_aws_vpc_vpn_connection.go
@@ -169,6 +169,7 @@ func listVpcVpnConnections(ctx context.Context, d *plugin.QueryData, _ *plugin.H
 
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_vpc_vpn_connection.listVpcVpnConnections", "api_error", err)
+		return nil, err
 	}
 
 	for _, vpnConnection := range resp.VpnConnections {


### PR DESCRIPTION
Note: If a Service Control Policy is applied to an account for a specific region, we should receive an access denied error, not an invalid memory address or nil pointer dereference error.

# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Before fix:
Error: rpc error: code = Internal desc = aws_org_1: rpc error: code = Internal desc = hydrate function listVpcEips failed with panic runtime error: invalid memory address or nil pointer dereference (SQLSTATE HV000)

+---------------+-----+-----------+------------------+--------+----------------+------------+-------------------+--------------------------+-------------+----------------------+----------------------+----------------------------+------>
| allocation_id | arn | public_ip | public_ipv4_pool | domain | association_id | carrier_ip | customer_owned_ip | customer_owned_ipv4_pool | instance_id | network_border_group | network_interface_id | network_interface_owner_id | priva>
+---------------+-----+-----------+------------------+--------+----------------+------------+-------------------+--------------------------+-------------+----------------------+----------------------+----------------------------+------>
+---------------+-----+-----------+------------------+--------+----------------+------------+-------------------+--------------------------+-------------+----------------------+----------------------+----------------------------+------>

After fix:
> select * from aws_org_1.aws_vpc_eip

Error: aws_org_1: operation error EC2: DescribeAddresses, https response error StatusCode: 401, RequestID: 410dc0a8-bb56-4a47-b077-d140e70c9feb, api error AuthFailure: AWS was not able to validate the provided access credentials (SQLSTATE HV000)

+---------------+-----+-----------+------------------+--------+----------------+------------+-------------------+--------------------------+-------------+----------------------+----------------------+----------------------------+------>
| allocation_id | arn | public_ip | public_ipv4_pool | domain | association_id | carrier_ip | customer_owned_ip | customer_owned_ipv4_pool | instance_id | network_border_group | network_interface_id | network_interface_owner_id | priva>
+---------------+-----+-----------+------------------+--------+----------------+------------+-------------------+--------------------------+-------------+----------------------+----------------------+----------------------------+------>
+---------------+-----+-----------+------------------+--------+----------------+------------+-------------------+--------------------------+-------------+----------------------+----------------------+----------------------------+------

```
</details>
