### PR TITLE
Column `account_password_present` for `aws_iam_account_summary` Table

### DIFF
--- a/aws/table_aws_iam_account_summary.go
+++ b/aws/table_aws_iam_account_summary.go
@@ -14,6 +14,7 @@ type awsIamAccountSummary struct {
 	AccessKeysPerUserQuota            int32
 	AccountAccessKeysPresent          int32
 	AccountMFAEnabled                 bool
+	AccountPasswordPresent            int32
 	AccountSigningCertificatesPresent int32
 	AssumeRolePolicySizeQuota         int32
 	AttachedPoliciesPerGroupQuota     int32
@@ -71,6 +72,11 @@ func tableAwsIamAccountSummary(_ context.Context) *plugin.Table {
 				Description: "Specifies whether MFA is enabled for the account.",
 				Type:        proto.ColumnType_BOOL,
 				Transform:   transform.FromField("AccountMFAEnabled"),
+			},
+			{
+				Name:        "account_password_present",
+				Description: "Specifies the number of account passwords present.",
+				Type:        proto.ColumnType_INT,
 			},
 			{
 				Name:        "account_signing_certificates_present",
@@ -245,6 +251,7 @@ func listAccountSummary(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		AccessKeysPerUserQuota:            summaryMap["AccessKeysPerUserQuota"],
 		AccountAccessKeysPresent:          summaryMap["AccountAccessKeysPresent"],
 		AccountMFAEnabled:                 summaryMap["AccountMFAEnabled"] == int32(1),
+		AccountPasswordPresent:            summaryMap["AccountPasswordPresent"],
 		AccountSigningCertificatesPresent: summaryMap["AccountSigningCertificatesPresent"],
 		AssumeRolePolicySizeQuota:         summaryMap["AssumeRolePolicySizeQuota"],
 		AttachedPoliciesPerGroupQuota:     summaryMap["AttachedPoliciesPerGroupQuota"],

--- a/aws/table_aws_iam_account_summary.go
+++ b/aws/table_aws_iam_account_summary.go
@@ -14,7 +14,7 @@ type awsIamAccountSummary struct {
 	AccessKeysPerUserQuota            int32
 	AccountAccessKeysPresent          int32
 	AccountMFAEnabled                 bool
-	AccountPasswordPresent            int32
+	AccountPasswordPresent            bool
 	AccountSigningCertificatesPresent int32
 	AssumeRolePolicySizeQuota         int32
 	AttachedPoliciesPerGroupQuota     int32
@@ -75,8 +75,8 @@ func tableAwsIamAccountSummary(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "account_password_present",
-				Description: "Specifies the number of account passwords present.",
-				Type:        proto.ColumnType_INT,
+				Description: "Specifies whether the root password is set for the account.",
+				Type:        proto.ColumnType_BOOL,
 			},
 			{
 				Name:        "account_signing_certificates_present",
@@ -251,7 +251,7 @@ func listAccountSummary(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		AccessKeysPerUserQuota:            summaryMap["AccessKeysPerUserQuota"],
 		AccountAccessKeysPresent:          summaryMap["AccountAccessKeysPresent"],
 		AccountMFAEnabled:                 summaryMap["AccountMFAEnabled"] == int32(1),
-		AccountPasswordPresent:            summaryMap["AccountPasswordPresent"],
+		AccountPasswordPresent:            summaryMap["AccountPasswordPresent"] == int32(1),
 		AccountSigningCertificatesPresent: summaryMap["AccountSigningCertificatesPresent"],
 		AssumeRolePolicySizeQuota:         summaryMap["AssumeRolePolicySizeQuota"],
 		AttachedPoliciesPerGroupQuota:     summaryMap["AttachedPoliciesPerGroupQuota"],


### PR DESCRIPTION
This PR adds the column `account_password_present` to the `aws_iam_account_summary` table. This column indicates if the root password for the account has been set or not.

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```sql
select sp_connection_name AS account, account_password_present from aws_iam_account_summary
```

```plaintext
+------------------+--------------------------+
| account          | account_password_present |
+------------------+--------------------------+
| test_aws_account | true                     |
+------------------+--------------------------+
```
</details>
