### PR TITLE
feat: add aws_msk_topic table

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -571,6 +571,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_mgn_application":                                          tableAwsMGNApplication(ctx),
 			"aws_mq_broker":                                                tableAwsMQBroker(ctx),
 			"aws_msk_cluster":                                              tableAwsMSKCluster(ctx),
+			"aws_msk_topic":                                                tableAwsMSKTopic(ctx),
 			"aws_msk_serverless_cluster":                                   tableAwsMSKServerlessCluster(ctx),
 			"aws_mskconnect_connector":                                     tableAwsMSKConnectConnector(ctx),
 			"aws_neptune_db_cluster_snapshot":                              tableAwsNeptuneDBClusterSnapshot(ctx),

--- a/aws/table_aws_msk_topic.go
+++ b/aws/table_aws_msk_topic.go
@@ -2,11 +2,10 @@ package aws
 
 import (
 	"context"
-	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/kafka/types"
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
@@ -28,10 +27,11 @@ func tableAwsMSKTopic(_ context.Context) *plugin.Table {
 			},
 		},
 		List: &plugin.ListConfig{
-			Hydrate:    listMSKTopics,
-			Tags:       map[string]string{"service": "kafka", "action": "ListTopics"},
+			Hydrate:       listMSKTopics,
+			ParentHydrate: listKafkaClusters(string(types.ClusterTypeProvisioned)),
+			Tags:          map[string]string{"service": "kafka", "action": "ListTopics"},
 			KeyColumns: plugin.KeyColumnSlice{
-				{Name: "cluster_arn", Require: plugin.Required},
+				{Name: "cluster_arn", Require: plugin.Optional},
 				{Name: "topic_name", Require: plugin.Optional},
 			},
 		},
