### PR TITLE
Add check when querying for disabled AMI

### DIFF
--- a/aws-test/tests/aws_ec2_ami/test-get-expected.json
+++ b/aws-test/tests/aws_ec2_ami/test-get-expected.json
@@ -6,7 +6,7 @@
         "DeviceName":"/dev/sda1",
         "Ebs": {
           "DeleteOnTermination":true,
-          "Encrypted":false,
+          "Encrypted":true,
           "Iops":null,
           "KmsKeyId":null,
           "OutpostArn": null,

--- a/aws-test/tests/aws_ec2_ami/variables.tf
+++ b/aws-test/tests/aws_ec2_ami/variables.tf
@@ -55,6 +55,7 @@ data "aws_region" "alternate" {
 resource "aws_ebs_volume" "my_volume" {
   availability_zone = "us-east-1a"
   size              = 8
+  encrypted         = true
   tags = {
     Name = "turbot-volume-test"
   }

--- a/aws-test/tests/aws_ec2_ami/variables.tf
+++ b/aws-test/tests/aws_ec2_ami/variables.tf
@@ -51,12 +51,6 @@ data "aws_region" "alternate" {
   provider = aws.alternate
 }
 
-data "null_data_source" "resource" {
-  inputs = {
-    scope = "arn:${data.aws_partition.current.partition}:::${data.aws_caller_identity.current.account_id}"
-  }
-}
-
 # Create AWS > EBS > Volume
 resource "aws_ebs_volume" "my_volume" {
   availability_zone = "us-east-1a"
@@ -100,18 +94,9 @@ resource "aws_ami_launch_permission" "deny_access" {
   account_id = var.trusted_accounts_deny
 }
 
-data "template_file" "resource_aka" {
-  template = "arn:$${partition}:ec2:$${region}:$${account_id}:image/${aws_ami.named_test_resource.id}"
-  vars = {
-    partition  = data.aws_partition.current.partition
-    account_id = data.aws_caller_identity.current.account_id
-    region     = data.aws_region.primary.name
-  }
-}
-
 output "resource_aka" {
   depends_on = [aws_ami.named_test_resource]
-  value      = data.template_file.resource_aka.rendered
+  value      = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.primary.name}:${data.aws_caller_identity.current.account_id}:image/${aws_ami.named_test_resource.id}"
 }
 
 output "account_id" {

--- a/aws/table_aws_ec2_ami.go
+++ b/aws/table_aws_ec2_ami.go
@@ -258,6 +258,17 @@ func listEc2Amis(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData
 
 	input := &ec2.DescribeImagesInput{}
 
+	input.IncludeDisabled = new(bool)
+	disabledState := "disabled"
+	state := getQualsValueByColumn(d.Quals, "state", "string")
+	if val, ok := state.(string); ok {
+		*input.IncludeDisabled = val == disabledState
+	} else if val, ok := state.([]string); ok {
+		for _, v := range val {
+			*input.IncludeDisabled = v == disabledState
+		}
+	}
+
 	filters := buildAmisWithOwnerFilter(input, d.Quals, ctx, d, h)
 	if len(filters) != 0 {
 		input.Filters = filters


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_ami []

PRETEST: tests/aws_ec2_ami

TEST: tests/aws_ec2_ami
Running terraform
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_caller_identity.current: Read complete after 0s [id=111222333444]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ami.named_test_resource will be created
  + resource "aws_ami" "named_test_resource" {
      + architecture         = "x86_64"
      + arn                  = (known after apply)
      + description          = "This is a test image."
      + hypervisor           = (known after apply)
      + id                   = (known after apply)
      + image_location       = (known after apply)
      + image_owner_alias    = (known after apply)
      + image_type           = (known after apply)
      + manage_ebs_snapshots = (known after apply)
      + name                 = "turbottest65167"
      + owner_id             = (known after apply)
      + platform             = (known after apply)
      + platform_details     = (known after apply)
      + public               = (known after apply)
      + root_device_name     = "/dev/sda1"
      + root_snapshot_id     = (known after apply)
      + sriov_net_support    = "simple"
      + tags                 = {
          + "Name" = "turbottest65167"
        }
      + tags_all             = {
          + "Name" = "turbottest65167"
        }
      + usage_operation      = (known after apply)
      + virtualization_type  = "hvm"

      + ebs_block_device {
          + delete_on_termination = true
          + device_name           = "/dev/sda1"
          + snapshot_id           = (known after apply)
          + throughput            = (known after apply)
          + volume_size           = 8
          + volume_type           = "standard"
            # (1 unchanged attribute hidden)
        }

      + ephemeral_block_device (known after apply)
    }

  # aws_ami_launch_permission.allow_access will be created
  + resource "aws_ami_launch_permission" "allow_access" {
      + account_id = "388460667113"
      + id         = (known after apply)
      + image_id   = (known after apply)
    }

  # aws_ami_launch_permission.deny_access will be created
  + resource "aws_ami_launch_permission" "deny_access" {
      + account_id = "013122550996"
      + id         = (known after apply)
      + image_id   = (known after apply)
    }

  # aws_ebs_snapshot.my_snapshot will be created
  + resource "aws_ebs_snapshot" "my_snapshot" {
      + arn                    = (known after apply)
      + data_encryption_key_id = (known after apply)
      + encrypted              = (known after apply)
      + id                     = (known after apply)
      + kms_key_id             = (known after apply)
      + owner_alias            = (known after apply)
      + owner_id               = (known after apply)
      + storage_tier           = (known after apply)
      + tags                   = {
          + "Name" = "turbot-snapshot-test"
        }
      + tags_all               = {
          + "Name" = "turbot-snapshot-test"
        }
      + volume_id              = (known after apply)
      + volume_size            = (known after apply)
    }

  # aws_ebs_volume.my_volume will be created
  + resource "aws_ebs_volume" "my_volume" {
      + arn               = (known after apply)
      + availability_zone = "us-east-1a"
      + encrypted         = true
      + final_snapshot    = false
      + id                = (known after apply)
      + iops              = (known after apply)
      + kms_key_id        = (known after apply)
      + size              = 8
      + snapshot_id       = (known after apply)
      + tags              = {
          + "Name" = "turbot-volume-test"
        }
      + tags_all          = {
          + "Name" = "turbot-volume-test"
        }
      + throughput        = (known after apply)
      + type              = (known after apply)
    }

Plan: 5 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "111222333444"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest65167"
  + snapshot_id   = (known after apply)
aws_ebs_volume.my_volume: Creating...
aws_ebs_volume.my_volume: Still creating... [10s elapsed]
aws_ebs_volume.my_volume: Creation complete after 12s [id=vol-0ae822fc0d262abbc]
aws_ebs_snapshot.my_snapshot: Creating...
aws_ebs_snapshot.my_snapshot: Still creating... [10s elapsed]
aws_ebs_snapshot.my_snapshot: Still creating... [20s elapsed]
aws_ebs_snapshot.my_snapshot: Still creating... [30s elapsed]
aws_ebs_snapshot.my_snapshot: Still creating... [40s elapsed]
aws_ebs_snapshot.my_snapshot: Still creating... [50s elapsed]
aws_ebs_snapshot.my_snapshot: Still creating... [1m0s elapsed]
aws_ebs_snapshot.my_snapshot: Creation complete after 1m1s [id=snap-0e6f24fa12901016d]
aws_ami.named_test_resource: Creating...
aws_ami.named_test_resource: Creation complete after 6s [id=ami-096ce72883800264c]
aws_ami_launch_permission.allow_access: Creating...
aws_ami_launch_permission.deny_access: Creating...
aws_ami_launch_permission.allow_access: Creation complete after 2s [id=ami-096ce72883800264c-388460667113]
aws_ami_launch_permission.deny_access: Creation complete after 2s [id=ami-096ce72883800264c-013122550996]

Apply complete! Resources: 5 added, 0 changed, 0 destroyed.

Outputs:

account_id = "111222333444"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:ec2:us-east-1:111222333444:image/ami-096ce72883800264c"
resource_id = "ami-096ce72883800264c"
resource_name = "turbottest65167"
snapshot_id = "snap-0e6f24fa12901016d"

Running SQL query: query.sql
[
  {
    "image_id": "ami-096ce72883800264c",
    "name": "turbottest65167"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "architecture": "x86_64",
    "block_device_mappings": [
      {
        "DeviceName": "/dev/sda1",
        "Ebs": {
          "DeleteOnTermination": true,
          "Encrypted": true,
          "Iops": null,
          "KmsKeyId": null,
          "OutpostArn": null,
          "SnapshotId": "snap-0e6f24fa12901016d",
          "Throughput": null,
          "VolumeSize": 8,
          "VolumeType": "standard"
        },
        "NoDevice": null,
        "VirtualName": null
      }
    ],
    "description": "This is a test image.",
    "ena_support": false,
    "hypervisor": "xen",
    "image_id": "ami-096ce72883800264c",
    "image_location": "111222333444/turbottest65167",
    "image_type": "machine",
    "name": "turbottest65167",
    "owner_id": "111222333444",
    "platform_details": "Linux/UNIX",
    "public": false,
    "root_device_name": "/dev/sda1",
    "root_device_type": "ebs",
    "sriov_net_support": "simple",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest65167"
      }
    ],
    "usage_operation": "RunInstances",
    "virtualization_type": "hvm"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:111222333444:image/ami-096ce72883800264c"
    ],
    "image_id": "ami-096ce72883800264c",
    "tags": {
      "Name": "turbottest65167"
    },
    "title": "turbottest65167"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "image_id": "ami-096ce72883800264c",
    "name": "turbottest65167"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_ami

TEARDOWN: tests/aws_ec2_ami

SUMMARY:

1/1 passed.

```
</details>

# Example query results
<details>
  <summary>Results</summary>

Query: `select count(image_id), state from aws_ec2_ami where state in ('disabled', 'available', 'failed') group by state`


```
+-------+-----------+
| count | state     |
+-------+-----------+
| 11822 | available |
| 46    | disabled  |
+-------+-----------+
```
</details>

closes #2276 
