### PR TITLE
Fixed aws_wafregional_rule table uses regional columns instead of global table columns Closes #2428

### DIFF
--- a/aws/table_aws_wafregional_rule.go
+++ b/aws/table_aws_wafregional_rule.go
@@ -44,7 +44,7 @@ func tableAwsWAFRegionalRule(_ context.Context) *plugin.Table {
 				Tags: map[string]string{"service": "waf-regional", "action": "GetRule"},
 			},
 		},
-		Columns: awsGlobalRegionColumns([]*plugin.Column{
+		Columns: awsRegionalColumns([]*plugin.Column{
 			{
 				Name:        "name",
 				Description: "The friendly name or description for the Rule.",


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

Earlier:
```
> select name, region from aws_wafregional_rule;
+-----------------+--------+
| name            | region |
+-----------------+--------+
| turbottest64128 | global |
+-----------------+--------+
```

Now:
```
> select name, region from aws_wafregional_rule;
+-----------------+-----------+
| name            | region    |
+-----------------+-----------+
| turbottest64128 | us-east-1 |
| test2           | us-east-2 |
+-----------------+-----------+

```

</details>
