### PR TITLE
Fix the table aws_availability_zone to respect `ignore_error_codes` and  `ignore_error_messages` from connection config

### DIFF
--- a/aws/table_aws_availability_zone.go
+++ b/aws/table_aws_availability_zone.go
@@ -144,7 +144,7 @@ func listAwsAvailabilityZones(ctx context.Context, d *plugin.QueryData, h *plugi
 	// execute list call
 	resp, err := svc.DescribeAvailabilityZones(ctx, input)
 	if err != nil {
-		// Due to parent hydrate use the default ignore error code configured in connection config is not respecting so we need to handle it here
+		// Due to parent hydrate usage, the default ignore error codes configured in connection config are not respected, so we need to handle it here
 		if shouldIgnoreErrorPluginDefault()(ctx, d, h, err) {
 			return nil, nil
 		}

--- a/aws/table_aws_availability_zone.go
+++ b/aws/table_aws_availability_zone.go
@@ -144,6 +144,10 @@ func listAwsAvailabilityZones(ctx context.Context, d *plugin.QueryData, h *plugi
 	// execute list call
 	resp, err := svc.DescribeAvailabilityZones(ctx, input)
 	if err != nil {
+		// Due to parent hydrate use the default ignore error code configured in connection config is not respecting so we need to handle it here
+		if shouldIgnoreErrorPluginDefault()(ctx, d, h, err) {
+			return nil, nil
+		}
 		plugin.Logger(ctx).Error("aws_availability_zone.listAwsAvailabilityZones", "api_error", err)
 		return nil, err
 	}


### PR DESCRIPTION
Note: It is a known error that the Steampipe SDK is failing to respect if the `ParentHydrate` is being used in the table. So we need to handle it in the LIST function itself

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
