### PR TITLE
Optimize query timing for the table aws_ecr_image_scan_finding

### DIFF
--- a/aws/table_aws_ecr_image_scan_finding.go
+++ b/aws/table_aws_ecr_image_scan_finding.go
@@ -24,9 +24,8 @@ func tableAwsEcrImageScanFinding(_ context.Context) *plugin.Table {
 		Name:        "aws_ecr_image_scan_finding",
 		Description: "AWS ECR Image Scan Finding",
 		List: &plugin.ListConfig{
-			ParentHydrate: listAwsEcrImageTags,
-			Hydrate:       listAwsEcrImageScanFindings,
-			Tags:          map[string]string{"service": "ecr", "action": "DescribeImageScanFindings"},
+			Hydrate: listAwsEcrImageScanFindings,
+			Tags:    map[string]string{"service": "ecr", "action": "DescribeImageScanFindings"},
 			IgnoreConfig: &plugin.IgnoreConfig{
 				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"RepositoryNotFoundException", "ImageNotFoundException", "ScanNotFoundException"}),
 			},
@@ -36,8 +35,8 @@ func tableAwsEcrImageScanFinding(_ context.Context) *plugin.Table {
 			// image_digest as it's more common/friendly to use.
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "repository_name", Require: plugin.Required},
-				{Name: "image_tag", Require: plugin.Optional},
-				{Name: "image_digest", Require: plugin.Optional},
+				{Name: "image_tag", Require: plugin.AnyOf},
+				{Name: "image_digest", Require: plugin.AnyOf},
 			},
 		},
 		GetMatrixItemFunc: SupportedRegionMatrix(ecrv1.EndpointsID),
@@ -122,7 +121,6 @@ func tableAwsEcrImageScanFinding(_ context.Context) *plugin.Table {
 
 // // LIST FUNCTION
 func listAwsEcrImageScanFindings(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	repositoryTag := h.Item.(*RepositoryImage)
 
 	// Create Session
 	svc, err := ECRClient(ctx, d)
@@ -133,13 +131,6 @@ func listAwsEcrImageScanFindings(ctx context.Context, d *plugin.QueryData, h *pl
 	imageTag := d.EqualsQuals["image_tag"]
 	imageDigest := d.EqualsQuals["image_digest"]
 	repositoryName := d.EqualsQuals["repository_name"]
-
-	if imageTag != nil && imageTag.GetStringValue() != *repositoryTag.ImageTag {
-		return nil, nil
-	}
-	if repositoryName != nil && repositoryName.GetStringValue() != *repositoryTag.RepositoryName {
-		return nil, nil
-	}
 
 	// Limiting the results
 	maxLimit := int32(1000)
@@ -152,11 +143,11 @@ func listAwsEcrImageScanFindings(ctx context.Context, d *plugin.QueryData, h *pl
 
 	input := &ecr.DescribeImageScanFindingsInput{
 		MaxResults:     aws.Int32(maxLimit),
-		RepositoryName: repositoryTag.RepositoryName,
+		RepositoryName: aws.String(repositoryName.GetStringValue()),
 	}
 
 	imageInfo := &types.ImageIdentifier{
-		ImageTag: repositoryTag.ImageTag,
+		ImageTag: aws.String(imageTag.GetStringValue()),
 	}
 
 	// Ideally, both image_tag and image_digest could be used.
@@ -237,70 +228,4 @@ func listAwsEcrImageScanFindings(ctx context.Context, d *plugin.QueryData, h *pl
 	}
 
 	return nil, err
-}
-
-//// Parent Hydrate
-
-type RepositoryImage struct {
-	RepositoryName *string
-	ImageTag       *string
-}
-
-// To preserve the existing table behavior (fetching findings based on image tags), we have retained the parent function.
-// Making `image_tags` an optional or `anyof` qualifier alters the query plan for complex join queries, causing query execution errors.
-// This issue is detailed here: https://github.com/turbot/steampipe-plugin-aws/issues/2367
-func listAwsEcrImageTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-
-	repoName := d.EqualsQuals["repository_name"].GetStringValue()
-
-	// Limiting the results
-	maxLimit := int32(100)
-
-	// Create Session
-	svc, err := ECRClient(ctx, d)
-	if err != nil {
-		plugin.Logger(ctx).Error("aws_ecr_image.listAwsEcrImageTags", "connection_error", err)
-		return nil, err
-	}
-
-	// Build the params
-	params := &ecr.DescribeImagesInput{
-		RepositoryName: &repoName,
-		MaxResults:     aws.Int32(maxLimit),
-	}
-
-	paginator := ecr.NewDescribeImagesPaginator(svc, params, func(o *ecr.DescribeImagesPaginatorOptions) {
-		o.Limit = maxLimit
-		o.StopOnDuplicateToken = true
-	})
-
-	// List call
-	for paginator.HasMorePages() {
-		// apply rate limiting
-		d.WaitForListRateLimit(ctx)
-
-		output, err := paginator.NextPage(ctx)
-		if err != nil {
-			var ae smithy.APIError
-			if errors.As(err, &ae) {
-				if ae.ErrorCode() == "RepositoryNotFoundException" {
-					return nil, nil
-				}
-			}
-			plugin.Logger(ctx).Error("aws_ecr_image.listAwsEcrImageTags", "api_error", err)
-			return nil, err
-		}
-
-		for _, items := range output.ImageDetails {
-			for _, tags := range items.ImageTags {
-				imageDetails := &RepositoryImage{
-					RepositoryName: items.RepositoryName,
-					ImageTag:       &tags,
-				}
-				d.StreamListItem(ctx, imageDetails)
-			}
-		}
-	}
-
-	return nil, nil
 }

--- a/aws/table_aws_ecr_image_scan_finding.go
+++ b/aws/table_aws_ecr_image_scan_finding.go
@@ -35,8 +35,8 @@ func tableAwsEcrImageScanFinding(_ context.Context) *plugin.Table {
 			// image_digest as it's more common/friendly to use.
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "repository_name", Require: plugin.Required},
-				{Name: "image_tag", Require: plugin.AnyOf},
-				{Name: "image_digest", Require: plugin.AnyOf},
+				{Name: "image_tag", Require: plugin.Optional},
+				{Name: "image_digest", Require: plugin.Optional},
 			},
 		},
 		GetMatrixItemFunc: SupportedRegionMatrix(ecrv1.EndpointsID),
