### PR TITLE
Fix nil pointer dereference when fetching certificate details for RDS Custom instance Closes #2435

### DIFF
--- a/aws/table_aws_rds_db_instance.go
+++ b/aws/table_aws_rds_db_instance.go
@@ -600,7 +600,7 @@ func getRDSDBInstancePendingMaintenanceAction(ctx context.Context, d *plugin.Que
 }
 
 func getRDSDBInstanceCertificate(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	caCertificateIdentifier := *h.Item.(types.DBInstance).CACertificateIdentifier
+	instance := h.Item.(types.DBInstance)
 
 	// Create service
 	svc, err := RDSClient(ctx, d)
@@ -610,7 +610,7 @@ func getRDSDBInstanceCertificate(ctx context.Context, d *plugin.QueryData, h *pl
 	}
 
 	params := &rds.DescribeCertificatesInput{
-		CertificateIdentifier: aws.String(caCertificateIdentifier),
+		CertificateIdentifier: instance.CACertificateIdentifier,
 	}
 
 	op, err := svc.DescribeCertificates(ctx, params)


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select db_instance_identifier, ca_certificate_identifier, certificate from aws_rds_db_instance;
+------------------------+---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| db_instance_identifier | ca_certificate_identifier | certificate                                                                                                                                                                                                           >
+------------------------+---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| database-1             | rds-ca-rsa2048-g1         | {"CertificateArn":"arn:aws:rds:us-east-1::cert:rds-ca-rsa2048-g1","CertificateIdentifier":"rds-ca-rsa2048-g1","CertificateType":"CA","CustomerOverride":false,"CustomerOverrideValidTill":null,"Thumbprint":"2fa77ef89>
| my-rds-custom-instance | <null>                    | {"CertificateArn":"arn:aws:rds:us-east-1::cert:rds-ca-ecc384-g1","CertificateIdentifier":"rds-ca-ecc384-g1","CertificateType":"CA","CustomerOverride":false,"CustomerOverrideValidTill":null,"Thumbprint":"24a97b91cbe>
+------------------------+---------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
```
</details>
