### PR TITLE
fix: upgrade urllib3, lodash and diff to fix high severity vulnerability

### DIFF
--- a/aws-test/package-lock.json
+++ b/aws-test/package-lock.json
@@ -8,10 +8,10 @@
       "dependencies": {
         "chalk": "^4.1.0",
         "custom-env": "^2.0.1",
-        "diff": "^4.0.2",
+        "diff": "^5.2.0",
         "fs-extra": "^9.0.1",
         "json-diff": "^0.5.4",
-        "lodash": "^4.17.21",
+        "lodash": "^4.17.23",
         "micromatch": "^4.0.8"
       }
     },
@@ -100,9 +100,10 @@
       }
     },
     "node_modules/diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -226,9 +227,10 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -351,9 +353,9 @@
       }
     },
     "diff": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A=="
     },
     "difflib": {
       "version": "0.2.4",
@@ -445,9 +447,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="
     },
     "micromatch": {
       "version": "4.0.8",

--- a/aws-test/package.json
+++ b/aws-test/package.json
@@ -3,10 +3,10 @@
   "dependencies": {
     "chalk": "^4.1.0",
     "custom-env": "^2.0.1",
-    "diff": "^4.0.2",
+    "diff": "^5.2.0",
     "fs-extra": "^9.0.1",
     "json-diff": "^0.5.4",
-    "lodash": "^4.17.21",
+    "lodash": "^4.17.23",
     "micromatch": "^4.0.8"
   }
 }

--- a/scripts/generate_aws_supported_endpoints/requirements.txt
+++ b/scripts/generate_aws_supported_endpoints/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.32.4
 jinja2==3.1.6
+urllib3==2.6.3

--- a/scripts/generate_parliament_iam_permissions/requirements.txt
+++ b/scripts/generate_parliament_iam_permissions/requirements.txt
@@ -4,4 +4,4 @@ chardet==4.0.0
 idna==3.7
 requests==2.32.4
 soupsieve==2.1
-urllib3==2.5.0
+urllib3==2.6.3


### PR DESCRIPTION
Title: fix: upgrade dependencies to resolve security vulnerabilities
Description:
This PR upgrades several dependencies to address high-severity security vulnerabilities (specifically related to decompression bombs and prototype pollution).

Changes:

Python Scripts: Upgraded urllib3 from 2.5.0 to 2.6.3 in [generate_parliament_iam_permissions](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [generate_aws_supported_endpoints](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html).
NPM (aws-test):
Upgraded [diff](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) from 4.0.2 to 5.2.2.
Upgraded lodash from 4.17.21 to 4.17.23.
Vulnerabilities Addressed:

[GHSA-2xpw-w6gg-jr37](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (urllib3: High 8.9)
[GHSA-38jv-5279-wg99](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (urllib3: High 8.9)
[GHSA-73rr-hh4g-fpgx](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (diff: Low 2.7)
[GHSA-xxjr-mmjv-4gpg](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (lodash: Moderate 6.9)