### PR TITLE
Fix the code column in aws_lambda_version table to correctly return data instead of null

### DIFF
--- a/aws/table_aws_lambda_version.go
+++ b/aws/table_aws_lambda_version.go
@@ -488,6 +488,5 @@ func getFunctionVersionCode(ctx context.Context, d *plugin.QueryData, h *plugin.
 		return nil, err
 	}
 
-	// Return just the Code field since that's what we want
-	return op.Code, nil
+	return op, nil
 }


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
select policy, code, code_sha_256, title from aws_lambda_version
+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| policy | code                                                                                                                                                                                                                                                              >
+--------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------->
| <null> | {"ImageUri":null,"Location":"https://awslambda-ap-ne-1-tasks.s3.us-east-1.amazonaws.com/snapshots/111111111111/dancing_cat_Glue-northeast-1-111111111-11111-4c9c-9686-111111111?versionId=1111111111111111111111\u002>
|        | 0026X-Amz-Algorithm=AWS4-11111-SHA256\u0026X-Amz-Date=11111111111\u0026X-Amz-SignedHeaders=host\111111-Amz-Expires=600\u0026X-Amz-Credential=11111111111%111111111%2Fus-east-1%2Fs3%2Faws4_request\u0026X-Amz-Signature=1111111111111111>
| <null> | {"ImageUri":null,"Location":"https://awslambda-ap-se-2-tasks.s3.us-east-1.amazonaws.com/snapshots/11111111111/dancing_cat_Glue-2-111111-11111-4720-9a2d-1111111?versionId=1111111111.pSjR..76XCV\u
```
</details>
