### PR TITLE
Fixed when using AWS profiles with cross-account role credentials, querying regional tables does not result in an error Closes #2074

### DIFF
--- a/aws/multi_region.go
+++ b/aws/multi_region.go
@@ -112,7 +112,7 @@ func SupportedRegionMatrix(serviceID string) func(ctx context.Context, d *plugin
 
 
 // This function is used in the GetMatrixItemFunc implementations within the table definitions.
-// GetMatrixItemFunc is designed to accept a dingle return type `[]map[string]interface{}``.
+// GetMatrixItemFunc is designed to accept a single return type `[]map[string]interface{}`.
 // AWS regional tables make API calls based on the region matrix return by the SupportedRegionMatrixWithExclusions function.
 // In cases of incorrect credential configurations, listQueryRegionsForConnection returns an error, such as: "Error: operation error STS: GetCallerIdentity, failed to sign request: failed to retrieve credentials: failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: a1028f7b-cb77-4b9e-b1e5-ce96ea77150e, api error InvalidClientTokenId: The security token included in the request is invalid."
 // When an error is encountered, it should trigger a panic with that error; otherwise, regional tables return an empty row.


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Before fix: 

Global table(Returns error):

> select * from assumed_role_from_aab.aws_iam_user

Error: assumed_role_from_aab: operation error IAM: ListUsers, failed to sign request: failed to retrieve credentials: failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: 225233fe-d5c2-4356-90a5-48c04ffe8810, api error InvalidClientTokenId: The security token included in the request is invalid. (SQLSTATE HV000)

+------+---------+------+-----+-------------+--------------------+--------------------------+---------------------------+-------------+---------------+-------------+--------+-----------------+---------------------+--------------------->
| name | user_id | path | arn | create_date | password_last_used | permissions_boundary_arn | permissions_boundary_type | mfa_enabled | login_profile | mfa_devices | groups | inline_policies | inline_policies_std | attached_policy_arns>
+------+---------+------+-----+-------------+--------------------+--------------------------+---------------------------+-------------+---------------+-------------+--------+-----------------+---------------------+--------------------->
+------+---------+------+-----+-------------+--------------------+--------------------------+---------------------------+-------------+---------------+-------------+--------+-----------------+---------------------+--------------------->



Regional Table (Doesn't return any error):

> select * from assumed_role_from_aab.aws_rds_db_instance
+------------------------+-----+-----------------------+--------+-------+-------------+-------------------+----------------------------+-------------------+-------------------------+---------------------------+--------------------+---->
| db_instance_identifier | arn | db_cluster_identifier | status | class | resource_id | allocated_storage | auto_minor_version_upgrade | availability_zone | backup_retention_period | ca_certificate_identifier | character_set_name | cop>
+------------------------+-----+-----------------------+--------+-------+-------------+-------------------+----------------------------+-------------------+-------------------------+---------------------------+--------------------+---->
+------------------------+-----+-----------------------+--------+-------+-------------+-------------------+----------------------------+-------------------+-------------------------+---------------------------+--------------------+---->



After fix:

Global table(Returns error):

> select * from assumed_role_from_aab.aws_account

Error: assumed_role_from_aab: operation error STS: GetCallerIdentity, failed to sign request: failed to retrieve credentials: failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: 462880e1-7ea7-4d19-81c3-2d60da4eb88c, api error InvalidClientTokenId: The security token included in the request is invalid. (SQLSTATE HV000)

+-----------------+-----+-----------------+------------------+--------------------------+---------------------------------+-----------------------------------+--------------------------------+-------------------------------------+----->
| account_aliases | arn | organization_id | organization_arn | organization_feature_set | organization_master_account_arn | organization_master_account_email | organization_master_account_id | organization_available_policy_types | titl>
+-----------------+-----+-----------------+------------------+--------------------------+---------------------------------+-----------------------------------+--------------------------------+-------------------------------------+----->
+-----------------+-----+-----------------+------------------+--------------------------+---------------------------------+-----------------------------------+--------------------------------+-------------------------------------+----->


Regional table(Returns error):

> select * from assumed_role_from_aab.aws_rds_db_instance

Error: operation error STS: GetCallerIdentity, failed to sign request: failed to retrieve credentials: failed to refresh cached credentials, operation error STS: AssumeRole, https response error StatusCode: 403, RequestID: 3512f747-06e5-4f45-a9fd-6f67cabe16e6, api error InvalidClientTokenId: The security token included in the request is invalid. (SQLSTATE HV000)

+------------------------+-----+-----------------------+--------+-------+-------------+-------------------+----------------------------+-------------------+-------------------------+---------------------------+--------------------+---->
| db_instance_identifier | arn | db_cluster_identifier | status | class | resource_id | allocated_storage | auto_minor_version_upgrade | availability_zone | backup_retention_period | ca_certificate_identifier | character_set_name | cop>
+------------------------+-----+-----------------------+--------+-------+-------------+-------------------+----------------------------+-------------------+-------------------------+---------------------------+--------------------+---->
+------------------------+-----+-----------------------+--------+-------+-------------+-------------------+----------------------------+-------------------+-------------------------+---------------------------+--------------------+----

```
</details>
