### PR TITLE
Enhanced the aws_auditmanager_control table to list controls by type and fixed the Get config error "get call returned 2 results"

### DIFF
--- a/aws/table_aws_auditmanager_control.go
+++ b/aws/table_aws_auditmanager_control.go
@@ -61,7 +61,7 @@ func tableAwsAuditManagerControl(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "type",
-				Description: "The type of control, such as custom or standard.",
+				Description: "The type of control, such as custom or standard. Possible values are 'Standard' | 'Custom' | 'Core'.",
 				Type:        proto.ColumnType_STRING,
 				Hydrate:     getAuditManagerControl,
 			},
@@ -169,8 +169,6 @@ func listAuditManagerControls(ctx context.Context, d *plugin.QueryData, _ *plugi
 	if d.EqualsQualString("type") != "" {
 		params.ControlType = types.ControlType(d.EqualsQualString("type"))
 	}
-
-	plugin.Logger(ctx).Error("Input Param  ==>>> ", params)
 
 	// Reduce the basic request limit down if the user has only requested a small number of rows
 	if d.QueryContext.Limit != nil {

--- a/docs/tables/aws_auditmanager_control.md
+++ b/docs/tables/aws_auditmanager_control.md
@@ -11,6 +11,10 @@ The AWS Audit Manager Control is a feature within AWS Audit Manager that allows 
 
 The `aws_auditmanager_control` table in Steampipe provides you with information about controls within AWS Audit Manager. This table allows you, as a DevOps engineer, to query control-specific details, including control source, control type, description, and associated metadata. You can utilize this table to gather insights on controls, such as their sources, types, descriptions, and more. The schema outlines the various attributes of the control for you, including the control id, name, type, source, description, and associated tags.
 
+**Important Notes**
+- This table by default returns the `Standard` controls.
+- You **must** specify `type` in a `where` clause to retrieve other control types. For more information, please refer to the [list of controls by specific type](https://docs.aws.amazon.com/audit-manager/latest/APIReference/API_ListControls.html#API_ListControls_RequestSyntax).
+
 ## Examples
 
 ### Basic info


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
 with test as (
select

distinct cms -> 'SourceKeyword' ->> 'KeywordValue' as steampipe_control,
region
from 
 aws_auditmanager_framework as f,
 jsonb_array_elements(control_sets) as cs, jsonb_array_elements(cs -> 'Controls') as c, jsonb_array_elements(c -> 'ControlMappingSources') as cms 
where lower(f.name) = 'nist cybersecurity framework (csf) v1.1' and cms ->> 'SourceType' = 'Core_Control' limit 10
)

select 
name, id, jsonb_pretty(control_mapping_sources) as control_mapping_sources 
from 
aws_auditmanager_control as c,
test as t
where c.id = t.steampipe_control
and c.type = 'Core'
and c.region = t.region
Warning: Server enforces maximum TTL of 300 seconds. Cannot set TTL to 900 seconds. TTL set to 300 seconds.
+------------------------------------------------------------------------------------------------------+--------------------------------------+----------------------------------------------------------------------------------------+
| name                                                                                                 | id                                   | control_mapping_sources                                                                |
+------------------------------------------------------------------------------------------------------+--------------------------------------+----------------------------------------------------------------------------------------+
| Encrypt data at rest in Amazon Neptune clusters                                                      | 0231b048-b423-71a2-6c48-2cf04632a02e | [                                                                                      |
|                                                                                                      |                                      |     {                                                                                  |
|                                                                                                      |                                      |         "SourceId": "9ab5528d-5e33-496b-bc94-d32456d4f565",                            |
|                                                                                                      |                                      |         "SourceName": null,                                                            |
|                                                                                                      |                                      |         "SourceType": "AWS_Config",                                                    |
|                                                                                                      |                                      |         "SourceKeyword": {                                                             |
|                                                                                                      |                                      |             "KeywordValue": "NEPTUNE_CLUSTER_ENCRYPTED",                               |
|                                                                                                      |                                      |             "KeywordInputType": "SELECT_FROM_LIST"                                     |
|                                                                                                      |                                      |         },                                                                             |
|                                                                                                      |                                      |         "SourceFrequency": "",                                                         |
|                                                                                                      |                                      |         "SourceDescription": null,                                                     |
|                                                                                                      |                                      |         "SourceSetUpOption": "System_Controls_Mapping",                                |
|                                                                                                      |                                      |         "TroubleshootingText": null                                                    |
|                                                                                                      |                                      |     }                                                                                  |
|                                                                                                      |                                      | ]                                                                                      |
```
</details>
