### PR TITLE
Add ShowShardDetails option to MemoryDB

### DIFF
--- a/aws/table_aws_memorydb_cluster.go
+++ b/aws/table_aws_memorydb_cluster.go
@@ -210,6 +210,7 @@ func listAwsMemoryDBClusters(ctx context.Context, d *plugin.QueryData, h *plugin
 	// Page size must be greater than 0 and less than or equal to 1000
 	input := &memorydb.DescribeClustersInput{
 		MaxResults: aws.Int32(maxLimit),
+		ShowShardDetails: aws.Bool(true),
 	}
 
 	paginator := memorydb.NewDescribeClustersPaginator(svc, input, func(o *memorydb.DescribeClustersPaginatorOptions) {


### PR DESCRIPTION
This adds the option **Shard Details** for MemoryDB cluster. Currently there is no way to get this information. This is useful to understand how many shards we have.