### PR TITLE
Add missing columns to aws_ssoadmin_instance table

### DIFF
--- a/aws/table_aws_ssoadmin_instance.go
+++ b/aws/table_aws_ssoadmin_instance.go
@@ -32,6 +32,26 @@ func tableAwsSsoAdminInstance(_ context.Context) *plugin.Table {
 				Description: "The identifier of the identity store that is connected to the SSO instance.",
 				Type:        proto.ColumnType_STRING,
 			},
+			{
+				Name:        "name",
+				Description: "The name of the Identity Center instance.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "created_date",
+				Description: "The date and time that the Identity Center instance was created.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "owner_account_id",
+				Description: "The AWS account ID number of the owner of the Identity Center instance.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "status",
+				Description: "The current status of this Identity Center instance.",
+				Type:        proto.ColumnType_STRING,
+			},
 
 			// Standard columns for all tables
 			{

--- a/docs/tables/aws_ssoadmin_instance.md
+++ b/docs/tables/aws_ssoadmin_instance.md
@@ -10,7 +10,7 @@ The AWS SSO Admin Instance is a component of AWS Single Sign-On (SSO) service th
 
 ## Table Usage Guide
 
-The `aws_ssoadmin_instance` table in Steampipe provides you with information about each AWS SSO instance in your AWS account. This table allows you, as a DevOps engineer, to query instance-specific details, including the instance ARN, identity store ID, and associated metadata. You can utilize this table to gather insights on instances, such as instance status, instance creation time, and more. The schema outlines the various attributes of the SSO admin instance for you, including the instance ARN, identity store ID, and instance status.
+The `aws_ssoadmin_instance` table in Steampipe provides you with information about each AWS SSO instance in your AWS account. This table allows you, as a DevOps engineer, to query instance-specific details, including the instance ARN, name, identity store ID, creation date, owner account ID, status, and associated metadata. You can utilize this table to gather insights on instances, such as instance status, instance creation time, ownership, and more. The schema outlines the various attributes of the SSO admin instance for you, including the instance ARN, name, identity store ID, owner account ID, creation date, and instance status.
 
 ## Examples
 
@@ -31,4 +31,62 @@ select
   identity_store_id
 from
   aws_ssoadmin_instance
+```
+
+### List instances with status and ownership details
+Explore which AWS Identity Center (SSO) instances exist in your account, including their operational status, creation date, and ownership information. This is useful for auditing instance configurations and understanding your Identity Center deployment.
+
+```sql+postgres
+select
+  name,
+  status,
+  created_date,
+  owner_account_id,
+  arn,
+  identity_store_id,
+  region
+from
+  aws_ssoadmin_instance;
+```
+
+```sql+sqlite
+select
+  name,
+  status,
+  created_date,
+  owner_account_id,
+  arn,
+  identity_store_id,
+  region
+from
+  aws_ssoadmin_instance;
+```
+
+### List instances ordered by creation date
+Identify the most recently created Identity Center instances to track deployment history and understand when SSO was enabled in your organization.
+
+```sql+postgres
+select
+  name,
+  status,
+  created_date,
+  owner_account_id,
+  region
+from
+  aws_ssoadmin_instance
+order by
+  created_date desc;
+```
+
+```sql+sqlite
+select
+  name,
+  status,
+  created_date,
+  owner_account_id,
+  region
+from
+  aws_ssoadmin_instance
+order by
+  created_date desc;
 ```


### PR DESCRIPTION
## Summary
- Adds four missing columns to the `aws_ssoadmin_instance` table: `name`, `created_date`, `owner_account_id`, and `status`
- These columns expose all available properties from the AWS SDK's `InstanceMetadata` type
- Updates documentation with examples showcasing the new columns

## Changes
- **aws/table_aws_ssoadmin_instance.go**: Added four new column definitions
- **docs/tables/aws_ssoadmin_instance.md**: Updated documentation with new examples

## Testing
- Built plugin successfully with `make install`
- Verified new columns appear in query results
- Confirmed data types and values are correct

Closes #2688