### PR TITLE
Fix boolean key qualifier values to be correctly passed as input para…

### DIFF
--- a/aws/utils.go
+++ b/aws/utils.go
@@ -165,9 +165,9 @@ func getQualsValueByColumn(equalQuals plugin.KeyColumnQualMap, columnName string
 		if dataType == "boolean" {
 			switch q.Operator {
 			case "<>":
-				value = "false"
+				value = !q.Value.GetBoolValue()
 			case "=":
-				value = "true"
+				value = q.Value.GetBoolValue()
 			}
 		}
 		if dataType == "int64" {


### PR DESCRIPTION
…meters Closes #2489

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
  volume_id,
  encrypted
from
  aws_ebs_volume
where
  not encrypted;
+-----------------------+-----------+
| volume_id             | encrypted |
+-----------------------+-----------+
| vol-08aa9104ea0e2b9c2 | false     |
| vol-0fa26bc6d1e19fa28 | false     |
| vol-0d500ab375b669433 | false     |
| vol-04edcb7a5b00b17f3 | false     |
| vol-009b450b64f881ad7 | false     |
+-----------------------+-----------+
```
</details>
