### PR TITLE
Add monitor specification transformation to aws_ce_anomaly_monitor and enhance aws_ce_cost_allocation_tags with new hydrate function for tag values retrieval

### DIFF
--- a/aws/table_aws_ce_anomaly_monitor.go
+++ b/aws/table_aws_ce_anomaly_monitor.go
@@ -55,6 +55,7 @@ func tableAwsCEAnomalyMonitor(_ context.Context) *plugin.Table {
 				Name:        "monitor_specification",
 				Description: "The monitor specification with cost categories, tags, or dimensions.",
 				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("MonitorSpecification"),
 			},
 			{
 				Name:        "creation_date",

--- a/docs/tables/aws_budgets_budget.md
+++ b/docs/tables/aws_budgets_budget.md
@@ -151,4 +151,297 @@ where
   time_unit = 'MONTHLY';
 ```
 
+### View cost filters
+Display all budgets with their cost filter settings to understand how budgets are scoped to specific services or dimensions.
+
+```sql+postgres
+select
+  name,
+  type,
+  limit_amount,
+  cost_filters
+from
+  aws_budgets_budget;
+```
+
+```sql+sqlite
+select
+  name,
+  type,
+  limit_amount,
+  cost_filters
+from
+  aws_budgets_budget;
+```
+
+### View cost types
+Show all budgets and the cost types they include (such as taxes, support, recurring charges, upfront costs, etc.).
+
+```sql+postgres
+select
+  name,
+  type,
+  limit_amount,
+  cost_types
+from
+  aws_budgets_budget;
+```
+
+```sql+sqlite
+select
+  name,
+  type,
+  limit_amount,
+  cost_types
+from
+  aws_budgets_budget;
+```
+
+### Filter budgets by service using cost_filters
+Query budgets that are filtered to monitor specific AWS services.
+
+```sql+postgres
+select
+  name,
+  type,
+  limit_amount,
+  cost_filters
+from
+  aws_budgets_budget
+where
+  cost_filters is not null;
+```
+
+```sql+sqlite
+select
+  name,
+  type,
+  limit_amount,
+  cost_filters
+from
+  aws_budgets_budget
+where
+  cost_filters is not null;
+```
+
+### View cost type breakdown
+Examine detailed cost type configurations to understand what is included in budget calculations (blended vs. unblended costs, taxes, support, etc.).
+
+```sql+postgres
+select
+  name,
+  cost_types->'IncludeTax' as include_tax,
+  cost_types->'IncludeSupport' as include_support,
+  cost_types->'IncludeUpfront' as include_upfront,
+  cost_types->'IncludeRecurring' as include_recurring,
+  cost_types->'UseBlended' as use_blended,
+  cost_types->'UseAmortized' as use_amortized
+from
+  aws_budgets_budget;
+```
+
+```sql+sqlite
+select
+  name,
+  json_extract(cost_types, '$.IncludeTax') as include_tax,
+  json_extract(cost_types, '$.IncludeSupport') as include_support,
+  json_extract(cost_types, '$.IncludeUpfront') as include_upfront,
+  json_extract(cost_types, '$.IncludeRecurring') as include_recurring,
+  json_extract(cost_types, '$.UseBlended') as use_blended,
+  json_extract(cost_types, '$.UseAmortized') as use_amortized
+from
+  aws_budgets_budget;
+```
+
+### Budgets using blended costs vs amortized costs
+Compare budgets configured with different cost calculation methods to understand cost accounting approaches.
+
+```sql+postgres
+select
+  name,
+  limit_amount,
+  cost_types->>'UseBlended' as use_blended,
+  cost_types->>'UseAmortized' as use_amortized
+from
+  aws_budgets_budget;
+```
+
+```sql+sqlite
+select
+  name,
+  limit_amount,
+  json_extract(cost_types, '$.UseBlended') as use_blended,
+  json_extract(cost_types, '$.UseAmortized') as use_amortized
+from
+  aws_budgets_budget;
+```
+
+### Budgets that include support costs
+Find all budgets that are configured to include AWS support costs in budget calculations.
+
+```sql+postgres
+select
+  name,
+  limit_amount,
+  cost_types->>'IncludeSupport' as include_support,
+  cost_types->>'IncludeTax' as include_tax
+from
+  aws_budgets_budget
+where
+  (cost_types->>'IncludeSupport')::boolean = true;
+```
+
+```sql+sqlite
+select
+  name,
+  limit_amount,
+  json_extract(cost_types, '$.IncludeSupport') as include_support,
+  json_extract(cost_types, '$.IncludeTax') as include_tax
+from
+  aws_budgets_budget
+where
+  json_extract(cost_types, '$.IncludeSupport') = 'true';
+```
+
+### Budgets with service-specific cost filters
+Query budgets that filter spending by specific AWS services or service groups.
+
+```sql+postgres
+select
+  name,
+  type,
+  limit_amount,
+  cost_filters->'Service' as filtered_services
+from
+  aws_budgets_budget
+where
+  cost_filters ? 'Service';
+```
+
+```sql+sqlite
+select
+  name,
+  type,
+  limit_amount,
+  json_extract(cost_filters, '$.Service') as filtered_services
+from
+  aws_budgets_budget
+where
+  json_extract(cost_filters, '$.Service') is not null;
+```
+
+### Budgets filtered by linked account
+Find budgets that are scoped to specific AWS linked accounts in an organization.
+
+```sql+postgres
+select
+  name,
+  type,
+  limit_amount,
+  cost_filters->'LinkedAccount' as linked_accounts
+from
+  aws_budgets_budget
+where
+  cost_filters ? 'LinkedAccount';
+```
+
+```sql+sqlite
+select
+  name,
+  type,
+  limit_amount,
+  json_extract(cost_filters, '$.LinkedAccount') as linked_accounts
+from
+  aws_budgets_budget
+where
+  json_extract(cost_filters, '$.LinkedAccount') is not null;
+```
+
+### Budgets filtered by region
+Query budgets that are scoped to monitor costs in specific AWS regions.
+
+```sql+postgres
+select
+  name,
+  type,
+  limit_amount,
+  cost_filters->'Region' as regions
+from
+  aws_budgets_budget
+where
+  cost_filters ? 'Region';
+```
+
+```sql+sqlite
+select
+  name,
+  type,
+  limit_amount,
+  json_extract(cost_filters, '$.Region') as regions
+from
+  aws_budgets_budget
+where
+  json_extract(cost_filters, '$.Region') is not null;
+```
+
+### Budgets that exclude refunds and credits
+Find budgets that are configured without refunds or credits in their cost calculations.
+
+```sql+postgres
+select
+  name,
+  limit_amount,
+  cost_types->>'IncludeRefund' as include_refund,
+  cost_types->>'IncludeCredit' as include_credit
+from
+  aws_budgets_budget
+where
+  (cost_types->>'IncludeRefund')::boolean = false
+  or (cost_types->>'IncludeCredit')::boolean = false;
+```
+
+```sql+sqlite
+select
+  name,
+  limit_amount,
+  json_extract(cost_types, '$.IncludeRefund') as include_refund,
+  json_extract(cost_types, '$.IncludeCredit') as include_credit
+from
+  aws_budgets_budget
+where
+  json_extract(cost_types, '$.IncludeRefund') = 'false'
+  or json_extract(cost_types, '$.IncludeCredit') = 'false';
+```
+
+### Cost types summary by budget
+Get a summary view of how different cost types are configured across all budgets.
+
+```sql+postgres
+select
+  name,
+  (cost_types->>'IncludeTax')::boolean as include_tax,
+  (cost_types->>'IncludeSupport')::boolean as include_support,
+  (cost_types->>'IncludeSubscription')::boolean as include_subscription,
+  (cost_types->>'IncludeRefund')::boolean as include_refund,
+  (cost_types->>'UseBlended')::boolean as use_blended
+from
+  aws_budgets_budget
+order by
+  name;
+```
+
+```sql+sqlite
+select
+  name,
+  json_extract(cost_types, '$.IncludeTax') as include_tax,
+  json_extract(cost_types, '$.IncludeSupport') as include_support,
+  json_extract(cost_types, '$.IncludeSubscription') as include_subscription,
+  json_extract(cost_types, '$.IncludeRefund') as include_refund,
+  json_extract(cost_types, '$.UseBlended') as use_blended
+from
+  aws_budgets_budget
+order by
+  name;
+```
+
 

--- a/docs/tables/aws_ce_anomaly_monitor.md
+++ b/docs/tables/aws_ce_anomaly_monitor.md
@@ -164,3 +164,89 @@ where
 order by
   creation_date desc;
 ```
+
+### View complete monitor specifications
+Get all details including the monitor specification which contains cost categories, tags, or dimensions configuration.
+
+```sql+postgres
+select
+  monitor_name,
+  monitor_type,
+  monitor_specification,
+  dimensional_value_count,
+  creation_date
+from
+  aws_ce_anomaly_monitor;
+```
+
+```sql+sqlite
+select
+  monitor_name,
+  monitor_type,
+  monitor_specification,
+  dimensional_value_count,
+  creation_date
+from
+  aws_ce_anomaly_monitor;
+```
+
+### Find monitors by dimension
+Retrieve monitors configured to track a specific dimension for anomaly detection.
+
+```sql+postgres
+select
+  monitor_name,
+  monitor_type,
+  monitor_dimension,
+  dimensional_value_count
+from
+  aws_ce_anomaly_monitor
+where
+  monitor_dimension = 'SERVICE'
+order by
+  dimensional_value_count desc;
+```
+
+```sql+sqlite
+select
+  monitor_name,
+  monitor_type,
+  monitor_dimension,
+  dimensional_value_count
+from
+  aws_ce_anomaly_monitor
+where
+  monitor_dimension = 'SERVICE'
+order by
+  dimensional_value_count desc;
+```
+
+### Get recently updated monitors
+List anomaly monitors sorted by their most recent update to track recent configuration changes.
+
+```sql+postgres
+select
+  monitor_name,
+  monitor_type,
+  last_updated_date,
+  last_evaluated_date,
+  creation_date
+from
+  aws_ce_anomaly_monitor
+order by
+  last_updated_date desc;
+```
+
+```sql+sqlite
+select
+  monitor_name,
+  monitor_type,
+  last_updated_date,
+  last_evaluated_date,
+  creation_date
+from
+  aws_ce_anomaly_monitor
+order by
+  last_updated_date desc;
+```
+

--- a/docs/tables/aws_ce_cost_allocation_tags.md
+++ b/docs/tables/aws_ce_cost_allocation_tags.md
@@ -294,3 +294,140 @@ where
 order by
   last_used_date desc;
 ```
+
+### List all cost allocation tag keys and their values
+Get a complete view of tag keys and all their associated values used across your AWS resources.
+
+```sql+postgres
+select
+  tag_key,
+  tag_value,
+  status,
+  type
+from
+  aws_ce_cost_allocation_tags
+where
+  tag_value is not null
+order by
+  tag_key,
+  tag_value;
+```
+
+```sql+sqlite
+select
+  tag_key,
+  tag_value,
+  status,
+  type
+from
+  aws_ce_cost_allocation_tags
+where
+  tag_value is not null
+order by
+  tag_key,
+  tag_value;
+```
+
+### Get all values for a specific tag key
+Retrieve all unique values that are being used for a specific tag key in your account.
+
+```sql+postgres
+select
+  tag_key,
+  tag_value,
+  status
+from
+  aws_ce_cost_allocation_tags
+where
+  tag_key = 'Environment'
+  and tag_value is not null
+order by
+  tag_value;
+```
+
+```sql+sqlite
+select
+  tag_key,
+  tag_value,
+  status
+from
+  aws_ce_cost_allocation_tags
+where
+  tag_key = 'Environment'
+  and tag_value is not null
+order by
+  tag_value;
+```
+
+### List active tag values for cost center allocation
+Get all active values for cost center tags to understand cost allocation distribution.
+
+```sql+postgres
+select
+  tag_key,
+  tag_value,
+  status,
+  last_used_date
+from
+  aws_ce_cost_allocation_tags
+where
+  tag_key = 'CostCenter'
+  and status = 'Active'
+  and tag_value is not null
+order by
+  tag_value;
+```
+
+```sql+sqlite
+select
+  tag_key,
+  tag_value,
+  status,
+  last_used_date
+from
+  aws_ce_cost_allocation_tags
+where
+  tag_key = 'CostCenter'
+  and status = 'Active'
+  and tag_value is not null
+order by
+  tag_value;
+```
+
+### Count unique tag values per tag key
+Analyze tag usage distribution to understand how many distinct values each tag key has.
+
+```sql+postgres
+select
+  tag_key,
+  status,
+  count(distinct tag_value) as unique_values
+from
+  aws_ce_cost_allocation_tags
+where
+  tag_value is not null
+group by
+  tag_key,
+  status
+order by
+  tag_key,
+  status;
+```
+
+```sql+sqlite
+select
+  tag_key,
+  status,
+  count(distinct tag_value) as unique_values
+from
+  aws_ce_cost_allocation_tags
+where
+  tag_value is not null
+group by
+  tag_key,
+  status
+order by
+  tag_key,
+  status;
+```
+


### PR DESCRIPTION


# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
