### PR TITLE
feat(table): add aws_elasticache_update_action

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -288,6 +288,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_elasticache_replication_group":                            tableAwsElastiCacheReplicationGroup(ctx),
 			"aws_elasticache_reserved_cache_node":                          tableAwsElastiCacheReservedCacheNode(ctx),
 			"aws_elasticache_subnet_group":                                 tableAwsElastiCacheSubnetGroup(ctx),
+			"aws_elasticache_update_action":                                tableAwsElasticacheUpdateAction(ctx),
 			"aws_elasticsearch_domain":                                     tableAwsElasticsearchDomain(ctx),
 			"aws_emr_block_public_access_configuration":                    tableAwsEmrBlockPublicAccessConfiguration(ctx),
 			"aws_emr_cluster":                                              tableAwsEmrCluster(ctx),

--- a/aws/table_aws_elasticache_cluster.go
+++ b/aws/table_aws_elasticache_cluster.go
@@ -396,9 +396,14 @@ func getElastiCacheClusterUpdateActions(ctx context.Context, d *plugin.QueryData
 		plugin.Logger(ctx).Error("aws_elasticache_cluster.getElastiCacheClusterUpdateActions", "connection_error", err)
 		return nil, err
 	}
-	paginator := elasticache.NewDescribeUpdateActionsPaginator(client, &elasticache.DescribeUpdateActionsInput{
-		CacheClusterIds: []string{*cluster.CacheClusterId},
-	})
+	input := &elasticache.DescribeUpdateActionsInput{}
+	if cluster.CacheClusterId != nil {
+		input.CacheClusterIds = []string{*cluster.CacheClusterId}
+	}
+	if cluster.ReplicationGroupId != nil {
+		input.ReplicationGroupIds = []string{*cluster.ReplicationGroupId}
+	}
+	paginator := elasticache.NewDescribeUpdateActionsPaginator(client, input)
 	var rs []types.UpdateAction
 	for paginator.HasMorePages() {
 		output, err := paginator.NextPage(ctx)

--- a/aws/table_aws_elasticache_update_action.go
+++ b/aws/table_aws_elasticache_update_action.go
@@ -1,0 +1,142 @@
+package aws
+
+import (
+	"context"
+	"github.com/aws/aws-sdk-go-v2/service/elasticache"
+	elasticachev1 "github.com/aws/aws-sdk-go/service/elasticache"
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+)
+
+func tableAwsElasticacheUpdateAction(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_elasticache_update_action",
+		Description: "AWS ElastiCache Update Action",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AnyColumn([]string{"cache_cluster_id", "replication_group_id"}),
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"CacheClusterNotFound", "InvalidParameterValue"}),
+			},
+			Hydrate: listElastiCacheUpdateActions,
+			Tags:    map[string]string{"service": "elasticache", "action": "DescribeCacheClusters"},
+		},
+		List: &plugin.ListConfig{
+			Hydrate: listElastiCacheUpdateActions,
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(elasticachev1.EndpointsID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "cache_cluster_id",
+				Description: "The ID of the cache cluster.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "replication_group_id",
+				Description: "The ID of the replication group.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "engine",
+				Description: "The ElastiCache engine (Redis or Memcached).",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "estimated_update_time",
+				Description: "The estimated length of time for the update to complete.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "nodes_updated",
+				Description: "The progress of the service update on the replication group.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "service_update_name",
+				Description: "The unique ID of the service update.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "service_update_recommended_apply_by_date",
+				Description: "Recommended date to apply the update for compliance.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "service_update_release_date",
+				Description: "The date the update was first available.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "service_update_severity",
+				Description: "Severity level of the service update.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "service_update_status",
+				Description: "Current status of the service update.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "service_update_type",
+				Description: "Type of service update (security update, etc).",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "sla_met",
+				Description: "Indicates if nodes were updated by recommended date.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "update_action_available_date",
+				Description: "Date the update became available to the replication group.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "update_action_status",
+				Description: "Current status of the update action.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "update_action_status_modified_date",
+				Description: "Last modification date of the update action status.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+		}),
+	}
+}
+
+// 核心数据获取逻辑
+func listElastiCacheUpdateActions(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	client, err := ElastiCacheClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_elasticache_update_action.listElastiCacheUpdateActions", "client_error", err)
+		return nil, err
+	}
+	input := &elasticache.DescribeUpdateActionsInput{}
+	if v, ok := d.EqualsQuals["cache_cluster_id"]; ok {
+		input.CacheClusterIds = []string{v.GetStringValue()}
+	}
+	if v, ok := d.EqualsQuals["replication_group_id"]; ok {
+		input.ReplicationGroupIds = []string{v.GetStringValue()}
+	}
+
+	paginator := elasticache.NewDescribeUpdateActionsPaginator(client, input)
+	for paginator.HasMorePages() {
+		// apply rate limiting
+		d.WaitForListRateLimit(ctx)
+
+		page, err := paginator.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_elasticache_update_action.listElastiCacheUpdateActions", "api_error", err)
+			return nil, err
+		}
+
+		for _, action := range page.UpdateActions {
+			d.StreamListItem(ctx, action)
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}

