### PR TITLE
Fixed table `aws_ssm_document_permission` to handle  `InvalidDocument` error code

### DIFF
--- a/aws/table_aws_ssm_document_permission.go
+++ b/aws/table_aws_ssm_document_permission.go
@@ -23,6 +23,11 @@ func tableAwsSSMDocumentPermission(_ context.Context) *plugin.Table {
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "document_name", Require: plugin.Required},
 			},
+			// Getting InvalidDocument error if document is not avaiable in any specific region
+			// Error: aws: operation error SSM: DescribeDocumentPermission, https response error StatusCode: 400, RequestID: fece9f20-9b41-40d9-abd3-933c1c1e4345, InvalidDocument: Document with name ssm_doc_test_delete does not exist. (SQLSTATE HV000)
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"InvalidDocument"}),
+			},
 		},
 		GetMatrixItemFunc: SupportedRegionMatrix(ssmv1.EndpointsID),
 		Columns: awsRegionalColumns([]*plugin.Column{


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
