### PR TITLE
Resolve interface conversion issue in aws_cloudformation_stack_resource and handle deleted stacks in list resources API Closes #2621

### DIFF
--- a/aws/table_aws_cloudformation_stack_resource.go
+++ b/aws/table_aws_cloudformation_stack_resource.go
@@ -130,7 +130,8 @@ func listCloudFormationStackResources(ctx context.Context, d *plugin.QueryData, 
 	}
 
 	// For the deleted stacks we will encounter the Error: aws: operation error CloudFormation: ListStackResources, https response error StatusCode: 400, RequestID: 4c97284f-3c37-461d-b0a1-5d4287bd170e, api error ValidationError: Stack with id ECS-Console-V2-Service-mongodb-service-zwwh6xcq-steampipe-test-env2Batchd22fbc22-01cd-3f17-9793-3e3ed0d605b2-03c4e5c1 does not exist
-	// so it is necessary to check the status of the stack before calling the ListStackResources API
+	// For deleted stacks, the ListStackResources API may return a validation error indicating that the stack does not exist.
+	// Therefore, it is necessary to check the status of the stack before calling the ListStackResources API.
 	if stack.StackStatus == types.StackStatusDeleteComplete {
 		return nil, nil
 	}


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_cloudformation_stack_resource

+-----------------------------------------+---------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------->
| logical_resource_id                     | stack_name                                                                | stack_id                                                                                                           >
+-----------------------------------------+---------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------->
| LocalExecutionRole                      | AWS-QuickSetup-SSM-LocalDeploymentRolesStack                              | arn:aws:cloudformation:ap-south-1:************:stack/AWS-QuickSetup-SSM-LocalDeploymentRolesStack/a5dacb50-cc0f-11e>
| LocalAdministrationRole                 | AWS-QuickSetup-SSM-LocalDeploymentRolesStack                              | arn:aws:cloudformation:ap-south-1:************:stack/AWS-QuickSetup-SSM-LocalDeploymentRolesStack/a5dacb50-cc0f-11e>
| LambdaLogGroup                          | test-lambda-log                                                           | arn:aws:cloudformation:us-east-1:************:stack/test-lambda-log/3eecada0-1903-11f0-bd2a-0affcc82041f           >
| CloudFormationStackTest                 | turbottest54732                                                           | arn:aws:cloudformation:us-west-2:************:stack/turbottest54732/fa644990-cb51-11ee-b96a-0af9604ce3cf           >
| SampleLambdaFunction                    | test-lambda-log                                                           | arn:aws:cloudformation:us-east-1:************:stack/test-lambda-log/3eecada0-1903-11f0-bd2a-0affcc82041f           >
| LambdaExecutionRole                     | test-lambda-log                                                           | arn:aws:cloudformation:us-east-1:************:stack/test-lambda-log/3eecada0-1903-11f0-bd2a-0affcc82041f           >
| LogBucket                               | test-lambda-log                                                           | arn:aws:cloudformation:us-east-1:************:stack/test-lambda-log/3eecada0-1903-11f0-bd2a-0affcc82041f           >
| AWSSSMRemediationAdminRole              | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| AWSSSMRemediationExecutionRole          | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| AWSSSMDiagnosisAdminRole                | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| SystemAssociationForManagingInstances   | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| AWSSSMDiagnosisExecutionRole            | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| SSMAgentUpdateAssociation               | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| EnableAREXAssociation                   | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| DiagnosisBucketPolicy                   | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| DiagnosisBucket                         | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| RoleForOnboardingAutomation             | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| RoleForLifecycleManagement              | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| SystemAssociationForEnablingExplorer    | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| SSMLifecycleOperatorLambda              | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| EnableDHMCAssociation                   | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| SSMLifecycleResource                    | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
| SystemAssociationForInventoryCollection | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:************:stack/StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b6>
+-----------------------------------------+---------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------->
23 rows
> .quit
➜  aws git:(issue-2621) ✗ steampipe query
Welcome to Steampipe v0.0.0-dev-HEAD.20250711132807
For more information, type .help
> select * from aws_cloudformation_stack_resource where logical_resource_id = 'LogBucket' and stack_name = 'test-lambda-log'
+---------------------+-----------------+----------------------------------------------------------------------------------------------------------+---------------------------+-----------------+-----------------+-------------+--------->
| logical_resource_id | stack_name      | stack_id                                                                                                 | last_updated_timestamp    | resource_status | resource_type   | description | physical>
+---------------------+-----------------+----------------------------------------------------------------------------------------------------------+---------------------------+-----------------+-----------------+-------------+--------->
| LogBucket           | test-lambda-log | arn:aws:cloudformation:us-east-1:************:stack/test-lambda-log/3eecada0-1903-11f0-bd2a-0affcc82041f | 2025-04-14T13:07:14+05:30 | CREATE_COMPLETE | AWS::S3::Bucket | <null>      | lambda-l>
+---------------------+-----------------+----------------------------------------------------------------------------------------------------------+---------------------------+-----------------+-----------------+-------------+--------->
1 row
```
</details>
