### PR TITLE
Added support for `ignore_error_messages` config arg to ignore errors by message Closes #2517

### DIFF
--- a/aws/connection_config.go
+++ b/aws/connection_config.go
@@ -16,6 +16,7 @@ type awsConfig struct {
 	SessionToken          *string  `hcl:"session_token"`
 	MaxErrorRetryAttempts *int     `hcl:"max_error_retry_attempts"`
 	MinErrorRetryDelay    *int     `hcl:"min_error_retry_delay"`
+	IgnoreErrorMessages   []string `hcl:"ignore_error_messages,optional"`
 	IgnoreErrorCodes      []string `hcl:"ignore_error_codes,optional"`
 	EndpointUrl           *string  `hcl:"endpoint_url"`
 	S3ForcePathStyle      *bool    `hcl:"s3_force_path_style"`

--- a/aws/errors.go
+++ b/aws/errors.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"path"
+	"regexp"
 
 	"github.com/aws/smithy-go"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
@@ -31,19 +32,37 @@ func shouldIgnoreErrors(notFoundErrors []string) plugin.ErrorPredicateWithContex
 	}
 }
 
-// shouldIgnoreErrorPluginDefault:: Plugin level default function to ignore a set errors for hydrate functions based on "ignore_error_codes" config argument
+// shouldIgnoreErrorPluginDefault:: Plugin level default function to ignore a set errors for hydrate functions based on "ignore_error_codes" and "ignore_error_messages" config argument
 func shouldIgnoreErrorPluginDefault() plugin.ErrorPredicateWithContext {
 	return func(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData, err error) bool {
-		if !hasIgnoredErrorCodes(d.Connection) {
+		if !hasIgnoredErrorCodesOrMessages(d.Connection) {
 			return false
 		}
 
 		awsConfig := GetConfig(d.Connection)
+
+		logger := plugin.Logger(ctx)
+
+		// Add to support regex match as per error message
+		for _, pattern := range awsConfig.IgnoreErrorMessages {
+			// Validate regex pattern
+			re, er := regexp.Compile(pattern)
+			if er != nil {
+				panic(er.Error() + " the regex pattern configured in 'ignore_error_messages' is invalid. Edit your connection configuration file and then restart Steampipe")
+			}
+			result := re.MatchString(err.Error())
+			if result {
+				logger.Debug("errors.shouldIgnoreErrors", "ignore_error_message", err.Error())
+				return true
+			}
+		}
+
 		var ae smithy.APIError
 		if errors.As(err, &ae) {
 			// Added to support regex in not found errors
 			for _, pattern := range awsConfig.IgnoreErrorCodes {
 				if ok, _ := path.Match(pattern, ae.ErrorCode()); ok {
+					logger.Debug("errors.shouldIgnoreErrorPluginDefault", "ignore_error_code", err.Error())
 					return true
 				}
 			}
@@ -52,7 +71,7 @@ func shouldIgnoreErrorPluginDefault() plugin.ErrorPredicateWithContext {
 	}
 }
 
-func hasIgnoredErrorCodes(connection *plugin.Connection) bool {
+func hasIgnoredErrorCodesOrMessages(connection *plugin.Connection) bool {
 	awsConfig := GetConfig(connection)
-	return len(awsConfig.IgnoreErrorCodes) > 0
+	return len(awsConfig.IgnoreErrorCodes) > 0 || len(awsConfig.IgnoreErrorMessages) > 0
 }

--- a/config/aws.spc
+++ b/config/aws.spc
@@ -42,6 +42,11 @@ connection "aws" {
   # By default, common not found error codes are ignored and will still be ignored even if this argument is not set.
   #ignore_error_codes = ["AccessDenied", "AccessDeniedException", "NotAuthorized", "UnauthorizedOperation", "UnrecognizedClientException", "AuthorizationError"]
 
+  # List of regular expressions to match error messages to ignore for all queries.
+  # When encountering errors matching these patterns, the API call will not be retried and empty results will be returned.
+  # This allows for more flexible error handling based on error message content rather than just error codes.
+  #ignore_error_messages = [".*with an explicit deny in a service control policy.*", ".*Support\\s+Subscription\\s+is\\s+required.*"]
+
   # Specify the endpoint URL used when making requests to AWS services.
   # If not set, the default AWS generated endpoint will be used.
   # Can also be set with the AWS_ENDPOINT_URL environment variable.


### PR DESCRIPTION

# Example query results
<details>
  <summary>Results</summary>

### Before changes: 

```
> select * from aws_trusted_advisor_check_summary where language = 'en'

Error: aws: operation error Support: DescribeTrustedAdvisorChecks, https response error StatusCode: 400, RequestID: 3cdb0e8d-57aa-4327-8308-c911f963a77e, api error SubscriptionRequiredException: Amazon Web Services Premium Support Subscription is required to use this service. (SQLSTATE HV000)

+------+----------+----------+----------+-------------+--------+-----------+-------------------+-------------------+---------------------+----------------------+------------->
| name | check_id | category | language | description | status | timestamp | resources_flagged | resources_ignored | resources_processed | resources_suppressed | category_spe>
+------+----------+----------+----------+-------------+--------+-----------+-------------------+-------------------+---------------------+----------------------+------------->
+------+----------+----------+----------+-------------+--------+-----------+-------------------+-------------------+---------------------+----------------------+------------->
0 rows
```

### After adding support `ignore_error_messages` config arg:

**Connection config:**

```
connection "aws" {
  plugin = "aws"

  regions = ["*"]
  profile = "default"

  ignore_error_messages = [".*Support\\s+Subscription\\s+is\\s+required.*"]
}
```

**Query result ignoring error:**

```
> select * from aws_trusted_advisor_check_summary where language = 'en'
+------+----------+----------+----------+-------------+--------+-----------+-------------------+-------------------+---------------------+----------------------+------------->
| name | check_id | category | language | description | status | timestamp | resources_flagged | resources_ignored | resources_processed | resources_suppressed | category_spe>
+------+----------+----------+----------+-------------+--------+-----------+-------------------+-------------------+---------------------+----------------------+------------->
+------+----------+----------+----------+-------------+--------+-----------+-------------------+-------------------+---------------------+----------------------+------------->
0 rows
```

</details>
