### PR TITLE
Add parent hydrate support for the  table aws_ecr_image_scan_finding to manage the complex join queries Closes #2367

### DIFF
--- a/aws/table_aws_ecr_image_scan_finding.go
+++ b/aws/table_aws_ecr_image_scan_finding.go
@@ -201,7 +201,7 @@ func listAwsEcrImageScanFindings(ctx context.Context, d *plugin.QueryData, h *pl
 		if err != nil {
 			var ae smithy.APIError
 			if errors.As(err, &ae) {
-				if ae.ErrorCode() == "ScanNotFoundException" {
+				if ae.ErrorCode() == "ScanNotFoundException" || ae.ErrorCode() == "RepositoryNotFoundException" || ae.ErrorCode() == "ImageNotFoundException" {
 					return nil, nil
 				}
 			}
@@ -281,6 +281,12 @@ func listAwsEcrImageTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hyd
 
 		output, err := paginator.NextPage(ctx)
 		if err != nil {
+			var ae smithy.APIError
+			if errors.As(err, &ae) {
+				if ae.ErrorCode() == "RepositoryNotFoundException" {
+					return nil, nil
+				}
+			}
 			plugin.Logger(ctx).Error("aws_ecr_image.listAwsEcrImageTags", "api_error", err)
 			return nil, err
 		}


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
  f.repository_name,
  f.image_tag,
  f.name,
  f.severity,
  jsonb_pretty(f.attributes) as attributes
from
  (
    select
      repository_name,
      jsonb_array_elements_text(image_tags) as image_tag
    from
      aws_ecr_image as i
  )
  images
  left outer join
    aws_ecr_image_scan_finding as f
    on images.repository_name = f.repository_name
    and images.image_tag = f.image_tag;
+-----------------+-----------+----------------+---------------+-----------------------------------------------------------------+
| repository_name | image_tag | name           | severity      | attributes                                                      |
+-----------------+-----------+----------------+---------------+-----------------------------------------------------------------+
| test            | latest    | CVE-2023-29383 | LOW           | [                                                               |
|                 |           |                |               |     {                                                           |
|                 |           |                |               |         "Key": "CVSS3_SCORE",                                   |
|                 |           |                |               |         "Value": "3.3"                                          |
|                 |           |                |               |     },                                                          |
|                 |           |                |               |     {                                                           |
|                 |           |                |               |         "Key": "package_version",                               |
|                 |           |                |               |         "Value": "1:4.8.1-1ubuntu5.20.04.5"                     |
|                 |           |                |               |     },                                                          |
|                 |           |                |               |     {                                                           |
|                 |           |                |               |         "Key": "package_name",                                  |
|                 |           |                |               |         "Value": "shadow"                                       |
|                 |           |                |               |     },                                                          |
|                 |           |                |               |     {                                                           |
|                 |           |                |               |         "Key": "CVSS3_VECTOR",                                  |
|                 |           |                |               |         "Value": "CVSS:3.1/AV:L/AC:L/PR:L/UI:N/S:U/C:N/I:L/A:N" |
|                 |           |                |               |     }                                                           |
|                 |           |                |               | ]                                                               |
| test            | latest    | CVE-2017-11164 | INFORMATIONAL | [                                                               |
|                 |           |                |               |     {                                                           |

```
</details>
