### PR TITLE
Resolved `InvalidParameterException` in `aws_ecs_service` table when listing tags for older services. Closes #2388

### DIFF
--- a/aws/table_aws_ecs_service.go
+++ b/aws/table_aws_ecs_service.go
@@ -2,12 +2,13 @@ package aws
 
 import (
 	"context"
-	"strings"
+	"errors"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/smithy-go"
 
 	ecsv1 "github.com/aws/aws-sdk-go/service/ecs"
 
@@ -222,11 +223,6 @@ func tableAwsEcsService(_ context.Context) *plugin.Table {
 	}
 }
 
-type ServiceInfo struct {
-	ClusterName *string
-	types.Service
-}
-
 //// LIST FUNCTION
 
 func listEcsServices(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -237,6 +233,7 @@ func listEcsServices(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 		return nil, err
 	}
 
+	// Get cluster details
 	cluster := h.Item.(types.Cluster)
 
 	// Limiting the results
@@ -300,7 +297,7 @@ func listEcsServices(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrate
 
 	for result := range serviceCh {
 		for _, service := range result.Services {
-			d.StreamListItem(ctx, ServiceInfo{cluster.ClusterName, service})
+			d.StreamListItem(ctx, service)
 
 			// Context may get cancelled due to manual cancellation or if the limit has been reached
 			if d.RowsRemaining(ctx) == 0 {
@@ -337,38 +334,10 @@ func getEcsService(serviceData string, clusterARN *string, svc *ecs.Client, ctx 
 
 // List api call is not returning the tags for the service, so we need to make a separate api call for getting the tag details
 func getEcsServiceTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	data := h.Item.(ServiceInfo)
+	data := h.Item.(types.Service)
 
 	if data.ServiceArn == nil {
 		return nil, nil
-	}
-
-	resourceArn := *data.ServiceArn
-
-	// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids
-	// We can have two arn format for the ESC Service:
-	// 1. arn:aws:ecs:<region>:<account_id>:service/<cluster_name>/<service_name> (Newer format)
-	// 2. arn:aws:ecs:<region>:<account_id>:service/<service_name> (Older format)
-	// While making the API with older service arn we are encountering the error:
-	// ERROR: rpc error: code = Unknown desc = my_aws_account: table 'aws_ecs_service' column 'tags' requires hydrate data from getEcsServiceTags,
-	// which failed with error operation error ECS: ListTagsForResource, https response error StatusCode: 400,
-	// RequestID: 076ed52f-8f0e-43b9-af89-3728995bb52b, InvalidParameterException: Long arn format must be used for tagging operations.
-	resourceArnSplitPart := strings.Split(resourceArn, "/")
-	if len(resourceArnSplitPart) < 3 {
-		// The List Clusters API does not return the cluster name. Therefore, for clusters using the older ARN format, we make a Get API call to retrieve the cluster name.
-		// We need the cluster name to make the List tag API call for service.
-		// From Cluster ARN(arn:aws:ecs:region:aws_account_id:container-instance/container-instance-id) we can not extract the cluster name as it doesn't contain it.
-		h.Item = types.Cluster{ClusterArn: data.ClusterArn}
-		res, err := getEcsCluster(ctx, d, h)
-		if err != nil {
-			plugin.Logger(ctx).Error("aws_ecs_service.getEcsServiceTags.getEcsCluster", "api_error", err)
-			return nil, err
-		}
-
-		cluster := res.(types.Cluster)
-		data.ClusterName = cluster.ClusterName
-
-		resourceArn = resourceArnSplitPart[0] + "/" + *data.ClusterName + "/" + *data.ServiceName
 	}
 
 	// Create Session
@@ -379,11 +348,25 @@ func getEcsServiceTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	}
 
 	params := &ecs.ListTagsForResourceInput{
-		ResourceArn: &resourceArn,
+		ResourceArn: data.ServiceArn,
 	}
 
 	response, err := svc.ListTagsForResource(ctx, params)
 	if err != nil {
+		// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids
+		// We can have two arn format for the ESC Service:
+		// 1. arn:aws:ecs:<region>:<account_id>:service/<cluster_name>/<service_name> (Newer format)
+		// 2. arn:aws:ecs:<region>:<account_id>:service/<service_name> (Older format)
+		// While making the API with older service arn we are encountering the error:
+		// ERROR: rpc error: code = Unknown desc = my_aws_account: table 'aws_ecs_service' column 'tags' requires hydrate data from getEcsServiceTags,
+		// which failed with error operation error ECS: ListTagsForResource, https response error StatusCode: 400,
+		// RequestID: 076ed52f-8f0e-43b9-af89-3728995bb52b, InvalidParameterException: Long arn format must be used for tagging operations.
+		var ae smithy.APIError
+		if errors.As(err, &ae) {
+			if ae.ErrorCode() == "InvalidParameterException" {
+				return nil, nil
+			}
+		}
 		plugin.Logger(ctx).Error("aws_ecs_service.getEcsServiceTags", "api_error", err)
 		return nil, err
 	}

--- a/aws/table_aws_ecs_service.go
+++ b/aws/table_aws_ecs_service.go
@@ -357,6 +357,7 @@ func getEcsServiceTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 	if len(resourceArnSplitPart) < 3 {
 		// The List Clusters API does not return the cluster name. Therefore, for clusters using the older ARN format, we make a Get API call to retrieve the cluster name.
 		// We need the cluster name to make the List tag API call for service.
+		// From Cluster ARN(arn:aws:ecs:region:aws_account_id:container-instance/container-instance-id) we can not extract the cluster name as it doesn't contain it.
 		h.Item = types.Cluster{ClusterArn: data.ClusterArn}
 		res, err := getEcsCluster(ctx, d, h)
 		if err != nil {

--- a/aws/table_aws_ecs_service.go
+++ b/aws/table_aws_ecs_service.go
@@ -2,11 +2,13 @@ package aws
 
 import (
 	"context"
+	"errors"
 	"sync"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecs"
 	"github.com/aws/aws-sdk-go-v2/service/ecs/types"
+	"github.com/aws/smithy-go"
 
 	ecsv1 "github.com/aws/aws-sdk-go/service/ecs"
 
@@ -351,6 +353,20 @@ func getEcsServiceTags(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 
 	response, err := svc.ListTagsForResource(ctx, params)
 	if err != nil {
+		// https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-account-settings.html#ecs-resource-ids
+		// We can have two arn format for the ESC Service:
+		// 1. arn:aws:ecs:<region>:<account_id>:service/<cluster_name>/<service_name> (Newer format)
+		// 2. arn:aws:ecs:<region>:<account_id>:service/<service_name> (Older format)
+		// While making the API with older service arn we are encountering the error:
+		// ERROR: rpc error: code = Unknown desc = my_aws_account: table 'aws_ecs_service' column 'tags' requires hydrate data from getEcsServiceTags, 
+		// which failed with error operation error ECS: ListTagsForResource, https response error StatusCode: 400, 
+		// RequestID: 076ed52f-8f0e-43b9-af89-3728995bb52b, InvalidParameterException: Long arn format must be used for tagging operations.
+		var ae smithy.APIError
+		if errors.As(err, &ae) {
+			if ae.ErrorCode() == "InvalidParameterException" {
+				return nil, nil
+			}
+		}
 		plugin.Logger(ctx).Error("aws_ecs_service.getEcsServiceTags", "api_error", err)
 		return nil, err
 	}


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select service_name, tags_src, tags from aws_ecs_service;
+-----------------+-------------------------------------------------------------+-----------------------------+
| service_name    | tags_src                                                    | tags                        |
+-----------------+-------------------------------------------------------------+-----------------------------+
| test-53-service | [{"Key":"help","Value":"me"},{"Key":"foo1","Value":"bar1"}] | {"foo1":"bar1","help":"me"} |
+-----------------+-------------------------------------------------------------+-----------------------------+
```
</details>
