### PR TITLE
Add columns steampipe_available and steampipe_default in the aws_region table

### DIFF
--- a/aws/table_aws_region.go
+++ b/aws/table_aws_region.go
@@ -52,7 +52,7 @@ func tableAwsRegion(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("RegionName"),
 			},
 			{
-				Name:        "connection_config_set",
+				Name:        "connection_config_region_set",
 				Description: "True if the region is specified in the connection config file.",
 				Type:        proto.ColumnType_BOOL,
 				Hydrate:     getAWSRegionsInConfig,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, opt_in_status, steampipe_available, steampipe_default from aws_region
+----------------+---------------------+---------------------+-------------------+
| name           | opt_in_status       | steampipe_available | steampipe_default |
+----------------+---------------------+---------------------+-------------------+
| eu-central-1   | opt-in-not-required | true                | false             |
| ap-northeast-2 | opt-in-not-required | true                | false             |
| ap-northeast-1 | opt-in-not-required | true                | false             |
| eu-west-3      | opt-in-not-required | true                | false             |
| eu-south-2     | not-opted-in        | false               | false             |
| me-south-1     | opted-in            | true                | false             |
| ca-west-1      | not-opted-in        | false               | false             |
| ap-northeast-3 | opt-in-not-required | true                | false             |
| eu-central-2   | not-opted-in        | false               | false             |
| me-central-1   | opted-in            | true                | false             |
| ap-southeast-3 | opted-in            | true                | false             |
| us-west-1      | opt-in-not-required | true                | false             |
| ap-southeast-1 | opt-in-not-required | true                | false             |
| ap-south-2     | not-opted-in        | false               | false             |
| eu-north-1     | opt-in-not-required | true                | false             |
| af-south-1     | opted-in            | true                | false             |
| sa-east-1      | opt-in-not-required | true                | false             |
| ca-central-1   | opt-in-not-required | true                | false             |
| ap-south-1     | opt-in-not-required | true                | false             |
| ap-east-1      | opted-in            | true                | false             |
| us-east-2      | opt-in-not-required | true                | false             |
| eu-west-1      | opt-in-not-required | true                | false             |
| ap-southeast-4 | not-opted-in        | false               | false             |
| ap-southeast-2 | opt-in-not-required | true                | false             |
| il-central-1   | not-opted-in        | false               | false             |
| eu-west-2      | opt-in-not-required | true                | true              |
| eu-south-1     | opted-in            | true                | false             |
| us-east-1      | opt-in-not-required | true                | false             |
| us-west-2      | opt-in-not-required | true                | false             |
+----------------+---------------------+---------------------+-------------------+
```
</details>
