### PR TITLE
feat: add tags to most Glue tables

### DIFF
--- a/aws/table_aws_glue_connection.go
+++ b/aws/table_aws_glue_connection.go
@@ -100,6 +100,12 @@ func tableAwsGlueConnection(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Name"),
 			},
 			{
+				Name:        "tags",
+				Description: resourceInterfaceDescription("tags"),
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getTagsForGlueConnection,
+			},
+			{
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
@@ -213,6 +219,11 @@ func getGlueConnection(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydra
 		return nil, err
 	}
 	return *data.Connection, nil
+}
+
+func getTagsForGlueConnection(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	arn, _ := getGlueConnectionArn(ctx, d, h)
+	return getTagsForGlueResource(ctx, d, arn.(string))
 }
 
 func getGlueConnectionArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/aws/table_aws_glue_crawler.go
+++ b/aws/table_aws_glue_crawler.go
@@ -158,6 +158,12 @@ func tableAwsGlueCrawler(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Name"),
 			},
 			{
+				Name:        "tags",
+				Description: resourceInterfaceDescription("tags"),
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getTagsForGlueCrawler,
+			},
+			{
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
@@ -260,6 +266,11 @@ func getGlueCrawler(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateD
 	}
 
 	return *data.Crawler, nil
+}
+
+func getTagsForGlueCrawler(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	arn, _ := getGlueCrawlerArn(ctx, d, h)
+	return getTagsForGlueResource(ctx, d, arn.(string))
 }
 
 func getGlueCrawlerArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/aws/table_aws_glue_dev_endpoint.go
+++ b/aws/table_aws_glue_dev_endpoint.go
@@ -170,6 +170,12 @@ func tableAwsGlueDevEndpoint(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("EndpointName"),
 			},
 			{
+				Name:        "tags",
+				Description: resourceInterfaceDescription("tags"),
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getTagsForGlueDevEndpoint,
+			},
+			{
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
@@ -274,6 +280,11 @@ func getGlueDevEndpoint(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 		return nil, err
 	}
 	return *data.DevEndpoint, nil
+}
+
+func getTagsForGlueDevEndpoint(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	arn, _ := getGlueDevEndpointArn(ctx, d, h)
+	return getTagsForGlueResource(ctx, d, arn.(string))
 }
 
 func getGlueDevEndpointArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/aws/table_aws_glue_job.go
+++ b/aws/table_aws_glue_job.go
@@ -176,6 +176,12 @@ func tableAwsGlueJob(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Name"),
 			},
 			{
+				Name:        "tags",
+				Description: resourceInterfaceDescription("tags"),
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getTagsForGlueJob,
+			},
+			{
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
@@ -307,6 +313,11 @@ func getGlueJobBookmark(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 		return nil, err
 	}
 	return data.JobBookmarkEntry, nil
+}
+
+func getTagsForGlueJob(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	arn, _ := getGlueJobArn(ctx, d, h)
+	return getTagsForGlueResource(ctx, d, arn.(string))
 }
 
 func getGlueJobArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/aws/table_aws_glue_security_configuration.go
