### PR TITLE
Enhance aws_cloudformation_stack_resource table to search by `physical_resource_id` and added new column `metadata` #2627

### DIFF
--- a/aws/table_aws_cloudformation_stack_resource.go
+++ b/aws/table_aws_cloudformation_stack_resource.go
@@ -133,6 +133,7 @@ func tableAwsCloudFormationStackResource(_ context.Context) *plugin.Table {
 }
 
 //// PARENT HYDRATE FUNCTION
+// For more details please see, https://github.com/turbot/steampipe-plugin-aws/issues/2627
 
 // Parent hydrate function that optimizes the query flow based on the provided qualifiers
 // This function implements the performance optimization strategy described in the design:

--- a/docs/tables/aws_cloudformation_stack_resource.md
+++ b/docs/tables/aws_cloudformation_stack_resource.md
@@ -162,3 +162,36 @@ from
 where
   resource_status = 'UPDATE_FAILED';
 ```
+
+### Find stack resource by physical resource ID
+Quickly locate a specific CloudFormation resource using its physical resource ID (e.g., ARN, instance ID, etc.). This is useful for mapping physical AWS resources back to their CloudFormation stack and logical resource definition.
+
+```sql+postgres
+select
+  stack_name,
+  stack_id,
+  logical_resource_id,
+  physical_resource_id,
+  resource_type,
+  resource_status,
+  last_updated_timestamp
+from
+  aws_cloudformation_stack_resource
+where
+  physical_resource_id = 'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-target-group/1234567890123456';
+```
+
+```sql+sqlite
+select
+  stack_name,
+  stack_id,
+  logical_resource_id,
+  physical_resource_id,
+  resource_type,
+  resource_status,
+  last_updated_timestamp
+from
+  aws_cloudformation_stack_resource
+where
+  physical_resource_id = 'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/my-target-group/1234567890123456';
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_cloudformation_stack_resource
+-----------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------->
| logical_resource_id                     | stack_name                                                                | stack_id                                                    >
+-----------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------->
| LocalAdministrationRole                 | AWS-QuickSetup-SSM-LocalDeploymentRolesStack                              | arn:aws:cloudformation:ap-south-1:123456789098:stack/AWS-Qui>
| LocalExecutionRole                      | AWS-QuickSetup-SSM-LocalDeploymentRolesStack                              | arn:aws:cloudformation:ap-south-1:123456789098:stack/AWS-Qui>
| CloudFormationStackTest                 | turbottest54732                                                           | arn:aws:cloudformation:us-west-2:123456789098:stack/turbotte>
| MyFreeS3Bucket                          | free-tier-demo-stack                                                      | arn:aws:cloudformation:us-east-1:123456789098:stack/free-tie>
| SampleLambdaFunction                    | test-lambda-log                                                           | arn:aws:cloudformation:us-east-1:123456789098:stack/test-lam>
| LogBucket                               | test-lambda-log                                                           | arn:aws:cloudformation:us-east-1:123456789098:stack/test-lam>
| LambdaExecutionRole                     | test-lambda-log                                                           | arn:aws:cloudformation:us-east-1:123456789098:stack/test-lam>
| LambdaLogGroup                          | test-lambda-log                                                           | arn:aws:cloudformation:us-east-1:123456789098:stack/test-lam>
| AWSSSMDiagnosisAdminRole                | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| AWSSSMDiagnosisExecutionRole            | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| DiagnosisBucket                         | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| AWSSSMRemediationAdminRole              | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| AWSSSMRemediationExecutionRole          | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| DiagnosisBucketPolicy                   | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| SystemAssociationForManagingInstances   | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| SSMLifecycleOperatorLambda              | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| SSMAgentUpdateAssociation               | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| RoleForOnboardingAutomation             | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| SSMLifecycleResource                    | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| EnableAREXAssociation                   | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| SystemAssociationForEnablingExplorer    | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| EnableDHMCAssociation                   | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| RoleForLifecycleManagement              | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
| SystemAssociationForInventoryCollection | StackSet-AWS-QuickSetup-SSM-LA-l07up-76f5313f-3905-4a4c-ae1b-b649cf3abe06 | arn:aws:cloudformation:us-east-1:123456789098:stack/StackSet>
+-----------------------------------------+---------------------------------------------------------------------------+------------------------------------------------------------->
```
</details>
