### PR TITLE
Fix the column `tags` to populate the value correctly for the table `aws_transfer_server` Closes #2483

### DIFF
--- a/aws/table_aws_transfer_server.go
+++ b/aws/table_aws_transfer_server.go
@@ -145,13 +145,21 @@ func tableAwsTransferServer(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getTransferServer,
 			},
+			{
+				Name:        "tags_src",
+				Description: "A list of tags associated with the transfer server.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getTransferServer,
+				Transform:   transform.FromField("Tags"),
+			},
 
 			// Steampipe standard columns
 			{
 				Name:        "tags",
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
-				Transform:   transform.FromField("Tags"),
+				Hydrate:     getTransferServer,
+				Transform:   transform.From(transferServerTurbotTags),
 			},
 			{
 				Name:        "title",
@@ -258,4 +266,18 @@ func getTransferServer(ctx context.Context, d *plugin.QueryData, h *plugin.Hydra
 		return op.Server, nil
 	}
 	return nil, nil
+}
+
+//// TRANSFORM FUNCTIONS
+
+func transferServerTurbotTags(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	tags := d.HydrateItem.(*types.DescribedServer)
+	var turbotTagsMap map[string]string
+	if tags.Tags != nil {
+		turbotTagsMap = map[string]string{}
+		for _, i := range tags.Tags {
+			turbotTagsMap[*i.Key] = *i.Value
+		}
+	}
+	return turbotTagsMap, nil
 }


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select server_id, tags_src, tags from aws_transfer_server;
+---------------------+-------------------------------+---------------+
| server_id           | tags_src                      | tags          |
+---------------------+-------------------------------+---------------+
| s-d2195f72b96646f78 | [{"Key":"foo","Value":"bar"}] | {"foo":"bar"} |
+---------------------+-------------------------------+---------------+
```
</details>
