### PR TITLE
Added missing columns to the table aws_lambda_version Closes #2228

### DIFF
--- a/aws-test/tests/aws_lambda_version/test-get-call-expected.json
+++ b/aws-test/tests/aws_lambda_version/test-get-call-expected.json
@@ -3,7 +3,7 @@
     "akas": ["{{ output.resource_aka.value }}:$LATEST"],
     "arn": "{{ output.resource_aka.value}}:$LATEST",
     "function_name": "{{resourceName}}",
-    "runtime": "python3.7",
+    "runtime": "python3.12",
     "title": "$LATEST",
     "version": "$LATEST"
   }

--- a/aws-test/tests/aws_lambda_version/test-list-call-expected.json
+++ b/aws-test/tests/aws_lambda_version/test-list-call-expected.json
@@ -3,7 +3,7 @@
     "akas": ["{{ output.resource_aka.value }}:$LATEST"],
     "arn": "{{ output.resource_aka.value}}:$LATEST",
     "function_name": "{{resourceName}}",
-    "runtime": "python3.7",
+    "runtime": "python3.12",
     "title": "$LATEST",
     "version": "$LATEST"
   }

--- a/aws-test/tests/aws_lambda_version/variables.tf
+++ b/aws-test/tests/aws_lambda_version/variables.tf
@@ -81,7 +81,7 @@ resource "aws_lambda_function" "named_test_resource" {
   function_name = var.resource_name
   role          = aws_iam_role.aws_lambda_function.arn
   handler       = "test.test"
-  runtime       = "python3.7"
+  runtime       = "python3.12"
   filename      = "${path.cwd}/../../test.zip"
   tags = {
     name = var.resource_name

--- a/aws/table_aws_lambda_version.go
+++ b/aws/table_aws_lambda_version.go
@@ -139,6 +139,43 @@ func tableAwsLambdaVersion(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("VpcConfig.VpcId"),
 			},
 			{
+				Name:        "kms_key_arn",
+				Description: "The KMS key that's used to encrypt the function's environment variables.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("KMSKeyArn"),
+			},
+			{
+				Name:        "role",
+				Description: "The function's execution role.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "signing_job_arn",
+				Description: "The ARN of the signing job.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "signing_profile_version_arn",
+				Description: "The ARN of the signing profile version.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "state_reason",
+				Description: "The reason for the function's current state.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "state_reason_code",
+				Description: "The reason code for the function's current state.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "ephemeral_storage_size",
+				Description: "The size of the function's /tmp directory in MB.",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromField("EphemeralStorage.Size"),
+			},
+			{
 				Name:        "environment_variables",
 				Description: "The environment variables that are accessible from function code during execution.",
 				Type:        proto.ColumnType_JSON,
@@ -169,19 +206,62 @@ func tableAwsLambdaVersion(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("VpcConfig.SubnetIds"),
 			},
-
-			// Standard columns for all tables
 			{
-				Name:        "title",
-				Description: resourceInterfaceDescription("title"),
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromField("Version"),
+				Name:        "architectures",
+				Description: "The instruction set architecture that the function supports.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "dead_letter_config",
+				Description: "The function's dead letter queue configuration.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "file_system_configs",
+				Description: "Connection settings for an Amazon EFS file system.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "image_config_response",
+				Description: "The function's image configuration values.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "layers",
+				Description: "The function's layers.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "logging_config",
+				Description: "The function's Amazon CloudWatch Logs configuration settings.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "runtime_version_config",
+				Description: "The ARN of the runtime and any errors that occurred.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "snap_start",
+				Description: "Configuration for creating a snapshot of the initialized execution environment.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "tracing_config",
+				Description: "The function's X-Ray tracing configuration.",
+				Type:        proto.ColumnType_JSON,
 			},
 			{
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
 				Transform:   transform.FromField("FunctionArn").Transform(arnToAkas),
+			},
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Version"),
 			},
 		}),
 	}

