### PR TITLE
Fixed table aws_ebs_snapshot is returning empty rows even though there is data present Closes #2184

### DIFF
--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -22,7 +22,7 @@ func tableAwsEBSSnapshot(_ context.Context) *plugin.Table {
 			Hydrate: listAwsEBSSnapshots,
 			Tags:    map[string]string{"service": "ec2", "action": "DescribeSnapshots"},
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"InvalidSnapshot.NotFound", "InvalidSnapshotID.Malformed", "InvalidParameterValue", "InvalidUserID.Malformed"}),
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"InvalidSnapshot.NotFound", "InvalidSnapshotID.Malformed", "InvalidUserID.Malformed"}),
 			},
 			KeyColumns: []*plugin.KeyColumn{
 				{
@@ -214,7 +214,9 @@ func listAwsEBSSnapshots(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 
 	// Build filter for ebs snapshot
 	filters := buildEbsSnapshotFilter(ctx, d, h, d.EqualsQuals, input)
-	input.Filters = filters
+	if len(filters) > 0 {
+		input.Filters = filters
+	}
 
 	paginator := ec2.NewDescribeSnapshotsPaginator(svc, input, func(o *ec2.DescribeSnapshotsPaginatorOptions) {
 		if input.MaxResults != nil {


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
SETUP: tests/aws_ebs_snapshot []

PRETEST: tests/aws_ebs_snapshot

TEST: tests/aws_ebs_snapshot
Running terraform
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 0s [id=xxxxxxxxxxxx]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ebs_snapshot.named_test_resource will be created
  + resource "aws_ebs_snapshot" "named_test_resource" {
      + arn                    = (known after apply)
      + data_encryption_key_id = (known after apply)
      + description            = "Test snapshot"
      + encrypted              = (known after apply)
      + id                     = (known after apply)
      + kms_key_id             = (known after apply)
      + owner_alias            = (known after apply)
      + owner_id               = (known after apply)
      + storage_tier           = (known after apply)
      + tags                   = {
          + "Name" = "turbottest7427"
        }
      + tags_all               = {
          + "Name" = "turbottest7427"
        }
      + volume_id              = (known after apply)
      + volume_size            = (known after apply)
    }

  # aws_ebs_volume.test_volume will be created
  + resource "aws_ebs_volume" "test_volume" {
      + arn               = (known after apply)
      + availability_zone = "us-east-1a"
      + encrypted         = (known after apply)
      + final_snapshot    = false
      + id                = (known after apply)
      + iops              = (known after apply)
      + kms_key_id        = (known after apply)
      + size              = 1
      + snapshot_id       = (known after apply)
      + tags_all          = (known after apply)
      + throughput        = (known after apply)
      + type              = (known after apply)
    }

  # aws_snapshot_create_volume_permission.example_perm will be created
  + resource "aws_snapshot_create_volume_permission" "example_perm" {
      + account_id  = "388460667113"
      + id          = (known after apply)
      + snapshot_id = (known after apply)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "xxxxxxxxxxxx"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest7427"
  + snapshot_id   = (known after apply)
  + volume_id     = (known after apply)
aws_ebs_volume.test_volume: Creating...
aws_ebs_volume.test_volume: Still creating... [10s elapsed]
aws_ebs_volume.test_volume: Creation complete after 12s [id=vol-0e28ca9730897b6c1]
aws_ebs_snapshot.named_test_resource: Creating...
aws_ebs_snapshot.named_test_resource: Still creating... [10s elapsed]
aws_ebs_snapshot.named_test_resource: Creation complete after 17s [id=snap-099a4d8c3f2f92311]
aws_snapshot_create_volume_permission.example_perm: Creating...
aws_snapshot_create_volume_permission.example_perm: Creation complete after 1s [id=snap-099a4d8c3f2f92311-388460667113]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "xxxxxxxxxxxx"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:ec2:us-east-1::snapshot/snap-099a4d8c3f2f92311"
resource_name = "turbottest7427"
snapshot_id = "snap-099a4d8c3f2f92311"
volume_id = "vol-0e28ca9730897b6c1"

Running SQL query: test-get-query.sql

Time: 4.9s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) aws_ebs_snapshot.aws: Time: 3.1s. Fetched: 1. Hydrates: 0. Quals: snapshot_id=snap-099a4d8c3f2f92311.

[
  {
    "description": "Test snapshot",
    "encrypted": false,
    "owner_id": "xxxxxxxxxxxx",
    "snapshot_id": "snap-099a4d8c3f2f92311",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest7427"
      }
    ],
    "volume_id": "vol-0e28ca9730897b6c1",
    "volume_size": 1
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql

Time: 9.7s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 2.

Scans:
  1) aws_ebs_snapshot.aws: Time: 8.5s. Fetched: 1. Hydrates: 2. Quals: snapshot_id=snap-099a4d8c3f2f92311.

[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:xxxxxxxxxxxx:snapshot/snap-099a4d8c3f2f92311"
    ],
    "create_volume_permissions": [
      {
        "Group": "",
        "UserId": "388460667113"
      }
    ],
    "snapshot_id": "snap-099a4d8c3f2f92311",
    "tags": {
      "Name": "turbottest7427"
    },
    "title": "snap-099a4d8c3f2f92311"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

Time: 9.4s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) aws_ebs_snapshot.aws: Time: 3.0s. Fetched: 1. Hydrates: 0. Quals: snapshot_id=snap-099a4d8c3f2f92311.

[
  {
    "snapshot_id": "snap-099a4d8c3f2f92311",
    "volume_id": "vol-0e28ca9730897b6c1"
  }
]
✔ PASSED

POSTTEST: tests/aws_ebs_snapshot

TEARDOWN: tests/aws_ebs_snapshot

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
1. SELET * FROM aws_ebs_snapshot; (OK)
2. SELECT * FROM aws_ebs_snapshot WHERE description = 'Copied for DestinationAmi ami-0da8f950581eea6e8 from SourceAmi ami-0d70546e43a941d70 for SourceSnapshot snap-010ba416b9cd2b353. Task created on 1,660,139,218,799.'; (OK)
3. SELECT * FROM aws_ebs_snapshot WHERE owner_alias IS NULL; (OK)
4. SELECT * FROM aws_ebs_snapshot WHERE owner_id = 'xxxxxxxxxxxx'; (OK)
5. SELECT * FROM aws_ebs_snapshot WHERE snapshot_id = 'snap-0aa97f0d110df2170'; (OK)
6. SELECT * FROM aws_ebs_snapshot WHERE state = 'completed'; (OK)
7. SELECT * FROM aws_ebs_snapshot WHERE progress = '100%'; (OK)
```
</details>
