### PR TITLE
Fixed aws_elasticache_cluster - configuration_endpoint not returned as JSON Closes #2213

### DIFF
--- a/aws-test/tests/aws_elasticache_cluster/variables.tf
+++ b/aws-test/tests/aws_elasticache_cluster/variables.tf
@@ -27,6 +27,7 @@ provider "aws" {
   region  = var.aws_region
 }
 
+
 provider "aws" {
   alias   = "alternate"
   profile = var.aws_profile
@@ -76,22 +77,13 @@ resource "aws_elasticache_cluster" "named_test_resource" {
   }
 }
 
-data "template_file" "resource_aka" {
-  template = "arn:$${partition}:elasticache:$${region}:$${account_id}:cluster:${aws_elasticache_cluster.named_test_resource.cluster_id}"
-  vars = {
-    partition  = data.aws_partition.current.partition
-    account_id = data.aws_caller_identity.current.account_id
-    region     = data.aws_region.primary.name
-  }
-}
-
 output "resource_name" {
   value = var.resource_name
 }
 
 output "resource_aka" {
   depends_on = [aws_elasticache_cluster.named_test_resource]
-  value      = data.template_file.resource_aka.rendered
+  value      = "arn:${data.aws_partition.current.partition}:elasticache:${data.aws_region.primary.name}:${data.aws_caller_identity.current.account_id}:cluster:${aws_elasticache_cluster.named_test_resource.cluster_id}"
 }
 
 output "resource_id" {

--- a/aws-test/tests/aws_elasticache_cluster/variables.tf
+++ b/aws-test/tests/aws_elasticache_cluster/variables.tf
@@ -27,7 +27,6 @@ provider "aws" {
   region  = var.aws_region
 }
 
-
 provider "aws" {
   alias   = "alternate"
   profile = var.aws_profile

--- a/aws/table_aws_elasticache_cluster.go
+++ b/aws/table_aws_elasticache_cluster.go
@@ -96,11 +96,6 @@ func tableAwsElastiCacheCluster(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
-				Name:        "configuration_endpoint",
-				Description: "Represents a Memcached cluster endpoint which can be used by an application to connect to any node in the cluster.",
-				Type:        proto.ColumnType_STRING,
-			},
-			{
 				Name:        "engine",
 				Description: "The name of the cache engine (memcached or redis) to be used for this cluster.",
 				Type:        proto.ColumnType_STRING,
@@ -163,6 +158,11 @@ func tableAwsElastiCacheCluster(_ context.Context) *plugin.Table {
 			{
 				Name:        "security_groups",
 				Description: "A list of VPC Security Groups associated with the cluster.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "configuration_endpoint",
+				Description: "Represents a Memcached cluster endpoint which can be used by an application to connect to any node in the cluster.",
 				Type:        proto.ColumnType_JSON,
 			},
 			{


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_elasticache_cluster []

PRETEST: tests/aws_elasticache_cluster

TEST: tests/aws_elasticache_cluster
Running terraform
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 0s [id=************]
data.null_data_source.resource: Reading...
data.aws_region.alternate: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]
data.aws_region.alternate: Read complete after 0s [id=us-east-2]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_elasticache_cluster.named_test_resource will be created
  + resource "aws_elasticache_cluster" "named_test_resource" {
      + apply_immediately          = (known after apply)
      + arn                        = (known after apply)
      + auto_minor_version_upgrade = "true"
      + availability_zone          = (known after apply)
      + az_mode                    = (known after apply)
      + cache_nodes                = (known after apply)
      + cluster_address            = (known after apply)
      + cluster_id                 = "turbottest69237"
      + configuration_endpoint     = (known after apply)
      + engine                     = "memcached"
      + engine_version             = (known after apply)
      + engine_version_actual      = (known after apply)
      + id                         = (known after apply)
      + ip_discovery               = (known after apply)
      + maintenance_window         = (known after apply)
      + network_type               = (known after apply)
      + node_type                  = "cache.t2.micro"
      + num_cache_nodes            = 2
      + parameter_group_name       = "default.memcached1.6"
      + port                       = 11211
      + preferred_outpost_arn      = (known after apply)
      + replication_group_id       = (known after apply)
      + security_group_ids         = (known after apply)
      + snapshot_window            = (known after apply)
      + subnet_group_name          = "turbottest69237"
      + tags                       = {
          + "name" = "turbottest69237"
        }
      + tags_all                   = {
          + "name" = "turbottest69237"
        }
      + transit_encryption_enabled = (known after apply)
    }

  # aws_elasticache_subnet_group.my_subnet_group will be created
  + resource "aws_elasticache_subnet_group" "my_subnet_group" {
      + arn         = (known after apply)
      + description = "Managed by Terraform"
      + id          = (known after apply)
      + name        = "turbottest69237"
      + subnet_ids  = (known after apply)
      + tags_all    = (known after apply)
      + vpc_id      = (known after apply)
    }

  # aws_subnet.my_subnet will be created
  + resource "aws_subnet" "my_subnet" {
      + arn                                            = (known after apply)
      + assign_ipv6_address_on_creation                = false
      + availability_zone                              = "us-east-1a"
      + availability_zone_id                           = (known after apply)
      + cidr_block                                     = "10.0.0.0/24"
      + enable_dns64                                   = false
      + enable_resource_name_dns_a_record_on_launch    = false
      + enable_resource_name_dns_aaaa_record_on_launch = false
      + id                                             = (known after apply)
      + ipv6_cidr_block_association_id                 = (known after apply)
      + ipv6_native                                    = false
      + map_public_ip_on_launch                        = false
      + owner_id                                       = (known after apply)
      + private_dns_hostname_type_on_launch            = (known after apply)
      + tags_all                                       = (known after apply)
      + vpc_id                                         = (known after apply)
    }

  # aws_vpc.my_vpc will be created
  + resource "aws_vpc" "my_vpc" {
      + arn                                  = (known after apply)
      + cidr_block                           = "10.0.0.0/16"
      + default_network_acl_id               = (known after apply)
      + default_route_table_id               = (known after apply)
      + default_security_group_id            = (known after apply)
      + dhcp_options_id                      = (known after apply)
      + enable_dns_hostnames                 = (known after apply)
      + enable_dns_support                   = true
      + enable_network_address_usage_metrics = (known after apply)
      + id                                   = (known after apply)
      + instance_tenancy                     = "default"
      + ipv6_association_id                  = (known after apply)
      + ipv6_cidr_block                      = (known after apply)
      + ipv6_cidr_block_network_border_group = (known after apply)
      + main_route_table_id                  = (known after apply)
      + owner_id                             = (known after apply)
      + tags_all                             = (known after apply)
    }

Plan: 4 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id       = "************"
  + cache_cluster_id = "turbottest69237"
  + resource_aka     = "arn:aws:elasticache:us-east-1:************:cluster:turbottest69237"
  + resource_id      = "turbottest69237"
  + resource_name    = "turbottest69237"
aws_vpc.my_vpc: Creating...
aws_vpc.my_vpc: Creation complete after 4s [id=vpc-0694f92b8469116d3]
aws_subnet.my_subnet: Creating...
aws_subnet.my_subnet: Creation complete after 2s [id=subnet-0a983b5353ab7d68c]
aws_elasticache_subnet_group.my_subnet_group: Creating...
aws_elasticache_subnet_group.my_subnet_group: Creation complete after 2s [id=turbottest69237]
aws_elasticache_cluster.named_test_resource: Creating...
aws_elasticache_cluster.named_test_resource: Still creating... [10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [7m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [7m10s elapsed]
aws_elasticache_cluster.named_test_resource: Creation complete after 7m20s [id=turbottest69237]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 4 added, 0 changed, 0 destroyed.

Outputs:

account_id = "************"
cache_cluster_id = "turbottest69237"
resource_aka = "arn:aws:elasticache:us-east-1:************:cluster:turbottest69237"
resource_id = "turbottest69237"
resource_name = "turbottest69237"

Running SQL query: test-get-query.sql

Time: 13.6s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 1.

Scans:
  1) aws_elasticache_cluster.aws: Time: 13.2s. Fetched: 1. Hydrates: 1. Quals: cache_cluster_id=turbottest69237.

[
  {
    "cache_cluster_id": "turbottest69237",
    "cache_node_type": "cache.t2.micro",
    "engine": "memcached",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest69237"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql

Time: 10.5s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 1.

Scans:
  1) aws_elasticache_cluster.aws: Time: 10.1s. Fetched: 1. Hydrates: 1. Quals: cache_cluster_id=turbottest69237.

[
  {
    "akas": [
      "arn:aws:elasticache:us-east-1:************:cluster:turbottest69237"
    ],
    "cache_cluster_id": "turbottest69237",
    "tags": {
      "name": "turbottest69237"
    },
    "title": "turbottest69237"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

Time: 29.4s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) aws_elasticache_cluster.aws: Time: 13.4s. Fetched: 1. Hydrates: 0.

[
  {
    "akas": [
      "arn:aws:elasticache:us-east-1:************:cluster:turbottest69237"
    ],
    "cache_cluster_id": "turbottest69237",
    "cache_node_type": "cache.t2.micro",
    "engine": "memcached",
    "title": "turbottest69237"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql

Time: 22.4s. Rows returned: 0.
[]
✔ PASSED

POSTTEST: tests/aws_elasticache_cluster

TEARDOWN: tests/aws_elasticache_cluster

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> SELECT cache_cluster_id, cache_cluster_status, configuration_endpoint, region FROM aws_elasticache_cluster
+-------------------+----------------------+--------------------------------------------------------------------------------+-----------+
| cache_cluster_id  | cache_cluster_status | configuration_endpoint                                                         | region    |
+-------------------+----------------------+--------------------------------------------------------------------------------+-----------+
| test8883-0001-001 | available            | <null>                                                                         | us-east-1 |
| test8883-0001-002 | available            | <null>                                                                         | us-east-1 |
| test8883-0002-002 | available            | <null>                                                                         | us-east-1 |
| turbottest42310   | available            | {"Address":"turbottest42310.1dmjsn.cfg.use1.cache.amazonaws.com","Port":11211} | us-east-1 |
| test8883-0002-001 | available            | <null>                                                                         | us-east-1 |
+-------------------+----------------------+--------------------------------------------------------------------------------+-----------+

```
</details>
