### PR TITLE
Add column full_snapshot_size_in_bytes to aws_ebs_snapshot table

### DIFF
--- a/aws-test/tests/aws_ebs_snapshot/test-get-expected.json
+++ b/aws-test/tests/aws_ebs_snapshot/test-get-expected.json
@@ -11,6 +11,7 @@
       }
     ],
     "volume_id": "{{ output.volume_id.value }}",
-    "volume_size": 1
+    "volume_size": 1,
+    "full_snapshot_size_in_bytes": 1073741824
   }
 ]

--- a/aws-test/tests/aws_ebs_snapshot/test-get-query.sql
+++ b/aws-test/tests/aws_ebs_snapshot/test-get-query.sql
@@ -1,3 +1,3 @@
-select snapshot_id, description, volume_id, volume_size, encrypted, owner_id, tags_src
+select snapshot_id, description, volume_id, volume_size, full_snapshot_size_in_bytes, encrypted, owner_id, tags_src
 from aws.aws_ebs_snapshot
 where snapshot_id = '{{ output.snapshot_id.value }}'

--- a/aws/table_aws_ebs_snapshot.go
+++ b/aws/table_aws_ebs_snapshot.go
@@ -101,6 +101,11 @@ func tableAwsEBSSnapshot(_ context.Context) *plugin.Table {
 				Type:        proto.ColumnType_STRING,
 			},
 			{
+				Name:        "full_snapshot_size_in_bytes",
+				Description: "The full size of the snapshot, in bytes.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
 				Name:        "encrypted",
 				Description: "Indicates whether the snapshot is encrypted.",
 				Type:        proto.ColumnType_BOOL,


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>

```
❯ steampipe query "select snapshot_id, full_snapshot_size_in_bytes from aws_all.aws_ebs_snapshot limit 11;"
+------------------------+-----------------------------+
| snapshot_id            | full_snapshot_size_in_bytes |
+------------------------+-----------------------------+
| snap-0e15d3b5f2e97bd3e | 0                           |
| snap-022eab4b76f840b62 | 268,435,456,000             |
| snap-05f25b66fbde41aff | 13,004,963,840              |
| snap-091f8ec383e667fc5 | 1,938,926,600,192           |
| snap-01ab30ef2b9ff0d3e | 4,606,918,656               |
| snap-082d77cf097d214ac | 2,300,051,456               |
| snap-0a8b4729f405dd9f3 | 24,033,361,920              |
| snap-0d670d1188b7c1b2a | 691,478,724,608             |
| snap-019e182597fa2d540 | 14,983,626,752              |
| snap-0642f72d7a7e6dce2 | 11,673,796,608              |
| snap-009ec07919f505494 | 23,556,784,128              |
+------------------------+-----------------------------+
```
</details>