### PR TITLE
Add column options to aws_ec2_transit_gateway_vpc_attachment table closes #2670

### DIFF
--- a/docs/tables/aws_ec2_transit_gateway_vpc_attachment.md
+++ b/docs/tables/aws_ec2_transit_gateway_vpc_attachment.md
@@ -64,3 +64,26 @@ from
 group by
   resource_type;
 ```
+
+### View attachment options configuration
+Query the configuration options for your transit gateway VPC attachments, including DNS support, IPv6 support, security group referencing, and appliance mode settings.
+
+```sql+postgres
+select
+  transit_gateway_attachment_id,
+  resource_id,
+  state,
+  options
+from
+  aws_ec2_transit_gateway_vpc_attachment;
+```
+
+```sql+sqlite
+select
+  transit_gateway_attachment_id,
+  resource_id,
+  state,
+  options
+from
+  aws_ec2_transit_gateway_vpc_attachment;
+```


### PR DESCRIPTION

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
 select title, options from aws_ec2_transit_gateway_vpc_attachment
+------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
| title                        | options                                                                                                                     |
+------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
| tgw-attach-0baa5afake1968111 | {"ApplianceModeSupport":"disable","DnsSupport":"enable","Ipv6Support":"disable","SecurityGroupReferencingSupport":"enable"} |
+------------------------------+-----------------------------------------------------------------------------------------------------------------------------+
```
</details>
