### PR TITLE
feat: add `tags` to `aws_backup_plan` table

### DIFF
--- a/aws/backup_tags.go
+++ b/aws/backup_tags.go
@@ -1,0 +1,55 @@
+package aws
+
+import (
+	"context"
+	"errors"
+	"regexp"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/backup"
+	"github.com/aws/smithy-go"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+func getAwsBackupResourceTags(ctx context.Context, d *plugin.QueryData, arn string, pattern string) (interface{}, error) { // Create a regular expression object
+	re := regexp.MustCompile(pattern)
+
+	// Only return the tags associated with the resovery point
+	if !re.MatchString(arn) {
+		return nil, nil
+	}
+
+	// Create Session
+	svc, err := BackupClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("backup_tags.getAwsBackupResourceTags", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	params := &backup.ListTagsInput{
+		ResourceArn: aws.String(arn),
+	}
+
+	op, err := svc.ListTags(ctx, params)
+	if err != nil {
+
+		var ae smithy.APIError
+		if errors.As(err, &ae) {
+			if ae.ErrorCode() == "ResourceNotFoundException" {
+				return &backup.ListTagsOutput{}, nil
+			}
+		}
+		plugin.Logger(ctx).Error("backup_tags.getAwsBackupResourceTags", "api_error", err)
+		return nil, err
+	}
+
+	if op.Tags == nil {
+		return nil, nil
+	}
+
+	return op, nil
+}

--- a/aws/table_aws_backup_plan.go
+++ b/aws/table_aws_backup_plan.go
@@ -227,10 +227,7 @@ func getAwsBackupPlan(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 func getAwsBackupPlanTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	arn := backupPlanArn(h.Item)
 
-	// Define the regex pattern for the recovery point ARN
-	pattern := `arn:aws:backup:[a-z0-9\-]+:[0-9]{12}:backup-plan:.*`
-
-	return getAwsBackupResourceTags(ctx, d, arn, pattern)
+	return getAwsBackupResourceTags(ctx, d, arn)
 }
 
 func backupPlanArn(item interface{}) string {

--- a/aws/table_aws_backup_recovery_point.go
+++ b/aws/table_aws_backup_recovery_point.go
@@ -328,10 +328,7 @@ func getAwsBackupRecoveryPoint(ctx context.Context, d *plugin.QueryData, h *plug
 func getAwsBackupRecoveryPointTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	arn := recoveryPointArn(h.Item)
 
-	// Define the regex pattern for the backup recovery point ARN
-	pattern := `arn:aws:backup:[a-z0-9\-]+:[0-9]{12}:recovery-point:.*`
-
-	return getAwsBackupResourceTags(ctx, d, arn, pattern)
+	return getAwsBackupResourceTags(ctx, d, arn)
 }
 
 func recoveryPointArn(item interface{}) string {

--- a/aws/table_aws_backup_vault.go
+++ b/aws/table_aws_backup_vault.go
@@ -296,10 +296,7 @@ func getAwsBackupVaultNotification(ctx context.Context, d *plugin.QueryData, h *
 func getAwsBackupVaultTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	arn := vaultArn(h.Item)
 
-	// Define the regex pattern for the backup vault ARN
-	pattern := `arn:aws:backup:[a-z0-9\-]+:[0-9]{12}:backup-vault:.*`
-
-	return getAwsBackupResourceTags(ctx, d, arn, pattern)
+	return getAwsBackupResourceTags(ctx, d, arn)
 }
 
 func getAwsBackupVaultAccessPolicy(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/aws/table_aws_backup_vault.go
+++ b/aws/table_aws_backup_vault.go
@@ -259,10 +259,6 @@ func getAwsBackupVaultNotification(ctx context.Context, d *plugin.QueryData, h *
 		plugin.Logger(ctx).Error("aws_backup_vault.getAwsBackupVaultNotification", "connection_error", err)
 		return nil, err
 	}
-	if svc == nil {
-		// Unsupported region, return no data
-		return nil, nil
-	}
 
 	if svc == nil {
 		// Unsupported region, return no data


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> SELECT
  name,
  region,
  tags
FROM aws_backup_plan
WHERE
  name LIKE '%pdecat%'

+-----------------------+-----------+-------------------+
| name                  | region    | tags              |
+-----------------------+-----------+-------------------+
| test-pdecat-plan-tags | eu-west-3 | {"test":"pdecat"} |
+-----------------------+-----------+-------------------+
```
</details>
