### PR TITLE
feat: add column `description` to `aws_health_event` table

### DIFF
--- a/aws/table_aws_health_event.go
+++ b/aws/table_aws_health_event.go
@@ -44,6 +44,13 @@ func tableAwsHealthEvent(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Region"),
 			},
 			{
+				Name:        "description",
+				Description: "The description of the event.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getHealthEventDescription,
+				Transform:   transform.FromValue(),
+			},
+			{
 				Name:        "availability_zone",
 				Description: "The Amazon Web Services Availability Zone of the event.",
 				Type:        proto.ColumnType_STRING,
@@ -161,6 +168,29 @@ func listHealthEvents(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 	}
 
 	return nil, err
+}
+
+func getHealthEventDescription(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	event := h.Item.(types.Event)
+
+	// Create Session
+	svc, err := HealthClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_health_event.getHealthEventDescription", "client error", err)
+		return nil, err
+	}
+
+	eventDetails, err := svc.DescribeEventDetails(ctx, &health.DescribeEventDetailsInput{EventArns: []string{*event.Arn}})
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_health_event.getHealthEventDescription", "api error", err)
+		return nil, err
+	}
+
+	if len(eventDetails.SuccessfulSet) == 1 {
+		return eventDetails.SuccessfulSet[0].EventDescription.LatestDescription, nil
+	}
+
+	return nil, nil
 }
 
 // / UTILITY FUNCTION


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>
  
```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>
  
```
# steampipe query 'select description from aws_health_event limit 1'
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| Current severity level: Operating normally                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| [RESOLVED] Connectivity Issues                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| [01:51 AM PDT] 午後 4:40 から午後 5:43 (日本時間) の間、AP-NORTHEAST-1 リージョンの単一のアベイラビリティーゾーン (apne1-az4) において、一部の EC2 インスタンスへの接続の問題が発生しました。これは、影響を受けた EC2 インスタンスへの主電源と二次電源が遮断されたことが原因でした。この間、お客さまは、影響を受けたアベイラビリティゾーンで起動されたインスタンスや、影響を受けた EC2 インスタンスを使用する他の AWS API において、エラー率やレイテンシーの増加の影響を受けた可能性があります。エンジニアは数分以内に自動的に対応し、すぐに緩和策の調査を開始しました。この問題は再発しないことが期待されています。残りの少数のインスタンスは、停電による悪 影響を受けたハードウェアでホストされています。影響を受けたすべてのインスタンスとボリュームの復旧に引き続き取り組んでいきますが、即座に復旧を行うためには、可能であれば、影響が残存しているインスタンスまたはボリュー ムを交換することをお勧めします。事象は解決し、サービスは正常に動作しています。 | Between 12:40 AM and 1:43 AM PDT, we experienced connectivity issues to a subset of EC2 instanc |
| es in a single Availability Zone (apne1-az4) in the AP-NORTHEAST-1 Region. This was the result of an issue in which the primary and secondary power was interrupted to the affected EC2 instances. During this time, customers may also have experienced increased error rates and latencies for instances launched in the affected zone, along with other AWS APIs that use the affected EC2 instances. Engineers were automatically engaged within minutes and immediately began investigating mitigations. We do not expect this issue to recur. The small number of remaining instances are hosted on hardware which was adversely affected by the loss of power. While we will continue to work to recover all affected instances and volumes, for immediate recovery, we recommend replacing any remaining affected instances or volumes if possible. The issue has been resolved and the service is operating normally.                                                                                                                                   |
|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| [01:21 AM PDT] 回復の兆しが見られ始めていますが、AWSは完全な回復に向けて引き続き注視し、取り組んでいます。他の AWS サービスもこの問題の影響を受けており、これらも回復の兆しが見られております。30〜60分以内に次のアップデートをご提供します。 | We are seeing initial signs of recovery but continue to monitor and work toward full recovery. Other AWS services are also impacted by this issue, and are also observing recovery. We will provide another update within the next 30-60 minutes.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| [01:15 AM PDT] 現在、AP-NORTHEAST-1 リージョンの単一アベイラビリティーゾーン (apne1-az4) のインスタンスに影響している接続問題を調査しています。 | We are investigating connectivity issues affecting instances in a single Availability Zone (apne1-az4) in the AP-NORTHEAST-1 Region.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
|                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                  |
| The following AWS services were previously impacted but are now operating normally: CLOUDWATCH, CODECOMMIT, EC2SYSTEMSMANAGER, ECS, ELB, LAMBDA, LOCATIONSERVICE, NATGATEWAY, NETWORKFIREWALL, PRIVATELINK, RDS, REDSHIFT, S3, TRANSITGATEWAY, WORKSPACES.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       |
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
```
</details>