@@ -119,26 +119,14 @@ type mskTopicRow struct {
 func listMSKTopics(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
 	logger := plugin.Logger(ctx)
 
-	clusterArn := d.EqualsQuals["cluster_arn"].GetStringValue()
-	if clusterArn == "" {
-		return nil, nil
-	}
+	cluster := h.Item.(types.Cluster)
+	clusterArn := cluster.ClusterArn
 
-	// The cluster_arn encodes the owning account (arn:aws:kafka:REGION:ACCOUNT_ID:cluster/...).
-	// Steampipe fans this query out to all configured connections, but only the connection
-	// whose account matches the cluster's account can call kafka-cluster:Connect on it.
-	// Skip early for non-owning connections to avoid cross-account 403 errors.
-	arnParts := strings.Split(clusterArn, ":")
-	if len(arnParts) >= 5 {
-		clusterAccountID := arnParts[4]
-		callerIdentityData, err := getCallerIdentity(ctx, d, &plugin.HydrateData{})
-		if err == nil && callerIdentityData != nil {
-			callerIdentity := callerIdentityData.(*sts.GetCallerIdentityOutput)
-			if callerIdentity.Account != nil && *callerIdentity.Account != clusterAccountID {
-				logger.Debug("aws_msk_topic.listMSKTopics", "skipping connection - account mismatch",
-					"connection_account", *callerIdentity.Account, "cluster_account", clusterAccountID)
-				return nil, nil
-			}
+	// If cluster_arn qual is provided, skip clusters that don't match
+	if d.EqualsQuals["cluster_arn"] != nil {
+		qualClusterArn := d.EqualsQuals["cluster_arn"].GetStringValue()
+		if qualClusterArn != *clusterArn {
+			return nil, nil
 		}
 	}
 
@@ -164,7 +152,7 @@ func listMSKTopics(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	}
 
 	input := kafka.ListTopicsInput{
-		ClusterArn: aws.String(clusterArn),
+		ClusterArn: clusterArn,
 		MaxResults: aws.Int32(maxLimit),
 	}
 
@@ -188,7 +176,7 @@ func listMSKTopics(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 
 		for _, topic := range output.Topics {
 			d.StreamListItem(ctx, mskTopicRow{
-				ClusterArn:            aws.String(clusterArn),
+				ClusterArn:            clusterArn,
 				TopicName:             topic.TopicName,
 				TopicArn:              topic.TopicArn,
 				PartitionCount:        topic.PartitionCount,

--- a/aws/table_aws_msk_topic.go
+++ b/aws/table_aws_msk_topic.go
@@ -1,0 +1,253 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kafka"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableAwsMSKTopic(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_msk_topic",
+		Description: "AWS MSK Topic",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AllColumns([]string{"cluster_arn", "topic_name"}),
+			Hydrate:    getMSKTopic,
+			Tags:       map[string]string{"service": "kafka", "action": "DescribeTopic"},
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"NotFoundException"}),
+			},
+		},
+		List: &plugin.ListConfig{
+			Hydrate:    listMSKTopics,
+			Tags:       map[string]string{"service": "kafka", "action": "ListTopics"},
+			KeyColumns: plugin.KeyColumnSlice{
+				{Name: "cluster_arn", Require: plugin.Required},
+				{Name: "topic_name", Require: plugin.Optional},
+			},
+		},
+		HydrateConfig: []plugin.HydrateConfig{
+			{
+				Func: describeMSKTopic,
+				Tags: map[string]string{"service": "kafka", "action": "DescribeTopic"},
+			},
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(AWS_KAFKA_SERVICE_ID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "cluster_arn",
+				Description: "The Amazon Resource Name (ARN) of the MSK cluster.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "topic_name",
+				Description: "The name of the Kafka topic.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "topic_arn",
+				Description: "The Amazon Resource Name (ARN) of the topic.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "partition_count",
+				Description: "The number of partitions for the topic.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "replication_factor",
+				Description: "The replication factor for the topic.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "out_of_sync_replica_count",
+				Description: "The number of out-of-sync replicas for the topic.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "status",
+				Description: "The status of the topic.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     describeMSKTopic,
+				Transform:   transform.FromField("Status"),
+			},
+			{
+				Name:        "configs",
+				Description: "Topic configurations encoded as a Base64 string.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     describeMSKTopic,
+				Transform:   transform.FromField("Configs"),
+			},
+
+			// Standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("TopicName"),
+			},
+			{
+				Name:        "akas",
+				Description: resourceInterfaceDescription("akas"),
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("TopicArn").Transform(transform.EnsureStringArray),
+			},
+		}),
+	}
+}
+
+type mskTopicRow struct {
+	ClusterArn           *string
+	TopicName            *string
+	TopicArn             *string
+	PartitionCount       *int32
+	ReplicationFactor    *int32
+	OutOfSyncReplicaCount *int32
+}
+
+//// LIST FUNCTION
+
+func listMSKTopics(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+
+	clusterArn := d.EqualsQuals["cluster_arn"].GetStringValue()
+	if clusterArn == "" {
+		return nil, nil
+	}
+
+	svc, err := KafkaClient(ctx, d)
+	if err != nil {
+		logger.Error("aws_msk_topic.listMSKTopics", "service_creation_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		return nil, nil
+	}
+
+	maxLimit := int32(100)
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxLimit {
+			if limit < 20 {
+				maxLimit = 20
+			} else {
+				maxLimit = limit
+			}
+		}
+	}
+
+	input := kafka.ListTopicsInput{
+		ClusterArn: aws.String(clusterArn),
+		MaxResults: aws.Int32(maxLimit),
+	}
+
+	if d.EqualsQuals["topic_name"] != nil {
+		input.TopicNameFilter = aws.String(d.EqualsQuals["topic_name"].GetStringValue())
+	}
+
+	paginator := kafka.NewListTopicsPaginator(svc, &input, func(o *kafka.ListTopicsPaginatorOptions) {
+		o.Limit = maxLimit
+		o.StopOnDuplicateToken = true
+	})
+
+	for paginator.HasMorePages() {
+		d.WaitForListRateLimit(ctx)
+
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			logger.Error("aws_msk_topic.listMSKTopics", "api_error", err)
+			return nil, err
+		}
+
+		for _, topic := range output.Topics {
+			d.StreamListItem(ctx, mskTopicRow{
+				ClusterArn:            aws.String(clusterArn),
+				TopicName:             topic.TopicName,
+				TopicArn:              topic.TopicArn,
+				PartitionCount:        topic.PartitionCount,
+				ReplicationFactor:     topic.ReplicationFactor,
+				OutOfSyncReplicaCount: topic.OutOfSyncReplicaCount,
+			})
+
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getMSKTopic(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+
+	clusterArn := d.EqualsQuals["cluster_arn"].GetStringValue()
+	topicName := d.EqualsQuals["topic_name"].GetStringValue()
+	if clusterArn == "" || topicName == "" {
+		return nil, nil
+	}
+
+	svc, err := KafkaClient(ctx, d)
+	if err != nil {
+		logger.Error("aws_msk_topic.getMSKTopic", "service_creation_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		return nil, nil
+	}
+
+	output, err := svc.DescribeTopic(ctx, &kafka.DescribeTopicInput{
+		ClusterArn: aws.String(clusterArn),
+		TopicName:  aws.String(topicName),
+	})
+	if err != nil {
+		logger.Error("aws_msk_topic.getMSKTopic", "api_error", err)
+		return nil, err
+	}
+
+	return mskTopicRow{
+		ClusterArn:        aws.String(clusterArn),
+		TopicName:         output.TopicName,
+		TopicArn:          output.TopicArn,
+		PartitionCount:    output.PartitionCount,
+		ReplicationFactor: output.ReplicationFactor,
+	}, nil
+}
+
+func describeMSKTopic(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	logger := plugin.Logger(ctx)
+	row := h.Item.(mskTopicRow)
+
+	if row.ClusterArn == nil || row.TopicName == nil {
+		return nil, nil
+	}
+
+	svc, err := KafkaClient(ctx, d)
+	if err != nil {
+		logger.Error("aws_msk_topic.describeMSKTopic", "service_creation_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		return nil, nil
+	}
+
+	output, err := svc.DescribeTopic(ctx, &kafka.DescribeTopicInput{
+		ClusterArn: row.ClusterArn,
+		TopicName:  row.TopicName,
+	})
+	if err != nil {
+		logger.Error("aws_msk_topic.describeMSKTopic", "api_error", err)
+		return nil, err
+	}
+
+	return output, nil
+}

--- a/aws/table_aws_msk_topic.go
+++ b/aws/table_aws_msk_topic.go
@@ -2,9 +2,11 @@ package aws
 
 import (
 	"context"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/kafka"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 
 	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
 	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
@@ -120,6 +122,24 @@ func listMSKTopics(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	clusterArn := d.EqualsQuals["cluster_arn"].GetStringValue()
 	if clusterArn == "" {
 		return nil, nil
+	}
+
+	// The cluster_arn encodes the owning account (arn:aws:kafka:REGION:ACCOUNT_ID:cluster/...).
+	// Steampipe fans this query out to all configured connections, but only the connection
+	// whose account matches the cluster's account can call kafka-cluster:Connect on it.
+	// Skip early for non-owning connections to avoid cross-account 403 errors.
+	arnParts := strings.Split(clusterArn, ":")
+	if len(arnParts) >= 5 {
+		clusterAccountID := arnParts[4]
+		callerIdentityData, err := getCallerIdentity(ctx, d, &plugin.HydrateData{})
+		if err == nil && callerIdentityData != nil {
+			callerIdentity := callerIdentityData.(*sts.GetCallerIdentityOutput)
+			if callerIdentity.Account != nil && *callerIdentity.Account != clusterAccountID {
+				logger.Debug("aws_msk_topic.listMSKTopics", "skipping connection - account mismatch",
+					"connection_account", *callerIdentity.Account, "cluster_account", clusterAccountID)
+				return nil, nil
+			}
+		}
 	}
 
 	svc, err := KafkaClient(ctx, d)

--- a/aws/table_aws_msk_topic.go
+++ b/aws/table_aws_msk_topic.go
@@ -122,6 +122,11 @@ func listMSKTopics(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 	cluster := h.Item.(types.Cluster)
 	clusterArn := cluster.ClusterArn
 
+	// Skip clusters that aren't ACTIVE — ListTopics fails on CREATING/DELETING clusters
+	if cluster.State != types.ClusterStateActive {
+		return nil, nil
+	}
+
 	// If cluster_arn qual is provided, skip clusters that don't match
 	if d.EqualsQuals["cluster_arn"] != nil {
 		qualClusterArn := d.EqualsQuals["cluster_arn"].GetStringValue()

--- a/docs/tables/aws_msk_topic.md
+++ b/docs/tables/aws_msk_topic.md
@@ -1,0 +1,139 @@
+---
+title: "Steampipe Table: aws_msk_topic - Query AWS MSK Topics using SQL"
+description: "Allows users to query Kafka topics on AWS Managed Streaming for Apache Kafka (MSK) clusters."
+folder: "MSK"
+---
+
+# Table: aws_msk_topic - Query AWS MSK Topics using SQL
+
+An AWS MSK topic is a category or feed name to which records are published in an Amazon Managed Streaming for Apache Kafka cluster. Topics are partitioned and replicated across the brokers in the cluster.
+
+## Table Usage Guide
+
+The `aws_msk_topic` table in Steampipe provides you with information about Kafka topics within AWS MSK clusters. This table allows you to query topic-specific details, including partition count, replication factor, and synchronization status. You can utilize this table to monitor topic health, identify under-replicated topics, and review topic configurations. Note that `cluster_arn` is a required key column for all queries.
+
+## Examples
+
+### Basic info
+Explore the topics configured on a specific MSK cluster.
+
+```sql+postgres
+select
+  topic_name,
+  topic_arn,
+  partition_count,
+  replication_factor,
+  cluster_arn
+from
+  aws_msk_topic
+where
+  cluster_arn = 'arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abcd1234';
+```
+
+```sql+sqlite
+select
+  topic_name,
+  topic_arn,
+  partition_count,
+  replication_factor,
+  cluster_arn
+from
+  aws_msk_topic
+where
+  cluster_arn = 'arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abcd1234';
+```
+
+### List topics with out-of-sync replicas
+Identify topics that have out-of-sync replicas, which may indicate potential data durability issues.
+
+```sql+postgres
+select
+  topic_name,
+  partition_count,
+  replication_factor,
+  out_of_sync_replica_count,
+  cluster_arn
+from
+  aws_msk_topic
+where
+  cluster_arn = 'arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abcd1234'
+  and out_of_sync_replica_count > 0;
+```
+
+```sql+sqlite
+select
+  topic_name,
+  partition_count,
+  replication_factor,
+  out_of_sync_replica_count,
+  cluster_arn
+from
+  aws_msk_topic
+where
+  cluster_arn = 'arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abcd1234'
+  and out_of_sync_replica_count > 0;
+```
+
+### Get topic details including status
+Retrieve detailed information about a specific topic including its status and configuration.
+
+```sql+postgres
+select
+  topic_name,
+  topic_arn,
+  partition_count,
+  replication_factor,
+  status,
+  configs,
+  cluster_arn
+from
+  aws_msk_topic
+where
+  cluster_arn = 'arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abcd1234'
+  and topic_name = 'my-topic';
+```
+
+```sql+sqlite
+select
+  topic_name,
+  topic_arn,
+  partition_count,
+  replication_factor,
+  status,
+  configs,
+  cluster_arn
+from
+  aws_msk_topic
+where
+  cluster_arn = 'arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abcd1234'
+  and topic_name = 'my-topic';
+```
+
+### List topics with low replication factor
+Find topics with a replication factor less than 3, which may not meet high-availability requirements.
+
+```sql+postgres
+select
+  topic_name,
+  partition_count,
+  replication_factor,
+  cluster_arn
+from
+  aws_msk_topic
+where
+  cluster_arn = 'arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abcd1234'
+  and replication_factor < 3;
+```
+
+```sql+sqlite
+select
+  topic_name,
+  partition_count,
+  replication_factor,
+  cluster_arn
+from
+  aws_msk_topic
+where
+  cluster_arn = 'arn:aws:kafka:us-east-1:123456789012:cluster/my-cluster/abcd1234'
+  and replication_factor < 3;
+```

--- a/docs/tables/aws_msk_topic.md
+++ b/docs/tables/aws_msk_topic.md
@@ -10,11 +10,36 @@ An AWS MSK topic is a category or feed name to which records are published in an
 
 ## Table Usage Guide
 
-The `aws_msk_topic` table in Steampipe provides you with information about Kafka topics within AWS MSK clusters. This table allows you to query topic-specific details, including partition count, replication factor, and synchronization status. You can utilize this table to monitor topic health, identify under-replicated topics, and review topic configurations. Note that `cluster_arn` is a required key column for all queries.
+The `aws_msk_topic` table in Steampipe provides you with information about Kafka topics within AWS MSK clusters. This table allows you to query topic-specific details, including partition count, replication factor, and synchronization status. You can utilize this table to monitor topic health, identify under-replicated topics, and review topic configurations across all provisioned MSK clusters. You can optionally filter by `cluster_arn` to narrow results to a specific cluster.
 
 ## Examples
 
 ### Basic info
+List all topics across all provisioned MSK clusters.
+
+```sql+postgres
+select
+  topic_name,
+  topic_arn,
+  partition_count,
+  replication_factor,
+  cluster_arn
+from
+  aws_msk_topic;
+```
+
+```sql+sqlite
+select
+  topic_name,
+  topic_arn,
+  partition_count,
+  replication_factor,
+  cluster_arn
+from
+  aws_msk_topic;
+```
+
+### List topics for a specific cluster
 Explore the topics configured on a specific MSK cluster.
 
 ```sql+postgres

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.1
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.41.1
+	github.com/aws/aws-sdk-go-v2 v1.41.4
 	github.com/aws/aws-sdk-go-v2/config v1.29.14
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.67
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.21
@@ -82,7 +82,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/inspector v1.21.4
 	github.com/aws/aws-sdk-go-v2/service/inspector2 v1.24.4
 	github.com/aws/aws-sdk-go-v2/service/iot v1.53.3
-	github.com/aws/aws-sdk-go-v2/service/kafka v1.31.2
+	github.com/aws/aws-sdk-go-v2/service/kafka v1.49.1
 	github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.23.6
 	github.com/aws/aws-sdk-go-v2/service/keyspaces v1.10.8
 	github.com/aws/aws-sdk-go-v2/service/kinesis v1.27.4
@@ -147,7 +147,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.48.2
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.29.4
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.38.4
-	github.com/aws/smithy-go v1.24.0
+	github.com/aws/smithy-go v1.24.2
 	github.com/gocarina/gocsv v0.0.0-20201208093247-67c824bc04d4
 	github.com/goccy/go-yaml v1.11.3
 	github.com/golang/protobuf v1.5.4
@@ -185,8 +185,8 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.11 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -632,8 +632,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmms
 github.com/aws/aws-sdk-go v1.44.122/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/aws/aws-sdk-go v1.44.183 h1:mUk45JZTIMMg9m8GmrbvACCsIOKtKezXRxp06uI5Ahk=
 github.com/aws/aws-sdk-go v1.44.183/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
-github.com/aws/aws-sdk-go-v2 v1.41.1 h1:ABlyEARCDLN034NhxlRUSZr4l71mh+T5KAeGh6cerhU=
-github.com/aws/aws-sdk-go-v2 v1.41.1/go.mod h1:MayyLB8y+buD9hZqkCW3kX1AKq07Y5pXxtgB+rRFhz0=
+github.com/aws/aws-sdk-go-v2 v1.41.4 h1:10f50G7WyU02T56ox1wWXq+zTX9I1zxG46HYuG1hH/k=
+github.com/aws/aws-sdk-go-v2 v1.41.4/go.mod h1:mwsPRE8ceUUpiTgF7QmQIJ7lgsKUPQOUl3o72QBrE1o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10 h1:zAybnyUQXIZ5mok5Jqwlf58/TFE7uvd3IAsa1aF9cXs=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.6.10/go.mod h1:qqvMj6gHLR/EXWZw4ZbqlPbQUyenf4h82UQUlKc+l14=
 github.com/aws/aws-sdk-go-v2/config v1.29.14 h1:f+eEi/2cKCg9pqKBoAIwRGzVb70MRKqWX4dg1BDcSJM=
@@ -644,10 +644,10 @@ github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30 h1:x793wxmUWVDhshP8WW2mln
 github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.16.30/go.mod h1:Jpne2tDnYiFascUEs2AWHJL9Yp7A5ZVy3TNyxaAjD6M=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.21 h1:1v8Ii0MRVGYB/sdhkbxrtolCA7Tp+lGh+5OJTs5vmZ8=
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.21/go.mod h1:cxdd1rc8yxCjKz28hi30XN1jDXr2DxZvD44vLxTz/bg=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17 h1:xOLELNKGp2vsiteLsvLPwxC+mYmO6OZ8PYgiuPJzF8U=
-github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.17/go.mod h1:5M5CI3D12dNOtH3/mk6minaRwI2/37ifCURZISxA/IQ=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17 h1:WWLqlh79iO48yLkj1v3ISRNiv+3KdQoZ6JWyfcsyQik=
-github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.17/go.mod h1:EhG22vHRrvF8oXSTYStZhJc1aUgKtnJe+aOiFEV90cM=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20 h1:CNXO7mvgThFGqOFgbNAP2nol2qAWBOGfqR/7tQlvLmc=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.20/go.mod h1:oydPDJKcfMhgfcgBUZaG+toBbwy8yPWubJXBVERtI4o=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20 h1:tN6W/hg+pkM+tf9XDkWUbDEjGLb+raoBMFsTodcoYKw=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.20/go.mod h1:YJ898MhD067hSHA6xYCx5ts/jEd8BSOLtQDL3iZsvbc=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3 h1:bIqFDwgGXXN1Kpp99pDOdKMTTb5d2KyU5X/BZxjOkRo=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.3/go.mod h1:H5O/EsxDWyU+LP/V8i5sm8cxoZgc2fdNR9bxlOFrQTo=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.11 h1:bKgSxk1TW//00PGQqYmrq83c+2myGidEclp+t9pPqVI=
@@ -808,8 +808,8 @@ github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15 h1:moLQUoVq91Liq
 github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.18.15/go.mod h1:ZH34PJUc8ApjBIfgQCFvkWcUDBtl/WTD+uiYHjd8igA=
 github.com/aws/aws-sdk-go-v2/service/iot v1.53.3 h1:d9R8dezHswXV9am8Sz+1HOsCas1/7YmJQQq7FmpD7rQ=
 github.com/aws/aws-sdk-go-v2/service/iot v1.53.3/go.mod h1:7rtIbAvSP5Nbc1f7sbeWa+uMV+T6khOkWAh6VHsbOZI=
-github.com/aws/aws-sdk-go-v2/service/kafka v1.31.2 h1:jODSVa9LbXmZKRLy4KLFHCfhKlCGzU8FPOClKTqrh9U=
-github.com/aws/aws-sdk-go-v2/service/kafka v1.31.2/go.mod h1:ofW8A+AyFHi/MMYwYI5YkJ5h2JWCCtyHR/P7UQONcyc=
+github.com/aws/aws-sdk-go-v2/service/kafka v1.49.1 h1:BgBatWcQIFqF1l6KGHjv66V0d/ISnWrTwxDx/Jf6EJM=
+github.com/aws/aws-sdk-go-v2/service/kafka v1.49.1/go.mod h1:pMpys+PlrN//vj8j5s0oOAMJjauj81VkHzIZxPVWOro=
 github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.23.6 h1:ihOQVwcgeNWwKNnlJ7Ar+2vNrT1vHf3TkMMbYkjMqRg=
 github.com/aws/aws-sdk-go-v2/service/kafkaconnect v1.23.6/go.mod h1:y37BbtndiEKtaB7oZAkqSIq3h5pdFqRDZQLV/WFu07s=
 github.com/aws/aws-sdk-go-v2/service/keyspaces v1.10.8 h1:GVvpQbXfUVPnpydvOt+CfZPaZgLcGyJoJRSefunMuIo=
@@ -944,8 +944,8 @@ github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.29.4 h1:OuFs453KXWTLBkem
 github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.29.4/go.mod h1:MRT/P9Cwn+7xCCVpD1sTvUESiWMAc9hA+FooRsW5fe8=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.38.4 h1:SvHYikdxmnyptMebU3zFfXbfU96SHzdUX+KXqa6pjYE=
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.38.4/go.mod h1:1XK49PATLHBd7mpKqO91GqRuV7bEsmyQ8Lslvn3fFj4=
-github.com/aws/smithy-go v1.24.0 h1:LpilSUItNPFr1eY85RYgTIg5eIEPtvFbskaFcmmIUnk=
-github.com/aws/smithy-go v1.24.0/go.mod h1:LEj2LM3rBRQJxPZTB4KuzZkaZYnZPnvgIhb4pu07mx0=
+github.com/aws/smithy-go v1.24.2 h1:FzA3bu/nt/vDvmnkg+R8Xl46gmzEDam6mZ1hzmwXFng=
+github.com/aws/smithy-go v1.24.2/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
Add new table to query Kafka topics on MSK clusters via the ListTopics and DescribeTopic APIs. Upgrade kafka SDK from v1.31.2 to v1.49.1 to access the topic management APIs.

# Example query results
<details>
  <summary>Results</summary>

```
steampipe query "select topic_arn from aws_msk_topic where cluster_arn = 'arn:aws:kafka:us-east-1:...'

+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| topic_arn                                                                                                                                                                                                            |
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
| arn:aws:kafka:us-east-1:...:topic/stage-use1-cdc/...        |
```
</details>
