### PR TITLE
Fixed Directory Service shared into account causes some queries like SELECT ... FROM aws_directory_service_directory to fail Closes #2155

### DIFF
--- a/aws/table_aws_directory_service_directory.go
+++ b/aws/table_aws_directory_service_directory.go
@@ -352,6 +352,12 @@ func getDirectoryServiceDirectory(ctx context.Context, d *plugin.QueryData, _ *p
 func getDirectoryServiceEventTopics(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	directory := h.Item.(types.DirectoryDescription)
 
+	// This operation is not supported for for Shared MicrosoftAD directories
+	// Error: aws: operation error Directory Service: DescribeEventTopics, https response error StatusCode: 400, RequestID: 56b47735-04a6-434c-97e4-7258c0a43d5b, ClientException: Operation is not supported for Shared MicrosoftAD directories. : RequestId: 56b47735-04a6-434c-97e4-7258c0a43d5b
+	if directory.Type == "SharedMicrosoftAD" {
+		return nil, nil
+	}
+
 	// Create service
 	svc, err := DirectoryServiceClient(ctx, d)
 	if err != nil {
@@ -382,6 +388,12 @@ func getDirectoryServiceEventTopics(ctx context.Context, d *plugin.QueryData, h 
 
 func getDirectoryServiceSnapshotLimit(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	directory := h.Item.(types.DirectoryDescription)
+
+	// This operation is not supported for for Shared MicrosoftAD directories
+	// Error: aws: operation error Directory Service: GetSnapshotLimits, https response error StatusCode: 400, RequestID: 5126ab72-c6e9-41a2-92df-d59f2a3e4ebb, ClientException: Snapshot limits can be fetched only for VPC or Microsoft AD directories. : RequestId: 5126ab72-c6e9-41a2-92df-d59f2a3e4ebb
+	if directory.Type == "SharedMicrosoftAD" {
+		return nil, nil
+	}
 
 	// Create service
 	svc, err := DirectoryServiceClient(ctx, d)

--- a/aws/table_aws_directory_service_directory.go
+++ b/aws/table_aws_directory_service_directory.go
@@ -353,7 +353,7 @@ func getDirectoryServiceEventTopics(ctx context.Context, d *plugin.QueryData, h 
 	directory := h.Item.(types.DirectoryDescription)
 
 	// This operation is not supported for for Shared MicrosoftAD directories
-	// Error: aws: operation error Directory Service: DescribeEventTopics, https response error StatusCode: 400, RequestID: 56b47735-04a6-434c-97e4-7258c0a43d5b, ClientException: Operation is not supported for Shared MicrosoftAD directories. : RequestId: 56b47735-04a6-434c-97e4-7258c0a43d5b
+	// Error: aws: operation error Directory Service: DescribeEventTopics, https response error StatusCode: 400, ClientException: Operation is not supported for Shared MicrosoftAD directories.
 	if directory.Type == "SharedMicrosoftAD" {
 		return nil, nil
 	}
@@ -390,8 +390,7 @@ func getDirectoryServiceSnapshotLimit(ctx context.Context, d *plugin.QueryData, 
 	directory := h.Item.(types.DirectoryDescription)
 
 	// This operation is not supported for for Shared MicrosoftAD directories
-	// Error: aws: operation error Directory Service: GetSnapshotLimits, https response error StatusCode: 400, RequestID: 5126ab72-c6e9-41a2-92df-d59f2a3e4ebb, ClientException: Snapshot limits can be fetched only for VPC or Microsoft AD directories. : RequestId: 5126ab72-c6e9-41a2-92df-d59f2a3e4ebb
-	if directory.Type == "SharedMicrosoftAD" {
+	// Error: aws: operation error Directory Service: GetSnapshotLimits, https response error StatusCode: 400, ClientException: Snapshot limits can be fetched only for VPC or Microsoft AD directories.
 		return nil, nil
 	}
 

--- a/aws/table_aws_directory_service_directory.go
+++ b/aws/table_aws_directory_service_directory.go
@@ -391,6 +391,7 @@ func getDirectoryServiceSnapshotLimit(ctx context.Context, d *plugin.QueryData, 
 
 	// This operation is not supported for for Shared MicrosoftAD directories
 	// Error: aws: operation error Directory Service: GetSnapshotLimits, https response error StatusCode: 400, ClientException: Snapshot limits can be fetched only for VPC or Microsoft AD directories.
+	if directory.Type == "SharedMicrosoftAD" {
 		return nil, nil
 	}
 


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_directory_service_directory []

PRETEST: tests/aws_directory_service_directory

TEST: tests/aws_directory_service_directory
Running terraform
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 0s [id=444444444444]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_directory_service_directory.named_test_resource will be created
  + resource "aws_directory_service_directory" "named_test_resource" {
      + access_url                           = (known after apply)
      + alias                                = (known after apply)
      + desired_number_of_domain_controllers = (known after apply)
      + dns_ip_addresses                     = (known after apply)
      + edition                              = (known after apply)
      + enable_sso                           = false
      + id                                   = (known after apply)
      + name                                 = "turbottest52398.com"
      + password                             = (sensitive value)
      + security_group_id                    = (known after apply)
      + short_name                           = (known after apply)
      + size                                 = "Small"
      + tags                                 = {
          + "Name" = "turbottest52398"
        }
      + tags_all                             = {
          + "Name" = "turbottest52398"
        }
      + type                                 = "SimpleAD"

      + vpc_settings {
          + availability_zones = (known after apply)
          + subnet_ids         = (known after apply)
          + vpc_id             = (known after apply)
        }
    }

  # aws_iam_role.my_role will be created
  + resource "aws_iam_role" "my_role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "dax.amazonaws.com"
                        }
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest52398"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)
    }

  # aws_subnet.my_subnet1 will be created
  + resource "aws_subnet" "my_subnet1" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.1.1.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_subnet.my_subnet2 will be created
  + resource "aws_subnet" "my_subnet2" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.1.2.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.my_vpc will be created
  + resource "aws_vpc" "my_vpc" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.1.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags_all                             = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "444444444444"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest52398"
aws_vpc.my_vpc: Creating...
aws_iam_role.my_role: Creating...
aws_iam_role.my_role: Creation complete after 2s [id=turbottest52398]
aws_vpc.my_vpc: Creation complete after 4s [id=vpc-0dc94de95520d0357]
aws_subnet.my_subnet2: Creating...
aws_subnet.my_subnet1: Creating...
aws_subnet.my_subnet1: Creation complete after 3s [id=subnet-0ab6556a9bd044b90]
aws_subnet.my_subnet2: Creation complete after 3s [id=subnet-0ff6e9e330cf395aa]
aws_directory_service_directory.named_test_resource: Creating...
aws_directory_service_directory.named_test_resource: Still creating... [10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [1m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [2m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [3m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [4m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [5m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m10s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m20s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m30s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m40s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [6m50s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [7m0s elapsed]
aws_directory_service_directory.named_test_resource: Still creating... [7m10s elapsed]
aws_directory_service_directory.named_test_resource: Creation complete after 7m10s [id=d-9067fc0a2f]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "444444444444"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:ds:us-east-1:444444444444:directory/d-9067fc0a2f"
resource_id = "d-9067fc0a2f"
resource_name = "turbottest52398"

Running SQL query: test-get-query.sql
[
  {
    "arn": "arn:aws:ds:us-east-1:444444444444:directory/d-9067fc0a2f",
    "directory_id": "d-9067fc0a2f",
    "name": "turbottest52398.com"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ds:us-east-1:444444444444:directory/d-9067fc0a2f"
    ],
    "name": "turbottest52398.com",
    "tags": {
      "Name": "turbottest52398"
    },
    "title": "turbottest52398.com"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "akas": [
      "arn:aws:ds:us-east-1:444444444444:directory/d-9067fc0a2f"
    ],
    "name": "turbottest52398.com",
    "title": "turbottest52398.com"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql
[]
✔ PASSED

POSTTEST: tests/aws_directory_service_directory

TEARDOWN: tests/aws_directory_service_directory

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_aab.aws_directory_service_directory
+------------------+--------------+----------------------------------------------------------+--------+-------------+--------------------------+--------------+-------------+--------------------------------------+----------+------------>
| name             | directory_id | arn                                                      | stage  | type        | access_url               | alias        | description | desired_number_of_domain_controllers | edition  | launch_time>
+------------------+--------------+----------------------------------------------------------+--------+-------------+--------------------------+--------------+-------------+--------------------------------------+----------+------------>
| hey.example9.com | d-9067fc0707 | arn:aws:ds:us-east-1:444444444444:directory/d-9067fc0707 | Active | MicrosoftAD | d-9067fc0707.awsapps.com | d-9067fc0707 | <null>      | 2                                    | Standard | 2024-04-02T>
+------------------+--------------+----------------------------------------------------------+--------+-------------+--------------------------+--------------+-------------+--------------------------------------+----------+------------>
> select * from aws_directory_service_directory
+------------------+--------------+----------------------------------------------------------+-----------+-------------------+------------+-------+-------------+--------------------------------------+---------+------------------------->
| name             | directory_id | arn                                                      | stage     | type              | access_url | alias | description | desired_number_of_domain_controllers | edition | launch_time             >
+------------------+--------------+----------------------------------------------------------+-----------+-------------------+------------+-------+-------------+--------------------------------------+---------+------------------------->
| hey.example9.com | d-9067fc09bc | arn:aws:ds:us-east-1:222222222222:directory/d-9067fc09bc | Requested | SharedMicrosoftAD |            |       | <null>      | 0                                    |         | 2024-04-02T11:37:11+05:3>
+------------------+--------------+----------------------------------------------------------+-----------+-------------------+------------+-------+-------------+--------------------------------------+---------+------------------------->
```
</details>