@@ -132,6 +132,10 @@ func listAwsEcrImageScanFindings(ctx context.Context, d *plugin.QueryData, h *pl
 	imageDigest := d.EqualsQuals["image_digest"]
 	repositoryName := d.EqualsQuals["repository_name"]
 
+	if imageTag == nil && imageDigest == nil {
+		return nil, errors.New("image_tag or image_digest must be provided")
+	}
+	
 	// Limiting the results
 	maxLimit := int32(1000)
 	if d.QueryContext.Limit != nil {


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select
    distinct REPLACE(
        REPLACE(innerq."AWS_ACCOUNT_NAME", 'aws_', ''),
        '_',
        '-'
    ) as "AWS_ACCOUNT_NAME",
    innerq.region as "AWS_REGION",
    innerq.repository_name as "AWS_REPO",
    innerq.image_tag as "ECR_IMAGE_TAG",
    innerq.name as "COMMON_VULN_ID",
    innerq.uri as "VULN_INFO_URL",
    innerq.severity as "VULN_SEVERITY",
    innerq.package_version as "VULN_PACKAGE_VERSION",
    innerq.package_name as "VULN_PACKAGE_NAME"
from
    (
        with latest_image_ts as (
            select
                repository_name,
                max(image_pushed_at) as image_pushed_at
            from
                myawsaccount.aws_ecr_image
            group by
                repository_name
        ),
        images_with_tags as (
            select
                _ctx,
                region,
                repository_name,
                image_pushed_at,
                jsonb_array_elements_text(image_tags) :: text as image_tag
            from
                myawsaccount.aws_ecr_image
        )
        select
            i._ctx ->> 'connection_name' as "AWS_ACCOUNT_NAME",
            i.region,
            i.repository_name,
            i.image_pushed_at,
            i.image_tag,
            f.name,
            f.uri,
            f.severity,
            f.description,
            (
                jsonb_path_query(f.attributes, '$[*] ? (@.Key == "package_name")') -> 'Value' #>>'{}')::text as package_name,
                (
                    jsonb_path_query(
                        f.attributes,
                        '$[*] ? (@.Key == "package_version")'
                    ) -> 'Value' #>>'{}')::text as package_version
                    from
                        images_with_tags i
                        join latest_image_ts l on (l.repository_name, l.image_pushed_at) = (i.repository_name, i.image_pushed_at)
                        join myawsaccount.aws_ecr_image_scan_finding f on (f.repository_name, f.image_tag) = (l.repository_name, i.image_tag)
                    order by
                        repository_name,
                        image_tag,
                        severity,
                        name,
                        package_name
                ) innerq;
                
+------------------+------------+---------------------+---------------+-----------------+--------------------------------------------------------------+---------------+--------------------------+-------------------+
| AWS_ACCOUNT_NAME | AWS_REGION | AWS_REPO            | ECR_IMAGE_TAG | COMMON_VULN_ID  | VULN_INFO_URL                                                | VULN_SEVERITY | VULN_PACKAGE_VERSION     | VULN_PACKAGE_NAME |
+------------------+------------+---------------------+---------------+-----------------+--------------------------------------------------------------+---------------+--------------------------+-------------------+
| aws              | ap-south-1 | steampipe-container | v1.0.1        | ALAS2-2025-2753 | https://alas.aws.amazon.com/AL2/ALAS-2025-2753.html          | MEDIUM        | 2:9.0.2153-1.amzn2.0.2   | vim-data          |
| aws              | ap-south-1 | steampipe-container | v1.0.1        | ALAS2-2025-2753 | https://alas.aws.amazon.com/AL2/ALAS-2025-2753.html          | MEDIUM        | 2:9.0.2153-1.amzn2.0.2   | vim-minimal       |
| aws              | ap-south-1 | steampipe-container | v1.0.1        | ALAS2-2025-2767 | https://alas.aws.amazon.com/AL2/ALAS-2025-2767.html          | HIGH          | 2.56.1-9.amzn2.0.8       | glib2             |
| aws              | ap-south-1 | steampipe-container | v1.0.1        | ALAS2-2025-2774 | https://alas.aws.amazon.com/AL2/ALAS-2025-2774.html          | MEDIUM        | 2.1.0-15.amzn2.0.4       | expat             |
| aws              | ap-south-1 | steampipe-container | v1.0.1        | ALAS2-2025-2780 | https://alas.aws.amazon.com/AL2/ALAS-2025-2780.html          | MEDIUM        | 1:1.0.2k-24.amzn2.0.14   | openssl-libs      |
| aws              | ap-south-1 | steampipe-container | v1.0.1        | ALAS2-2025-2783 | https://alas.aws.amazon.com/AL2/ALAS-2025-2783.html          | HIGH          | 2.9.1-6.amzn2.5.14       | libxml2           |
| aws              | ap-south-1 | test                | latest        | CVE-2013-4235   | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2013-4235  | LOW           | 1:4.8.1-1ubuntu5.20.04.5 | shadow            |
| aws              | ap-south-1 | test                | latest        | CVE-2016-20013  | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-20013 | INFORMATIONAL | 2.31-0ubuntu9.14         | glibc             |
| aws              | ap-south-1 | test                | latest        | CVE-2016-2781   | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2016-2781  | LOW           | 8.30-3ubuntu2            | coreutils         |
| aws              | ap-south-1 | test                | latest        | CVE-2017-11164  | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2017-11164 | INFORMATIONAL | 2:8.39-12ubuntu0.1       | pcre3             |
| aws              | ap-south-1 | test                | latest        | CVE-2022-3219   | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-3219  | LOW           | 2.2.19-3ubuntu2.2        | gnupg2            |
| aws              | ap-south-1 | test                | latest        | CVE-2022-41409  | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2022-41409 | LOW           | 10.34-7ubuntu0.1         | pcre2             |
| aws              | ap-south-1 | test                | latest        | CVE-2023-26604  | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2023-26604 | LOW           | 245.4-4ubuntu3.23        | systemd           |
| aws              | ap-south-1 | test                | latest        | CVE-2023-29383  | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2023-29383 | LOW           | 1:4.8.1-1ubuntu5.20.04.5 | shadow            |
| aws              | ap-south-1 | test                | latest        | CVE-2023-45918  | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2023-45918 | LOW           | 6.2-0ubuntu2.1           | ncurses           |
| aws              | ap-south-1 | test                | latest        | CVE-2023-50495  | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2023-50495 | LOW           | 6.2-0ubuntu2.1           | ncurses           |
| aws              | ap-south-1 | test                | latest        | CVE-2023-7008   | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2023-7008  | LOW           | 245.4-4ubuntu3.23        | systemd           |
| aws              | ap-south-1 | test                | latest        | CVE-2024-10041  | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2024-10041 | MEDIUM        | 1.3.1-5ubuntu4.7         | pam               |
| aws              | ap-south-1 | test                | latest        | CVE-2024-12133  | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2024-12133 | MEDIUM        | 4.16.0-2                 | libtasn1-6        |
| aws              | ap-south-1 | test                | latest        | CVE-2024-12243  | http://people.ubuntu.com/~ubuntu-security/cve/CVE-2024-12243 | MEDIUM        | 3.6.13-2ubuntu1.10       | gnutls28          |
```
</details>
