### PR TITLE
Fix aws_health_* tables to correctly reference the Global endpoint instead of regional endpoint closes #2449

### DIFF
--- a/aws/service.go
+++ b/aws/service.go
@@ -861,7 +861,7 @@ func GuardDutyClient(ctx context.Context, d *plugin.QueryData) (*guardduty.Clien
 }
 
 func HealthClient(ctx context.Context, d *plugin.QueryData) (*health.Client, error) {
-	cfg, err := getClientForQueryRegion(ctx, d)
+	cfg, err := getClientForDefaultRegion(ctx, d)
 	if err != nil {
 		return nil, err
 	}

--- a/aws/table_aws_health_affected_entity.go
+++ b/aws/table_aws_health_affected_entity.go
@@ -7,8 +7,6 @@ import (
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
 
-	healthv1 "github.com/aws/aws-sdk-go/service/health"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/health"
 	"github.com/aws/aws-sdk-go-v2/service/health/types"
@@ -22,9 +20,6 @@ func tableAwsHealthAffectedEntity(_ context.Context) *plugin.Table {
 			ParentHydrate: listHealthEvents,
 			Hydrate:       listHealthAffectedEntities,
 			Tags:          map[string]string{"service": "health", "action": "DescribeAffectedEntities"},
-			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"SubscriptionRequiredException"}),
-			},
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "arn", Require: plugin.Optional},
 				{Name: "event_arn", Require: plugin.Optional},
@@ -33,7 +28,6 @@ func tableAwsHealthAffectedEntity(_ context.Context) *plugin.Table {
 				{Name: "last_updated_time", Require: plugin.Optional, Operators: []string{">", ">=", "<", "<=", "="}},
 			},
 		},
-		GetMatrixItemFunc: SupportedRegionMatrix(healthv1.EndpointsID),
 		Columns: awsGlobalRegionColumns([]*plugin.Column{
 			{
 				Name:        "arn",
@@ -150,7 +144,7 @@ func listHealthAffectedEntities(ctx context.Context, d *plugin.QueryData, h *plu
 	return nil, err
 }
 
-//// UTILITY FUNCTION
+// // UTILITY FUNCTION
 // Build health affected entity list call input filter
 func buildHealthAffectedEntityFilter(d *plugin.QueryData) *types.EntityFilter {
 	filter := &types.EntityFilter{}

--- a/aws/table_aws_health_event.go
+++ b/aws/table_aws_health_event.go
@@ -7,8 +7,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/health"
 	"github.com/aws/aws-sdk-go-v2/service/health/types"
 
-	healthv1 "github.com/aws/aws-sdk-go/service/health"
-
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
@@ -33,7 +31,6 @@ func tableAwsHealthEvent(_ context.Context) *plugin.Table {
 				{Name: "status_code", Require: plugin.Optional},
 			},
 		},
-		GetMatrixItemFunc: SupportedRegionMatrix(healthv1.EndpointsID),
 		Columns: awsGlobalRegionColumns([]*plugin.Column{
 			{
 				Name:        "arn",


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
