### PR TITLE
Add ignore error config to aws_rds_db_instance and aws_rds_pending_maintenance_action tables fixes #2543

### DIFF
--- a/aws/table_aws_rds_db_instance.go
+++ b/aws/table_aws_rds_db_instance.go
@@ -21,7 +21,7 @@ func tableAwsRDSDBInstance(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("db_instance_identifier"),
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"DBInstanceNotFound", "InvalidParameterValue"}),
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"DBInstanceNotFound"}),
 			},
 			Hydrate: getRDSDBInstance,
 			Tags:    map[string]string{"service": "rds", "action": "DescribeDBInstances"},

--- a/aws/table_aws_rds_db_instance.go
+++ b/aws/table_aws_rds_db_instance.go
@@ -21,7 +21,7 @@ func tableAwsRDSDBInstance(_ context.Context) *plugin.Table {
 		Get: &plugin.GetConfig{
 			KeyColumns: plugin.SingleColumn("db_instance_identifier"),
 			IgnoreConfig: &plugin.IgnoreConfig{
-				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"DBInstanceNotFound"}),
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"DBInstanceNotFound", "InvalidParameterValue"}),
 			},
 			Hydrate: getRDSDBInstance,
 			Tags:    map[string]string{"service": "rds", "action": "DescribeDBInstances"},

--- a/aws/table_aws_rds_pending_maintenance_action.go
+++ b/aws/table_aws_rds_pending_maintenance_action.go
@@ -25,6 +25,9 @@ func tableAwsRDSPendingMaintenanceAction(_ context.Context) *plugin.Table {
 					Require: plugin.Optional,
 				},
 			},
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"DBInstanceNotFound", "InvalidParameterValue"}),
+			},
 		},
 		GetMatrixItemFunc: SupportedRegionMatrix(AWS_RDS_SERVICE_ID),
 		Columns: awsRegionalColumns([]*plugin.Column{


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Before the fix:

> select
  a.db_instance_identifier,
  b.action,
  a.status,
  b.opt_in_status,
  b.forced_apply_date,
  b.current_apply_date,
  b.auto_applied_after_date
from
  aws_rds_db_instance as a
  join aws_rds_pending_maintenance_action as b on b.resource_identifier = a.arn;

Error: aws_a: operation error RDS: DescribePendingMaintenanceActions, https response error StatusCode: 400, RequestID: b6c9c600-35e3-4969-9340-8a20782ef111, api error InvalidParameterValue: The parameter Filter: resource-id is not a valid identifier. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens.
	aws_b: operation error RDS: DescribePendingMaintenanceActions, https response error StatusCode: 400, RequestID: e6d6e682-b692-496b-994a-9bb04b016111, api error InvalidParameterValue: The parameter Filter: resource-id is not a valid identifier. Identifiers must begin with a letter; must contain only ASCII letters, digits, and hyphens; and must not end with a hyphen or contain two consecutive hyphens. (SQLSTATE HV000)

+------------------------+---------------+-----------+---------------+-------------------+--------------------+-------------------------+
| db_instance_identifier | action        | status    | opt_in_status | forced_apply_date | current_apply_date | auto_applied_after_date |
+------------------------+---------------+-----------+---------------+-------------------+--------------------+-------------------------+
| test           | system-update | available | <null>        | <null>            | <null>             | <null>                  |
+------------------------+---------------+-----------+---------------+-------------------+--------------------+-------------------------+

After the fix:

> select
  a.db_instance_identifier,
  b.action,
  a.status,
  b.opt_in_status,
  b.forced_apply_date,
  b.current_apply_date,
  b.auto_applied_after_date
from
  aws_rds_db_instance as a
  join aws_rds_pending_maintenance_action as b on b.resource_identifier = a.arn;
+------------------------+---------------+-----------+---------------+-------------------+--------------------+-------------------------+
| db_instance_identifier | action        | status    | opt_in_status | forced_apply_date | current_apply_date | auto_applied_after_date |
+------------------------+---------------+-----------+---------------+-------------------+--------------------+-------------------------+
| test-a          | system-update | available | <null>        | <null>            | <null>             | <null>                  |
| test-b             | system-update | available | <null>        | <null>            | <null>             | <null>                  |
| test-c            | system-update | available | <null>        | <null>            | <null>             | <null>                  |
| test-d         | system-update | available | <null>        | <null>            | <null>             | <null>                  |
| test-e         | system-update | available | <null>        | <null>            | <null>             | <null>                  |
+------------------------+---------------+-----------+---------------+-------------------+--------------------+-------------------------+
```
</details>
