### PR TITLE
Fixed aws_servicequotas_service_quota queries fail when querying multiple regions with the same service_code Closes #2313

### DIFF
--- a/aws/table_aws_servicequotas_service_quota.go
+++ b/aws/table_aws_servicequotas_service_quota.go
@@ -24,8 +24,10 @@ func tableAwsServiceQuotasServiceQuota(_ context.Context) *plugin.Table {
 			ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"NoSuchResourceException"}),
 		},
 		Get: &plugin.GetConfig{
-			KeyColumns: plugin.AllColumns([]string{"service_code", "quota_code"}),
+			// By design, the Get config is expected to return a single row, regardless of regions.
+			// To prevent the error "get call returned 23 results - the key column is not globally unique," we have included the "region" in the key columns.
 			Hydrate:    getServiceQuota,
+			KeyColumns: plugin.AllColumns([]string{"service_code", "quota_code", "region"}),
 			Tags:       map[string]string{"service": "servicequotas", "action": "GetServiceQuota"},
 			IgnoreConfig: &plugin.IgnoreConfig{
 				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"NoSuchResourceException"}),


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_servicequotas_service_quota WHERE quota_code = 'L-0263D0A3' and service_code = 'ec2'
+---------------------+------------+------------------------------------------------------------------+--------------+-------------------------------------------+--------------+------------+------+------------------------+-------+--------------+--------+----------+--------------+---------------+--------+--------->
| quota_name          | quota_code | quota_arn                                                        | global_quota | service_name                              | service_code | adjustable | unit | quota_applied_at_level | value | error_reason | period | tags_src | usage_metric | quota_context | tags   | title   >
+---------------------+------------+------------------------------------------------------------------+--------------+-------------------------------------------+--------------+------------+------+------------------------+-------+--------------+--------+----------+--------------+---------------+--------+--------->
| EC2-VPC Elastic IPs | L-0263D0A3 | arn:aws:servicequotas:me-central-1:xxxxxxxxxxxx:ec2/L-0263D0A3   | false        | Amazon Elastic Compute Cloud (Amazon EC2) | ec2          | true       | None | ACCOUNT                | 5     | <null>       | <null> | []       | <null>       | <null>        | <null> | EC2-VPC >
| EC2-VPC Elastic IPs | L-0263D0A3 | arn:aws:servicequotas:af-south-1:xxxxxxxxxxxx:ec2/L-0263D0A3     | false        | Amazon Elastic Compute Cloud (Amazon EC2) | ec2          | true       | None | ACCOUNT                | 5     | <null>       | <null> | []       | <null>       | <null>        | <null> | EC2-VPC >
| EC2-VPC Elastic IPs | L-0263D0A3 | arn:aws:servicequotas:ap-south-1:xxxxxxxxxxxx:ec2/L-0263D0A3     | false        | Amazon Elastic Compute Cloud (Amazon EC2) | ec2          | true       | None | ACCOUNT                | 5     | <null>       | <null> | []       | <null>       | <null>        | <null> | EC2-VPC >
| EC2-VPC Elastic IPs | L-0263D0A3 | arn:aws:servicequotas:ca-central-1:xxxxxxxxxxxx:ec2/L-0263D0A3   | false        | Amazon Elastic Compute Cloud (Amazon EC2) | ec2          | true       | None | ACCOUNT                | 5     | <null>       | <null> | []       | <null>       | <null>        | <null> | EC2-VPC >
| EC2-VPC Elastic IPs | L-0263D0A3 | arn:aws:servicequotas:us-east-2:xxxxxxxxxxxx:ec2/L-0263D0A3      | false        | Amazon Elastic Compute Cloud (Amazon EC2) | ec2          | true       | None | ACCOUNT                | 5     | <null>       | <null> | []       | <null>       | <null>        | <null> | EC2-VPC >
| EC2-VPC Elastic IPs | L-0263D0A3 | arn:aws:servicequotas:ap-northeast-3:xxxxxxxxxxxx:ec2/L-0263D0A3 | false        | Amazon Elastic Compute Cloud (Amazon EC2) | ec2          | true       | None | ACCOUNT                | 5     | <null>       | <null> | []       | <null>       | <null>        | <null> | EC2-VPC >
| EC2-VPC Elastic IPs | L-0263D0A3 | arn:aws:servicequotas:ap-east-1:xxxxxxxxxxxx:ec2/L-0263D0A3      | false        | Amazon Elastic Compute Cloud (Amazon EC2) | ec2          | true       | None | ACCOUNT                | 5     | <null>       | <null> | []       | <null>       | <null>        | <null> | EC2-VPC >
| EC2-VPC Elastic IPs | L-0263D0A3 | arn:aws:servicequotas:me-south-1:xxxxxxxxxxxx:ec2/L-0263D0A3     | false        | Amazon Elastic Compute Cloud (Amazon EC2) | ec2          | true       | None | ACCOUNT                | 5     | <null>       | <null> | []       | <null>       | <null>        | <null> | EC2-VPC >
| EC2-VPC Elastic IPs | L-0263D0A3 | arn:aws:servicequotas:ap-southeast-3:xxxxxxxxxxxx:ec2/L-0263D0A3 | false        | Amazon Elastic Compute Cloud (Amazon EC2) | ec2          | true       | None | ACCOUNT                | 5     | <null>       | <null> | []       | <null>       | <null>        | <null> | EC2-VPC >
| EC2-VPC Elastic IPs | L-0263D0A3 | arn:aws:servicequotas:eu-west-1:xxxxxxxxxxxx:ec2/L-0263D0A3      | false        | Amazon Elastic Compute Cloud (Amazon EC2) | ec2          | true       | None | ACCOUNT                | 5     | <null>       | <null> | []       | <null>       | <null>        | <null> | EC2-VPC >

```
</details>
