### PR TITLE
feat: add a few more rate limiters

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -73,6 +73,58 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 				Scope:      []string{"connection", "region", "service", "action"},
 				Where:      "service = 'servicequotas' and action = 'ListTagsForResource'",
 			},
+			// Not documented
+			// https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/cloudfront-limits.html
+			{
+				Name:           "aws_cloudfront",
+				MaxConcurrency: 10,
+				FillRate:       5,
+				BucketSize:     10,
+				Scope:          []string{"connection", "service"},
+				Where:          "service = 'cloudfront'",
+			},
+			// For the Amazon Kinesis Streams APIs, five requests per second per account or stream (not available as a scope).
+			// https://docs.aws.amazon.com/streams/latest/dev/service-sizes-and-limits.html#kds-api-limits
+			{
+				Name:           "aws_kinesis",
+				MaxConcurrency: 10,
+				FillRate:       5,
+				BucketSize:     10,
+				Scope:          []string{"connection", "service", "action"},
+				Where:          "service = 'kinesis' and action in ('ListStreamConsumers', 'ListStreams', 'ListTagsForStream')",
+			},
+			// For the Amazon Route 53 APIs five requests per second per AWS account.
+			// https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/DNSLimitations.html#limits-api-requests
+			{
+				Name:           "aws_route53",
+				MaxConcurrency: 10,
+				FillRate:       5,
+				BucketSize:     10,
+				Scope:          []string{"connection", "service"},
+				Where:          "service = 'route53'",
+			},
+			// AWS WAF Classic has the following fixed quotas on calls per account per Region
+			// Maximum number of calls to any individual List action, if no other quota is defined for it: 5 requests per second
+			// https://docs.aws.amazon.com/waf/latest/developerguide/classic-limits.html
+			{
+				Name:           "aws_waf",
+				MaxConcurrency: 10,
+				FillRate:       5,
+				BucketSize:     10,
+				Scope:          []string{"connection", "region", "service"},
+				Where:          "service = 'waf'",
+			},
+			// AWS WAF has the following fixed quotas on calls per account per Region
+			// Maximum number of calls to any individual Get or List action, if no other quota is defined for it: Five requests per second
+			// https://docs.aws.amazon.com/waf/latest/developerguide/limits.html
+			{
+				Name:           "aws_wafv2",
+				MaxConcurrency: 10,
+				FillRate:       5,
+				BucketSize:     10,
+				Scope:          []string{"connection", "region", "service"},
+				Where:          "service = 'wafv2'",
+			},
 		},
 		TableMap: map[string]*plugin.Table{
 			"aws_accessanalyzer_analyzer":                                  tableAwsAccessAnalyzer(ctx),


### PR DESCRIPTION
This PR adds a few more rate limiters for the AWS CloudFront, Kinesis, Route53, WAF Classic and WAF v2 services.