### PR TITLE
Add tag retrieval example to `aws_ses_domain_identity table` documentation closes #2396

### DIFF
--- a/aws/table_aws_ses_domain_identity.go
+++ b/aws/table_aws_ses_domain_identity.go
@@ -81,6 +81,7 @@ func tableAwsSESDomainIdentity(_ context.Context) *plugin.Table {
 				Hydrate:     getSESIdentityNotificationAttributes,
 				Transform:   transform.FromValue(),
 			},
+
 			// Standard columns for all tables
 			{
 				Name:        "title",

--- a/aws/table_aws_ses_domain_identity.go
+++ b/aws/table_aws_ses_domain_identity.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 
+	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
 	"github.com/aws/aws-sdk-go-v2/service/ses"
 	"github.com/aws/aws-sdk-go-v2/service/ses/types"
 
@@ -79,6 +80,13 @@ func tableAwsSESDomainIdentity(_ context.Context) *plugin.Table {
 				Description: "Represents the notification attributes of an identity.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getSESIdentityNotificationAttributes,
+				Transform:   transform.FromValue(),
+			},
+			{
+				Name:        "tags",
+				Description: "A map of tags associated with the SES domain identity.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getSESDomainIdentityTags,
 				Transform:   transform.FromValue(),
 			},
 
@@ -223,4 +231,64 @@ func getSESDomainIdentityMailFromDomainAttributes(ctx context.Context, d *plugin
 	}
 
 	return nil, nil
+}
+
+func getSESDomainIdentityTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+
+	// Fetch the ARN using the hydrate function
+	arnData, err := getSESIdentityARN(ctx, d, h)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ses_domain_identity.getSESDomainIdentityTags", "arn_fetch_error", err)
+		return nil, err
+	}
+	arn, ok := arnData.(string)
+	if !ok || arn == "" {
+		plugin.Logger(ctx).Warn("aws_ses_domain_identity.getSESDomainIdentityTags", "missing_arn", "ARN could not be determined for SES identity")
+		return nil, nil
+	}
+
+	// Create AWS Resource Tagging Client
+	svc, err := ResourceTaggingClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ses_domain_identity.getSESDomainIdentityTags", "connection_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region
+		return nil, nil
+	}
+
+	// Get tags using AWS Resource Groups Tagging API
+	input := &resourcegroupstaggingapi.GetResourcesInput{
+		ResourceARNList: []string{arn},
+	}
+
+	result, err := svc.GetResources(ctx, input)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ses_domain_identity.getSESDomainIdentityTags", "api_error", err)
+		return nil, err
+	}
+
+	// If no tags are found, return nil (which will be converted to NULL in the query output)
+	if len(result.ResourceTagMappingList) == 0 {
+		return nil, nil
+	}
+
+	// Extract tags
+	tagMap := map[string]string{}
+	for _, resourceTag := range result.ResourceTagMappingList {
+		if *resourceTag.ResourceARN == arn {
+			for _, tag := range resourceTag.Tags {
+				tagMap[*tag.Key] = *tag.Value
+			}
+			break
+		}
+	}
+
+	// If the tagMap is empty, return nil instead of an empty map
+	if len(tagMap) == 0 {
+		return nil, nil
+	}
+
+	return tagMap, nil
 }

--- a/aws/utils.go
+++ b/aws/utils.go
@@ -14,9 +14,6 @@ import (
 	"unicode"
 	"unicode/utf8"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/config"
-	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
 	sagemakerTypes "github.com/aws/aws-sdk-go-v2/service/sagemaker/types"
 	"github.com/turbot/go-kit/helpers"
 	"github.com/turbot/go-kit/types"
@@ -276,26 +273,4 @@ func readEnvVarToInt(name string, defaultVal int) int {
 		}
 	}
 	return val
-}
-
-func ResourceTaggingClient(ctx context.Context, d *plugin.QueryData) (*resourcegroupstaggingapi.Client, error) {
-	// Get AWS session
-	sess, err := getSession(ctx, d)
-	if err != nil {
-		return nil, err
-	}
-
-	// Create AWS Resource Tagging client
-	return resourcegroupstaggingapi.NewFromConfig(*sess), nil
-}
-
-// getSession initializes an AWS SDK v2 session using Steampipe's connection config.
-func getSession(ctx context.Context, d *plugin.QueryData) (*aws.Config, error) {
-	// Load the AWS configuration with default credentials and region handling
-	cfg, err := config.LoadDefaultConfig(ctx)
-	if err != nil {
-		plugin.Logger(ctx).Error("getSession", "config_error", err)
-		return nil, err
-	}
-	return &cfg, nil
 }

--- a/docs/tables/aws_ses_domain_identity.md
+++ b/docs/tables/aws_ses_domain_identity.md
@@ -60,3 +60,28 @@ from
 where
   verification_status = 'Failed';
 ```
+
+### Retrieve tags for SES domain identities
+Identify the tags associated with domain identities in Amazon SES. This query retrieves domain identity details along with their assigned tags, enabling better resource management and organization.
+
+```sql+postgres
+select 
+  i.arn,
+  i.identity,
+  r.tags_src,
+  r.tags
+from 
+  aws_ses_domain_identity as i
+  join aws_tagging_resource as r on r.arn = i.arn;
+```
+
+```sql+sqlite
+select 
+  i.arn,
+  i.identity,
+  r.tags_src,
+  r.tags
+from 
+  aws_ses_domain_identity as i
+  join aws_tagging_resource as r on r.arn = i.arn;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
select tags, title, region, _ctx from aws_ses_domain_identity
+-------------------+------------+-----------+-----------------------------------------------------------------------+
| tags              | title      | region    | _ctx                                                                  |
+-------------------+------------+-----------+-----------------------------------------------------------------------+
| {"test":"delete"} | abc.com | us-east-1 | {"connection_name":"test","steampipe":{"sdk_version":"5.10.4"}} |
+-------------------+------------+-----------+-----------------------------------------------------------------------+
> .cache clear
> .cache off
> select tags, title, region, _ctx from aws_ses_domain_identity
+--------+------------+-----------+-----------------------------------------------------------------------+
| tags   | title      | region    | _ctx                                                                  |
+--------+------------+-----------+-----------------------------------------------------------------------+
| <null> | abc.com | us-east-1 | {"connection_name":"test","steampipe":{"sdk_version":"5.10.4"}} |
+--------+------------+-----------+-----------------------------------------------------------------------+
```
</details>
