### PR TITLE
Add table aws_accessanalyzer_finding. Closes #1812

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -43,6 +43,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 		},
 		TableMap: map[string]*plugin.Table{
 			"aws_accessanalyzer_analyzer":                                  tableAwsAccessAnalyzer(ctx),
+			"aws_accessanalyzer_finding":                                  tableAwsAccessAnalyzerFinding(ctx),
 			"aws_account":                                                  tableAwsAccount(ctx),
 			"aws_account_alternate_contact":                                tableAwsAccountAlternateContact(ctx),
 			"aws_account_contact":                                          tableAwsAccountContact(ctx),

--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -43,7 +43,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 		},
 		TableMap: map[string]*plugin.Table{
 			"aws_accessanalyzer_analyzer":                                  tableAwsAccessAnalyzer(ctx),
-			"aws_accessanalyzer_finding":                                  tableAwsAccessAnalyzerFinding(ctx),
+			"aws_accessanalyzer_finding":                                   tableAwsAccessAnalyzerFinding(ctx),
 			"aws_account":                                                  tableAwsAccount(ctx),
 			"aws_account_alternate_contact":                                tableAwsAccountAlternateContact(ctx),
 			"aws_account_contact":                                          tableAwsAccountContact(ctx),

--- a/aws/table_aws_accessanalyzer_analyzer.go
+++ b/aws/table_aws_accessanalyzer_analyzer.go
@@ -88,7 +88,7 @@ func tableAwsAccessAnalyzer(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "findings",
-				Description: "A list of findings retrieved from the analyzer that match the filter criteria specified, if any.",
+				Description: "[DEPRECATED] This column has been deprecated and will be removed in a future release, use table aws_accessanalyzer_finding instead. A list of findings retrieved from the analyzer that match the filter criteria specified, if any.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     listAccessAnalyzerFindings,
 				Transform:   transform.FromValue(),

--- a/aws/table_aws_accessanalyzer_finding.go
+++ b/aws/table_aws_accessanalyzer_finding.go
@@ -28,9 +28,9 @@ func tableAwsAccessAnalyzerFinding(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.AllColumns([]string{"id", "access_analyzer_arn"}),
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ResourceNotFoundException", "ValidationException", "InvalidParameter"}),
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ResourceNotFoundException"}),
 			},
-			Hydrate: getAccessAnalyzerFindings,
+			Hydrate: getAccessAnalyzerFinding,
 			Tags:    map[string]string{"service": "access-analyzer", "action": "GetFinding"},
 		},
 		List: &plugin.ListConfig{
@@ -162,7 +162,7 @@ func tableAwsAccessAnalyzerFinding(_ context.Context) *plugin.Table {
 
 //// LIST FUNCTION
 
-func listAccessAnalyzersFindings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+func listAccessAnalyzersFinding(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 
 	var arn string
 	if h.Item != nil {
@@ -183,7 +183,7 @@ func listAccessAnalyzersFindings(ctx context.Context, d *plugin.QueryData, h *pl
 	// Create session
 	svc, err := AccessAnalyzerClient(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_accessanalyzer_finding.listAccessAnalyzersFindings", "client_error", err)
+		plugin.Logger(ctx).Error("aws_accessanalyzer_finding.listAccessAnalyzersFinding", "client_error", err)
 		return nil, err
 	}
 
@@ -215,7 +215,7 @@ func listAccessAnalyzersFindings(ctx context.Context, d *plugin.QueryData, h *pl
 
 		output, err := paginator.NextPage(ctx)
 		if err != nil {
-			plugin.Logger(ctx).Error("aws_accessanalyzer_finding.listAccessAnalyzersFindings", "api_error", err)
+			plugin.Logger(ctx).Error("aws_accessanalyzer_finding.listAccessAnalyzersFinding", "api_error", err)
 			return nil, err
 		}
 
@@ -257,14 +257,14 @@ func getAccessAnalyzerFindings(ctx context.Context, d *plugin.QueryData, h *plug
 		return nil, nil
 	}
 
-	// 	// Create Session
+	// Create Session
 	svc, err := AccessAnalyzerClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_accessanalyzer_finding.getAccessAnalyzerFindings", "client_error", err)
 		return nil, err
 	}
 
-	// 	// Build the params
+	// Build the params
 	params := &accessanalyzer.GetFindingInput{
 		AnalyzerArn: &arn,
 		Id:          &id,

--- a/aws/table_aws_accessanalyzer_finding.go
+++ b/aws/table_aws_accessanalyzer_finding.go
@@ -3,9 +3,6 @@ package aws
 import (
 	"context"
 	"errors"
-	"strconv"
-
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
 	"github.com/aws/smithy-go"
@@ -43,69 +40,6 @@ func tableAwsAccessAnalyzerFinding(_ context.Context) *plugin.Table {
 			IgnoreConfig: &plugin.IgnoreConfig{
 				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ResourceNotFoundException", "ValidationException"}),
 			},
-			KeyColumns: []*plugin.KeyColumn{
-				{
-					Name:    "access_analyzer_arn",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "id",
-					Require: plugin.Optional,
-
-				},
-				{
-					Name:    "action",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "analyzed_at",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "condition",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "created_at",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "error",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "is_public",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "principal",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "resource",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "resource_owner_account",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "resource_type",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "sources",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "status",
-					Require: plugin.Optional,
-				},
-				{
-					Name:    "updated_at",
-					Require: plugin.Optional,
-				},
-			},
 		},
 		GetMatrixItemFunc: SupportedRegionMatrix(accessanalyzerv1.EndpointsID),
 		Columns: awsRegionalColumns([]*plugin.Column{
@@ -121,22 +55,10 @@ func tableAwsAccessAnalyzerFinding(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Finding.Id"),
 			},
 			{
-				Name:        "action",
-				Description: "The action in the analyzed policy statement that an external principal has permission to use.",
-				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Finding.Action"),
-			},
-			{
 				Name:        "analyzed_at",
 				Description: "The time at which the resource-based policy that generated the finding was analyzed.",
 				Type:        proto.ColumnType_TIMESTAMP,
 				Transform:   transform.FromField("Finding.AnalyzedAt"),
-			},
-			{
-				Name:        "condition",
-				Description: "The condition in the analyzed policy statement that resulted in a finding.",
-				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Finding.Condition"),
 			},
 			{
 				Name:        "created_at",
@@ -157,12 +79,6 @@ func tableAwsAccessAnalyzerFinding(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Finding.IsPublic"),
 			},
 			{
-				Name:        "principal",
-				Description: "The external principal that has access to a resource within the zone of trust.",
-				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Finding.Principal"),
-			},
-			{
 				Name:        "resource",
 				Description: "The resource that the external principal has access to.",
 				Type:        proto.ColumnType_STRING,
@@ -181,12 +97,6 @@ func tableAwsAccessAnalyzerFinding(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Finding.ResourceType"),
 			},
 			{
-				Name:        "sources",
-				Description: "The sources of the finding, indicating how the access that generated the finding is granted. It is populated for Amazon S3 bucket findings.",
-				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Finding.Sources"),
-			},
-			{
 				Name:        "status",
 				Description: "The status of the finding.",
 				Type:        proto.ColumnType_STRING,
@@ -198,7 +108,30 @@ func tableAwsAccessAnalyzerFinding(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_TIMESTAMP,
 				Transform:   transform.FromField("Finding.UpdatedAt"),
 			},
-
+			{
+				Name:        "action",
+				Description: "The action in the analyzed policy statement that an external principal has permission to use.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Finding.Action"),
+			},
+			{
+				Name:        "sources",
+				Description: "The sources of the finding, indicating how the access that generated the finding is granted. It is populated for Amazon S3 bucket findings.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Finding.Sources"),
+			},
+			{
+				Name:        "principal",
+				Description: "The external principal that has access to a resource within the zone of trust.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Finding.Principal"),
+			},
+			{
+				Name:        "condition",
+				Description: "The condition in the analyzed policy statement that resulted in a finding.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Finding.Condition"),
+			},
 			// Steampipe standard columns
 			{
 				Name:        "title",
@@ -249,11 +182,8 @@ func listAccessAnalyzersFindings(ctx context.Context, d *plugin.QueryData, h *pl
 		}
 	}
 
-	filters := buildListFindingsFilters(d.Quals)
-
 	input := &accessanalyzer.ListFindingsInput{
 		AnalyzerArn: &arn,
-		Filter:      filters,
 		MaxResults:  &maxItems,
 	}
 
@@ -353,56 +283,4 @@ func getAccessAnalyzerFinding(ctx context.Context, d *plugin.QueryData, h *plugi
 	}
 
 	return accessanalyzerFindingInfo{*data.Finding, arn}, nil
-}
-
-// Build the list call input filter
-//// UTILITY FUNCTION
-
-// Build Access Analyzer list call input filter
-func buildListFindingsFilters(quals plugin.KeyColumnQualMap) map[string]types.Criterion {
-	filters := make(map[string]types.Criterion)
-
-	for qualName, qual := range quals {
-			criterion := types.Criterion{}
-
-			switch qualName {
-			case "contains", "eq", "neq":
-					var stringPointers []*string
-					for _, q := range qual.Quals {
-						// Convert each string to a *string and append to the slice
-						stringVal := q.Value.GetStringValue() // Get the string value
-						stringPointers = append(stringPointers, &stringVal) // Append the pointer to the slice
-					}
-
-					// Convert the slice of string pointers to a slice of strings
-					var stringSlice []string
-					for _, sp := range stringPointers {
-						stringSlice = append(stringSlice, *sp)
-					}
-
-					// Directly assign the slice of strings to the appropriate field
-					if qualName == "contains" {
-						criterion.Contains = stringSlice
-					} else if qualName == "eq" {
-						criterion.Eq = stringSlice
-					} else if qualName == "neq" {
-						criterion.Neq = stringSlice
-					}
-
-			case "exists":
-					if len(qual.Quals) > 0 {
-							existsValue, err := strconv.ParseBool(qual.Quals[0].Value.GetStringValue())
-							if err == nil {
-									criterion.Exists = aws.Bool(existsValue) // Directly use aws.Bool for a boolean pointer
-							}
-					}
-			}
-
-			// Ensure criterion is not empty before adding to filters
-			if len(criterion.Contains) > 0 || len(criterion.Eq) > 0 || len(criterion.Neq) > 0 || criterion.Exists != nil {
-					filters[qualName] = criterion
-			}
-	}
-
-	return filters
 }

--- a/aws/table_aws_accessanalyzer_finding.go
+++ b/aws/table_aws_accessanalyzer_finding.go
@@ -197,10 +197,6 @@ func listAccessAnalyzersFindings(ctx context.Context, d *plugin.QueryData, h *pl
 		d.WaitForListRateLimit(ctx)
 
 		output, err := paginator.NextPage(ctx)
-		if err != nil {
-			plugin.Logger(ctx).Error("aws_accessanalyzer_finding.listAccessAnalyzersFindings", "api_error", err)
-			return nil, err
-		}
 
 		if err != nil {
 			var ae smithy.APIError
@@ -231,7 +227,7 @@ func listAccessAnalyzersFindings(ctx context.Context, d *plugin.QueryData, h *pl
 			}
 			d.StreamListItem(ctx, accessanalyzerFindingInfo{f, arn})
 
-			// Context may get cancelled due to manual cancellation or if the limit has been reached
+			// Context may get canceled due to manual cancellation or if the limit has been reached
 			if d.RowsRemaining(ctx) == 0 {
 				return nil, nil
 			}
@@ -266,10 +262,6 @@ func getAccessAnalyzerFinding(ctx context.Context, d *plugin.QueryData, h *plugi
 
 	// Get call
 	data, err := svc.GetFinding(ctx, params)
-	if err != nil {
-		plugin.Logger(ctx).Debug("aws_accessanalyzer_finding.getAccessAnalyzerFinding", "api_error", err)
-		return nil, err
-	}
 
 	if err != nil {
 		var ae smithy.APIError

--- a/aws/table_aws_accessanalyzer_finding.go
+++ b/aws/table_aws_accessanalyzer_finding.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
 	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
 	"github.com/aws/smithy-go"
@@ -48,28 +47,16 @@ func tableAwsAccessAnalyzerFinding(_ context.Context) *plugin.Table {
 					Require: plugin.Optional,
 				},
 				{
-					Name:      "id",
-					Require:   plugin.Optional,
-					Operators: []string{"=", "<>"},
-				},
-				{
-					Name:    "is_public",
+					Name:    "id",
 					Require: plugin.Optional,
 				},
 				{
-					Name:      "resource_owner_account",
-					Require:   plugin.Optional,
-					Operators: []string{"=", "<>"},
+					Name:    "resource",
+					Require: plugin.Optional,
 				},
 				{
-					Name:      "resource_type",
-					Require:   plugin.Optional,
-					Operators: []string{"=", "<>"},
-				},
-				{
-					Name:      "status",
-					Require:   plugin.Optional,
-					Operators: []string{"=", "<>"},
+					Name:    "status",
+					Require: plugin.Optional,
 				},
 			},
 		},
@@ -218,11 +205,6 @@ func listAccessAnalyzersFindings(ctx context.Context, d *plugin.QueryData, h *pl
 	}
 
 	// set optional params
-	if d.EqualsQuals["is_public"] != nil {
-		input.Filter["is_public"] = types.Criterion{
-			Exists: aws.Bool(d.EqualsQuals["is_public"].GetBoolValue()),
-		}
-	}
 	setFilterCriteria(d, input)
 
 	paginator := accessanalyzer.NewListFindingsPaginator(svc, input, func(o *accessanalyzer.ListFindingsPaginatorOptions) {
@@ -317,20 +299,11 @@ func getAccessAnalyzerFinding(ctx context.Context, d *plugin.QueryData, h *plugi
 }
 
 func setFilterCriteria(d *plugin.QueryData, input *accessanalyzer.ListFindingsInput) {
-	params := []string{"id", "resource_owner_account", "resource_type", "status"}
+	params := []string{"id", "status", "resource"}
 	for _, param := range params {
 		if d.Quals[param] != nil {
-			for _, q := range d.Quals[param].Quals {
-				switch q.Operator {
-				case "=":
-					input.Filter[param] = types.Criterion{
-						Eq: []string{d.EqualsQualString(param)},
-					}
-				case "<>":
-					input.Filter[param] = types.Criterion{
-						Neq: []string{d.EqualsQualString(param)},
-					}
-				}
+			input.Filter[param] = types.Criterion{
+				Eq: []string{d.EqualsQualString(param)},
 			}
 		}
 	}

--- a/aws/table_aws_accessanalyzer_finding.go
+++ b/aws/table_aws_accessanalyzer_finding.go
@@ -1,0 +1,265 @@
+package aws
+
+import (
+	"context"
+	// "strings"
+
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer"
+	"github.com/aws/aws-sdk-go-v2/service/accessanalyzer/types"
+
+	accessanalyzerv1 "github.com/aws/aws-sdk-go/service/accessanalyzer"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+
+type listFindingsInfo = struct {
+	Finding types.FindingSummary
+	Arn     string
+}
+
+type getFindingInfo = struct {
+	Finding types.Finding
+	Arn     string
+}
+
+func tableAwsAccessAnalyzerFinding(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_accessanalyzer_finding",
+		Description: "AWS Access Analyzer Finding",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AllColumns([]string{"id", "access_analyzer_arn"}),
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ResourceNotFoundException", "ValidationException", "InvalidParameter"}),
+			},
+			Hydrate: getAccessAnalyzerFindings,
+			Tags:    map[string]string{"service": "access-analyzer", "action": "GetFinding"},
+		},
+		List: &plugin.ListConfig{
+			ParentHydrate: listAccessAnalyzers,
+			Hydrate:       listAccessAnalyzersFindings,
+			Tags:          map[string]string{"service": "access-analyzer", "action": "ListFindings"},
+			KeyColumns: []*plugin.KeyColumn{
+				{
+					Name:    "access_analyzer_arn",
+					Require: plugin.Optional,
+				},
+			},
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(accessanalyzerv1.EndpointsID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "access_analyzer_arn",
+				Description: "The Amazon Resource Name (ARN) of the analyzer that generated the finding.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Arn"),
+			},
+			{
+				Name:        "id",
+				Description: "The ID of the finding.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Finding.Id"),
+			},
+			{
+				Name:        "action",
+				Description: "The action in the analyzed policy statement that an external principal has permission to use.",
+				Type:        proto.ColumnType_JSON,
+				Transform:  transform.FromField("Finding.Action"),
+			},
+			{
+				Name:        "analyzed_at",
+				Description: "The time at which the resource-based policy that generated the finding was analyzed.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("Finding.AnalyzedAt"),
+			},
+			{
+				Name:        "condition",
+				Description: "The condition in the analyzed policy statement that resulted in a finding.",
+				Type:        proto.ColumnType_JSON,
+				Transform:  transform.FromField("Finding.Condition"),
+			},
+			{
+				Name:        "created_at",
+				Description: "The time at which the finding was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("Finding.CreatedAt"),
+			},
+			{
+				Name:        "error",
+				Description: "The error that resulted in an Error finding.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Finding.Error"),
+			},
+			{
+				Name:        "is_public",
+				Description: "Indicates whether the finding reports a resource that has a policy that allows public access.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromField("Finding.IsPublic"),
+			},
+			{
+				Name:        "principal",
+				Description: "The external principal that has access to a resource within the zone of trust.",
+				Type:        proto.ColumnType_JSON,
+				Transform:  transform.FromField("Finding.Principal"),
+			},
+			{
+				Name:        "resource",
+				Description: "The resource that the external principal has access to.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Finding.Resource"),
+			},
+			{
+				Name:        "resource_owner_account",
+				Description: "The Amazon Web Services account ID that owns the resource.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Finding.ResourceOwnerAccount"),
+			},
+			{
+				Name:        "resource_type",
+				Description: "The type of the resource that the external principal has access to.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Finding.ResourceType"),
+			},
+			{
+				Name:        "sources",
+				Description: "The sources of the finding, indicating how the access that generated the finding is granted. It is populated for Amazon S3 bucket findings.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Finding.Sources"),
+			},
+			{
+				Name:        "status",
+				Description: "The status of the finding.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Finding.Status"),
+			},
+			{
+				Name:        "updated_at",
+				Description: "The time at which the finding was most recently updated.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("Finding.UpdatedAt"),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Finding.Id"),
+			},
+			{
+				Name:        "tags",
+				Description: "A placeholder for tags, as findings typically do not have tags but are included for consistency.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromConstant(map[string]*string{}),
+			},
+			{
+				Name:        "akas",
+				Description: resourceInterfaceDescription("akas"),
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Arn").Transform(arnToAkas),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listAccessAnalyzersFindings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	arn := d.EqualsQualString("access_analyzer_arn")
+
+	if arn == "" {
+		arn = *h.Item.(types.AnalyzerSummary).Arn
+	}
+
+	// Create session
+	svc, err := AccessAnalyzerClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_accessanalyzer_finding.listAccessAnalyzersFindings", "client_error", err)
+		return nil, err
+	}
+
+	// The maximum number for MaxResults parameter is not defined by the API
+	// We have set the MaxResults to 1000 based on our test
+	maxItems := int32(1000)
+	input := &accessanalyzer.ListFindingsInput{
+		AnalyzerArn: &arn,
+	}
+
+	// Reduce the basic request limit down if the user has only requested a small number of rows
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxItems {
+			if limit < 1 {
+				maxItems = int32(1)
+			} else {
+				maxItems = int32(limit)
+			}
+		}
+	}
+
+	input.MaxResults = &maxItems
+
+	paginator := accessanalyzer.NewListFindingsPaginator(svc, input, func(o *accessanalyzer.ListFindingsPaginatorOptions) {
+		o.Limit = maxItems
+		o.StopOnDuplicateToken = true
+	})
+
+	for paginator.HasMorePages() {
+		// apply rate limiting
+		d.WaitForListRateLimit(ctx)
+
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_accessanalyzer_finding.listAccessAnalyzersFindings", "api_error", err)
+			return nil, err
+		}
+
+		for _, finding := range output.Findings {
+			d.StreamListItem(ctx, listFindingsInfo{finding, arn})
+
+			// Context may get cancelled due to manual cancellation or if the limit has been reached
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getAccessAnalyzerFindings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	id := d.EqualsQuals["id"].GetStringValue()
+	arn := d.EqualsQuals["access_analyzer_arn"].GetStringValue()
+	
+	if len(id) < 1 || len(arn) < 1 {
+		return nil, nil
+	}
+
+// 	// Create Session
+	svc, err := AccessAnalyzerClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_accessanalyzer_finding.getAccessAnalyzerFindings", "client_error", err)
+		return nil, err
+	}
+
+// 	// Build the params
+	params := &accessanalyzer.GetFindingInput{
+		AnalyzerArn: &arn,
+		Id:          &id,
+	}
+
+	// Get call
+	data, err := svc.GetFinding(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Debug("aws_accessanalyzer_finding.getAccessAnalyzerFindings", "api_error", err)
+		return nil, err
+	}
+
+	return getFindingInfo{*data.Finding, arn}, nil
+}

--- a/docs/tables/aws_accessanalyzer_finding.md
+++ b/docs/tables/aws_accessanalyzer_finding.md
@@ -1,0 +1,121 @@
+---
+title: "Steampipe Table: aws_accessanalyzer_finding - Query AWS Access Analyzer Findings using SQL"
+description: "Allows users to query Access Analyzer findings in AWS IAM to retrieve detailed information about potential security risks."
+---
+
+# Table: aws_accessanalyzer_finding - Query AWS Access Analyzer Findings using SQL
+
+AWS Access Analyzer findings provide detailed information about potential security risks in your AWS environment. These findings are generated when Access Analyzer identifies resources that are shared with an external entity, highlighting potential unintended access. By analyzing the resource-based policies, Access Analyzer helps you understand how access to your resources is granted and suggests modifications to achieve desired access policies, enhancing your security posture.
+
+## Table Usage Guide
+
+The `aws_accessanalyzer_finding` table in Steampipe allows you to query information related to findings from the AWS IAM Access Analyzer. This table is essential for security and compliance teams, enabling them to identify, analyze, and manage findings related to resource access policies. Through this table, users can access detailed information about each finding, including the actions involved, the condition that led to the finding, the resource and principal involved, and the finding's status. By leveraging this table, you can efficiently address security and compliance issues in your AWS environment.
+
+## Examples
+
+### Basic Info
+
+Retrieve essential details of findings to understand potential access issues and their current status. This query helps in identifying the nature of each finding, the resources involved, and the actions recommended or taken to resolve these issues.
+
+```sql+postgres
+select
+  id,
+  analyzed_at,
+  resource_type,
+  status,
+  is_public
+from
+  aws_accessanalyzer_finding;
+```
+
+```sql+sqlite
+select
+  id,
+  analyzed_at,
+  resource_type,
+  status,
+  is_public
+from
+  aws_accessanalyzer_finding;
+```
+
+### Findings involving public access
+
+Identify findings where resources are potentially exposed to public access. Highlighting such findings is critical for prioritizing issues that may lead to unauthorized access. This query helps in swiftly identifying and addressing potential vulnerabilities, ensuring that resources are adequately secured against public exposure.
+
+```sql+postgres
+select
+  id,
+  resource_type,
+  resource_arn,
+  status,
+  is_public
+from
+  aws_accessanalyzer_finding
+where
+  is_public = true;
+```
+
+```sql+sqlite
+select
+  id,
+  resource,
+  analyzed_at,
+  is_public
+from
+  aws_accessanalyzer_finding
+where
+  is_public = true;
+```
+
+### Findings by resource type
+
+Aggregate findings by resource type to focus remediation efforts on specific types of resources. This categorization helps in streamlining the security review process by allowing teams to prioritize resources based on their sensitivity and exposure.
+
+```sql+postgres
+select
+  resource_type,
+  count(*) as findings_count
+from
+  aws_accessanalyzer_finding
+group by
+  resource_type;
+```
+  
+```sql+sqlite
+select
+  resource_type,
+  count(*) as findings_count
+from
+  aws_accessanalyzer_finding
+group by
+  resource_type;
+```
+
+### Recent findings
+
+Focus on findings that have been identified recently to address potentially new security risks. This query aids in maintaining an up-to-date security posture by ensuring that recent findings are promptly reviewed and addressed.
+
+```sql+postgres
+select
+  id,
+  resource,
+  status,
+  analyzed_at
+from
+  aws_accessanalyzer_finding
+where
+  analyzed_at > current_date - interval '30 days';
+```
+
+```sql+sqlite
+select
+  id,
+  resource,
+  status,
+  analyzed_at
+from
+  aws_accessanalyzer_finding
+where
+  analyzed_at > date('now', '-30 day');
+```

--- a/docs/tables/aws_accessanalyzer_finding.md
+++ b/docs/tables/aws_accessanalyzer_finding.md
@@ -20,6 +20,7 @@ Retrieve essential details of findings to understand potential access issues and
 ```sql+postgres
 select
   id,
+  access_analyzer_arn,
   analyzed_at,
   resource_type,
   status,
@@ -47,7 +48,7 @@ Identify findings where resources are potentially exposed to public access. High
 select
   id,
   resource_type,
-  resource_arn,
+  access_analyzer_arn,
   status,
   is_public
 from
@@ -59,8 +60,9 @@ where
 ```sql+sqlite
 select
   id,
-  resource,
-  analyzed_at,
+  resource_type,
+  access_analyzer_arn,
+  status,
   is_public
 from
   aws_accessanalyzer_finding


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
select
  id,
  analyzed_at,
  resource_type,
  status,
  is_public
from
  aws_accessanalyzer_finding;
+--------------------------------------+---------------------------+-----------------------------+----------+-----------+
| id                                   | analyzed_at               | resource_type               | status   | is_public |
+--------------------------------------+---------------------------+-----------------------------+----------+-----------+
| 05c16136-d793-46b6-9b30-13f4d85687ac | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| a200ea7b-209d-47cb-9200-4f9f3014aed0 | 2024-03-13T21:15:43+05:30 | AWS::RDS::DBClusterSnapshot | RESOLVED | false     |
| 7a81051c-bb77-47ad-b69e-13b66f1d4221 | 2024-03-19T19:19:10+05:30 | AWS::IAM::Role              | RESOLVED | false     |
| b8304c91-e5c7-454f-bd1b-b569a786caa1 | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| 03474fac-23cb-47a8-9f93-f18154adcc8f | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| ab0fb4c1-a7ee-4aaf-a0b9-3810ef323ce9 | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| 2e4efe81-7379-452c-be5f-5dcd69d77d47 | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| 75415a95-9bef-4948-b768-0954779ae62e | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| db335174-130d-4e5e-9e86-d38cd34abef6 | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| 1c79e4ad-6238-4efe-821b-503320042201 | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| adafb8d3-84fc-4419-ad51-7378519b16ef | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| 29be6ef7-ce2e-4258-9c23-c8b5ae219a1e | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| 9cbf5147-2029-4f1a-9e45-173b98ea7905 | 2024-03-21T06:50:35+05:30 | AWS::Lambda::Function       | ACTIVE   | true      |
| a909450c-be6c-46d7-9d64-bf5da838e238 | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| c8438c60-a2a8-4636-8b59-9932ce1e06df | 2024-03-21T06:50:35+05:30 | AWS::EFS::FileSystem        | ACTIVE   | true      |
| 30290d0c-0086-4a3c-a0f9-c05affe1c30a | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| adef1d4c-522f-4d82-9f83-167f45217ae1 | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| f02cf82e-2f3d-4c96-8602-5172df134b65 | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| 271ffb48-a191-4d12-83ed-060c31c918c8 | 2024-03-21T06:50:35+05:30 | AWS::S3::Bucket             | ACTIVE   | false     |
| 679f38c3-ff45-486b-a50e-891fdc1eba57 | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| a17ca21d-c681-49d1-96bc-3ae6aff6fbb9 | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| 7fc72ddc-8fc5-4ed6-9db5-e8ae58018602 | 2024-03-13T21:15:43+05:30 | AWS::RDS::DBClusterSnapshot | RESOLVED | false     |
| 6d289fcf-ea69-4bfe-82cf-74e477598707 | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| 6fc9178b-8e93-461f-8c4d-54dab5a0af28 | 2024-03-21T06:50:35+05:30 | AWS::IAM::Role              | ACTIVE   | false     |
| 870bc2de-2088-4315-ac3e-a4d9de1b0098 | 2024-03-13T21:15:43+05:30 | AWS::RDS::DBClusterSnapshot | RESOLVED | false     |
| 921d692f-9724-4a5e-8f73-92262f43e38e | 2024-03-21T06:50:35+05:30 | AWS::SNS::Topic             | ACTIVE   | false     |
| 89202894-fbf5-48fd-befe-34a27ee14683 | 2024-03-13T21:20:35+05:30 | AWS::RDS::DBClusterSnapshot | RESOLVED | true      |
+--------------------------------------+---------------------------+-----------------------------+----------+-----------+


select
  id,
  resource_type,
  access_analyzer_arn,
  status,
  is_public
from
  aws_accessanalyzer_finding
where
  is_public = true;
+--------------------------------------+-----------------------------+------------------------------------------------------------------------------------------------------------>
| id                                   | resource_type               | access_analyzer_arn                                                                                        >
+--------------------------------------+-----------------------------+------------------------------------------------------------------------------------------------------------>
| 9cbf5147-2029-4f1a-9e45-173b98ea7905 | AWS::Lambda::Function       | arn:aws:access-analyzer:us-east-1:555555555555:analyzer/ConsoleAnalyzer-79c29b10-ce7f-409d-994d-f4f96fa0b1d>
| c8438c60-a2a8-4636-8b59-9932ce1e06df | AWS::EFS::FileSystem        | arn:aws:access-analyzer:us-east-1:555555555555:analyzer/ConsoleAnalyzer-79c29b10-ce7f-409d-994d-f4f96fa0b1d>
| 89202894-fbf5-48fd-befe-34a27ee14683 | AWS::RDS::DBClusterSnapshot | arn:aws:access-analyzer:us-east-1:555555555555:analyzer/ConsoleAnalyzer-79c29b10-ce7f-409d-994d-f4f96fa0b1d>
+--------------------------------------+-----------------------------+-----------------------------------------------------------------------------------------------------------

select
  resource_type,
  count(*) as findings_count
from
  aws_accessanalyzer_finding
group by
  resource_type;
+-----------------------------+----------------+
| resource_type               | findings_count |
+-----------------------------+----------------+
| AWS::EFS::FileSystem        | 1              |
| AWS::IAM::Role              | 19             |
| AWS::Lambda::Function       | 1              |
| AWS::RDS::DBClusterSnapshot | 4              |
| AWS::S3::Bucket             | 1              |
| AWS::SNS::Topic             | 1              |
+-----------------------------+----------------+

select
  id,
  resource,
  status,
  analyzed_at
from
  aws_accessanalyzer_finding
where
  analyzed_at > current_date - interval '30 days';
+--------------------------------------+----------------------------------------------------------------------------------------------------------------------+----------+-------->
| id                                   | resource                                                                                                             | status   | analyze>
+--------------------------------------+----------------------------------------------------------------------------------------------------------------------+----------+-------->
| a200ea7b-209d-47cb-9200-4f9f3014aed0 | arn:aws:rds:us-east-1:555555555555:cluster-snapshot:docdb-2022-05-16-13-57-40-2022-05-17-00-01                       | RESOLVED | 2024-03>
| 7a81051c-bb77-47ad-b69e-13b66f1d4221 | arn:aws:iam::555555555555:role/nagraj-cross-account                                                                  | RESOLVED | 2024-03>
| ab0fb4c1-a7ee-4aaf-a0b9-3810ef323ce9 | arn:aws:iam::555555555555:role/databricks-workspace-stack-ea6c4-metastore-role                                       | ACTIVE   | 2024-03>
| 2e4efe81-7379-452c-be5f-5dcd69d77d47 | arn:aws:iam::555555555555:role/OrganizationAccountAccessRole                                                         | ACTIVE   | 2024-03>
| 6d289fcf-ea69-4bfe-82cf-74e477598707 | arn:aws:iam::555555555555:role/service-role/role-identity-pool                                                       | ACTIVE   | 2024-03>
| a909450c-be6c-46d7-9d64-bf5da838e238 | arn:aws:iam::555555555555:role/lm-mods                                                                               | ACTIVE   | 2024-03>
| 03474fac-23cb-47a8-9f93-f18154adcc8f | arn:aws:iam::555555555555:role/turbot/core/turbot_metadata                                                           | ACTIVE   | 2024-03>
| f02cf82e-2f3d-4c96-8602-5172df134b65 | arn:aws:iam::555555555555:role/service-role/cognito-identity-pool-role                                               | ACTIVE   | 2024-03>
| adef1d4c-522f-4d82-9f83-167f45217ae1 | arn:aws:iam::555555555555:role/aws-reserved/sso.amazonaws.com/us-east-2/AWSReservedSSO_SSO-Admin_82e86f5fa51880a8    | ACTIVE   | 2024-03>
| b8304c91-e5c7-454f-bd1b-b569a786caa1 | arn:aws:iam::555555555555:role/aws-reserved/sso.amazonaws.com/us-east-2/AWSReservedSSO_SSO-ReadOnly_f70a13ddfdac8fb7 | ACTIVE   | 2024-03>
| 6fc9178b-8e93-461f-8c4d-54dab5a0af28 | arn:aws:iam::555555555555:role/databricks-workspace-stack-ea6c4-role                                                 | ACTIVE   | 2024-03>
| 921d692f-9724-4a5e-8f73-92262f43e38e | arn:aws:sns:us-east-1:555555555555:aws-cis-handling                                                                  | ACTIVE   | 2024-03>
| adafb8d3-84fc-4419-ad51-7378519b16ef | arn:aws:iam::555555555555:role/a-role-mfa                                                                            | ACTIVE   | 2024-03>
| c8438c60-a2a8-4636-8b59-9932ce1e06df | arn:aws:elasticfilesystem:us-east-1:555555555555:file-system/fs-08414c1c5df10851a                                    | ACTIVE   | 2024-03>
| 30290d0c-0086-4a3c-a0f9-c05affe1c30a | arn:aws:iam::555555555555:role/databricks-workspace-stack-a6c3d-metastore-role                                       | ACTIVE   | 2024-03>
| 29be6ef7-ce2e-4258-9c23-c8b5ae219a1e | arn:aws:iam::555555555555:role/databricks-s3-ingest-29245-db_s3_iam                                                  | ACTIVE   | 2024-03>
| 05c16136-d793-46b6-9b30-13f4d85687ac | arn:aws:iam::555555555555:role/turbot_superuser5                                                                     | ACTIVE   | 2024-03>
| 7fc72ddc-8fc5-4ed6-9db5-e8ae58018602 | arn:aws:rds:us-east-1:555555555555:cluster-snapshot:docdb-2022-05-16-13-57-40-2022-05-17-00-01                       | RESOLVED | 2024-03>
| 1c79e4ad-6238-4efe-821b-503320042201 | arn:aws:iam::555555555555:role/turbot_superuser5                                                                     | ACTIVE   | 2024-03>
| 870bc2de-2088-4315-ac3e-a4d9de1b0098 | arn:aws:rds:us-east-1:555555555555:cluster-snapshot:docdb-2022-05-16-13-57-40-2022-05-17-00-01                       | RESOLVED | 2024-03>
| 679f38c3-ff45-486b-a50e-891fdc1eba57 | arn:aws:iam::555555555555:role/databricks-workspace-stack-a6c3d-role                                                 | ACTIVE   | 2024-03>
| 89202894-fbf5-48fd-befe-34a27ee14683 | arn:aws:rds:us-east-1:555555555555:cluster-snapshot:docdb-2022-05-16-13-57-40-2022-05-17-00-01                       | RESOLVED | 2024-03>
| db335174-130d-4e5e-9e86-d38cd34abef6 | arn:aws:iam::555555555555:role/CloudWatch-CrossAccountSharingRole                                                    | ACTIVE   | 2024-03>
| 271ffb48-a191-4d12-83ed-060c31c918c8 | arn:aws:s3:::databricks-workspace-stack-a6c3d-bucket                                                                 | ACTIVE   | 2024-03>
| 9cbf5147-2029-4f1a-9e45-173b98ea7905 | arn:aws:lambda:us-east-1:555555555555:function:funt67                                                                | ACTIVE   | 2024-03>
| a17ca21d-c681-49d1-96bc-3ae6aff6fbb9 | arn:aws:iam::555555555555:role/cross-account-testing                                                                 | ACTIVE   | 2024-03>
| 75415a95-9bef-4948-b768-0954779ae62e | arn:aws:iam::555555555555:role/turbot/core/turbot_superuser                                                          | ACTIVE   | 2024-03>
+--------------------------------------+----------------------------------------------------------------------------------------------------------------------+----------+-------->

select * from aws_accessanalyzer_finding where id = '....' and access_analyzer_arn = '...' and region = 'us-east-1'
+---------------------+----+--------+-------------+-----------+------------+-------+-----------+-----------+----------+------------------------+---------------+---------+-------->
| access_analyzer_arn | id | action | analyzed_at | condition | created_at | error | is_public | principal | resource | resource_owner_account | resource_type | sources | status >
+---------------------+----+--------+-------------+-----------+------------+-------+-----------+-----------+----------+------------------------+---------------+---------+-------->
+---------------------+----+--------+-------------+-----------+------------+-------+-----------+-----------+----------+------------------------+---------------+---------+-------
```
</details>
