### PR TITLE
Fixed error handling for table_aws_iam_user and table_aws_s3_bucket

### DIFF
--- a/aws/table_aws_iam_user.go
+++ b/aws/table_aws_iam_user.go
@@ -320,7 +320,7 @@ func getAwsIamUserData(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 		UserName: user.UserName,
 	}
 
-	userData, _ := svc.GetUser(ctx, params)
+	userData, err := svc.GetUser(ctx, params)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_iam_user.getAwsIamUserData", "api_error", err)
 		return nil, err
@@ -367,7 +367,7 @@ func getAwsIamUserAttachedPolicies(ctx context.Context, d *plugin.QueryData, h *
 		UserName: user.UserName,
 	}
 
-	userData, _ := svc.ListAttachedUserPolicies(ctx, params)
+	userData, err := svc.ListAttachedUserPolicies(ctx, params)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_iam_user.getAwsIamUserAttachedPolicies", "api_error", err)
 		return nil, err
@@ -398,7 +398,7 @@ func getAwsIamUserGroups(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 		UserName: user.UserName,
 	}
 
-	userData, _ := svc.ListGroupsForUser(ctx, params)
+	userData, err := svc.ListGroupsForUser(ctx, params)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_iam_user.getAwsIamUserGroups", "api_error", err)
 		return nil, err
@@ -421,7 +421,7 @@ func getAwsIamUserMfaDevices(ctx context.Context, d *plugin.QueryData, h *plugin
 		UserName: user.UserName,
 	}
 
-	userData, _ := svc.ListMFADevices(ctx, params)
+	userData, err := svc.ListMFADevices(ctx, params)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_iam_user.getAwsIamUserMfaDevices", "api_error", err)
 		return nil, err

--- a/aws/table_aws_s3_bucket.go
+++ b/aws/table_aws_s3_bucket.go
@@ -689,7 +689,7 @@ func getBucketTagging(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 	params := &s3.GetBucketTaggingInput{Bucket: bucketName}
 
-	bucketTags, _ := svc.GetBucketTagging(ctx, params)
+	bucketTags, err := svc.GetBucketTagging(ctx, params)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_s3_bucket.getBucketTagging", "api_error", err)
 		return nil, err
@@ -711,7 +711,7 @@ func getBucketWebsite(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 	params := &s3.GetBucketWebsiteInput{Bucket: bucketName}
 
-	bucketwebsites, _ := svc.GetBucketWebsite(ctx, params)
+	bucketwebsites, err := svc.GetBucketWebsite(ctx, params)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_s3_bucket.getBucketWebsite", "api_error", err)
 		return nil, err


### PR DESCRIPTION
This PR fixes the error handling for some APIs for the `table_aws_iam_user` and `table_aws_s3_bucket` table. If an error occurs (e.g., missing permissions for the respective API), a nil pointer dereference error is thrown.

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
