### PR TITLE
Fixed the table aws_organizations_account fails to display result when we pass both parent_id and id as query parameter Closes #2235ved

### DIFF
--- a/aws/table_aws_organizations_account.go
+++ b/aws/table_aws_organizations_account.go
@@ -16,7 +16,15 @@ func tableAwsOrganizationsAccount(_ context.Context) *plugin.Table {
 		Name:        "aws_organizations_account",
 		Description: "AWS Organizations Account",
 		Get: &plugin.GetConfig{
-			KeyColumns: plugin.SingleColumn("id"),
+			// We have added "parent_id" as an optional qual because the column value is being populated using "FromQual()". If we add it as an optional or required qual, the column value will be populated.
+
+			// The query SELECT * FROM aws_organizations_account WHERE parent_id = 'r-kjsdw' AND id = 'xxxxxxxxxxxx' returns the value by making the Get API call since the "id" value is passed in the query parameter. However, it displays an empty result due to Steampipe's level filtration on the "parent_id" value("FromQual()" returns null value if we don't include "parent_id" as optional quals).
+
+			// By including "parent_id" as an optional qual, the above query returns the expected result.
+			KeyColumns: plugin.KeyColumnSlice{
+				{Name: "id", Require: plugin.Required},
+				{Name: "parent_id", Require: plugin.Optional},
+			},
 			IgnoreConfig: &plugin.IgnoreConfig{
 				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"AccountNotFoundException", "InvalidInputException"}),
 			},


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> with cost_data as (
  select
    linked_account_id,
    period_start,
    unblended_cost_amount as this_month,
    lag(unblended_cost_amount, 1) over(
      partition by linked_account_id
      order by
        period_start desc
    ) as previous_month
  from
    aws_cost_by_account_monthly
)
select
  linked_account_id,
  period_start,
  this_month :: numeric :: float,
  previous_month :: numeric :: float,
  ((this_month + previous_month) / 2) :: numeric :: money as "60_day_avg"
from
  cost_data
join aws_organizations_account as acc on acc.id = cost_data.linked_account_id
where acc.parent_id = 'r-bhwu'
order by
  linked_account_id,
  period_start;
+-------------------+---------------------------+----------------+----------------+------------+
| linked_account_id | period_start              | this_month     | previous_month | 60_day_avg |
+-------------------+---------------------------+----------------+----------------+------------+
| xxxxxxxxxxxx      | 2023-07-03T05:30:00+05:30 | 349.2449938927 | 33.2081890726  | $191.23    |
| xxxxxxxxxxxx      | 2023-08-01T05:30:00+05:30 | 33.2081890726  | 123.6535233683 | $78.43     |
| xxxxxxxxxxxx      | 2023-09-01T05:30:00+05:30 | 123.6535233683 | -0.0000147239  | $61.83     |
| xxxxxxxxxxxx      | 2023-10-01T05:30:00+05:30 | -0.0000147239  | 150.1021639716 | $75.05     |
| xxxxxxxxxxxx      | 2023-11-01T05:30:00+05:30 | 150.1021639716 | 148.9409804602 | $149.52    |
| xxxxxxxxxxxx      | 2023-12-01T05:30:00+05:30 | 148.9409804602 | 144.4520678504 | $146.70    |
| xxxxxxxxxxxx      | 2024-01-01T05:30:00+05:30 | 144.4520678504 | 143.5126080015 | $143.98    |
| xxxxxxxxxxxx      | 2024-02-01T05:30:00+05:30 | 143.5126080015 | 214.8022529982 | $179.16    |
| xxxxxxxxxxxx      | 2024-03-01T05:30:00+05:30 | 214.8022529982 | 146.9339251547 | $180.87    |
| xxxxxxxxxxxx      | 2024-04-01T05:30:00+05:30 | 146.9339251547 | 110.3291507393 | $128.63    |
| xxxxxxxxxxxx      | 2024-05-01T05:30:00+05:30 | 110.3291507393 | 98.49682533    | $104.41    |
| xxxxxxxxxxxx      | 2024-06-01T05:30:00+05:30 | 98.49682533    | 5.0175839387   | $51.76     |
| xxxxxxxxxxxx      | 2024-07-01T05:30:00+05:30 | 5.0175839387   | <null>         | <null>     |
+-------------------+---------------------------+----------------+----------------+------------+

Time: 2.5s. Rows returned: 13. Rows fetched: 26 (13 cached). Hydrate calls: 0. Scans: 14.

Scans:
  1) aws_cost_by_account_monthly.aws: Time: 1.7s. Fetched: 13. Hydrates: 0.
  2) aws_organizations_account.aws: Time: 6ms. Fetched: 1 (cached). Hydrates: 0. Quals: parent_id=r-bhwu, parent_id=r-bhwu, id=xxxxxxxxxxxx.
  3) aws_organizations_account.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: parent_id=r-bhwu, parent_id=r-bhwu, id=xxxxxxxxxxxx.
  4) aws_organizations_account.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: parent_id=r-bhwu, parent_id=r-bhwu, id=xxxxxxxxxxxx.
  5) aws_organizations_account.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: parent_id=r-bhwu, parent_id=r-bhwu, id=xxxxxxxxxxxx.
  6) aws_organizations_account.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: parent_id=r-bhwu, parent_id=r-bhwu, id=xxxxxxxxxxxx.
  7) aws_organizations_account.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: parent_id=r-bhwu, parent_id=r-bhwu, id=xxxxxxxxxxxx.
  8) aws_organizations_account.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: parent_id=r-bhwu, parent_id=r-bhwu, id=xxxxxxxxxxxx.
  9) aws_organizations_account.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: parent_id=r-bhwu, parent_id=r-bhwu, id=xxxxxxxxxxxx.
  10) aws_organizations_account.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: parent_id=r-bhwu, parent_id=r-bhwu, id=xxxxxxxxxxxx.
  11) aws_organizations_account.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: parent_id=r-bhwu, parent_id=r-bhwu, id=xxxxxxxxxxxx.
  12) aws_organizations_account.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: parent_id=r-bhwu, parent_id=r-bhwu, id=xxxxxxxxxxxx.
  13) aws_organizations_account.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: parent_id=r-bhwu, parent_id=r-bhwu, id=xxxxxxxxxxxx.
  14) aws_organizations_account.aws: Time: 3ms. Fetched: 1 (cached). Hydrates: 0. Quals: id=xxxxxxxxxxxx, parent_id=r-bhwu, parent_id=r-bhwu.

```
</details>
