### PR TITLE
Bug Fix: Wrong Comparison Operator for Number and Date Filter in `aws_inspector2_finding`

### DIFF
--- a/aws/table_aws_inspector2_finding.go
+++ b/aws/table_aws_inspector2_finding.go
@@ -850,9 +850,9 @@ func buildNumberFilters(d *plugin.QueryData, filter *types.FilterCriteria) {
 				val := aws.Float64(q.Value.GetDoubleValue())
 				var f types.NumberFilter
 				switch q.Operator {
-				case "<=":
-					f = types.NumberFilter{LowerInclusive: val}
 				case ">=":
+					f = types.NumberFilter{LowerInclusive: val}
+				case "<=":
 					f = types.NumberFilter{UpperInclusive: val}
 				}
 				*field = append(*field, f)
@@ -869,9 +869,9 @@ func buildDateFilters(d *plugin.QueryData, filter *types.FilterCriteria) {
 				val := aws.Time(q.Value.GetTimestampValue().AsTime())
 				var f types.DateFilter
 				switch q.Operator {
-				case "<=":
-					f = types.DateFilter{StartInclusive: val}
 				case ">=":
+					f = types.DateFilter{StartInclusive: val}
+				case "<=":
 					f = types.DateFilter{EndInclusive: val}
 				}
 				*field = append(*field, f)


### PR DESCRIPTION
This PR fixes a nasty bug which made the `aws_inspector2_finding` table returned no results if the SQL query contains the `<=` or `>=` operator for number or date columns.

To explain the bug take this query:

```sql
select
  title,
  epss_score
from
  aws_inspector2_finding
where
  epss_score >= 0.7
```

In this case, the call to the Inspector2 findings API should contain the NumberFilter for the EPSS score field with the field `LowerInclusive` and the value 0.7. However, in the code the SQL operator `>=` was mapped to the NumberFilter field `UpperInclusive`. This leads to the API response with exactly the opposite results we actually wanted to retrieve. When the list function returned the result list to Steampipe, the SQL query operator was applied to the result set, which then filtered out all the results.

This bug affected all columns for which the NumberFilter and DateFilter was applied.

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
