### PR TITLE
Fixed base64DecodedData function to remove null characters from the decoded output

### DIFF
--- a/aws/utils.go
+++ b/aws/utils.go
@@ -101,7 +101,10 @@ func base64DecodedData(_ context.Context, d *transform.TransformData) (interface
 	} else if !utf8.Valid(data) {
 		return types.SafeString(d.Value), nil
 	}
-	return data, nil
+
+	// Remove null characters
+	processedData := strings.ReplaceAll(string(data), "\x00", "")
+	return processedData, nil
 }
 
 // Transform function for sagemaker resources tags

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -98,7 +98,7 @@ func isControlCharacter(r rune) bool {
 	return r < 32 || r == 127
 }
 
-// isPrintable checks if a character is printable.
+// isPrintable checks if a character is printable
 func isPrintable(r rune) bool {
 	return unicode.IsPrint(r) && !isControlCharacter(r)
 }

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -103,7 +103,6 @@ func isPrintable(r rune) bool {
 	return unicode.IsPrint(r) && !isControlCharacter(r)
 }
 
-
 // cleanString removes control characters and ensures valid UTF-8 encoding
 func cleanString(data string) string {
 	var builder strings.Builder

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 	"unicode/utf8"
 
 	sagemakerTypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
@@ -92,18 +93,44 @@ func lastPathElement(_ context.Context, d *transform.TransformData) (interface{}
 	return getLastPathElement(types.SafeString(d.Value)), nil
 }
 
-func base64DecodedData(_ context.Context, d *transform.TransformData) (interface{}, error) {
+// isControlCharacter checks if a character is a control character
+func isControlCharacter(r rune) bool {
+	return r < 32 || r == 127
+}
+
+// isPrintable checks if a character is printable.
+func isPrintable(r rune) bool {
+	return unicode.IsPrint(r) && !isControlCharacter(r)
+}
+
+
+// cleanString removes control characters and ensures valid UTF-8 encoding
+func cleanString(data string) string {
+	var builder strings.Builder
+	for _, r := range data {
+		// Only add valid and printable runes to the builder
+		if utf8.ValidRune(r) && isPrintable(r) {
+			builder.WriteRune(r)
+		}
+	}
+	return builder.String()
+}
+
+func base64DecodedData(ctx context.Context, d *transform.TransformData) (interface{}, error) {
 	data, err := base64.StdEncoding.DecodeString(types.SafeString(d.Value))
 	// check if CorruptInputError or invalid UTF-8
 	// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instancedata-add-user-data.html
 	if err != nil {
 		return nil, nil
-	} else if !utf8.Valid(data) {
+	} 
+	// Check for valid UTF-8
+	if !utf8.Valid(data) {
 		return types.SafeString(d.Value), nil
 	}
-
-	// Remove null characters
-	processedData := strings.ReplaceAll(string(data), "\x00", "")
+	// Convert byte slice to string
+	decodedString := string(data)
+	// Clean the string by removing invalid UTF-8 and control characters
+	processedData := cleanString(decodedString)
 	return processedData, nil
 }
 


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

Before
```
select instance_id, user_data from aws_unicode.aws_ec2_instance where instance_id='i-0de5b360e69bab111'
+---------------------+-----------+
| instance_id         | user_data |
+---------------------+-----------+
| i-0de5b360e69bab111 | pfconf    |
+---------------------+-----------+
```
After

```
select instance_id, user_data from aws_unicode.aws_ec2_instance where instance_id='i-0de5b360e69ba1111'
+---------------------+--------------------------------------------------------------------------------------------------------------------->
| instance_id         | user_data                                                                                                           >
+---------------------+--------------------------------------------------------------------------------------------------------------------->
| i-0de5b360e69ba1111 | pfconf000644 000766 000024 00000001762 14450131036 014363 0ustar00patrick.kreppsstaff000000 000000 >/etc/pf.confhome>
|                     | pass  out quick inet proto UDP  from $wan_if0 to any port $wan_tcp_out_portsrcconf000644 000766 000024 00000000132 1>
|                     | ###############################################################################pf_enable=""YES""                 # E>
|                     | g of execution by each shell## see also csh(1), environ(7).# more examples available at /usr/share/examples/csh/#ali>
|                     | ward-delete-word      bindkey -k up history-search-backward      bindkey -k down history-search-forward   endifendif>
|                     | /usr/share/examples/csh/#alias h      history 25alias j      jobs -lalias la     ls -aFalias lf     ls -FAalias ll  >
|                     | sstaff000000 000000 >/usr/home/ec2-user/.exrc"" Comments are preceeded by a double-quote."" Line numbers take up eig>
|                     | arn:aws:ec2:us-east-2:1111111111:instance/i-111111111111,t4g.micro,running,disabled,arm64,uefi,<nil>,517fbabb>
+---------------------+------------------------------------------------------------------------------------------------------------------
```
</details>
