### PR TITLE
Use 'UnmarshalJSON' transform instead of 'UnmarshalYAML' for the 'policy' column to avoid conversion failures. Closes #2528

### DIFF
--- a/aws/table_aws_iam_policy.go
+++ b/aws/table_aws_iam_policy.go
@@ -118,7 +118,7 @@ func tableAwsIamPolicy(_ context.Context) *plugin.Table {
 				Description: "Contains the details about the policy.",
 				Type:        proto.ColumnType_JSON,
 				Hydrate:     getPolicyVersion,
-				Transform:   transform.FromField("PolicyVersion.Document").Transform(transform.UnmarshalYAML),
+				Transform:   transform.FromField("PolicyVersion.Document").Transform(transform.UnmarshalJSON),
 			},
 			{
 				Name:        "policy_std",

--- a/go.mod
+++ b/go.mod
@@ -146,7 +146,7 @@ require (
 	github.com/hashicorp/go-hclog v1.6.3
 	github.com/rs/dnscache v0.0.0-20230804202142-fc85eb664529
 	github.com/turbot/go-kit v1.1.0
-	github.com/turbot/steampipe-plugin-sdk/v5 v5.11.7
+	github.com/turbot/steampipe-plugin-sdk/v5 v5.12.0
 	golang.org/x/sync v0.12.0
 	golang.org/x/text v0.23.0
 )

--- a/go.sum
+++ b/go.sum
@@ -423,8 +423,6 @@ github.com/aws/aws-sdk-go-v2/service/redshift v1.43.5 h1:qiwrbGdDKuD0OD2hxNezyiu
 github.com/aws/aws-sdk-go-v2/service/redshift v1.43.5/go.mod h1:8ldsMsikORLj0GZUozSvbQdctrumAPYhizmj/3AAATI=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.17.4 h1:aCgDTg7NalOIbcz26fFRsz7JtxDUvBHm5/YBT/5J2S8=
 github.com/aws/aws-sdk-go-v2/service/redshiftserverless v1.17.4/go.mod h1:XIPGtb7MKsA/uAfS9pngCspt+NfjDxlIAg1hSwvtQQs=
-github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.10.5 h1:jZRmSjW91mFQ6BNUu9wTZ41ZBtEwWH7HNCGLjus2uos=
-github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.10.5/go.mod h1:tZurYgz9ed3t1LNo2QL6cRTWYoYVOf4wPniYaY3Y5sc=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.17.4 h1:c+JJu+m/FoXVVaRj82+ef+cpMI4VMZbg92M2bg014Vs=
 github.com/aws/aws-sdk-go-v2/service/resourceexplorer2 v1.17.4/go.mod h1:E9gRM9YBkYKE1AjYGcQRjYUyEIB52+cSMihMQBjB/FE=
 github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.21.4 h1:c1jtPWZSmgMmPkCgwv67GE0ugdEgnLVo/BHR1wl3Dm0=
@@ -871,8 +869,8 @@ github.com/tkrajina/go-reflector v0.5.6 h1:hKQ0gyocG7vgMD2M3dRlYN6WBBOmdoOzJ6njQ
 github.com/tkrajina/go-reflector v0.5.6/go.mod h1:ECbqLgccecY5kPmPmXg1MrHW585yMcDkVl6IvJe64T4=
 github.com/turbot/go-kit v1.1.0 h1:2gW+MFDJD+mN41GcvhAajTrwR8HgN9KKJ8HnYwPGTV0=
 github.com/turbot/go-kit v1.1.0/go.mod h1:1xmRuQ0cn/10QUMNLNOAFIqN8P6Rz5s3VLT8mkN3nF8=
-github.com/turbot/steampipe-plugin-sdk/v5 v5.11.7 h1:imNeaO3aJ/1aBu80cBPiikYIAApql/HuXrAjZdy4nGk=
-github.com/turbot/steampipe-plugin-sdk/v5 v5.11.7/go.mod h1:kkkm+Xb7r+WwKsn8tGVAaLtS6cPzqCpNK060N1xUmMQ=
+github.com/turbot/steampipe-plugin-sdk/v5 v5.12.0 h1:e04aCz+YWwvu0yVXy9x5jBxYe8/CAHnw1b9AShQ0/Mk=
+github.com/turbot/steampipe-plugin-sdk/v5 v5.12.0/go.mod h1:kkkm+Xb7r+WwKsn8tGVAaLtS6cPzqCpNK060N1xUmMQ=
 github.com/ulikunitz/xz v0.5.10 h1:t92gobL9l3HE202wg3rlk19F6X+JOxl9BBrCCMYEYd8=
 github.com/ulikunitz/xz v0.5.10/go.mod h1:nbz6k7qbPmH4IRqmfOplQw/tblSgqTqBwxkY0oWt/14=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
The data received is already JSON, so no point using UnmarhalYAML, which again converts it to JSON and then unmarshals it. In the `yamlToJSON` conversion, we sometimes get errors when the encoded string contains non-printable characters.

Using UnmarshalJSON fixes the issue.

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