--- a/aws/table_aws_lambda_version.go
+++ b/aws/table_aws_lambda_version.go
@@ -251,17 +251,19 @@ func tableAwsLambdaVersion(_ context.Context) *plugin.Table {
 				Description: "The function's X-Ray tracing configuration.",
 				Type:        proto.ColumnType_JSON,
 			},
-			{
-				Name:        "akas",
-				Description: resourceInterfaceDescription("akas"),
-				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("FunctionArn").Transform(arnToAkas),
-			},
+
+			// Standard columns for all tables
 			{
 				Name:        "title",
 				Description: resourceInterfaceDescription("title"),
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromField("Version"),
+			},
+			{
+				Name:        "akas",
+				Description: resourceInterfaceDescription("akas"),
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("FunctionArn").Transform(arnToAkas),
 			},
 		}),
 	}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_lambda_version []

PRETEST: tests/aws_lambda_version

TEST: tests/aws_lambda_version
Running terraform
data.aws_partition.current: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_caller_identity.current: Read complete after 0s [id=xxxxxxxxxxxx]
data.null_data_source.resource: Reading...
data.null_data_source.resource: Read complete after 0s [id=static]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create
 <= read (data resources)

Terraform will perform the following actions:

  # data.archive_file.zip will be read during apply
  # (depends on a resource or a module with changes pending)
 <= data "archive_file" "zip" {
      + id                  = (known after apply)
      + output_base64sha256 = (known after apply)
      + output_base64sha512 = (known after apply)
      + output_md5          = (known after apply)
      + output_path         = "/private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/aws_lambda_version/terraform/test/../../test.zip"
      + output_sha          = (known after apply)
      + output_sha256       = (known after apply)
      + output_sha512       = (known after apply)
      + output_size         = (known after apply)
      + source_file         = "/private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/aws_lambda_version/terraform/test/../../test.py"
      + type                = "zip"
    }

  # aws_iam_role.aws_lambda_function will be created
  + resource "aws_iam_role" "aws_lambda_function" {
      + arn                   = (known after apply)
      + assume_role_policy    = jsonencode(
            {
              + Statement = [
                  + {
                      + Action    = "sts:AssumeRole"
                      + Effect    = "Allow"
                      + Principal = {
                          + Service = "lambda.amazonaws.com"
                        }
                      + Sid       = ""
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + create_date           = (known after apply)
      + force_detach_policies = false
      + id                    = (known after apply)
      + managed_policy_arns   = (known after apply)
      + max_session_duration  = 3600
      + name                  = "turbottest66898"
      + name_prefix           = (known after apply)
      + path                  = "/"
      + tags_all              = (known after apply)
      + unique_id             = (known after apply)
    }

  # aws_lambda_function.named_test_resource will be created
  + resource "aws_lambda_function" "named_test_resource" {
      + architectures                  = (known after apply)
      + arn                            = (known after apply)
      + code_sha256                    = (known after apply)
      + filename                       = "/private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/aws_lambda_version/terraform/test/../../test.zip"
      + function_name                  = "turbottest66898"
      + handler                        = "test.test"
      + id                             = (known after apply)
      + invoke_arn                     = (known after apply)
      + last_modified                  = (known after apply)
      + memory_size                    = 128
      + package_type                   = "Zip"
      + publish                        = false
      + qualified_arn                  = (known after apply)
      + qualified_invoke_arn           = (known after apply)
      + reserved_concurrent_executions = -1
      + role                           = (known after apply)
      + runtime                        = "python3.12"
      + signing_job_arn                = (known after apply)
      + signing_profile_version_arn    = (known after apply)
      + skip_destroy                   = false
      + source_code_hash               = (known after apply)
      + source_code_size               = (known after apply)
      + tags                           = {
          + "name" = "turbottest66898"
        }
      + tags_all                       = {
          + "name" = "turbottest66898"
        }
      + timeout                        = 3
      + version                        = (known after apply)
    }

  # local_file.python_file will be created
  + resource "local_file" "python_file" {
      + content_base64sha256 = (known after apply)
      + content_base64sha512 = (known after apply)
      + content_md5          = (known after apply)
      + content_sha1         = (known after apply)
      + content_sha256       = (known after apply)
      + content_sha512       = (known after apply)
      + directory_permission = "0777"
      + file_permission      = "0777"
      + filename             = "/private/var/folders/v1/slpk6xvx5977gdtb0j_397kc0000gn/T/tests/aws_lambda_version/terraform/test/../../test.py"
      + id                   = (known after apply)
      + sensitive_content    = (sensitive value)
    }

Plan: 3 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "xxxxxxxxxxxx"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_name = "turbottest66898"
local_file.python_file: Creating...
local_file.python_file: Creation complete after 0s [id=31a055a187e07d0bd8fca8ceb1f633aa4497fe53]
data.archive_file.zip: Reading...
data.archive_file.zip: Read complete after 0s [id=3d2780bc13324b697460b666c413908a395d952e]
aws_iam_role.aws_lambda_function: Creating...
aws_iam_role.aws_lambda_function: Creation complete after 3s [id=turbottest66898]
aws_lambda_function.named_test_resource: Creating...
aws_lambda_function.named_test_resource: Still creating... [10s elapsed]
aws_lambda_function.named_test_resource: Creation complete after 13s [id=turbottest66898]

Warning: Deprecated

  with data.null_data_source.resource,
  on variables.tf line 44, in data "null_data_source" "resource":
  44: data "null_data_source" "resource" {

The null_data_source was historically used to construct intermediate values
to re-use elsewhere in configuration, the same can now be achieved using
locals or the terraform_data resource type in Terraform 1.4 and later.

(and one more similar warning elsewhere)

Warning: Attribute Deprecated

  with local_file.python_file,
  on variables.tf line 53, in resource "local_file" "python_file":
  53:   sensitive_content = "def test (event, context):\n\tprint ('This is a test for integration testing to check creation of a lambda function')"

Use the `local_sensitive_file` resource instead

(and 2 more similar warnings elsewhere)

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.

Outputs:

account_id = "xxxxxxxxxxxx"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:turbottest66898"
resource_name = "turbottest66898"

Running SQL query: query.sql

Time: 5.5s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) aws_lambda_version.aws: Time: 5.3s. Fetched: 1. Hydrates: 0. Quals: function_name=turbottest66898, version=$LATEST.

[
  {
    "arn": "arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:turbottest66898:$LATEST",
    "function_name": "turbottest66898",
    "version": "$LATEST"
  }
]
✔ PASSED

Running SQL query: test-get-call-query.sql

Time: 5.5s. Rows returned: 1. Rows fetched: 1. Hydrate calls: 0.

Scans:
  1) aws_lambda_version.aws: Time: 5.2s. Fetched: 1. Hydrates: 0. Quals: function_name=turbottest66898, version=$LATEST.

[
  {
    "akas": [
      "arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:turbottest66898:$LATEST"
    ],
    "arn": "arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:turbottest66898:$LATEST",
    "function_name": "turbottest66898",
    "runtime": "python3.12",
    "title": "$LATEST",
    "version": "$LATEST"
  }
]
✔ PASSED

Running SQL query: test-list-call-query.sql

Time: 5.2s. Rows returned: 1. Rows fetched: 9. Hydrate calls: 0.

Scans:
  1) aws_lambda_version.aws: Time: 4.9s. Fetched: 9. Hydrates: 0. Quals: akas=[
    "arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:turbottest66898:$LATEST"
].

[
  {
    "akas": [
      "arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:turbottest66898:$LATEST"
    ],
    "arn": "arn:aws:lambda:us-east-1:xxxxxxxxxxxx:function:turbottest66898:$LATEST",
    "function_name": "turbottest66898",
    "runtime": "python3.12",
    "title": "$LATEST",
    "version": "$LATEST"
  }
]
✔ PASSED

TEARDOWN: tests/aws_lambda_version

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_lambda_version limit 2
{
 "rows": [
  {
   "_ctx": {
    "connection_name": "aws",
    "steampipe": {
     "sdk_version": "5.10.0"
    }
   },
   "account_id": "xxxxxxxxxxxx",
   "akas": [
    "arn:aws:lambda:ap-northeast-1:xxxxxxxxxxxx:function:SecurityLake_Glue_Partition_Updater_Lambda_ap-northeast-1:$LATEST"
   ],
   "architectures": [
    "x86_64"
   ],
   "arn": "arn:aws:lambda:ap-northeast-1:xxxxxxxxxxxx:function:SecurityLake_Glue_Partition_Updater_Lambda_ap-northeast-1:$LATEST",
   "code_sha_256": "xq2xxo5QCkys5Akc2hmOgx8m9ECOciDJxSlfBxlo4uQ=",
   "code_size": 2954,
   "dead_letter_config": null,
   "description": "",
   "environment_variables": {
    "GLUE_REGIONAL_DATABASE_NAME": "amazon_security_lake_glue_db_ap_northeast_1",
    "GLUE_REGIONAL_TABLE_PREFIX": "amazon_security_lake_table_ap_northeast_1"
   },
   "ephemeral_storage_size": 512,
   "file_system_configs": null,
   "function_name": "SecurityLake_Glue_Partition_Updater_Lambda_ap-northeast-1",
   "handler": "lambda_handler.lambda_handler",
   "image_config_response": null,
   "kms_key_arn": null,
   "last_modified": "2022-12-01T15:37:17+05:30",
   "last_update_status": "",
   "last_update_status_reason": null,
   "last_update_status_reason_code": "",
   "layers": null,
   "logging_config": {
    "ApplicationLogLevel": "",
    "LogFormat": "Text",
    "LogGroup": "/aws/lambda/SecurityLake_Glue_Partition_Updater_Lambda_ap-northeast-1",
    "SystemLogLevel": ""
   },
   "master_arn": null,
   "memory_size": 3008,
   "partition": "aws",
   "policy": null,
   "policy_std": null,
   "region": "ap-northeast-1",
   "revision_id": "35d93bf3-5104-4fc6-bd31-c0a598432ed0",
   "role": "arn:aws:iam::xxxxxxxxxxxx:role/AmazonSecurityLakeMetaStoreManager",
   "runtime": "python3.9",
   "runtime_version_config": null,
   "signing_job_arn": null,
   "signing_profile_version_arn": null,
   "snap_start": {
    "ApplyOn": "None",
    "OptimizationStatus": "Off"
   },
   "sp_connection_name": "aws",
   "sp_ctx": {
    "connection_name": "aws",
    "steampipe": {
     "sdk_version": "5.10.0"
    }
   },
   "state": "",
   "state_reason": null,
   "state_reason_code": "",
   "timeout": 45,
   "title": "$LATEST",
   "tracing_config": {
    "Mode": "PassThrough"
   },
   "version": "$LATEST",
   "vpc_id": null,
   "vpc_security_group_ids": null,
   "vpc_subnet_ids": null
  },
  {
   "_ctx": {
    "connection_name": "aws",
    "steampipe": {
     "sdk_version": "5.10.0"
    }
   },
   "account_id": "xxxxxxxxxxxx",
   "akas": [
    "arn:aws:lambda:ap-southeast-2:xxxxxxxxxxxx:function:SecurityLake_Glue_Partition_Updater_Lambda_ap-southeast-2:$LATEST"
   ],
   "architectures": [
    "x86_64"
   ],
   "arn": "arn:aws:lambda:ap-southeast-2:xxxxxxxxxxxx:function:SecurityLake_Glue_Partition_Updater_Lambda_ap-southeast-2:$LATEST",
   "code_sha_256": "xq2xxo5QCkys5Akc2hmOgx8m9ECOciDJxSlfBxlo4uQ=",
   "code_size": 2954,
   "dead_letter_config": null,
   "description": "",
   "environment_variables": {
    "GLUE_REGIONAL_DATABASE_NAME": "amazon_security_lake_glue_db_ap_southeast_2",
    "GLUE_REGIONAL_TABLE_PREFIX": "amazon_security_lake_table_ap_southeast_2"
   },
   "ephemeral_storage_size": 512,
   "file_system_configs": null,
   "function_name": "SecurityLake_Glue_Partition_Updater_Lambda_ap-southeast-2",
   "handler": "lambda_handler.lambda_handler",
   "image_config_response": null,
   "kms_key_arn": null,
   "last_modified": "2022-12-01T15:37:38+05:30",
   "last_update_status": "",
   "last_update_status_reason": null,
   "last_update_status_reason_code": "",
   "layers": null,
   "logging_config": {
    "ApplicationLogLevel": "",
    "LogFormat": "Text",
    "LogGroup": "/aws/lambda/SecurityLake_Glue_Partition_Updater_Lambda_ap-southeast-2",
    "SystemLogLevel": ""
   },
   "master_arn": null,
   "memory_size": 3008,
   "partition": "aws",
   "policy": null,
   "policy_std": null,
   "region": "ap-southeast-2",
   "revision_id": "fb486e9f-9f7b-4529-9a09-a1619788cbe5",
   "role": "arn:aws:iam::xxxxxxxxxxxx:role/AmazonSecurityLakeMetaStoreManager",
   "runtime": "python3.9",
   "runtime_version_config": null,
   "signing_job_arn": null,
   "signing_profile_version_arn": null,
   "snap_start": {
    "ApplyOn": "None",
    "OptimizationStatus": "Off"
   },
   "sp_connection_name": "aws",
   "sp_ctx": {
    "connection_name": "aws",
    "steampipe": {
     "sdk_version": "5.10.0"
    }
   },
   "state": "",
   "state_reason": null,
   "state_reason_code": "",
   "timeout": 45,
   "title": "$LATEST",
   "tracing_config": {
    "Mode": "PassThrough"
   },
   "version": "$LATEST",
   "vpc_id": null,
   "vpc_security_group_ids": null,
   "vpc_subnet_ids": null
  }
 ],
 "metadata": {
  "duration_ms": 239,
  "scans": [
   {
    "connection": "aws",
    "table": "aws_lambda_version",
    "cache_hit": true,
    "rows_fetched": 8,
    "hydrate_calls": 0,
    "start_time": "2024-06-28T10:02:44+05:30",
    "duration_ms": 24,
    "columns": [
     "role",
     "akas",
     "vpc_id",
     "kms_key_arn",
     "policy_std",
     "architectures",
     "image_config_response",
     "layers",
     "state",
     "code_sha_256",
     "sp_connection_name",
     "snap_start",
     "partition",
     "last_update_status",
     "signing_job_arn",
     "ephemeral_storage_size",
     "file_system_configs",
     "logging_config",
     "account_id",
     "code_size",
     "description",
     "_ctx",
     "last_update_status_reason",
     "tracing_config",
     "master_arn",
     "last_update_status_reason_code",
     "runtime",
     "state_reason",
     "state_reason_code",
     "vpc_subnet_ids",
     "function_name",
     "arn",
     "region",
     "revision_id",
     "policy",
     "dead_letter_config",
     "title",
     "version",
     "last_modified",
     "timeout",
     "vpc_security_group_ids",
     "sp_ctx",
     "handler",
     "memory_size",
     "runtime_version_config",
     "signing_profile_version_arn",
     "environment_variables"
    ],
    "limit": 2
   }
  ],
  "scan_count": 1,
  "rows_returned": 2,
  "uncached_rows_fetched": 0,
  "cached_rows_fetched": 8,
  "hydrate_calls": 0,
  "connection_count": 1
 }
}

Time: 239ms. Rows returned: 2. Rows fetched: 8 (cached). Hydrate calls: 0.

Scans:
  1) aws_lambda_version.aws: Time: 24ms. Fetched: 8 (cached). Hydrates: 0. Limit: 2.

```
</details>
