### PR TITLE
Inline policy for Identity Center Permission Sets

### DIFF
--- a/aws/table_aws_ssoadmin_permission_set.go
+++ b/aws/table_aws_ssoadmin_permission_set.go
@@ -91,6 +91,20 @@ func tableAwsSsoAdminPermissionSet(_ context.Context) *plugin.Table {
 				Hydrate:   getSsoAdminPermissionSetTags,
 				Transform: transform.FromValue(),
 			},
+			{
+				Name:        "inline_policy",
+				Description: "The policy document embedded inline for the permission set.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getSsoAdminPermissionSetInlinePolicy,
+				Transform:   transform.FromValue().Transform(transform.UnmarshalYAML),
+			},
+			{
+				Name:        "inline_policy_std",
+				Description: "Inline policy in canonical form for the permission set.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getSsoAdminPermissionSetInlinePolicy,
+				Transform:   transform.FromValue().Transform(unescape).Transform(policyToCanonical),
+			},
 
 			// Standard columns for all tables
 			{
@@ -252,6 +266,37 @@ func getSsoAdminPermissionSetTags(ctx context.Context, d *plugin.QueryData, h *p
 		plugin.Logger(ctx).Error("aws_ssoadmin_permission_set.getSsoAdminPermissionSetTags", "api_error", err)
 	}
 	return tags, err
+}
+
+func getSsoAdminPermissionSetInlinePolicy(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	// Create session
+	svc, err := SSOAdminClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ssoadmin_permission_set.getSsoAdminPermissionSetInlinePolicy", "connection_error", err)
+
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region, return no data
+		return nil, nil
+	}
+
+	permissionSet := h.Item.(*PermissionSetItem)
+	permissionSetArn := *permissionSet.PermissionSetArn
+	instanceArn := *permissionSet.InstanceArn
+
+	params := &ssoadmin.GetInlinePolicyForPermissionSetInput{
+		InstanceArn:      aws.String(instanceArn),
+		PermissionSetArn: aws.String(permissionSetArn),
+	}
+
+	resp, err := svc.GetInlinePolicyForPermissionSet(ctx, params)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_ssoadmin_permission_set.getSsoAdminPermissionSetInlinePolicy", "api_error", err)
+		return nil, err
+	}
+
+	return resp.InlinePolicy, nil
 }
 
 func getSsoAdminResourceTags(ctx context.Context, d *plugin.QueryData, instanceArn, resourceArn string) (interface{}, error) {


### PR DESCRIPTION
This PR adds two columns, `inline_policy` and `inline_policy_std`, to the `aws_ssoadmin_permission_set` table using the [sso:GetInlinePolicyForPermissionSet](https://docs.aws.amazon.com/singlesignon/latest/APIReference/API_GetInlinePolicyForPermissionSet.html) API.

# Integration test logs
<details>
  <summary>Logs</summary>

```
N/A
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
select 
  arn, 
  inline_policy 
from aws_ssoadmin_permission_set

+-------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| arn                                                                     | inline_policy                                                                                                          |
+-------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+
| arn:aws:sso:::permissionSet/ssoins-123456/ps-123456                     | {"Statement":[{"Action":["ec2:*"], "Effect":"Allow","Resource":"*","Sid":"1"}],"Version":"2012-10-17"}                 |
+-------------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------+

```
</details>
