### PR TITLE
Add column ephemeral_storage to aws_lambda_function table closes #2504

### DIFF
--- a/aws/table_aws_lambda_function.go
+++ b/aws/table_aws_lambda_function.go
@@ -221,6 +221,12 @@ func tableAwsLambdaFunction(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("Configuration.FileSystemConfigs", "FileSystemConfigs"),
 			},
 			{
+				Name:        "ephemeral_storage",
+				Description: "The size of the function's /tmp directory in MB. The default value is 512, but can be any whole number between 512 and 10,240 MB.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Configuration.EphemeralStorage", "EphemeralStorage"),
+			},
+			{
 				Name:        "policy",
 				Description: "The resource-based iam policy of Lambda function.",
 				Type:        proto.ColumnType_JSON,


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
 select title, ephemeral_storage from aws_lambda_function
+-----------------------------------------------------------+-------------------+
| title                                                     | ephemeral_storage |
+-----------------------------------------------------------+-------------------+
| SecurityLake_Glue_Partition_Updater_Lambda_us-west-2      | {"Size":512}      |
| testfn                                                    | {"Size":512}      |
| test-node-lambda                                          | {"Size":512}      |
| aws-quicksetup-lifecycle-LA-l07up                         | {"Size":512}      |
| SampleLambda-test-lambda-log                              | {"Size":512}      |
```
</details>
