### PR TITLE
Added the missing columns to the table  aws_elasticache_cluster Closes #2223

### DIFF
--- a/aws/table_aws_elasticache_cluster.go
+++ b/aws/table_aws_elasticache_cluster.go
@@ -141,6 +141,36 @@ func tableAwsElastiCacheCluster(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_BOOL,
 			},
 			{
+				Name:        "auth_token_last_modified_date",
+				Description: "The date the auth token was last modified.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "ip_discovery",
+				Description: "The network type associated with the cluster, either ipv4 or ipv6.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "network_type",
+				Description: "Must be either ipv4, ipv6, or dual_stack.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "preferred_outpost_arn",
+				Description: "The outpost ARN in which the cache cluster is created.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "replication_group_log_delivery_enabled",
+				Description: "A boolean value indicating whether log delivery is enabled for the replication group.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "transit_encryption_mode",
+				Description: "A setting that allows you to migrate your clients to use in-transit encryption, with no downtime.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "cache_parameter_group",
 				Description: "Status of the cache parameter group.",
 				Type:        proto.ColumnType_JSON,
@@ -163,6 +193,21 @@ func tableAwsElastiCacheCluster(_ context.Context) *plugin.Table {
 			{
 				Name:        "configuration_endpoint",
 				Description: "Represents a Memcached cluster endpoint which can be used by an application to connect to any node in the cluster.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "cache_nodes",
+				Description: "A list of cache nodes that are members of the cluster.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "cache_security_groups",
+				Description: "A list of cache security group elements, composed of name and status sub-elements.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "log_delivery_configurations",
+				Description: "Returns the destination, format, and type of the logs.",
 				Type:        proto.ColumnType_JSON,
 			},
 			{
@@ -208,7 +253,8 @@ func listElastiCacheClusters(ctx context.Context, d *plugin.QueryData, _ *plugin
 	}
 
 	input := &elasticache.DescribeCacheClustersInput{
-		MaxRecords: aws.Int32(100),
+		ShowCacheNodeInfo: aws.Bool(true),
+		MaxRecords:        aws.Int32(100),
 	}
 
 	if d.QueryContext.Limit != nil {


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_elasticache_cluster []

PRETEST: tests/aws_elasticache_cluster

TEST: tests/aws_elasticache_cluster
Running terraform
data.aws_region.primary: Reading...
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
aws_vpc.my_vpc: Refreshing state... [id=vpc-04e9acce04f2ac144]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 0s [id=xxxxxxxxxxxx]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
aws_subnet.my_subnet: Refreshing state... [id=subnet-070f8c747269b3cd5]
aws_elasticache_subnet_group.my_subnet_group: Refreshing state... [id=turbottest42352]
aws_elasticache_cluster.named_test_resource: Refreshing state... [id=turbottest42352]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
-/+ destroy and then create replacement

Terraform will perform the following actions:

  # aws_elasticache_cluster.named_test_resource is tainted, so must be replaced
-/+ resource "aws_elasticache_cluster" "named_test_resource" {
      + apply_immediately          = (known after apply)
      ~ arn                        = "arn:aws:elasticache:us-east-1:xxxxxxxxxxxx:cluster:turbottest42352" -> (known after apply)
      ~ availability_zone          = "us-east-1a" -> (known after apply)
      ~ az_mode                    = "single-az" -> (known after apply)
      ~ cache_nodes                = [
          - {
              - address           = "turbottest42352.1dmjsn.0001.use1.cache.amazonaws.com"
              - availability_zone = "us-east-1a"
              - id                = "0001"
              - outpost_arn       = ""
              - port              = 11211
            },
          - {
              - address           = "turbottest42352.1dmjsn.0002.use1.cache.amazonaws.com"
              - availability_zone = "us-east-1a"
              - id                = "0002"
              - outpost_arn       = ""
              - port              = 11211
            },
        ] -> (known after apply)
      ~ cluster_address            = "turbottest42352.1dmjsn.cfg.use1.cache.amazonaws.com" -> (known after apply)
      ~ cluster_id                 = "turbottest42352" -> "turbottest25981"
      ~ configuration_endpoint     = "turbottest42352.1dmjsn.cfg.use1.cache.amazonaws.com:11211" -> (known after apply)
      ~ engine_version             = "1.6.22" -> (known after apply)
      ~ engine_version_actual      = "1.6.22" -> (known after apply)
      ~ id                         = "turbottest42352" -> (known after apply)
      ~ ip_discovery               = "ipv4" -> (known after apply)
      ~ maintenance_window         = "sat:10:00-sat:11:00" -> (known after apply)
      ~ network_type               = "ipv4" -> (known after apply)
      + preferred_outpost_arn      = (known after apply)
      + replication_group_id       = (known after apply)
      ~ security_group_ids         = [] -> (known after apply)
      - snapshot_retention_limit   = 0 -> null
      + snapshot_window            = (known after apply)
      ~ subnet_group_name          = "turbottest42352" -> "turbottest25981"
      ~ tags                       = {
          ~ "name" = "turbottest42352" -> "turbottest25981"
        }
      ~ tags_all                   = {
          ~ "name" = "turbottest42352" -> "turbottest25981"
        }
      ~ transit_encryption_enabled = false -> (known after apply)
        # (6 unchanged attributes hidden)
    }

  # aws_elasticache_subnet_group.my_subnet_group must be replaced
-/+ resource "aws_elasticache_subnet_group" "my_subnet_group" {
      ~ arn         = "arn:aws:elasticache:us-east-1:xxxxxxxxxxxx:subnetgroup:turbottest42352" -> (known after apply)
      ~ id          = "turbottest42352" -> (known after apply)
      ~ name        = "turbottest42352" -> "turbottest25981" # forces replacement
      - tags        = {} -> null
      ~ tags_all    = {} -> (known after apply)
      ~ vpc_id      = "vpc-04e9acce04f2ac144" -> (known after apply)
        # (2 unchanged attributes hidden)
    }

Plan: 2 to add, 0 to change, 2 to destroy.

Changes to Outputs:
  ~ cache_cluster_id = "turbottest42352" -> "turbottest25981"
  ~ resource_aka     = "arn:aws:elasticache:us-east-1:xxxxxxxxxxxx:cluster:turbottest42352" -> "arn:aws:elasticache:us-east-1:xxxxxxxxxxxx:cluster:turbottest25981"
  ~ resource_id      = "turbottest42352" -> "turbottest25981"
  ~ resource_name    = "turbottest42352" -> "turbottest25981"
aws_elasticache_cluster.named_test_resource: Destroying... [id=turbottest42352]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 10s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 20s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 30s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 40s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 50s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 1m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 1m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 1m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 1m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 1m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 1m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 2m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 2m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 2m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 2m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 2m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 2m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 3m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 3m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 3m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 3m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 3m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 3m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 4m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 4m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 4m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 4m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 4m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 4m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 5m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 5m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 5m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 5m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 5m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 5m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 6m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 6m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 6m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 6m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 6m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still destroying... [id=turbottest42352, 6m50s elapsed]
aws_elasticache_cluster.named_test_resource: Destruction complete after 6m58s
aws_elasticache_subnet_group.my_subnet_group: Destroying... [id=turbottest42352]
aws_elasticache_subnet_group.my_subnet_group: Destruction complete after 0s
aws_elasticache_subnet_group.my_subnet_group: Creating...
aws_elasticache_subnet_group.my_subnet_group: Creation complete after 2s [id=turbottest25981]
aws_elasticache_cluster.named_test_resource: Creating...
aws_elasticache_cluster.named_test_resource: Still creating... [10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [1m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [2m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [3m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [4m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [5m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [6m50s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [7m0s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [7m10s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [7m20s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [7m30s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [7m40s elapsed]
aws_elasticache_cluster.named_test_resource: Still creating... [7m50s elapsed]
aws_elasticache_cluster.named_test_resource: Creation complete after 7m50s [id=turbottest25981]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 43, in data "null_data_source" "resource":
  43: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Apply complete! Resources: 2 added, 0 changed, 2 destroyed.

Outputs:

account_id = "xxxxxxxxxxxx"
cache_cluster_id = "turbottest25981"
resource_aka = "arn:aws:elasticache:us-east-1:xxxxxxxxxxxx:cluster:turbottest25981"
resource_id = "turbottest25981"
resource_name = "turbottest25981"

Running SQL query: test-get-query.sql

Time: 14.2s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 1.

Scans:
  1) aws_elasticache_cluster.aws: Time: 13.9s. Fetched: 1. Hydrates: 1. Quals: cache_cluster_id=turbottest25981.

[
  {
    "cache_cluster_id": "turbottest25981",
    "cache_node_type": "cache.t2.micro",
    "engine": "memcached",
    "tags_src": [
      {
        "Key": "name",
        "Value": "turbottest25981"
      }
    ]
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql

Time: 19.9s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 1.

Scans:
  1) aws_elasticache_cluster.aws: Time: 19.6s. Fetched: 1. Hydrates: 1. Quals: cache_cluster_id=turbottest25981.

[
  {
    "akas": [
      "arn:aws:elasticache:us-east-1:xxxxxxxxxxxx:cluster:turbottest25981"
    ],
    "cache_cluster_id": "turbottest25981",
    "tags": {
      "name": "turbottest25981"
    },
    "title": "turbottest25981"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql

Time: 9.6s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) aws_elasticache_cluster.aws: Time: 9.0s. Fetched: 1. Hydrates: 0.

[
  {
    "akas": [
      "arn:aws:elasticache:us-east-1:xxxxxxxxxxxx:cluster:turbottest25981"
    ],
    "cache_cluster_id": "turbottest25981",
    "cache_node_type": "cache.t2.micro",
    "engine": "memcached",
    "title": "turbottest25981"
  }
]
✔ PASSED

Running SQL query: test-notfound-query.sql

Time: 15.8s. Rows returned: 0.
[]
✔ PASSED

POSTTEST: tests/aws_elasticache_cluster

TEARDOWN: tests/aws_elasticache_cluster

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_elasticache_cluster
{
 "rows": [
  {
   "_ctx": {
    "connection_name": "aws",
    "steampipe": {
     "sdk_version": "5.10.0"
    }
   },
   "account_id": "xxxxxxxxxxxx",
   "akas": [
    "arn:aws:elasticache:us-east-1:xxxxxxxxxxxx:cluster:turbottest42352"
   ],
   "arn": "arn:aws:elasticache:us-east-1:xxxxxxxxxxxx:cluster:turbottest42352",
   "at_rest_encryption_enabled": false,
   "auth_token_enabled": false,
   "auth_token_last_modified_date": null,
   "auto_minor_version_upgrade": true,
   "cache_cluster_create_time": "2024-06-25T09:56:20+05:30",
   "cache_cluster_id": "turbottest42352",
   "cache_cluster_status": "available",
   "cache_node_type": "cache.t2.micro",
   "cache_nodes": [
    {
     "CacheNodeCreateTime": "2024-06-25T04:26:20.142Z",
     "CacheNodeId": "0001",
     "CacheNodeStatus": "available",
     "CustomerAvailabilityZone": "us-east-1a",
     "CustomerOutpostArn": null,
     "Endpoint": {
      "Address": "turbottest42352.1dmjsn.0001.use1.cache.amazonaws.com",
      "Port": 11211
     },
     "ParameterGroupStatus": "in-sync",
     "SourceCacheNodeId": null
    },
    {
     "CacheNodeCreateTime": "2024-06-25T04:26:20.142Z",
     "CacheNodeId": "0002",
     "CacheNodeStatus": "available",
     "CustomerAvailabilityZone": "us-east-1a",
     "CustomerOutpostArn": null,
     "Endpoint": {
      "Address": "turbottest42352.1dmjsn.0002.use1.cache.amazonaws.com",
      "Port": 11211
     },
     "ParameterGroupStatus": "in-sync",
     "SourceCacheNodeId": null
    }
   ],
   "cache_parameter_group": {
    "CacheNodeIdsToReboot": [],
    "CacheParameterGroupName": "default.memcached1.6",
    "ParameterApplyStatus": "in-sync"
   },
   "cache_security_groups": [],
   "cache_subnet_group_name": "turbottest42352",
   "client_download_landing_page": "https://console.aws.amazon.com/elasticache/home#client-download:",
   "configuration_endpoint": {
    "Address": "turbottest42352.1dmjsn.cfg.use1.cache.amazonaws.com",
    "Port": 11211
   },
   "engine": "memcached",
   "engine_version": "1.6.22",
   "ip_discovery": "ipv4",
   "log_delivery_configurations": [],
   "network_type": "ipv4",
   "notification_configuration": null,
   "num_cache_nodes": 2,
   "partition": "aws",
   "pending_modified_values": {
    "AuthTokenStatus": "",
    "CacheNodeIdsToRemove": null,
    "CacheNodeType": null,
    "EngineVersion": null,
    "LogDeliveryConfigurations": null,
    "NumCacheNodes": null,
    "TransitEncryptionEnabled": null,
    "TransitEncryptionMode": ""
   },
   "preferred_availability_zone": "us-east-1a",
   "preferred_maintenance_window": "sat:10:00-sat:11:00",
   "preferred_outpost_arn": null,
   "region": "us-east-1",
   "replication_group_id": null,
   "replication_group_log_delivery_enabled": false,
   "security_groups": null,
   "snapshot_retention_limit": null,
   "snapshot_window": null,
   "sp_connection_name": "aws",
   "sp_ctx": {
    "connection_name": "aws",
    "steampipe": {
     "sdk_version": "5.10.0"
    }
   },
   "tags": {
    "name": "turbottest42352"
   },
   "tags_src": [
    {
     "Key": "name",
     "Value": "turbottest42352"
    }
   ],
   "title": "turbottest42352",
   "transit_encryption_enabled": false,
   "transit_encryption_mode": ""
  }
 ],
 "metadata": {
  "duration_ms": 18512,
  "scans": [
   {
    "connection": "aws",
    "table": "aws_elasticache_cluster",
    "cache_hit": false,
    "rows_fetched": 1,
    "hydrate_calls": 2,
    "start_time": "2024-06-25T11:35:40+05:30",
    "duration_ms": 8970,
    "columns": [
     "partition",
     "sp_ctx",
     "auto_minor_version_upgrade",
     "cache_parameter_group",
     "preferred_outpost_arn",
     "pending_modified_values",
     "security_groups",
     "akas",
     "engine_version",
     "preferred_availability_zone",
     "snapshot_retention_limit",
     "auth_token_last_modified_date",
     "network_type",
     "cache_nodes",
     "tags_src",
     "arn",
     "cache_cluster_create_time",
     "engine",
     "sp_connection_name",
     "transit_encryption_enabled",
     "_ctx",
     "cache_cluster_status",
     "at_rest_encryption_enabled",
     "cache_security_groups",
     "log_delivery_configurations",
     "tags",
     "account_id",
     "client_download_landing_page",
     "notification_configuration",
     "ip_discovery",
     "replication_group_log_delivery_enabled",
     "configuration_endpoint",
     "title",
     "region",
     "preferred_maintenance_window",
     "replication_group_id",
     "auth_token_enabled",
     "cache_subnet_group_name",
     "num_cache_nodes",
     "snapshot_window",
     "transit_encryption_mode",
     "cache_cluster_id",
     "cache_node_type"
    ]
   }
  ],
  "scan_count": 1,
  "rows_returned": 1,
  "uncached_rows_fetched": 1,
  "cached_rows_fetched": 0,
  "hydrate_calls": 2,
  "connection_count": 1
 }
}

Time: 18.5s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 2.

```
</details>
