### PR TITLE
Added support to the table aws_cloudformation_stack to fetch the stack with DELETE_COMPLETE state Closes #2542

### DIFF
--- a/aws/table_aws_cloudformation_stack.go
+++ b/aws/table_aws_cloudformation_stack.go
@@ -38,7 +38,7 @@ func tableAwsCloudFormationStack(_ context.Context) *plugin.Table {
 			Tags:    map[string]string{"service": "cloudformation", "action": "DescribeStacks"},
 			KeyColumns: []*plugin.KeyColumn{
 				{
-					Name:    "name",
+					Name:    "status",
 					Require: plugin.Optional,
 				},
 			},
@@ -47,10 +47,16 @@ func tableAwsCloudFormationStack(_ context.Context) *plugin.Table {
 			{
 				Func: getStackTemplate,
 				Tags: map[string]string{"service": "cloudformation", "action": "GetTemplate"},
+				IgnoreConfig: &plugin.IgnoreConfig{
+					ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ValidationError"}),
+				},
 			},
 			{
 				Func: describeStackResources,
 				Tags: map[string]string{"service": "cloudformation", "action": "DescribeStackResources"},
+				IgnoreConfig: &plugin.IgnoreConfig{
+					ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ValidationError"}),
+				},
 			},
 		},
 		GetMatrixItemFunc: SupportedRegionMatrix(AWS_CLOUDFORMATION_SERVICE_ID),
@@ -77,16 +83,19 @@ func tableAwsCloudFormationStack(_ context.Context) *plugin.Table {
 				Name:        "stack_status_reason",
 				Description: "Success/failure message associated with the stack status.",
 				Type:        proto.ColumnType_STRING,
+				Hydrate:     getCloudFormationStack,
 			},
 			{
 				Name:        "change_set_id",
 				Description: "The unique ID of the change set.",
 				Type:        proto.ColumnType_STRING,
+				Hydrate:     getCloudFormationStack,
 			},
 			{
 				Name:        "detailed_status",
 				Description: "The detailed status of the resource or stack.",
 				Type:        proto.ColumnType_STRING,
+				Hydrate:     getCloudFormationStack,
 			},
 			{
 				Name:        "creation_time",
@@ -102,16 +111,19 @@ func tableAwsCloudFormationStack(_ context.Context) *plugin.Table {
 				Name:        "retain_except_on_create",
 				Description: "When set to true , newly created resources are deleted when the operation rolls back.",
 				Type:        proto.ColumnType_BOOL,
+				Hydrate:     getCloudFormationStack,
 			},
 			{
 				Name:        "disable_rollback",
 				Description: "Boolean to enable or disable rollback on stack creation failures.",
 				Type:        proto.ColumnType_BOOL,
+				Hydrate:     getCloudFormationStack,
 			},
 			{
 				Name:        "enable_termination_protection",
 				Description: "Specifies whether termination protection is enabled for the stack.",
 				Type:        proto.ColumnType_BOOL,
+				Hydrate:     getCloudFormationStack,
 			},
 			{
 				Name:        "last_updated_time",
@@ -127,6 +139,7 @@ func tableAwsCloudFormationStack(_ context.Context) *plugin.Table {
 				Name:        "role_arn",
 				Description: "The Amazon Resource Name (ARN) of an AWS Identity and Access Management (IAM) role that is associated with the stack.",
 				Type:        proto.ColumnType_STRING,
+				Hydrate:     getCloudFormationStack,
 				Transform:   transform.FromField("RoleARN"),
 			},
 			{
@@ -138,32 +151,38 @@ func tableAwsCloudFormationStack(_ context.Context) *plugin.Table {
 				Name:        "description",
 				Description: "A user-defined description associated with the stack.",
 				Type:        proto.ColumnType_STRING,
+				Hydrate:     getCloudFormationStack,
 			},
 			{
 				Name:        "timeout_in_minutes",
 				Description: "The amount of time within which stack creation should complete.",
 				Type:        proto.ColumnType_INT,
+				Hydrate:     getCloudFormationStack,
 			},
 			{
 				Name:        "notification_arns",
 				Description: "SNS topic ARNs to which stack related events are published.",
 				Type:        proto.ColumnType_JSON,
+				Hydrate:     getCloudFormationStack,
 				Transform:   transform.FromField("NotificationARNs"),
 			},
 			{
 				Name:        "outputs",
 				Description: "A list of output structures.",
 				Type:        proto.ColumnType_JSON,
+				Hydrate:     getCloudFormationStack,
 			},
 			{
 				Name:        "rollback_configuration",
 				Description: "The rollback triggers for AWS CloudFormation to monitor during stack creation and updating operations, and for the specified monitoring period afterwards.",
 				Type:        proto.ColumnType_JSON,
+				Hydrate:     getCloudFormationStack,
 			},
 			{
 				Name:        "capabilities",
 				Description: "The capabilities allowed in the stack.",
 				Type:        proto.ColumnType_JSON,
+				Hydrate:     getCloudFormationStack,
 			},
 			{
 				Name:        "stack_drift_status",
@@ -175,6 +194,7 @@ func tableAwsCloudFormationStack(_ context.Context) *plugin.Table {
 				Name:        "parameters",
 				Description: "A list of Parameter structures.",
 				Type:        proto.ColumnType_JSON,
+				Hydrate:     getCloudFormationStack,
 			},
 			{
 				Name:        "template_body",
@@ -201,6 +221,7 @@ func tableAwsCloudFormationStack(_ context.Context) *plugin.Table {
 				Name:        "tags_src",
 				Description: "A list of tags associated with stack.",
 				Type:        proto.ColumnType_JSON,
+				Hydrate:     getCloudFormationStack,
 				Transform:   transform.FromField("Tags"),
 			},
 
@@ -209,6 +230,7 @@ func tableAwsCloudFormationStack(_ context.Context) *plugin.Table {
 				Name:        "tags",
 				Description: resourceInterfaceDescription("tags"),
 				Type:        proto.ColumnType_JSON,
+				Hydrate:     getCloudFormationStack,
 				Transform:   transform.From(cfnStackTagsToTurbotTags),
 			},
 			{
@@ -243,14 +265,15 @@ func listCloudFormationStacks(ctx context.Context, d *plugin.QueryData, _ *plugi
 	}
 
 	// We can not pass the MaxResult value in param so we can't limit the result per page
-	input := &cloudformation.DescribeStacksInput{}
+	input := &cloudformation.ListStacksInput{}
 
 	// Additonal Filter
 	equalQuals := d.EqualsQuals
-	if equalQuals["name"] != nil {
-		input.StackName = aws.String(equalQuals["name"].GetStringValue())
+	if equalQuals["status"] != nil {
+		input.StackStatusFilter = []types.StackStatus{types.StackStatus(equalQuals["status"].GetStringValue())}
+		// aws.String(equalQuals["name"].GetStringValue())
 	}
-	paginator := cloudformation.NewDescribeStacksPaginator(svc, input, func(o *cloudformation.DescribeStacksPaginatorOptions) {
+	paginator := cloudformation.NewListStacksPaginator(svc, input, func(o *cloudformation.ListStacksPaginatorOptions) {
 		o.StopOnDuplicateToken = true
 	})
 	for paginator.HasMorePages() {
@@ -263,7 +286,7 @@ func listCloudFormationStacks(ctx context.Context, d *plugin.QueryData, _ *plugi
 			return nil, err
 		}
 
-		for _, stack := range output.Stacks {
+		for _, stack := range output.StackSummaries {
 			d.StreamListItem(ctx, stack)
 			// Context can be cancelled due to manual cancellation or the limit has been hit
 			if d.RowsRemaining(ctx) == 0 {
@@ -277,22 +300,28 @@ func listCloudFormationStacks(ctx context.Context, d *plugin.QueryData, _ *plugi
 
 //// HYDRATE FUNCTIONS
 
-func getCloudFormationStack(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+func getCloudFormationStack(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	// Create Session
 	svc, err := CloudFormationClient(ctx, d)
 	if err != nil {
 		plugin.Logger(ctx).Error("aws_cloudformation_stack.getCloudFormationStack", "connection_error", err)
 		return nil, err
 	}
+	var stackInfo types.StackSummary
+	if h.Item != nil {
+		stackInfo = h.Item.(types.StackSummary)
+	}
 
 	if svc == nil {
 		// Unsupported region check
 		return nil, nil
 	}
+	params := &cloudformation.DescribeStacksInput{}
 
-	name := d.EqualsQuals["name"].GetStringValue()
-	params := &cloudformation.DescribeStacksInput{
-		StackName: aws.String(name),
+	if d.EqualsQuals["name"].GetStringValue() != "" {
+		params.StackName = aws.String(d.EqualsQuals["name"].GetStringValue())
+	} else {
+		params.StackName = stackInfo.StackName
 	}
 
 	op, err := svc.DescribeStacks(ctx, params)
@@ -309,7 +338,14 @@ func getCloudFormationStack(ctx context.Context, d *plugin.QueryData, _ *plugin.
 }
 
 func getStackTemplate(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	stack := h.Item.(types.Stack)
+	stackName := ""
+
+	switch h.Item.(type) {
+	case types.Stack:
+		stackName = *h.Item.(types.Stack).StackName
+	case types.StackSummary:
+		stackName = *h.Item.(types.StackSummary).StackName
+	}
 
 	// Create Session
 	svc, err := CloudFormationClient(ctx, d)
@@ -325,7 +361,7 @@ func getStackTemplate(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 
 	// template_body is the template in its original string form
 	params := &cloudformation.GetTemplateInput{
-		StackName: stack.StackName,
+		StackName: aws.String(stackName),
 	}
 	stackTemplate, err := svc.GetTemplate(ctx, params)
 	if err != nil {
@@ -337,7 +373,14 @@ func getStackTemplate(ctx context.Context, d *plugin.QueryData, h *plugin.Hydrat
 }
 
 func describeStackResources(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	stack := h.Item.(types.Stack)
+	stackName := ""
+
+	switch h.Item.(type) {
+	case types.Stack:
+		stackName = *h.Item.(types.Stack).StackName
+	case types.StackSummary:
+		stackName = *h.Item.(types.StackSummary).StackName
+	}
 
 	// Create Session
 	svc, err := CloudFormationClient(ctx, d)
@@ -352,7 +395,7 @@ func describeStackResources(ctx context.Context, d *plugin.QueryData, h *plugin.
 	}
 
 	params := &cloudformation.DescribeStackResourcesInput{
-		StackName: stack.StackName,
+		StackName: aws.String(stackName),
 	}
 
 	stackResources, err := svc.DescribeStackResources(ctx, params)

--- a/aws/table_aws_cloudformation_stack.go
+++ b/aws/table_aws_cloudformation_stack.go
@@ -44,6 +44,7 @@ func tableAwsCloudFormationStack(_ context.Context) *plugin.Table {
 			},
 		},
 		HydrateConfig: []plugin.HydrateConfig{
+			// For deleted stacks we are encountering error "ValidationError"
 			{
 				Func: getStackTemplate,
 				Tags: map[string]string{"service": "cloudformation", "action": "GetTemplate"},
@@ -51,6 +52,7 @@ func tableAwsCloudFormationStack(_ context.Context) *plugin.Table {
 					ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ValidationError"}),
 				},
 			},
+			// For deleted stacks we are encountering error "ValidationError"
 			{
 				Func: describeStackResources,
 				Tags: map[string]string{"service": "cloudformation", "action": "DescribeStackResources"},

--- a/aws/table_aws_cloudformation_stack.go
+++ b/aws/table_aws_cloudformation_stack.go
@@ -273,7 +273,6 @@ func listCloudFormationStacks(ctx context.Context, d *plugin.QueryData, _ *plugi
 	equalQuals := d.EqualsQuals
 	if equalQuals["status"] != nil {
 		input.StackStatusFilter = []types.StackStatus{types.StackStatus(equalQuals["status"].GetStringValue())}
-		// aws.String(equalQuals["name"].GetStringValue())
 	}
 	paginator := cloudformation.NewListStacksPaginator(svc, input, func(o *cloudformation.ListStacksPaginatorOptions) {
 		o.StopOnDuplicateToken = true
@@ -318,6 +317,7 @@ func getCloudFormationStack(ctx context.Context, d *plugin.QueryData, h *plugin.
 		// Unsupported region check
 		return nil, nil
 	}
+
 	params := &cloudformation.DescribeStacksInput{}
 
 	if d.EqualsQuals["name"].GetStringValue() != "" {

--- a/docs/tables/aws_cloudformation_stack.md
+++ b/docs/tables/aws_cloudformation_stack.md
@@ -15,6 +15,7 @@ The `aws_cloudformation_stack` table in Steampipe provides you with information 
 ## Examples
 
 ### Find the status of each cloudformation stack
+
 Explore the current status of each AWS CloudFormation stack to monitor the health and progress of your infrastructure deployments. This can help in identifying any potential issues or failures in your stack deployments.
 
 ```sql+postgres
@@ -35,8 +36,8 @@ from
   aws_cloudformation_stack;
 ```
 
-
 ### List of cloudformation stack where rollback is disabled
+
 Discover the segments that have disabled rollback in their AWS CloudFormation stacks. This can be useful for identifying potential risk areas, as these stacks will not automatically revert to a previous state if an error occurs during stack operations.
 
 ```sql+postgres
@@ -59,8 +60,8 @@ where
   disable_rollback = 1;
 ```
 
-
 ### List of stacks where termination protection is not enabled
+
 Discover the segments that have not enabled termination protection in their stacks. This is crucial to identify potential risk areas and ensure the safety of your resources.
 
 ```sql+postgres
@@ -83,8 +84,8 @@ where
   enable_termination_protection = 0;
 ```
 
-
 ### Rollback configuration info for each cloudformation stack
+
 Explore the settings of your AWS CloudFormation stacks to understand their rollback configurations, including how long they monitor for signs of trouble and what triggers a rollback. This can help optimize your stack management by adjusting these settings based on your operational needs.
 
 ```sql+postgres
@@ -105,8 +106,8 @@ from
   aws_cloudformation_stack;
 ```
 
-
 ### Resource ARNs where notifications about stack actions will be sent
+
 Determine the areas in which notifications related to stack actions will be sent. This is useful for managing and tracking changes in your AWS CloudFormation stacks.
 
 ```sql+postgres
@@ -124,4 +125,31 @@ select
 from
   aws_cloudformation_stack,
   json_each(notification_arns);
+```
+
+### List deleted stacks
+Identify CloudFormation stacks that have been successfully deleted. This is useful for cleanup verification and understanding which stacks have been removed from your infrastructure.
+
+```sql+postgres
+select
+  name,
+  id,
+  status,
+  deletion_time
+from
+  aws_cloudformation_stack
+where
+  status = 'DELETE_COMPLETE';
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  status,
+  deletion_time
+from
+  aws_cloudformation_stack
+where
+  status = 'DELETE_COMPLETE';
 ```

--- a/docs/tables/aws_cloudformation_stack.md
+++ b/docs/tables/aws_cloudformation_stack.md
@@ -15,7 +15,6 @@ The `aws_cloudformation_stack` table in Steampipe provides you with information 
 ## Examples
 
 ### Find the status of each cloudformation stack
-
 Explore the current status of each AWS CloudFormation stack to monitor the health and progress of your infrastructure deployments. This can help in identifying any potential issues or failures in your stack deployments.
 
 ```sql+postgres
@@ -37,7 +36,6 @@ from
 ```
 
 ### List of cloudformation stack where rollback is disabled
-
 Discover the segments that have disabled rollback in their AWS CloudFormation stacks. This can be useful for identifying potential risk areas, as these stacks will not automatically revert to a previous state if an error occurs during stack operations.
 
 ```sql+postgres
@@ -61,7 +59,6 @@ where
 ```
 
 ### List of stacks where termination protection is not enabled
-
 Discover the segments that have not enabled termination protection in their stacks. This is crucial to identify potential risk areas and ensure the safety of your resources.
 
 ```sql+postgres
@@ -85,7 +82,6 @@ where
 ```
 
 ### Rollback configuration info for each cloudformation stack
-
 Explore the settings of your AWS CloudFormation stacks to understand their rollback configurations, including how long they monitor for signs of trouble and what triggers a rollback. This can help optimize your stack management by adjusting these settings based on your operational needs.
 
 ```sql+postgres
@@ -107,7 +103,6 @@ from
 ```
 
 ### Resource ARNs where notifications about stack actions will be sent
-
 Determine the areas in which notifications related to stack actions will be sent. This is useful for managing and tracking changes in your AWS CloudFormation stacks.
 
 ```sql+postgres

--- a/docs/tables/aws_cloudformation_stack.md
+++ b/docs/tables/aws_cloudformation_stack.md
@@ -12,6 +12,10 @@ The AWS CloudFormation Stack is a service that allows you to manage and provisio
 
 The `aws_cloudformation_stack` table in Steampipe provides you with information about stacks within AWS CloudFormation. This table enables you as a DevOps engineer to query stack-specific details, including stack name, status, creation time, and associated tags. You can utilize this table to gather insights on stacks, such as stack status, stack resources, stack capabilities, and more. The schema outlines the various attributes of the CloudFormation stack for you, including stack ID, stack name, creation time, stack status, and associated tags.
 
+**Important Notes**
+- This table supports the optional list key column `status`, which comes with the following requirements:
+- For supported values of the `status`, please refer [StackStatusFilter](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_ListStacks.html).
+
 ## Examples
 
 ### Find the status of each cloudformation stack

--- a/docs/tables/aws_cloudformation_stack.md
+++ b/docs/tables/aws_cloudformation_stack.md
@@ -13,7 +13,7 @@ The AWS CloudFormation Stack is a service that allows you to manage and provisio
 The `aws_cloudformation_stack` table in Steampipe provides you with information about stacks within AWS CloudFormation. This table enables you as a DevOps engineer to query stack-specific details, including stack name, status, creation time, and associated tags. You can utilize this table to gather insights on stacks, such as stack status, stack resources, stack capabilities, and more. The schema outlines the various attributes of the CloudFormation stack for you, including stack ID, stack name, creation time, stack status, and associated tags.
 
 **Important Notes**
-- This table supports the optional list key column `status`, which comes with the following requirements:
+- This table supports the optional list key column `status`.
 - For supported values of the `status`, please refer [StackStatusFilter](https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_ListStacks.html).
 
 ## Examples


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select name, status from aws_cloudformation_stack;
+---------------------------------------------------------------------------+-----------------+
| name                                                                      | status          |
+---------------------------------------------------------------------------+-----------------+
| AWS-QuickSetup-SSM-LocalDeploymentRolesStack                              | CREATE_COMPLETE |
| StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | CREATE_COMPLETE |
| test-ecs-35                                                               | DELETE_COMPLETE |
| my-vpc-stack                                                              | DELETE_COMPLETE |
| awsconfigconforms-turbottest19414-conformance-pack-eof8ouhfa              | DELETE_COMPLETE |
| test-ecs                                                                  | DELETE_COMPLETE |
| MWAA-VPC-Stack                                                            | DELETE_COMPLETE |
| test-ecs                                                                  | DELETE_COMPLETE |
| awseb-e-nkerhmdbuq-stack                                                  | DELETE_COMPLETE |
| test93-ecs                                                                | DELETE_COMPLETE |
| test-lambda-log                                                           | CREATE_COMPLETE |
| turbottest41077                                                           | DELETE_COMPLETE |
| test-31-ecs                                                               | DELETE_COMPLETE |
| turbottest72916                                                           | DELETE_COMPLETE |
| test-31-ecs                                                               | DELETE_COMPLETE |
| turbottest54732                                                           | CREATE_COMPLETE |
+---------------------------------------------------------------------------+-----------------+
> select name, status from aws_cloudformation_stack where status = 'DELETE_COMPLETE'
+--------------------------------------------------------------+-----------------+
| name                                                         | status          |
+--------------------------------------------------------------+-----------------+
| my-vpc-stack                                                 | DELETE_COMPLETE |
| turbottest41077                                              | DELETE_COMPLETE |
| awseb-e-nkerhmdbuq-stack                                     | DELETE_COMPLETE |
| test-31-ecs                                                  | DELETE_COMPLETE |
| turbottest72916                                              | DELETE_COMPLETE |
| MWAA-VPC-Stack                                               | DELETE_COMPLETE |
| test-ecs-35                                                  | DELETE_COMPLETE |
| test93-ecs                                                   | DELETE_COMPLETE |
| awsconfigconforms-turbottest19414-conformance-pack-eof8ouhfa | DELETE_COMPLETE |
| test-31-ecs                                                  | DELETE_COMPLETE |
| test-ecs                                                     | DELETE_COMPLETE |
| test-ecs                                                     | DELETE_COMPLETE |
+--------------------------------------------------------------+-----------------+
> select name, status from aws_cloudformation_stack where status = 'CREATE_COMPLETE'
+---------------------------------------------------------------------------+-----------------+
| name                                                                      | status          |
+---------------------------------------------------------------------------+-----------------+
| AWS-QuickSetup-SSM-LocalDeploymentRolesStack                              | CREATE_COMPLETE |
| StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | CREATE_COMPLETE |
| test-lambda-log                                                           | CREATE_COMPLETE |
| turbottest54732                                                           | CREATE_COMPLETE |
+---------------------------------------------------------------------------+-----------------+
```
</details>