+++ b/aws/table_aws_glue_security_configuration.go
@@ -71,6 +71,12 @@ func tableAwsGlueSecurityConfiguration(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Name"),
 			},
 			{
+				Name:        "tags",
+				Description: resourceInterfaceDescription("tags"),
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getTagsForGlueSecurityConfiguration,
+			},
+			{
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
@@ -162,6 +168,11 @@ func getGlueSecurityConfiguration(ctx context.Context, d *plugin.QueryData, _ *p
 		return nil, err
 	}
 	return *data.SecurityConfiguration, nil
+}
+
+func getTagsForGlueSecurityConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	arn, _ := getGlueSecurityConfigurationArn(ctx, d, h)
+	return getTagsForGlueResource(ctx, d, arn.(string))
 }
 
 func getGlueSecurityConfigurationArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {

--- a/aws/table_aws_glue_security_configuration.go
+++ b/aws/table_aws_glue_security_configuration.go
@@ -71,12 +71,6 @@ func tableAwsGlueSecurityConfiguration(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Name"),
 			},
 			{
-				Name:        "tags",
-				Description: resourceInterfaceDescription("tags"),
-				Type:        proto.ColumnType_JSON,
-				Hydrate:     getTagsForGlueSecurityConfiguration,
-			},
-			{
 				Name:        "akas",
 				Description: resourceInterfaceDescription("akas"),
 				Type:        proto.ColumnType_JSON,
@@ -168,11 +162,6 @@ func getGlueSecurityConfiguration(ctx context.Context, d *plugin.QueryData, _ *p
 		return nil, err
 	}
 	return *data.SecurityConfiguration, nil
-}
-
-func getTagsForGlueSecurityConfiguration(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	arn, _ := getGlueSecurityConfigurationArn(ctx, d, h)
-	return getTagsForGlueResource(ctx, d, arn.(string))
 }
 
 func getGlueSecurityConfigurationArn(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
> SELECT
  name,
  akas,
  tags
FROM
  aws_glue_catalog_database
+----------------------------+-----------------------------------------------------------------------------+-------------------+
| name                       | akas                                                                        | tags              |
+----------------------------+-----------------------------------------------------------------------------+-------------------+
| default                    | ["arn:aws:glue:eu-west-3:012345678901:database/default"]                    | {}                |
| ec2_marketplace_offers     | ["arn:aws:glue:eu-west-3:012345678901:database/ec2_marketplace_offers"]     | {}                |
| 3cr-data                   | ["arn:aws:glue:eu-west-3:012345678901:database/3cr-data"]                   | {"test":"pdecat"} |
| proxy_metrics_lab          | ["arn:aws:glue:eu-west-3:012345678901:database/proxy_metrics_lab"]          | {}                |
| aws_usage_queries_database | ["arn:aws:glue:eu-west-3:012345678901:database/aws_usage_queries_database"] | {}                |
| carbon_emissions           | ["arn:aws:glue:eu-west-3:012345678901:database/carbon_emissions"]           | {}                |
| aws_backup_reporting       | ["arn:aws:glue:eu-west-3:012345678901:database/aws_backup_reporting"]       | {}                |
| default                    | ["arn:aws:glue:eu-west-1:012345678901:database/default"]                    | {}                |
| 3cr-data                   | ["arn:aws:glue:eu-west-1:012345678901:database/3cr-data"]                   | {}                |
+----------------------------+-----------------------------------------------------------------------------+-------------------+
```

```
> SELECT
  name,
  akas,
  tags
FROM
  aws_glue_connection
+-------------+----------------------------------------------------------------+-------------------+
| name        | akas                                                           | tags              |
+-------------+----------------------------------------------------------------+-------------------+
| test-pdecat | ["arn:aws:glue:eu-west-3:012345678901:connection/test-pdecat"] | {"test":"pdecat"} |
+-------------+----------------------------------------------------------------+-------------------+
```

```
> SELECT
  name,
  akas,
  tags
FROM
  aws_glue_crawler
+---------------------------+---------------------------------------------------------------------------+-------------------+
| name                      | akas                                                                      | tags              |
+---------------------------+---------------------------------------------------------------------------+-------------------+
| test-pdecat               | ["arn:aws:glue:eu-west-3:012345678901:crawler/test-pdecat"]               | {"test":"pdecat"} |
| 3cr-data-crawler          | ["arn:aws:glue:eu-west-1:012345678901:crawler/3cr-data-crawler"]          | {}                |
| ec2_marketplace_ri_offers | ["arn:aws:glue:eu-west-3:012345678901:crawler/ec2_marketplace_ri_offers"] | {}                |
+---------------------------+---------------------------------------------------------------------------+-------------------+
```

```
> SELECT
  akas,
  tags
FROM
  aws_glue_job where region = 'eu-west-3'
+----------------------------------------------------------------+-------------------+
| akas                                                           | tags              |
+----------------------------------------------------------------+-------------------+
| ["arn:aws:glue:eu-west-3:706303552994:job/3cr-data-transform"] | {"test":"pdecat"} |
+----------------------------------------------------------------+-------------------+

```
</details>
