### PR TITLE
Fix VPC Elastic IP ARNs in aws_vpc_eip table

### DIFF
--- a/aws/table_aws_vpc_eip.go
+++ b/aws/table_aws_vpc_eip.go
@@ -246,7 +246,7 @@ func getVpcEipARN(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDat
 	}
 
 	// Get resource ARN
-	arn := "arn:" + commonColumnData.Partition + ":ec2:" + region + ":" + commonColumnData.AccountId + ":eip/" + *eip.AllocationId
+	arn := "arn:" + commonColumnData.Partition + ":ec2:" + region + ":" + commonColumnData.AccountId + ":elastic-ip/" + *eip.AllocationId
 
 	return arn, nil
 }


### PR DESCRIPTION
Correct format is `arn:${Partition}:ec2:${Region}:${Account}:elastic-ip/${AllocationId}` (so `elastic-ip` instead of `eip`). 

Can be verified using [policy_sentry](https://policy-sentry.readthedocs.io/en/latest/querying/arn-table/): 
```
$ policy_sentry query arn-table --service ec2 --fmt json --list-arn-types
=> 
{
    "elastic-ip": "arn:${Partition}:ec2:${Region}:${Account}:elastic-ip/${AllocationId}",
    ...
}
```

This format with `elastic-ip` is also the one appearing for the resource in the CUR.