### PR TITLE
Fixed aws_elastic_beanstalk_environment - cname/endpoint_url fields return NULL Closes #2193

### DIFF
--- a/aws-test/tests/aws_elastic_beanstalk_environment/variables.tf
+++ b/aws-test/tests/aws_elastic_beanstalk_environment/variables.tf
@@ -81,18 +81,18 @@ resource "aws_internet_gateway" "testinternetgateway" {
 }
 
 resource "aws_route_table" "route" {
-  vpc_id = "${aws_vpc.my_vpc.id}"
+  vpc_id = aws_vpc.my_vpc.id
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${aws_internet_gateway.testinternetgateway.id}"
+    gateway_id = aws_internet_gateway.testinternetgateway.id
   }
 }
 
 resource "aws_subnet" "my_subnet1" {
-  vpc_id            = "${aws_vpc.my_vpc.id}"
-  availability_zone = "${var.aws_region}b"
+  vpc_id                  = aws_vpc.my_vpc.id
+  availability_zone       = "${var.aws_region}b"
   map_public_ip_on_launch = "true"
-  cidr_block        = "10.0.2.0/24"
+  cidr_block              = "10.0.2.0/24"
 }
 
 resource "aws_route_table_association" "routeassociation1" {
@@ -101,29 +101,29 @@ resource "aws_route_table_association" "routeassociation1" {
 }
 
 resource "aws_security_group" "ssh-allowed" {
-    vpc_id = aws_vpc.my_vpc.id
-    egress {
-        from_port = 0
-        to_port = 0
-        protocol = -1
-        cidr_blocks = ["0.0.0.0/0"]
-    }
-    ingress {
-        from_port = 22
-        to_port = 22
-        protocol = "tcp"
-        // This means, all ip address are allowed to ssh !
-        // Do not do it in the production.
-        // Put your office or home address in it!
-        cidr_blocks = ["0.0.0.0/0"]
-    }
-    //If you do not add this rule, you can not reach the NGIX
-    ingress {
-        from_port = 80
-        to_port = 80
-        protocol = "tcp"
-        cidr_blocks = ["0.0.0.0/0"]
-    }
+  vpc_id = aws_vpc.my_vpc.id
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = -1
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  ingress {
+    from_port = 22
+    to_port   = 22
+    protocol  = "tcp"
+    // This means, all ip address are allowed to ssh !
+    // Do not do it in the production.
+    // Put your office or home address in it!
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+  //If you do not add this rule, you can not reach the NGIX
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
 }
 
 resource "aws_elastic_beanstalk_application" "application_test" {
@@ -136,7 +136,7 @@ resource "aws_elastic_beanstalk_application" "application_test" {
 resource "aws_elastic_beanstalk_environment" "named_test_resource" {
   name                   = var.resource_name
   application            = aws_elastic_beanstalk_application.application_test.name
-  solution_stack_name    = "64bit Amazon Linux 2015.03 v2.0.3 running Go 1.4"
+  solution_stack_name    = "64bit Amazon Linux 2023 v4.0.7 running Go 1"
   wait_for_ready_timeout = "45m"
   setting {
     namespace = "aws:autoscaling:launchconfiguration"
@@ -146,17 +146,17 @@ resource "aws_elastic_beanstalk_environment" "named_test_resource" {
   setting {
     namespace = "aws:ec2:vpc"
     name      = "VPCId"
-    value     = "${aws_vpc.my_vpc.id}"
+    value     = aws_vpc.my_vpc.id
   }
   setting {
     namespace = "aws:ec2:vpc"
     name      = "ELBSubnets"
-    value     = "${aws_subnet.my_subnet1.id}"
+    value     = aws_subnet.my_subnet1.id
   }
   setting {
     namespace = "aws:ec2:vpc"
     name      = "Subnets"
-    value     = "${aws_subnet.my_subnet1.id}"
+    value     = aws_subnet.my_subnet1.id
   }
 }
 

--- a/aws/table_aws_elastic_beanstalk_environment.go
+++ b/aws/table_aws_elastic_beanstalk_environment.go
@@ -96,6 +96,7 @@ func tableAwsElasticBeanstalkEnvironment(_ context.Context) *plugin.Table {
 				Description: "The URL to the CNAME for this environment.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getElasticBeanstalkEnvironment,
+				Transform:   transform.FromField("CNAME"),
 			},
 			{
 				Name:        "date_updated",
@@ -107,6 +108,7 @@ func tableAwsElasticBeanstalkEnvironment(_ context.Context) *plugin.Table {
 				Description: "The URL to the LoadBalancer.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getElasticBeanstalkEnvironment,
+				Transform:   transform.FromField("EndpointURL"),
 			},
 			{
 				Name:        "health",


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_elastic_beanstalk_environment []

PRETEST: tests/aws_elastic_beanstalk_environment

TEST: tests/aws_elastic_beanstalk_environment
Running terraform
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_caller_identity.current: Read complete after 0s [id=xxxxxxxxxxxx]
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_elastic_beanstalk_application.application_test will be created
  + resource "aws_elastic_beanstalk_application" "application_test" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + name     = "turbottest94730"
      + tags_all = (known after apply)

      + appversion_lifecycle {
          + service_role = "arn:aws:iam::xxxxxxxxxxxx:role/aws-service-role/elasticbeanstalk.amazonaws.com/AWSServiceRoleForElasticBeanstalk"
        }
    }

  # aws_elastic_beanstalk_environment.named_test_resource will be created
  + resource "aws_elastic_beanstalk_environment" "named_test_resource" {
      + all_settings           = (known after apply)
      + application            = "turbottest94730"
      + arn                    = (known after apply)
      + autoscaling_groups     = (known after apply)
      + cname                  = (known after apply)
      + cname_prefix           = (known after apply)
      + endpoint_url           = (known after apply)
      + id                     = (known after apply)
      + instances              = (known after apply)
      + launch_configurations  = (known after apply)
      + load_balancers         = (known after apply)
      + name                   = "turbottest94730"
      + platform_arn           = (known after apply)
      + queues                 = (known after apply)
      + solution_stack_name    = "64bit Amazon Linux 2023 v4.0.7 running Go 1"
      + tags_all               = (known after apply)
      + tier                   = "WebServer"
      + triggers               = (known after apply)
      + version_label          = (known after apply)
      + wait_for_ready_timeout = "45m"

      + setting {
          + name      = "ELBSubnets"
          + namespace = "aws:ec2:vpc"
          + value     = (known after apply)
        }
      + setting {
          + name      = "IamInstanceProfile"
          + namespace = "aws:autoscaling:launchconfiguration"
          + value     = "turbottest94730"
        }
      + setting {
          + name      = "Subnets"
          + namespace = "aws:ec2:vpc"
          + value     = (known after apply)
        }
      + setting {
          + name      = "VPCId"
          + namespace = "aws:ec2:vpc"
          + value     = (known after apply)
        }
    }

  # aws_iam_instance_profile.instance_profile will be created
  + resource "aws_iam_instance_profile" "instance_profile" {
      + arn         = (known after apply)
      + create_date = (known after apply)
      + id          = (known after apply)
      + name        = "turbottest94730"
      + name_prefix = (known after apply)
      + path        = "/"
      + role        = "turbottest94730"
      + tags_all    = (known after apply)
      + unique_id   = (known after apply)
    }

  # aws_iam_role.role will be created
  + resource "aws_iam_role" "role" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "ec2.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest94730"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)
    }

  # aws_internet_gateway.testinternetgateway will be created
  + resource "aws_internet_gateway" "testinternetgateway" {
      + arn      = (known after apply)
      + id       = (known after apply)
      + owner_id = (known after apply)
      + tags_all = (known after apply)
      + vpc_id   = (known after apply)
    }

  # aws_route_table.route will be created
  + resource "aws_route_table" "route" {
      + arn              = (known after apply)
      + id               = (known after apply)
      + owner_id         = (known after apply)
      + propagating_vgws = (known after apply)
      + route            = [
          + {
              + carrier_gateway_id         = ""
              + cidr_block                 = "0.0.0.0/0"
              + core_network_arn           = ""
              + destination_prefix_list_id = ""
              + egress_only_gateway_id     = ""
              + gateway_id                 = (known after apply)
              + ipv6_cidr_block            = ""
              + local_gateway_id           = ""
              + nat_gateway_id             = ""
              + network_interface_id       = ""
              + transit_gateway_id         = ""
              + vpc_endpoint_id            = ""
              + vpc_peering_connection_id  = ""
            },
        ]
      + tags_all         = (known after apply)
      + vpc_id           = (known after apply)
    }

  # aws_route_table_association.routeassociation1 will be created
  + resource "aws_route_table_association" "routeassociation1" {
      + id             = (known after apply)
      + route_table_id = (known after apply)
      + subnet_id      = (known after apply)
    }

  # aws_security_group.ssh-allowed will be created
  + resource "aws_security_group" "ssh-allowed" {
      + arn                    = (known after apply)
      + description            = "Managed by Terraform"
      + egress                 = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 0
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "-1"
              + security_groups  = []
              + self             = false
              + to_port          = 0
            },
        ]
      + id                     = (known after apply)
      + ingress                = [
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 22
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 22
            },
          + {
              + cidr_blocks      = [
                  + "0.0.0.0/0",
                ]
              + description      = ""
              + from_port        = 80
              + ipv6_cidr_blocks = []
              + prefix_list_ids  = []
              + protocol         = "tcp"
              + security_groups  = []
              + self             = false
              + to_port          = 80
            },
        ]
      + name                   = (known after apply)
      + name_prefix            = (known after apply)
      + owner_id               = (known after apply)
      + revoke_rules_on_delete = false
      + tags_all               = (known after apply)
      + vpc_id                 = (known after apply)
    }

  # aws_subnet.my_subnet1 will be created
  + resource "aws_subnet" "my_subnet1" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1b"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.2.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = true
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.my_vpc will be created
  + resource "aws_vpc" "my_vpc" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags_all                             = (known after apply)
    }

Plan: 10 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "xxxxxxxxxxxx"
  + aws_partition = "aws"
  + aws_region    = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest94730"
aws_iam_role.role: Creating...
aws_vpc.my_vpc: Creating...
aws_elastic_beanstalk_application.application_test: Creating...
aws_iam_role.role: Creation complete after 2s [id=turbottest94730]
aws_iam_instance_profile.instance_profile: Creating...
aws_elastic_beanstalk_application.application_test: Creation complete after 3s [id=turbottest94730]
aws_iam_instance_profile.instance_profile: Creation complete after 2s [id=turbottest94730]
aws_vpc.my_vpc: Creation complete after 7s [id=vpc-0b579587af31cf7c7]
aws_internet_gateway.testinternetgateway: Creating...
aws_subnet.my_subnet1: Creating...
aws_security_group.ssh-allowed: Creating...
aws_internet_gateway.testinternetgateway: Creation complete after 2s [id=igw-0ee9edaeb4fa28317]
aws_route_table.route: Creating...
aws_route_table.route: Creation complete after 3s [id=rtb-0df6db44840d7862e]
aws_security_group.ssh-allowed: Creation complete after 6s [id=sg-0c66b6c0744f0d467]
aws_subnet.my_subnet1: Still creating... [10s elapsed]
aws_subnet.my_subnet1: Creation complete after 14s [id=subnet-08ef09b454647aca0]
aws_route_table_association.routeassociation1: Creating...
aws_elastic_beanstalk_environment.named_test_resource: Creating...
aws_route_table_association.routeassociation1: Creation complete after 1s [id=rtbassoc-0c61c1f1e88eebb0c]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [10s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [20s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [30s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [40s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [50s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [1m0s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [1m10s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [1m20s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [1m30s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [1m40s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [1m50s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [2m0s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [2m10s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [2m20s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [2m30s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [2m40s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [2m50s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Still creating... [3m0s elapsed]
aws_elastic_beanstalk_environment.named_test_resource: Creation complete after 3m2s [id=e-ikmpg2d8kj]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 10 added, 0 changed, 0 destroyed.

Outputs:

account_id = "xxxxxxxxxxxx"
aws_partition = "aws"
aws_region = "us-east-1"
resource_aka = "arn:aws:elasticbeanstalk:us-east-1:xxxxxxxxxxxx:environment/turbottest94730/turbottest94730"
resource_id = "e-ikmpg2d8kj"
resource_name = "turbottest94730"

Running SQL query: test-get-query.sql

Time: 1.7s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 2.

Scans:
  1) aws_elastic_beanstalk_environment.aws: Time: 1.5s. Fetched: 1. Hydrates: 2. Quals: environment_name=turbottest94730.

[
  {
    "akas": [
      "arn:aws:elasticbeanstalk:us-east-1:xxxxxxxxxxxx:environment/turbottest94730/turbottest94730"
    ],
    "application_name": "turbottest94730",
    "environment_id": "e-ikmpg2d8kj",
    "environment_name": "turbottest94730",
    "partition": "aws",
    "region": "us-east-1",
    "tags": {
      "Name": "turbottest94730",
      "elasticbeanstalk:environment-id": "e-ikmpg2d8kj",
      "elasticbeanstalk:environment-name": "turbottest94730"
    },
    "title": "turbottest94730"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql

Time: 117ms. Rows returned: 1. Rows fetched: 1 (cached). Hydrate calls: 0.

Scans:
  1) aws_elastic_beanstalk_environment.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: environment_name=turbottest94730.

[
  {
    "akas": [
      "arn:aws:elasticbeanstalk:us-east-1:xxxxxxxxxxxx:environment/turbottest94730/turbottest94730"
    ],
    "environment_name": "turbottest94730",
    "tags": {
      "Name": "turbottest94730",
      "elasticbeanstalk:environment-id": "e-ikmpg2d8kj",
      "elasticbeanstalk:environment-name": "turbottest94730"
    },
    "title": "turbottest94730"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

Time: 0.6s. Rows returned: 1. Rows fetched: 2. Hydrate calls: 2.

Scans:
  1) aws_elastic_beanstalk_environment.aws: Time: 375ms. Fetched: 2. Hydrates: 2.

[
  {
    "application_name": "turbottest94730",
    "environment_id": "e-ikmpg2d8kj",
    "environment_name": "turbottest94730",
    "partition": "aws",
    "region": "us-east-1"
  }
]
✔ PASSED

Running SQL query: test-not-found-query.sql

Time: 0.7s. Rows returned: 0.
[]
✔ PASSED

Running SQL query: test-turbot-query.sql

Time: 95ms. Rows returned: 1. Rows fetched: 1 (cached). Hydrate calls: 0.

Scans:
  1) aws_elastic_beanstalk_environment.aws: Time: 2ms. Fetched: 1 (cached). Hydrates: 0. Quals: environment_name=turbottest94730.

[
  {
    "account_id": "xxxxxxxxxxxx",
    "akas": [
      "arn:aws:elasticbeanstalk:us-east-1:xxxxxxxxxxxx:environment/turbottest94730/turbottest94730"
    ],
    "region": "us-east-1",
    "title": "turbottest94730"
  }
]
✔ PASSED

POSTTEST: tests/aws_elastic_beanstalk_environment

TEARDOWN: tests/aws_elastic_beanstalk_environment

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> SELECT environment_id,status, cname, endpoint_url FROM aws_elastic_beanstalk_environment
+----------------+------------+-------------------------------------------------------------+-----------------------------------------------------------------------+
| environment_id | status     | cname                                                       | endpoint_url                                                          |
+----------------+------------+-------------------------------------------------------------+-----------------------------------------------------------------------+
| e-3kbxvpbppn   | Terminated | test53.us-east-1.elasticbeanstalk.com                       | <null>                                                                |
| e-ikmpg2d8kj   | Launching  | turbottest94730.eba-qisiphwf.us-east-1.elasticbeanstalk.com | awseb-e-i-AWSEBLoa-S8SJH6LSS1YM-549612342.us-east-1.elb.amazonaws.com |
+----------------+------------+-------------------------------------------------------------+-----------------------------------------------------------------------+
```
</details>
