### PR TITLE
Add column routing_config to aws_lambda_alias table closes #2641

### DIFF
--- a/aws/table_aws_lambda_alias.go
+++ b/aws/table_aws_lambda_alias.go
@@ -105,6 +105,12 @@ func tableAwsLambdaAlias(_ context.Context) *plugin.Table {
 				Hydrate:     getLambdaAliasUrlConfig,
 				Transform:   transform.FromValue(),
 			},
+			{
+				Name:        "routing_config",
+				Description: "The routing configuration of the alias, including additional version weights for traffic splitting.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Alias.RoutingConfig"),
+			},
 
 			// Steampipe standard columns
 			{

--- a/docs/tables/aws_lambda_alias.md
+++ b/docs/tables/aws_lambda_alias.md
@@ -97,3 +97,30 @@ select
 from
   aws_lambda_alias;
 ```
+
+### List aliases with traffic routing configurations
+Identify Lambda aliases that use traffic routing between multiple function versions. This helps in understanding and managing gradual deployments and version transitions.
+
+```sql+postgres
+select
+  name,
+  function_name,
+  function_version as primary_version,
+  jsonb_pretty(routing_config) as routing_config
+from
+  aws_lambda_alias
+where
+  routing_config is not null;
+```
+
+```sql+sqlite
+select
+  name,
+  function_name,
+  function_version as primary_version,
+  routing_config
+from
+  aws_lambda_alias
+where
+  routing_config is not null;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
select
  name,
  function_name,
  function_version as primary_version,
  jsonb_pretty(routing_config) as routing_config
from
  aws_lambda_alias
where
  routing_config is not null;
+-------------------+---------------------+-----------------+-----------------------------------+
| name              | function_name       | primary_version | routing_config                    |
+-------------------+---------------------+-----------------+-----------------------------------+
| test-alias-delete | securityhub-finding | 1               | {                                 |
|                   |                     |                 |     "AdditionalVersionWeights": { |
|                   |                     |                 |         "2": 0.01                 |
|                   |                     |                 |     }                             |
|                   |                     |                 | }                                 |
+-------------------+---------------------+-----------------+-----------------------------------+
```
</details>
