### PR TITLE
Updated the table aws_ec2_instance_type for populating the column value per region and filter results by instance_type Closes #2195

### DIFF
--- a/aws/table_aws_ec2_instance_type.go
+++ b/aws/table_aws_ec2_instance_type.go
@@ -8,6 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 
+	ec2v1 "github.com/aws/aws-sdk-go/service/ec2"
+
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -20,7 +22,9 @@ func tableAwsInstanceType(_ context.Context) *plugin.Table {
 		Name:        "aws_ec2_instance_type",
 		Description: "AWS EC2 Instance Type",
 		Get: &plugin.GetConfig{
-			KeyColumns: plugin.SingleColumn("instance_type"),
+			// We must have to include the region in the query parameter to make the gate API call.
+			// Otherwise we will get an Error: get call returned 9 results - the key column is not globally unique (SQLSTATE HV000)
+			KeyColumns: plugin.AllColumns([]string{"instance_type", "region"}),
 			IgnoreConfig: &plugin.IgnoreConfig{
 				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"InvalidInstanceType"}),
 			},
@@ -29,6 +33,9 @@ func tableAwsInstanceType(_ context.Context) *plugin.Table {
 		},
 		List: &plugin.ListConfig{
 			Hydrate: listAwsInstanceTypesOfferings,
+			KeyColumns: plugin.KeyColumnSlice{
+				{Name: "instance_type", Require: plugin.Optional, Operators: []string{"="}},
+			},
 			Tags:    map[string]string{"service": "ec2", "action": "DescribeInstanceTypeOfferings"},
 		},
 		HydrateConfig: []plugin.HydrateConfig{
@@ -37,7 +44,8 @@ func tableAwsInstanceType(_ context.Context) *plugin.Table {
 				Tags: map[string]string{"service": "ec2", "action": "DescribeInstanceTypes"},
 			},
 		},
-		Columns: []*plugin.Column{
+		GetMatrixItemFunc: SupportedRegionMatrix(ec2v1.EndpointsID),
+		Columns: awsRegionalColumns([]*plugin.Column{
 			{
 				Name:        "instance_type",
 				Description: "The instance type. For more information, see [ Instance Types ](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html) in the Amazon Elastic Compute Cloud User Guide.",
@@ -173,35 +181,17 @@ func tableAwsInstanceType(_ context.Context) *plugin.Table {
 				Hydrate:     instanceTypeDataToAkas,
 				Transform:   transform.FromValue(),
 			},
-		},
+		}),
 	}
 }
 
 //// LIST FUNCTION
 
 func listAwsInstanceTypesOfferings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-
-	// get the primary region for aws based on its partition
-
-	commonData, err := getCommonColumns(ctx, d, h)
-	if err != nil {
-		return nil, err
-	}
-	commonColumnData := commonData.(*awsCommonColumnData)
-
-	region := "us-east-1"
-	if commonColumnData.Partition == "aws-us-gov" {
-		region = "us-gov-east-1"
-	} else if commonColumnData.Partition == "aws-cn" {
-		region = "cn-north-1"
-	} else if commonColumnData.Partition == "aws-iso" {
-		region = "us-iso-east-1"
-	} else if commonColumnData.Partition == "aws-iso-b" {
-		region = "us-isob-east-1"
-	}
+	region := d.EqualsQualString(matrixKeyRegion)
 
 	// Create Session
-	svc, err := EC2ClientForRegion(ctx, d, region)
+	svc, err := EC2Client(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ec2_instance_type.listAwsInstanceTypesOfferings", "connection_error", err)
 		return nil, err
@@ -232,6 +222,10 @@ func listAwsInstanceTypesOfferings(ctx context.Context, d *plugin.QueryData, h *
 
 	var filters []types.Filter
 	filters = append(filters, types.Filter{Name: aws.String("location"), Values: []string{region}})
+	if d.EqualsQualString("instance_type") != "" {
+		filters = append(filters, types.Filter{Name: aws.String("instance-type"), Values: []string{d.EqualsQualString("instance_type")}})
+	}
+
 	input.Filters = filters
 
 	paginator := ec2.NewDescribeInstanceTypeOfferingsPaginator(svc, input, func(o *ec2.DescribeInstanceTypeOfferingsPaginatorOptions) {
@@ -274,23 +268,8 @@ func describeInstanceType(ctx context.Context, d *plugin.QueryData, h *plugin.Hy
 		instanceType = types.InstanceType(d.EqualsQuals["instance_type"].GetStringValue())
 	}
 
-	// get the primary region for aws based on its partition
-
-	commonData, err := getCommonColumns(ctx, d, h)
-	if err != nil {
-		return nil, err
-	}
-	commonColumnData := commonData.(*awsCommonColumnData)
-
-	region := "us-east-1"
-	if commonColumnData.Partition == "aws-us-gov" {
-		region = "us-gov-east-1"
-	} else if commonColumnData.Partition == "aws-cn" {
-		region = "cn-north-1"
-	}
-
 	// Create Session
-	svc, err := EC2ClientForRegion(ctx, d, region)
+	svc, err := EC2Client(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_ec2_instance_type.describeInstanceType", "connection_error", err)
 		return nil, err


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select count(*) from aws_ec2_instance_type
+-------+
| count |
+-------+
| 11139 |
+-------+

> select count(*) from aws_ec2_instance_type where region = 'us-east-1'
+-------+
| count |
+-------+
| 776   |
+-------+

> select count(*) from aws_ec2_instance_type where region = 'ap-south-1'
+-------+
| count |
+-------+
| 518   |
+-------+

> select instance_type, region from aws_gov.aws_ec2_instance_type
+-------------------+---------------+
| instance_type     | region        |
+-------------------+---------------+
| r6g.large         | us-gov-west-1 |
| r5dn.xlarge       | us-gov-west-1 |
| c6gd.4xlarge      | us-gov-west-1 |
| r6in.2xlarge      | us-gov-west-1 |
| r6idn.16xlarge    | us-gov-west-1 |
| r7i.2xlarge       | us-gov-west-1 |
| r6g.8xlarge       | us-gov-west-1 |
| f1.2xlarge        | us-gov-west-1 |
| m1.small          | us-gov-west-1 |
| c6gn.8xlarge      | us-gov-west-1 |

```
</details>
