### PR TITLE
Fix query sample on `aws_cloudtrail_lookup_event` table documentation page

### DIFF
--- a/docs/tables/aws_cloudtrail_lookup_event.md
+++ b/docs/tables/aws_cloudtrail_lookup_event.md
@@ -107,7 +107,7 @@ select
 from
   aws_cloudtrail_lookup_event
 where
-  and event_source = 'iam.amazonaws.com'
+  event_source = 'iam.amazonaws.com'
   and event_time >= now() - interval '1 hour';
 ```
 
@@ -120,6 +120,6 @@ select
 from
   aws_cloudtrail_lookup_event
 where
-  and event_source = 'iam.amazonaws.com'
+  event_source = 'iam.amazonaws.com'
   and event_time >= datetime('now', '-1 hour');
 ```

--- a/docs/tables/aws_cloudtrail_lookup_event.md
+++ b/docs/tables/aws_cloudtrail_lookup_event.md
@@ -12,6 +12,7 @@ AWS CloudTrail Lookup Events is a feature within AWS CloudTrail, a service that 
 The `aws_cloudtrail_lookup_event` table in Steampipe provides you with information about each trail event within AWS CloudTrail. This table allows you, as a DevOps engineer, to query event-specific details, including event time, event name, resources involved, and more. You can utilize this table to gather insights on trail events, such as event source, user identity, and request parameters. The schema outlines the various attributes of the CloudTrail event for you, including the event ID, event version, read only, and associated tags.
 
 **Important notes:**
+
 - For improved performance, it is advised that you use the optional qual `start_time` and `end_time` to limit the result set to a specific time period.
 - This table supports optional quals. Queries with optional quals are optimised to use CloudWatch filters. Optional quals are supported for the following columns:
   - `read_only`
@@ -28,6 +29,7 @@ The `aws_cloudtrail_lookup_event` table in Steampipe provides you with informati
 ## Examples
 
 ### List events that occurred over the last five minutes
+
 This query is useful for gaining insights into recent activity within your AWS environment. It provides a quick overview of the events that have taken place in the last five minutes, which can be particularly useful for immediate incident response or real-time monitoring.
 
 ```sql+postgres
@@ -59,6 +61,7 @@ where
 ```
 
 ### List all action events, i.e., not ReadOnly that occurred over the last hour
+
 Explore which action events have occurred in the last hour on AWS Cloudtrail. This is useful for identifying recent activities that have potentially altered your system.
 
 ```sql+postgres
@@ -96,6 +99,7 @@ order by
 ```
 
 ### List events for a specific service (IAM) that occurred over the last hour
+
 This query allows users to monitor recent activity for a specific service, in this case, AWS's Identity and Access Management (IAM). It is particularly useful for security audits, as it provides a chronological overview of events, including who initiated them and what actions were taken, over the last hour.
 
 ```sql+postgres


### PR DESCRIPTION
There was an error in a sample query on `aws_cloudtrail_lookup_event` [documentation page](https://hub.steampipe.io/plugins/turbot/aws/tables/aws_cloudtrail_lookup_event):

<img width="390" alt="image" src="https://github.com/user-attachments/assets/ee9f6be8-5856-48ca-9cf1-d38897571834" />

This PR fix that