### PR TITLE
Fixed the error CertificateNotFound: Certificate rds-ca-2019 not found when querying RDS Instances Closes #2362

### DIFF
--- a/aws/table_aws_rds_db_instance.go
+++ b/aws/table_aws_rds_db_instance.go
@@ -46,6 +46,11 @@ func tableAwsRDSDBInstance(_ context.Context) *plugin.Table {
 			{
 				Func: getRDSDBInstanceCertificate,
 				Tags: map[string]string{"service": "rds", "action": "DescribeCertificates"},
+				// Certificate "rds-ca-2019" not found due to discontinuation, Amazon RDS and Amazon Aurora Expire in 2024.
+				// AWS announcement ref: https://aws.amazon.com/blogs/aws/rotate-your-ssl-tls-certificates-now-amazon-rds-and-amazon-aurora-expire-in-2024/
+				IgnoreConfig: &plugin.IgnoreConfig{
+					ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"CertificateNotFound"}),
+				},
 			},
 			{
 				Func: getRDSDBInstanceProcessorFeatures,


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select db_instance_identifier, ca_certificate_identifier, certificate from aws_rds_db_instance
+------------------------+---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| db_instance_identifier | ca_certificate_identifier | certificate                                                                                                                                                                                                           >
+------------------------+---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| database-1-instance-1  | rds-ca-rsa2048-g1         | {"CertificateArn":"arn:aws:rds:us-east-2::cert:rds-ca-rsa2048-g1","CertificateIdentifier":"rds-ca-rsa2048-g1","CertificateType":"CA","CustomerOverride":false,"CustomerOverrideValidTill":null,"Thumbprint":"8cf85e3e2>
+------------------------+---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
```
</details>
