### PR TITLE
Option to filter tags by service or resource type in aws_tagging_resource table

### DIFF
--- a/docs/tables/aws_tagging_resource.md
+++ b/docs/tables/aws_tagging_resource.md
@@ -65,3 +65,203 @@ from
 where
   compliance_status is not null;
 ```
+
+### Filter Resources by Resource Types
+
+Filter results to retrieve only resources from specific AWS services or resource types. The `resource_types` column accepts a JSON array of strings in two formats:
+
+- `service` — All resources from a service (e.g., `"ec2"`)
+- `service:resourceType` — Specific resource type (e.g., `"ec2:instance"`)
+
+#### Examples
+
+**Get tags for EC2 instances only:**
+```sql+postgres
+select
+  name,
+  arn,
+  tags,
+  region
+from
+  aws_tagging_resource
+where
+  resource_types = '["ec2:instance"]';
+```
+
+```sql+sqlite
+select
+  name,
+  arn,
+  tags,
+  region
+from
+  aws_tagging_resource
+where
+  resource_types = '["ec2:instance"]';
+```
+
+**Get tags for multiple resource types:**
+```sql+postgres
+select
+  name,
+  arn,
+  tags,
+  region
+from
+  aws_tagging_resource
+where
+  resource_types = '["ec2:instance", "s3:bucket", "rds:db"]';
+```
+
+```sql+sqlite
+select
+  name,
+  arn,
+  tags,
+  region
+from
+  aws_tagging_resource
+where
+  resource_types = '["ec2:instance", "s3:bucket", "rds:db"]';
+```
+
+**Get tags for all resources in specific services:**
+```sql+postgres
+select
+  name,
+  arn,
+  tags,
+  region
+from
+  aws_tagging_resource
+where
+  resource_types = '["lambda", "dynamodb"]';
+```
+
+```sql+sqlite
+select
+  name,
+  arn,
+  tags,
+  region
+from
+  aws_tagging_resource
+where
+  resource_types = '["lambda", "dynamodb"]';
+```
+
+#### Common Resource Types
+
+| Category | Resource Types |
+|----------|----------------|
+| Compute | `["ec2:instance", "lambda:function", "ecs:cluster", "eks:cluster"]` |
+| Storage | `["s3:bucket", "ec2:volume", "elasticfilesystem:file-system"]` |
+| Database | `["rds:db", "rds:cluster", "dynamodb:table"]` |
+| Network | `["ec2:vpc", "ec2:subnet", "ec2:security-group", "elasticloadbalancing:loadbalancer"]` |
+| Security | `["iam:role", "iam:policy", "kms:key"]` |
+| Monitoring | `["logs:log-group", "cloudwatch:alarm", "cloudwatch:dashboard"]` |
+
+### API Behavior and Resource Type Discovery
+
+#### Automatic Batching
+
+The AWS Resource Groups Tagging API limits each request to 100 resource type filters. Steampipe handles this limitation transparently:
+
+1. **Automatic splitting**: Resource type lists exceeding 100 items are automatically split into batches
+2. **Sequential execution**: Each batch is processed as a separate API request
+3. **Result aggregation**: All results are combined and deduplicated by ARN
+4. **Seamless streaming**: Results are returned as a single, unified dataset
+
+This means you can query hundreds of resource types without manual batching:
+
+```sql+postgres
+-- This works seamlessly even though it exceeds the 100-item API limit
+select name, arn, tags
+from aws_tagging_resource
+where resource_types = '[
+  "ec2:instance", "ec2:volume", "ec2:snapshot", "ec2:image", "ec2:security-group",
+  "s3:bucket", "lambda:function", "rds:db", "rds:cluster", "dynamodb:table",
+  -- ... add as many as needed
+]';
+```
+
+```sql+sqlite
+-- This works seamlessly even though it exceeds the 100-item API limit
+select name, arn, tags
+from aws_tagging_resource
+where resource_types = '[
+  "ec2:instance", "ec2:volume", "ec2:snapshot", "ec2:image", "ec2:security-group",
+  "s3:bucket", "lambda:function", "rds:db", "rds:cluster", "dynamodb:table",
+  -- ... add as many as needed
+]';
+```
+
+#### Discovering Available Resource Types
+
+To find which resource types you can query, use these approaches:
+
+**1. Query AWS Resource Explorer for supported types:**
+```sql+postgres
+-- List all available resource types
+select
+  service,
+  resource_type,
+  service || ':' || resource_type as full_resource_type
+from
+  aws_resource_explorer_supported_resource_type
+order by
+  service, resource_type;
+```
+
+```sql+sqlite
+-- List all available resource types
+select
+  service,
+  resource_type,
+  service || ':' || resource_type as full_resource_type
+from
+  aws_resource_explorer_supported_resource_type
+order by
+  service, resource_type;
+```
+
+**2. Find resource types for a specific service:**
+```sql+postgres
+-- Example: Find all EC2 resource types
+select
+  service,
+  resource_type,
+  service || ':' || resource_type as full_resource_type
+from
+  aws_resource_explorer_supported_resource_type
+where
+  service = 'ec2'
+order by
+  resource_type;
+```
+
+```sql+sqlite
+-- Example: Find all EC2 resource types
+select
+  service,
+  resource_type,
+  service || ':' || resource_type as full_resource_type
+from
+  aws_resource_explorer_supported_resource_type
+where
+  service = 'ec2'
+order by
+  resource_type;
+```
+
+#### Important Notes
+
+- **JSON array format**: Resource types must always be specified as a JSON array, even for single values: `'["ec2:instance"]'`
+- **Service vs. resource type**: Use `"ec2"` to query all EC2 resources, or `"ec2:instance"` for specific types
+- **Case sensitivity**: Resource type filters are case-sensitive and must match AWS conventions
+- **Performance**: While batching is automatic, querying many resource types may take longer due to multiple API calls
+- **Regional data**: Results are returned for the region specified in your connection configuration
+
+For the complete list of supported services and resource types, refer to:
+- [AWS Resource Groups Tagging API supported services](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/supported-services.html)
+- The [`aws_resource_explorer_supported_resource_type`](https://hub.steampipe.io/plugins/turbot/aws/tables/aws_resource_explorer_supported_resource_type) table in your Steampipe instance


### PR DESCRIPTION
Adds the option to filter the `aws_tagging_resource` table by resource types, e.g. `ec2:instance,s3:bucket,auditmanager` for limiting the response to only Amazon EC2 instances, Amazon S3 buckets, or any AWS Audit Manager resource.

- [API docs for the resource type filters](https://docs.aws.amazon.com/resourcegroupstagging/latest/APIReference/API_GetResources.html#resourcegrouptagging-GetResources-request-ResourceTypeFilters)

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example queries
```sql
-- Filter for all tagged EC2 & RDS resources, plus S3 buckets
select arn from aws_tagging_resource where resource_types = '["ec2", "rds", "s3:bucket"]';
-- => Returns only tags for expected resources

