### PR TITLE
feat: add `multi_region` and `multi_region_configuration` columns to `aws_kms_key` table

### DIFF
--- a/aws/table_aws_kms_key.go
+++ b/aws/table_aws_kms_key.go
@@ -183,6 +183,20 @@ func tableAwsKmsKey(ctx context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getAwsKmsKeyTagging,
 			},
+			{
+				Name:        "multi_region",
+				Description: "Specifies whether the CMK is KMS key is a multi-Region (true) or regional (false) key.",
+				Type:        proto.ColumnType_BOOL,
+				Hydrate:     getAwsKmsKeyData,
+				Transform:   transform.FromField("KeyMetadata.MultiRegion"),
+			},
+			{
+				Name:        "multi_region_configuration",
+				Description: "Lists the primary and replica keys in same multi-Region key.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getAwsKmsKeyData,
+				Transform:   transform.FromField("KeyMetadata.MultiRegionConfiguration"),
+			},
 
 			/// Standard columns for all tables
 			{


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> SELECT
  substring(aliases[0] ->> 'AliasName' FROM 7) AS "alias",
  arn,
  creation_date,
  multi_region,
  multi_region_configuration ->> 'MultiRegionKeyType' AS key_type,
  multi_region_configuration -> 'PrimaryKey' -> 'Arn' AS primary_key_arn
FROM
  aws_kms_key
WHERE
  aliases[0] ->> 'AliasName' NOT LIKE 'alias/aws/%'
ORDER BY
  alias, arn
+-----------------------------------------------------------+-----------------------------------------------------------------------------+---------------------------+--------------+----------+-------------------------------------------------------------------------------+
| alias                                                     | arn                                                                         | creation_date             | multi_region | key_type | primary_key_arn                                                               |
+-----------------------------------------------------------+-----------------------------------------------------------------------------+---------------------------+--------------+----------+-------------------------------------------------------------------------------+
| QuickSetupConfigRecordingKey                              | arn:aws:kms:eu-west-1:************:key/a62008d8-d265-****-****-4c1ce0952739 | 2022-07-25T17:28:53+02:00 | false        | <null>   | <null>                                                                        |
| ********-**-preprod-********-**-preprod-euw3-kms-alias    | arn:aws:kms:eu-west-3:************:key/bd73d0fa-1cb6-****-****-1a782f722306 | 2024-08-08T13:57:30+02:00 | false        | <null>   | <null>                                                                        |
| ********-**-preprod-********-**-preprod-euw3-kms-cw-alias | arn:aws:kms:eu-west-3:************:key/302454b5-2621-****-****-9c2cf02673af | 2024-08-08T13:57:30+02:00 | false        | <null>   | <null>                                                                        |
| test-pdecat                                               | arn:aws:kms:eu-west-1:************:key/mrk-5d0e3b73350540d884ed9fbcb26c1ce0 | 2024-11-08T17:39:12+01:00 | true         | REPLICA  | "arn:aws:kms:eu-west-3:************:key/mrk-5d0e3b73350540d884ed9fbcb26c1ce0" |
| test-pdecat                                               | arn:aws:kms:eu-west-3:************:key/mrk-5d0e3b73350540d884ed9fbcb26c1ce0 | 2024-11-08T17:18:55+01:00 | true         | PRIMARY  | "arn:aws:kms:eu-west-3:************:key/mrk-5d0e3b73350540d884ed9fbcb26c1ce0" |
+-----------------------------------------------------------+-----------------------------------------------------------------------------+---------------------------+--------------+----------+-------------------------------------------------------------------------------+
```
</details>
