### PR TITLE
Fixed the table  aws_s3_object - hydrate function listS3Objects failed with panic Closes #2218

### DIFF
--- a/aws/table_aws_s3_object.go
+++ b/aws/table_aws_s3_object.go
@@ -394,8 +394,8 @@ func getBucketRegionForObjects(ctx context.Context, d *plugin.QueryData, h *plug
 	return doGetBucketRegion(ctx, d, h, bucketName)
 }
 
-// We cannot define the Hydrate Config for the List Hydrate call.
-// Therefore, we need to make an explicit API call to get the bucket location.
+// We cannot define the Hydrate Config for the List Hydrate call with hydrate dependencies.
+// Therefore, we need to make an explicit hydrate call to get the bucket location.
 func listS3Objects(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	bucketName := d.EqualsQuals["bucket_name"].GetStringValue()
 

--- a/aws/table_aws_s3_object.go
+++ b/aws/table_aws_s3_object.go
@@ -469,7 +469,19 @@ func listS3Objects(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 
 func getS3Object(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	bucketName := d.EqualsQuals["bucket_name"].GetStringValue()
-	bucketRegion := h.HydrateResults["getBucketRegion"].(string)
+	bucketRegion := ""
+
+	// Bucket location will be nil if getBucketLocationForObjects returned an error but
+	// was ignored through ignore_error_codes config arg
+	res := h.HydrateResults["getBucketRegionForObjects"]
+	if res != nil {
+		bucketRegion = res.(string)
+	}
+
+	// Bucket region empty check
+	if bucketRegion == "" {
+		return nil, nil
+	}
 
 	// Create client
 	svc, err := S3Client(ctx, d, bucketRegion)
@@ -500,7 +512,19 @@ func getS3Object(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 
 func getS3ObjectAttributes(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	bucketName := d.EqualsQuals["bucket_name"].GetStringValue()
-	bucketRegion := h.HydrateResults["getBucketRegion"].(string)
+	bucketRegion := ""
+
+	// Bucket location will be nil if getBucketLocationForObjects returned an error but
+	// was ignored through ignore_error_codes config arg
+	res := h.HydrateResults["getBucketRegionForObjects"]
+	if res != nil {
+		bucketRegion = res.(string)
+	}
+
+	// Bucket region empty check
+	if bucketRegion == "" {
+		return nil, nil
+	}
 
 	// Create client
 	svc, err := S3Client(ctx, d, bucketRegion)
@@ -528,7 +552,19 @@ func getS3ObjectAttributes(ctx context.Context, d *plugin.QueryData, h *plugin.H
 
 func getS3ObjectACL(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	bucketName := d.EqualsQuals["bucket_name"].GetStringValue()
-	bucketRegion := h.HydrateResults["getBucketRegion"].(string)
+	bucketRegion := ""
+
+	// Bucket location will be nil if getBucketLocationForObjects returned an error but
+	// was ignored through ignore_error_codes config arg
+	res := h.HydrateResults["getBucketRegionForObjects"]
+	if res != nil {
+		bucketRegion = res.(string)
+	}
+
+	// Bucket region empty check
+	if bucketRegion == "" {
+		return nil, nil
+	}
 
 	object := h.Item.(types.Object)
 
@@ -561,7 +597,19 @@ func getS3ObjectACL(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateD
 
 func getS3ObjectTagging(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	bucketName := d.EqualsQuals["bucket_name"].GetStringValue()
-	bucketRegion := h.HydrateResults["getBucketRegion"].(string)
+	bucketRegion := ""
+
+	// Bucket location will be nil if getBucketLocationForObjects returned an error but
+	// was ignored through ignore_error_codes config arg
+	res := h.HydrateResults["getBucketRegionForObjects"]
+	if res != nil {
+		bucketRegion = res.(string)
+	}
+
+	// Bucket region empty check
+	if bucketRegion == "" {
+		return nil, nil
+	}
 
 	object := h.Item.(types.Object)
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> SELECT key, bucket_name, region
FROM   aws_s3_object
WHERE  bucket_name = 'test-delete90'
+-----------------------+---------------+-----------+
| key                   | bucket_name   | region    |
+-----------------------+---------------+-----------+
| test1/template.txt    | test-delete90 | us-east-2 |
| AWSLogs/632902152528/ | test-delete90 | us-east-2 |
| test1/                | test-delete90 | us-east-2 |
+-----------------------+---------------+-----------+

Time: 0.5s. Rows returned: 3. Rows fetched: 3. Hydrate calls: 3.

> select * from aws_s3_object where bucket_name = 'test-delete90'
+-----------------------+--------------------------------------------------+---------------+---------------------------+---------------+----------------------------------+---------------+--------------------+--------------------+---------------+----------------+------->
| key                   | arn                                              | bucket_name   | last_modified             | storage_class | version_id                       | accept_ranges | body               | bucket_key_enabled | cache_control | checksum_crc32 | checks>
+-----------------------+--------------------------------------------------+---------------+---------------------------+---------------+----------------------------------+---------------+--------------------+--------------------+---------------+----------------+------->
| AWSLogs/xxxxxxxxxxxx/ | arn:aws:s3:::test-delete90/AWSLogs/xxxxxxxxxxxx/ | test-delete90 | 2024-03-11T22:18:53+05:30 | STANDARD      | JQ2gZcH2CyiV7c36H9457vIZr1Be64lx | bytes         |                    | <null>             | <null>        | <null>         | <null>>
| test1/                | arn:aws:s3:::test-delete90/test1/                | test-delete90 | 2022-10-18T11:27:00+05:30 | STANDARD      | null                             | bytes         |                    | <null>             | <null>        | <null>         | <null>>
| test1/template.txt    | arn:aws:s3:::test-delete90/test1/template.txt    | test-delete90 | 2023-12-21T17:42:16+05:30 | STANDARD      | .5wzvZjKelnbRLZZBadtraZ5BeUtK5gb | bytes         |  Hi, I am here.... | <null>             | <null>        | <null>         | <null>>

```
</details>
