### PR TITLE
fix typo in query example (missing comma)

### DIFF
--- a/docs/tables/aws_health_affected_entity.md
+++ b/docs/tables/aws_health_affected_entity.md
@@ -80,7 +80,7 @@ select
   e.entity_url,
   e.event_arn,
   v.event_type_category,
-  v.event_type_code
+  v.event_type_code,
   v.service
 from
   aws_health_affected_entity as e,


### PR DESCRIPTION
fix typo in aws_health_affected_entity query example (missing comma)