-- FIlter for EC2 instances, RDS database instances and S3 buckets
select arn from aws_tagging_resource where resource_types = '["ec2:instance", "rds:db", "s3:bucket"]';
-- => Returns only tags for expected resources

-- Filter gets ignored when empty
select arn from aws_tagging_resource where resource_types = '[]';
-- => Returns tags for all tagged resources

-- Filter for all resource types supported
select count(*) from aws_tagging_resource where resource_types = '["access-analyzer","acm","acm-pca","airflow","amplify","apigateway","app-integrations","appconfig","appflow","appmesh","apprunner","appstream","appsync","aps","athena","auditmanager","backup","batch","ce","cloud9","cloudformation","cloudfront","cloudtrail","cloudwatch","codeartifact","codebuild","codecommit","codeconnections","codedeploy","codeguru-profiler","codeguru-reviewer","codepipeline","codestar-connections","cognito-identity","cognito-idp","comprehend","connect","databrew","dataexchange","datapipeline","datasync","dax","detective","devicefarm","dms","ds","dynamodb","ec2","ecr","ecr-public","ecs","eks","elasticache","elasticbeanstalk","elasticfilesystem","elasticloadbalancing","elasticmapreduce","emr-containers","emr-serverless","es","events","evidently","finspace","firehose","fis","forecast","frauddetector","fsx","gamelift","geo","glacier","globalaccelerator","glue","grafana","greengrass","groundstation","guardduty","healthlake","iam","imagebuilder","inspector","iot","iotanalytics","iotdeviceadvisor","iotevents","iotfleetwise","iotsitewise","iottwinmaker","iotwireless","ivs","ivschat","kafka","kendra","kinesis","kinesisanalytics","kinesisvideo","kms","lambda","lex","logs","lookoutmetrics","lookoutvision","m2","managedblockchain","mediapackage","mediapackage-vod","mediatailor","memorydb","mobiletargeting","mq","network-firewall","networkmanager","oam","omics","outposts","panorama","personalize","pipes","proton","qldb","quicksight","ram","rds","redshift","refactor-spaces","rekognition","resiliencehub","resource-explorer-2","resource-groups","route53","route53-recovery-control","route53-recovery-readiness","route53resolver","rum","s3","sagemaker","scheduler","schemas","secretsmanager","servicecatalog","servicediscovery","ses","signer","sns","sqs","ssm","states","storagegateway","synthetics","transfer","wisdom","workspaces","chatbot","config","organizations","payments","securityhub"]'
```
