### PR TITLE
Add StreamModeDetails column to Kinesis stream table

### DIFF
--- a/aws/table_aws_kinesis_stream.go
+++ b/aws/table_aws_kinesis_stream.go
@@ -132,6 +132,13 @@ func tableAwsKinesisStream(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("StreamDescription.EnhancedMonitoring"),
 			},
 			{
+				Name:        "stream_mode_details",
+				Description: "Represents the current mode of the stream.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     describeStream,
+				Transform:   transform.FromField("StreamDescription.StreamModeDetails"),
+			},
+			{
 				Name:        "tags_src",
 				Description: "A list of tags associated with the stream.",
 				Type:        proto.ColumnType_JSON,


### PR DESCRIPTION
## First-time Contributor:
This is my first contribution to the Steampipe project, and I’m excited to collaborate with the team! Please feel free to provide any feedback or guidance on improvements. I’m happy to make any adjustments as needed. Thank you for reviewing my contribution!

## Details 
This PR introduces a new column, StreamModeDetails, in the aws/table_aws_kinesis_stream.go table. The purpose of this column is to provide essential information about the mode of Kinesis streams, allowing users to easily identify whether a stream is provisioned or on-demand.

## Key Changes:
Added StreamModeDetails column to the Kinesis Stream table definition.
Updated logic to retrieve and display stream mode details.

## Benefits:
Enhances the visibility of Kinesis stream configuration by indicating the stream mode.
Simplifies resource monitoring and management for users dealing with both provisioned and on-demand Kinesis streams.

## Query example 
<img width="620" alt="image" src="https://github.com/user-attachments/assets/206698c0-d6c7-4380-a618-0d9cb7a927a3">