--- a/docs/tables/aws_elasticache_update_action.md
+++ b/docs/tables/aws_elasticache_update_action.md
@@ -1,0 +1,37 @@
+---
+title: "Steampipe Table: aws_elasticache_update_action - Query Amazon ElastiCache Update Actions using SQL"
+description: "Allows users to query Amazon ElastiCache Update Actions, providing information about service updates for ElastiCache clusters and nodes within the AWS account."
+---
+
+# Table: aws_elasticache_update_action - Query Amazon ElastiCache Update Actions using SQL
+
+The Amazon ElastiCache Update Action is a feature of AWS's ElastiCache service that allows users to manage and schedule updates for their ElastiCache clusters and nodes. This resource is designed to ensure that your caching infrastructure remains secure, performant, and compliant with the latest updates and patches.
+
+## Table Usage Guide
+
+The `aws_elasticache_update_action` table in Steampipe provides you with information about service updates for ElastiCache clusters and nodes within your AWS account. This table enables you, as a DevOps engineer, database administrator, or IT professional, to query update-specific details, including the status of updates, recommended application dates, and more. You can utilize this table to gather insights on updates, such as their severity, type, and compliance requirements. The schema outlines the various attributes of the ElastiCache Update Action for you, including the update action ID, associated cache cluster and replication group IDs, and relevant dates.
+
+## Examples
+
+### List all pending ElastiCache update actions
+Retrieve a list of all service updates that are pending for your ElastiCache clusters and nodes. This is essential for ensuring that your caching infrastructure is up to date.
+
+```sql
+select
+  cache_cluster_id,
+  replication_group_id,
+  engine,
+  estimated_update_time,
+  nodes_updated,
+  service_update_name,
+  service_update_recommended_apply_by_date,
+  service_update_release_date,
+  service_update_severity,
+  service_update_status,
+  service_update_type,
+  sla_met,
+  update_action_available_date,
+  update_action_status,
+  update_action_status_modified_date
+from
+  aws_elasticache_update_action;

--- a/docs/tables/aws_elasticache_update_action.md
+++ b/docs/tables/aws_elasticache_update_action.md
@@ -35,3 +35,4 @@ select
   update_action_status_modified_date
 from
   aws_elasticache_update_action;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
 cache_cluster_id                         | replication_group_id            | engine    | estimated_update_time | nodes_updated | service_update_name                                  | service_update_recommended_apply_by_date | service_update_release_date | service_update_severi>
+------------------------------------------+---------------------------------+-----------+-----------------------+---------------+------------------------------------------------------+------------------------------------------+-----------------------------+---------------------->
| <null>                                   | xxxxxxxxxxxxxx                  | redis     | 30 minutes per node   | 0/2           | elasticache-patch-update-202501                      | 2025-02-05T18:59:59+08:00                | 2025-01-06T19:00:00+08:00   | important            >
| <null>                                   | xxxxxxxxxxxxxx                  | redis     | 30 minutes per node   | 0/3           | elasticache-patch-update-2-202501                    | 2025-02-10T17:59:59+08:00                | 2025-01-11T18:00:00+08:00   | important            >
| <null>                                   | xxxxxxxxxxxxxx                  | redis     | 30 minutes per node   | 0/2           | elasticache-patch-update-2-202501                    | 2025-02-10T17:59:59+08:00                | 2025-01-11T18:00:00+08:00   | important            >
| xxxxxxxxxxxxxx                           | <null>                          | redis     | 30 minutes per node   | 0/1           | elasticache-patch-update-202501                      | 2025-02-05T18:59:59+08:00                | 2025-01-06T19:00:00+08:00   | important            >
| <null>                                   | xxxxxxxxxxxxxx                  | redis     | 30 minutes per node   | 0/2           | elasticache-patch-update-2-202501                    | 2025-02-10T17:59:59+08:00                | 2025-01-11T18:00:00+08:00   | important            >
| <null>                                   | xxxxxxxxxxxxxx                  | redis     | 30 minutes per node   | 0/1           | elasticache-patch-update-2-202501                    | 2025-02-10T17:59:59+08:00                | 2025-01-11T18:00:00+08:00   | important            >
```
</details>
