### PR TITLE
fix lag direction in examples of aws_cost_* table docs

### DIFF
--- a/docs/tables/aws_cost_by_account_monthly.md
+++ b/docs/tables/aws_cost_by_account_monthly.md
@@ -113,7 +113,7 @@ with cost_data as (
     linked_account_id,
     period_start,
     unblended_cost_amount as this_month,
-    lag(unblended_cost_amount,1) over(partition by linked_account_id order by period_start desc) as previous_month
+    lag(unblended_cost_amount,-1) over(partition by linked_account_id order by period_start desc) as previous_month
   from 
     aws_cost_by_account_monthly
 )
@@ -136,7 +136,7 @@ with cost_data as (
     linked_account_id,
     period_start,
     unblended_cost_amount as this_month,
-    lag(unblended_cost_amount, 1) over(partition by linked_account_id order by period_start desc) as previous_month
+    lag(unblended_cost_amount, -1) over(partition by linked_account_id order by period_start desc) as previous_month
   from 
     aws_cost_by_account_monthly
 )

--- a/docs/tables/aws_cost_by_service_monthly.md
+++ b/docs/tables/aws_cost_by_service_monthly.md
@@ -180,7 +180,7 @@ with cost_data as (
     service,
     period_start,
     unblended_cost_amount as this_month,
-    lag(unblended_cost_amount,1) over(partition by service order by period_start desc) as previous_month
+    lag(unblended_cost_amount,-1) over(partition by service order by period_start desc) as previous_month
   from 
     aws_cost_by_service_monthly
 )
@@ -207,7 +207,7 @@ with cost_data as (
     service,
     period_start,
     unblended_cost_amount as this_month,
-    lag(unblended_cost_amount,1) over(partition by service order by period_start desc) as previous_month
+    lag(unblended_cost_amount,-1) over(partition by service order by period_start desc) as previous_month
   from 
     aws_cost_by_service_monthly
 )


### PR DESCRIPTION
I believe these example are using the wrong direction!
