### PR TITLE
Add ec2 keypair create_time field (#2196)

### DIFF
--- a/aws/table_aws_ec2_key_pair.go
+++ b/aws/table_aws_ec2_key_pair.go
@@ -82,7 +82,6 @@ func tableAwsEc2KeyPair(_ context.Context) *plugin.Table {
 				Name:        "create_time",
 				Description: "The time that the keypair was created or imported",
 				Type:        proto.ColumnType_TIMESTAMP,
-				Transform:   transform.FromField("CreateTime"),
 			},
 		}),
 	}

--- a/aws/table_aws_ec2_key_pair.go
+++ b/aws/table_aws_ec2_key_pair.go
@@ -78,6 +78,12 @@ func tableAwsEc2KeyPair(_ context.Context) *plugin.Table {
 				Hydrate:     getAwsEc2KeyPairAkas,
 				Transform:   transform.FromValue(),
 			},
+			{
+				Name:        "create_time",
+				Description: "The time that the keypair was created or imported",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("CreateTime"),
+			},
 		}),
 	}
 }


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> .inspect aws_ec2_key_pair
+--------------------+--------------------------+------------------------------+
| column             | type                     | description                  |
+--------------------+--------------------------+------------------------------+
| _ctx               | jsonb                    | Steampipe context in JSON fo |
|                    |                          | rm.                          |
| account_id         | text                     | The AWS Account ID in which  |
|                    |                          | the resource is located.     |
| akas               | jsonb                    | Array of globally unique ide |
|                    |                          | ntifier strings (also known  |
|                    |                          | as) for the resource.        |
| create_time        | timestamp with time zone | The time that the keypair wa |
|                    |                          | s created or imported        |
| key_fingerprint    | text                     | If key pair was created usin |
|                    |                          | g CreateKeyPair, this is the |
|                    |                          |  SHA-1 digest of the DER enc |
|                    |                          | oded private key. If key pai |
|                    |                          | r was created using ImportKe |
|                    |                          | yPair to provide AWS the pub |
|                    |                          | lic key, this is the MD5 pub |
|                    |                          | lic key fingerprint as speci |
|                    |                          | fied in section 4 of RFC4716 |
| key_name           | text                     | The name of the key pair     |
| key_pair_id        | text                     | The ID of the key pair       |
| partition          | text                     | The AWS partition in which t |
|                    |                          | he resource is located (aws, |
|                    |                          |  aws-cn, or aws-us-gov).     |
| region             | text                     | The AWS Region in which the  |
|                    |                          | resource is located.         |
| sp_connection_name | text                     | Steampipe connection name.   |
| sp_ctx             | jsonb                    | Steampipe context in JSON fo |
|                    |                          | rm.                          |
| tags               | jsonb                    | A map of tags for the resour |
|                    |                          | ce.                          |
| tags_src           | jsonb                    | A list of tags assigned to t |
|                    |                          | he key pair                  |
| title              | text                     | Title of the resource.       |
+--------------------+--------------------------+------------------------------+
> select key_name, key_fingerprint, title, create_time from dev.aws_ec2_key_pair where key_name='amos'
+-------------+----------------------------------------------+-------------+---------------------------+
| key_name    | key_fingerprint                              | title       | create_time               |
+-------------+----------------------------------------------+-------------+---------------------------+
| amos | <reducted> | amos | 2024-01-30T14:24:20+11:00 |
+-------------+----------------------------------------------+-------------+---------------------------+
```
I also verified with `aws` cli that the new timestamp field contains the correct time.
</details>
