### PR TITLE
refactor: clean up AWS service IDs and add new regions in endpoint configurations

### DIFF
--- a/aws/endpoint_service_ids_gen.go
+++ b/aws/endpoint_service_ids_gen.go
@@ -30,8 +30,6 @@ const AWS_API_ECR_SERVICE_ID = "api.ecr"
 
 const AWS_API_ECR_PUBLIC_SERVICE_ID = "api.ecr-public"
 
-const AWS_API_FLEETHUB_IOT_SERVICE_ID = "api.fleethub.iot"
-
 const AWS_API_IOTDEVICEADVISOR_SERVICE_ID = "api.iotdeviceadvisor"
 
 const AWS_API_IOTWIRELESS_SERVICE_ID = "api.iotwireless"
@@ -65,8 +63,6 @@ const AWS_APPRUNNER_SERVICE_ID = "apprunner"
 const AWS_APPSTREAM2_SERVICE_ID = "appstream2"
 
 const AWS_APPSYNC_SERVICE_ID = "appsync"
-
-const AWS_APPTEST_SERVICE_ID = "apptest"
 
 const AWS_APS_SERVICE_ID = "aps"
 
@@ -135,6 +131,8 @@ const AWS_CODECATALYST_SERVICE_ID = "codecatalyst"
 const AWS_CODECOMMIT_SERVICE_ID = "codecommit"
 
 const AWS_CODEDEPLOY_SERVICE_ID = "codedeploy"
+
+const AWS_CODEGURU_PROFILER_SERVICE_ID = "codeguru-profiler"
 
 const AWS_CODEGURU_REVIEWER_SERVICE_ID = "codeguru-reviewer"
 
@@ -232,8 +230,6 @@ const AWS_ELASTICLOADBALANCING_SERVICE_ID = "elasticloadbalancing"
 
 const AWS_ELASTICMAPREDUCE_SERVICE_ID = "elasticmapreduce"
 
-const AWS_ELASTICTRANSCODER_SERVICE_ID = "elastictranscoder"
-
 const AWS_EMAIL_SERVICE_ID = "email"
 
 const AWS_EMR_CONTAINERS_SERVICE_ID = "emr-containers"
@@ -245,8 +241,6 @@ const AWS_ENTITLEMENT_MARKETPLACE_SERVICE_ID = "entitlement.marketplace"
 const AWS_ES_SERVICE_ID = "es"
 
 const AWS_EVENTS_SERVICE_ID = "events"
-
-const AWS_EVIDENTLY_SERVICE_ID = "evidently"
 
 const AWS_FINSPACE_SERVICE_ID = "finspace"
 
@@ -306,8 +300,6 @@ const AWS_INTERNETMONITOR_SERVICE_ID = "internetmonitor"
 
 const AWS_IOT_SERVICE_ID = "iot"
 
-const AWS_IOTANALYTICS_SERVICE_ID = "iotanalytics"
-
 const AWS_IOTEVENTS_SERVICE_ID = "iotevents"
 
 const AWS_IOTEVENTSDATA_SERVICE_ID = "ioteventsdata"
@@ -361,10 +353,6 @@ const AWS_LIGHTSAIL_SERVICE_ID = "lightsail"
 const AWS_LOGS_SERVICE_ID = "logs"
 
 const AWS_LOOKOUTEQUIPMENT_SERVICE_ID = "lookoutequipment"
-
-const AWS_LOOKOUTMETRICS_SERVICE_ID = "lookoutmetrics"
-
-const AWS_LOOKOUTVISION_SERVICE_ID = "lookoutvision"
 
 const AWS_M2_SERVICE_ID = "m2"
 
@@ -434,15 +422,13 @@ const AWS_NOTIFICATIONS_SERVICE_ID = "notifications"
 
 const AWS_NOTIFICATIONS_CONTACTS_SERVICE_ID = "notifications-contacts"
 
+const AWS_NOVA_ACT_SERVICE_ID = "nova-act"
+
 const AWS_OAM_SERVICE_ID = "oam"
 
 const AWS_OIDC_SERVICE_ID = "oidc"
 
 const AWS_OMICS_SERVICE_ID = "omics"
-
-const AWS_OPSWORKS_SERVICE_ID = "opsworks"
-
-const AWS_OPSWORKS_CM_SERVICE_ID = "opsworks-cm"
 
 const AWS_ORGANIZATIONS_SERVICE_ID = "organizations"
 
@@ -451,6 +437,8 @@ const AWS_OSIS_SERVICE_ID = "osis"
 const AWS_OUTPOSTS_SERVICE_ID = "outposts"
 
 const AWS_PARTICIPANT_CONNECT_SERVICE_ID = "participant.connect"
+
+const AWS_PARTNERCENTRAL_CHANNEL_SERVICE_ID = "partnercentral-channel"
 
 const AWS_PERSONALIZE_SERVICE_ID = "personalize"
 
@@ -464,15 +452,11 @@ const AWS_POLLY_SERVICE_ID = "polly"
 
 const AWS_PORTAL_SSO_SERVICE_ID = "portal.sso"
 
-const AWS_PRIVATE_NETWORKS_SERVICE_ID = "private-networks"
-
 const AWS_PROFILE_SERVICE_ID = "profile"
 
 const AWS_PROTON_SERVICE_ID = "proton"
 
 const AWS_QBUSINESS_SERVICE_ID = "qbusiness"
-
-const AWS_QLDB_SERVICE_ID = "qldb"
 
 const AWS_QUERY_TIMESTREAM_SERVICE_ID = "query.timestream"
 
@@ -497,8 +481,6 @@ const AWS_RESILIENCEHUB_SERVICE_ID = "resiliencehub"
 const AWS_RESOURCE_EXPLORER_2_SERVICE_ID = "resource-explorer-2"
 
 const AWS_RESOURCE_GROUPS_SERVICE_ID = "resource-groups"
-
-const AWS_ROBOMAKER_SERVICE_ID = "robomaker"
 
 const AWS_ROLESANYWHERE_SERVICE_ID = "rolesanywhere"
 
@@ -552,15 +534,11 @@ const AWS_SERVICEDISCOVERY_SERVICE_ID = "servicediscovery"
 
 const AWS_SERVICEQUOTAS_SERVICE_ID = "servicequotas"
 
-const AWS_SESSION_QLDB_SERVICE_ID = "session.qldb"
-
 const AWS_SHIELD_SERVICE_ID = "shield"
 
 const AWS_SIGNER_SERVICE_ID = "signer"
 
 const AWS_SIMSPACEWEAVER_SERVICE_ID = "simspaceweaver"
-
-const AWS_SMS_SERVICE_ID = "sms"
 
 const AWS_SMS_VOICE_SERVICE_ID = "sms-voice"
 

--- a/aws/multi_region.go
+++ b/aws/multi_region.go
@@ -761,7 +761,9 @@ func awsCommercialRegionPrefixes() []string {
 		"ap",
 		"ca",
 		"eu",
+		"il",
 		"me",
+		"mx",
 		"sa",
 		"us",
 	}

--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -214,8 +214,8 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			{
 				// All other control plane APIs (including ListFunctions) share a limit of 15 requests per second
 				Name:       "aws_lambda_list_functions_and_get_function_url_config",
-				FillRate:   10,
-				BucketSize: 10,
+				FillRate:   15,
+				BucketSize: 15,
 				Scope:      []string{"connection", "region", "service", "action"},
 				Where:      "service = 'lambda' and action in ('ListFunctions', 'GetFunctionUrlConfig')",
 			},
@@ -276,7 +276,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_bedrock_guardrail":                                        tableAwsBedrockGuardrail(ctx),
 			"aws_budgets_budget":                                           tableAwsBudgetsBudget(ctx),
 			"aws_ce_anomaly_monitor":                                       tableAwsCEAnomalyMonitor(ctx),
-			"aws_ce_cost_allocation_tags":                                   tableAwsCECostAllocationTags(ctx),
+			"aws_ce_cost_allocation_tags":                                  tableAwsCECostAllocationTags(ctx),
 			"aws_cloudcontrol_resource":                                    tableAwsCloudControlResource(ctx),
 			"aws_cloudformation_stack_resource":                            tableAwsCloudFormationStackResource(ctx),
 			"aws_cloudformation_stack_set":                                 tableAwsCloudFormationStackSet(ctx),

--- a/aws/service.go
+++ b/aws/service.go
@@ -230,24 +230,9 @@ func APIGatewayClient(ctx context.Context, d *plugin.QueryData) (*apigateway.Cli
 }
 
 func APIGatewayV2Client(ctx context.Context, d *plugin.QueryData) (*apigatewayv2.Client, error) {
-	// API Gateway V2 has the same endpoint information in the SDK as API Gateway, but
-	// is actually available in less regions. We have to manually remove them
-	// here.
-	// Source - https://www.aws-services.info/apigatewayv2.html
-	excludeRegions := []string{
-		"ap-south-2",     // Hyderabad
-		"ap-southeast-3", // Jakarta
-		"ap-southeast-4", // Melbourne
-		"eu-central-2",   // Zurich
-		"eu-south-2",     // Spain
-		"il-central-1",   // Israel (Tel Aviv)
-	}
-	cfg, err := getClientForQuerySupportedRegionWithExclusions(ctx, d, AWS_APIGATEWAY_SERVICE_ID, excludeRegions)
+	cfg, err := getClientForQueryRegion(ctx, d)
 	if err != nil {
 		return nil, err
-	}
-	if cfg == nil {
-		return nil, nil
 	}
 	return apigatewayv2.NewFromConfig(*cfg), nil
 }
@@ -1274,13 +1259,12 @@ func RDSDBRecommendationClient(ctx context.Context, d *plugin.QueryData) (*rds.C
 	// RDS DB Recommendation has the same endpoint information in the SDK as RDS, but
 	// is actually available in less regions. We have to manually remove them
 	// here.
-	// Source - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UserRecommendationsView.html
+	// Source - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/monitoring-recommendations.html
 	excludeRegions := []string{
 		"af-south-1",     // Africa (Cape Town)
 		"ap-east-1",      // Asia Pacific (Hong Kong)
 		"ap-northeast-3", // Asia Pacific (Osaka)
 		"ap-southeast-3", // Asia Pacific (Jakarta)
-		"eu-north-1",     // Europe (Stockholm)
 		"eu-south-1",     // Europe (Milan)
 		"me-central-1",   // Middle East (UAE)
 		"me-south-1",     // Middle East (Bahrain)
@@ -1302,26 +1286,9 @@ func RDSDBRecommendationClient(ctx context.Context, d *plugin.QueryData) (*rds.C
 }
 
 func RDSDBProxyClient(ctx context.Context, d *plugin.QueryData) (*rds.Client, error) {
-	// RDS DB Proxy has the same endpoint information in the SDK as RDS, but
-	// is actually available in less regions. We have to manually remove them
-	// here.
-	// Source - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Concepts.RDS_Fea_Regions_DB-eng.Feature.RDSProxy.html
-	excludeRegions := []string{
-		"ap-south-2",     // Hyderabad
-		"ap-southeast-3", // Jakarta
-		"ap-southeast-4", // Melbourne
-		"eu-central-2",   // Zurich
-		"eu-south-2",     // Spain
-		"me-central-1",   // UAE
-	}
-	excludeRegions = append(excludeRegions, getRegionByPartition("aws-cn")...)
-	excludeRegions = append(excludeRegions, getRegionByPartition("aws-us-gov")...)
-	cfg, err := getClientForQuerySupportedRegionWithExclusions(ctx, d, AWS_RDS_SERVICE_ID, excludeRegions)
+	cfg, err := getClientForQueryRegion(ctx, d)
 	if err != nil {
 		return nil, err
-	}
-	if cfg == nil {
-		return nil, nil
 	}
 	return rds.NewFromConfig(*cfg), nil
 }

--- a/internal/aws_endpoint_generator/endpoints.json
+++ b/internal/aws_endpoint_generator/endpoints.json
@@ -29,6 +29,9 @@
       "ap-east-1" : {
         "description" : "Asia Pacific (Hong Kong)"
       },
+      "ap-east-2" : {
+        "description" : "Asia Pacific (Taipei)"
+      },
       "ap-northeast-1" : {
         "description" : "Asia Pacific (Tokyo)"
       },
@@ -58,6 +61,9 @@
       },
       "ap-southeast-5" : {
         "description" : "Asia Pacific (Malaysia)"
+      },
+      "ap-southeast-6" : {
+        "description" : "Asia Pacific (New Zealand)"
       },
       "ap-southeast-7" : {
         "description" : "Asia Pacific (Thailand)"
@@ -135,6 +141,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "access-analyzer.ap-northeast-1.api.aws",
@@ -195,6 +202,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "access-analyzer.ap-southeast-7.api.aws",
@@ -411,6 +419,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -421,6 +430,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -522,6 +532,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -532,6 +543,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -649,6 +661,8 @@
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
           "eu-central-1" : { },
@@ -744,7 +758,9 @@
           "ap-east-1" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
+          "ap-northeast-3" : { },
           "ap-south-1" : { },
+          "ap-south-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ca-central-1" : { },
@@ -989,6 +1005,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "credentialScope" : {
               "region" : "ap-northeast-1"
@@ -1089,6 +1106,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "credentialScope" : {
               "region" : "ap-southeast-7"
@@ -1431,71 +1449,6 @@
           }
         }
       },
-      "api.fleethub.iot" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-northeast-2" : { },
-          "ap-south-1" : { },
-          "ap-southeast-1" : { },
-          "ap-southeast-2" : { },
-          "ca-central-1" : {
-            "variants" : [ {
-              "hostname" : "api.fleethub.iot-fips.ca-central-1.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "eu-central-1" : { },
-          "eu-north-1" : { },
-          "eu-west-1" : { },
-          "eu-west-2" : { },
-          "fips-ca-central-1" : {
-            "credentialScope" : {
-              "region" : "ca-central-1"
-            },
-            "deprecated" : true,
-            "hostname" : "api.fleethub.iot-fips.ca-central-1.amazonaws.com"
-          },
-          "fips-us-east-1" : {
-            "credentialScope" : {
-              "region" : "us-east-1"
-            },
-            "deprecated" : true,
-            "hostname" : "api.fleethub.iot-fips.us-east-1.amazonaws.com"
-          },
-          "fips-us-east-2" : {
-            "credentialScope" : {
-              "region" : "us-east-2"
-            },
-            "deprecated" : true,
-            "hostname" : "api.fleethub.iot-fips.us-east-2.amazonaws.com"
-          },
-          "fips-us-west-2" : {
-            "credentialScope" : {
-              "region" : "us-west-2"
-            },
-            "deprecated" : true,
-            "hostname" : "api.fleethub.iot-fips.us-west-2.amazonaws.com"
-          },
-          "us-east-1" : {
-            "variants" : [ {
-              "hostname" : "api.fleethub.iot-fips.us-east-1.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "us-east-2" : {
-            "variants" : [ {
-              "hostname" : "api.fleethub.iot-fips.us-east-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "us-west-2" : {
-            "variants" : [ {
-              "hostname" : "api.fleethub.iot-fips.us-west-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          }
-        }
-      },
       "api.iotdeviceadvisor" : {
         "endpoints" : {
           "ap-northeast-1" : {
@@ -1581,6 +1534,7 @@
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-north-1" : { },
@@ -1615,6 +1569,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -1625,6 +1580,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -1772,6 +1728,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "api.iot-tunneling-fips.ca-central-1.api.aws",
@@ -1796,6 +1753,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-south-2" : { },
           "eu-west-1" : {
             "variants" : [ {
               "hostname" : "api.iot-tunneling.eu-west-1.api.aws",
@@ -1921,6 +1879,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -1931,6 +1890,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -2043,6 +2003,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -2053,6 +2014,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -2079,6 +2041,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -2089,6 +2052,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -2186,6 +2150,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -2196,6 +2161,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -2757,8 +2723,11 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
+          "eu-south-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
@@ -2769,6 +2738,7 @@
             "deprecated" : true,
             "hostname" : "appstream2-fips.us-west-2.amazonaws.com"
           },
+          "il-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
@@ -2867,12 +2837,15 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "appsync.ca-central-1.api.aws",
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ca-west-1" : { },
           "eu-central-1" : {
             "variants" : [ {
               "hostname" : "appsync.eu-central-1.api.aws",
@@ -2971,26 +2944,14 @@
           }
         }
       },
-      "apptest" : {
-        "endpoints" : {
-          "ap-southeast-2" : { },
-          "eu-central-1" : { },
-          "fips-us-east-1" : {
-            "deprecated" : true
-          },
-          "sa-east-1" : { },
-          "us-east-1" : {
-            "variants" : [ {
-              "tags" : [ "fips" ]
-            } ]
-          }
-        }
-      },
       "aps" : {
         "defaults" : {
           "protocols" : [ "https" ]
         },
         "endpoints" : {
+          "af-south-1" : { },
+          "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -3001,11 +2962,13 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-northeast-3" : { },
           "ap-south-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-south-2" : { },
           "ap-southeast-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -3016,17 +2979,25 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-central-2" : { },
           "eu-north-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-south-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -3042,6 +3013,10 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "il-central-1" : { },
+          "me-central-1" : { },
+          "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -3071,6 +3046,7 @@
           "us-east-2-fips" : {
             "deprecated" : true
           },
+          "us-west-1" : { },
           "us-west-2" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -3089,6 +3065,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -3099,6 +3076,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -3135,6 +3113,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "athena.ap-northeast-1.api.aws",
@@ -3195,6 +3174,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -3456,6 +3436,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -3466,6 +3447,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -3593,6 +3575,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -3603,6 +3586,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -3660,6 +3644,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -3670,6 +3655,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -3742,6 +3728,8 @@
       },
       "bedrock" : {
         "endpoints" : {
+          "af-south-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -3749,6 +3737,11 @@
           "ap-south-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "bedrock-ap-northeast-1" : {
             "credentialScope" : {
               "region" : "ap-northeast-1"
@@ -4038,6 +4031,7 @@
             "hostname" : "bedrock.us-west-2.amazonaws.com"
           },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
           "eu-north-1" : { },
@@ -4046,9 +4040,14 @@
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
+          "il-central-1" : { },
+          "me-central-1" : { },
+          "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
+          "us-west-1" : { },
           "us-west-2" : { }
         }
       },
@@ -4112,6 +4111,7 @@
       },
       "cases" : {
         "endpoints" : {
+          "af-south-1" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-southeast-1" : { },
@@ -4166,6 +4166,7 @@
             "deprecated" : true,
             "hostname" : "cassandra-fips.us-west-2.amazonaws.com"
           },
+          "me-central-1" : { },
           "me-south-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
@@ -4519,6 +4520,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "cloudcontrolapi.ap-northeast-1.api.aws",
@@ -4579,6 +4581,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "cloudcontrolapi.ap-southeast-7.api.aws",
@@ -4796,6 +4799,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -4806,6 +4810,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -4961,12 +4966,14 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "cloudhsmv2.ca-central-1.api.aws",
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ca-west-1" : { },
           "eu-central-1" : {
             "variants" : [ {
               "hostname" : "cloudhsmv2.eu-central-1.api.aws",
@@ -4991,6 +4998,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-south-2" : { },
           "eu-west-1" : {
             "variants" : [ {
               "hostname" : "cloudhsmv2.eu-west-1.api.aws",
@@ -5027,6 +5035,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "variants" : [ {
               "hostname" : "cloudhsmv2.sa-east-1.api.aws",
@@ -5077,6 +5086,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -5087,6 +5097,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -5390,6 +5401,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -5400,6 +5412,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -5468,6 +5481,20 @@
             "deprecated" : true,
             "hostname" : "codedeploy-fips.us-west-2.amazonaws.com"
           }
+        }
+      },
+      "codeguru-profiler" : {
+        "endpoints" : {
+          "ap-northeast-1" : { },
+          "ap-southeast-1" : { },
+          "ap-southeast-2" : { },
+          "eu-central-1" : { },
+          "eu-north-1" : { },
+          "eu-west-1" : { },
+          "eu-west-2" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-2" : { }
         }
       },
       "codeguru-reviewer" : {
@@ -5634,6 +5661,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "cognito-identity.ap-northeast-1.amazonaws.com",
@@ -5694,6 +5722,8 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "cognito-identity.ca-central-1.amazonaws.com",
@@ -5800,6 +5830,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "variants" : [ {
               "hostname" : "cognito-identity.sa-east-1.amazonaws.com",
@@ -5870,6 +5901,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "cognito-idp.ap-northeast-1.amazonaws.com",
@@ -5930,6 +5962,8 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "cognito-idp.ca-central-1.amazonaws.com",
@@ -6036,6 +6070,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "variants" : [ {
               "hostname" : "cognito-idp.sa-east-1.amazonaws.com",
@@ -6473,6 +6508,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -6483,6 +6519,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -6606,6 +6643,9 @@
       "connect-campaigns" : {
         "endpoints" : {
           "af-south-1" : { },
+          "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
+          "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
@@ -6656,6 +6696,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -6666,6 +6707,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -6789,6 +6831,7 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "data.iot-fips.ca-central-1.amazonaws.com",
@@ -6797,6 +6840,7 @@
           },
           "eu-central-1" : { },
           "eu-north-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
@@ -6960,6 +7004,7 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "data.jobs.iot-fips.ca-central-1.amazonaws.com",
@@ -6968,6 +7013,7 @@
           },
           "eu-central-1" : { },
           "eu-north-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
@@ -7006,6 +7052,7 @@
             "deprecated" : true,
             "hostname" : "data.jobs.iot-fips.us-west-2.amazonaws.com"
           },
+          "me-central-1" : { },
           "me-south-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
@@ -7156,6 +7203,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "datasync.ap-northeast-1.api.aws",
@@ -7216,6 +7264,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "datasync.ap-southeast-7.api.aws",
@@ -7426,6 +7475,9 @@
           } ]
         },
         "endpoints" : {
+          "af-south-1" : { },
+          "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "datazone.ap-northeast-1.api.aws"
           },
@@ -7456,6 +7508,7 @@
           "ap-southeast-5" : {
             "hostname" : "datazone.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "datazone.ap-southeast-7.api.aws"
           },
@@ -7472,12 +7525,14 @@
           "eu-central-1" : {
             "hostname" : "datazone.eu-central-1.api.aws"
           },
+          "eu-central-2" : { },
           "eu-north-1" : {
             "hostname" : "datazone.eu-north-1.api.aws"
           },
           "eu-south-1" : {
             "hostname" : "datazone.eu-south-1.api.aws"
           },
+          "eu-south-2" : { },
           "eu-west-1" : {
             "hostname" : "datazone.eu-west-1.api.aws"
           },
@@ -7639,6 +7694,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -7649,6 +7705,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -7768,6 +7825,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "dlm.ap-northeast-1.api.aws",
@@ -7828,6 +7886,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "dlm.ap-southeast-7.api.aws",
@@ -7972,6 +8031,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -7982,6 +8042,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -8352,6 +8413,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -8362,6 +8424,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -8467,6 +8530,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -8477,6 +8541,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -8588,6 +8653,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "ec2.ap-northeast-1.api.aws",
@@ -8623,6 +8689,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -8776,6 +8843,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -8786,6 +8854,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -8877,6 +8946,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -8887,6 +8957,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -8973,6 +9044,7 @@
           "ap-east-1" : {
             "hostname" : "eks-auth.ap-east-1.api.aws"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "eks-auth.ap-northeast-1.api.aws"
           },
@@ -9003,6 +9075,7 @@
           "ap-southeast-5" : {
             "hostname" : "eks-auth.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "eks-auth.ap-southeast-7.api.aws"
           },
@@ -9069,6 +9142,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -9079,6 +9153,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -9194,6 +9269,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-south-2" : { },
           "ap-southeast-1" : {
             "variants" : [ {
               "hostname" : "elasticbeanstalk.ap-southeast-1.api.aws",
@@ -9212,18 +9288,24 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "elasticbeanstalk.ca-central-1.api.aws",
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ca-west-1" : { },
           "eu-central-1" : {
             "variants" : [ {
               "hostname" : "elasticbeanstalk.eu-central-1.api.aws",
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-central-2" : { },
           "eu-north-1" : {
             "variants" : [ {
               "hostname" : "elasticbeanstalk.eu-north-1.api.aws",
@@ -9236,6 +9318,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-south-2" : { },
           "eu-west-1" : {
             "variants" : [ {
               "hostname" : "elasticbeanstalk.eu-west-1.api.aws",
@@ -9288,6 +9371,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "me-central-1" : { },
           "me-south-1" : {
             "variants" : [ {
               "hostname" : "elasticbeanstalk.me-south-1.api.aws",
@@ -9364,6 +9448,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "elasticfilesystem-fips.ap-northeast-1.amazonaws.com",
@@ -9424,6 +9509,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "elasticfilesystem-fips.ap-southeast-7.amazonaws.com",
@@ -9777,6 +9863,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -9787,6 +9874,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -9865,6 +9953,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -9875,6 +9964,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -9975,18 +10065,6 @@
           }
         }
       },
-      "elastictranscoder" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-south-1" : { },
-          "ap-southeast-1" : { },
-          "ap-southeast-2" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { },
-          "us-west-1" : { },
-          "us-west-2" : { }
-        }
-      },
       "email" : {
         "endpoints" : {
           "af-south-1" : { },
@@ -9994,16 +10072,20 @@
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
           "ap-south-1" : { },
+          "ap-south-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "email-fips.ca-central-1.amazonaws.com",
               "tags" : [ "fips" ]
             } ]
           },
+          "ca-west-1" : { },
           "eu-central-1" : { },
+          "eu-central-2" : { },
           "eu-north-1" : { },
           "eu-south-1" : { },
           "eu-west-1" : { },
@@ -10045,6 +10127,7 @@
             "hostname" : "email-fips.us-west-2.amazonaws.com"
           },
           "il-central-1" : { },
+          "me-central-1" : { },
           "me-south-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
@@ -10175,6 +10258,8 @@
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "emr-serverless-fips.ca-central-1.amazonaws.com",
@@ -10183,6 +10268,7 @@
           },
           "ca-west-1" : { },
           "eu-central-1" : { },
+          "eu-central-2" : { },
           "eu-north-1" : { },
           "eu-south-1" : { },
           "eu-south-2" : { },
@@ -10224,6 +10310,7 @@
             "deprecated" : true,
             "hostname" : "emr-serverless-fips.us-west-2.amazonaws.com"
           },
+          "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
           "sa-east-1" : { },
@@ -10282,6 +10369,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "aos.ap-northeast-1.api.aws",
@@ -10342,6 +10430,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "aos.ap-southeast-7.api.aws",
@@ -10525,6 +10614,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "events.ap-northeast-1.api.aws",
@@ -10585,6 +10675,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "events.ap-southeast-7.api.aws",
@@ -10759,37 +10850,6 @@
           }
         }
       },
-      "evidently" : {
-        "endpoints" : {
-          "ap-northeast-1" : {
-            "hostname" : "evidently.ap-northeast-1.amazonaws.com"
-          },
-          "ap-southeast-1" : {
-            "hostname" : "evidently.ap-southeast-1.amazonaws.com"
-          },
-          "ap-southeast-2" : {
-            "hostname" : "evidently.ap-southeast-2.amazonaws.com"
-          },
-          "eu-central-1" : {
-            "hostname" : "evidently.eu-central-1.amazonaws.com"
-          },
-          "eu-north-1" : {
-            "hostname" : "evidently.eu-north-1.amazonaws.com"
-          },
-          "eu-west-1" : {
-            "hostname" : "evidently.eu-west-1.amazonaws.com"
-          },
-          "us-east-1" : {
-            "hostname" : "evidently.us-east-1.amazonaws.com"
-          },
-          "us-east-2" : {
-            "hostname" : "evidently.us-east-2.amazonaws.com"
-          },
-          "us-west-2" : {
-            "hostname" : "evidently.us-west-2.amazonaws.com"
-          }
-        }
-      },
       "finspace" : {
         "endpoints" : {
           "ap-northeast-1" : { },
@@ -10827,6 +10887,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "firehose.ap-northeast-1.api.aws",
@@ -10882,6 +10943,7 @@
             } ]
           },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "firehose.ap-southeast-7.api.aws",
@@ -11073,6 +11135,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "fms-fips.ap-northeast-1.amazonaws.com",
@@ -11108,6 +11171,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -11449,6 +11513,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -11665,6 +11730,8 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-north-1" : { },
@@ -11696,6 +11763,7 @@
           "ap-east-1" : {
             "hostname" : "gameliftstreams.ap-east-1.api.aws"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "gameliftstreams.ap-northeast-1.api.aws"
           },
@@ -11726,6 +11794,7 @@
           "ap-southeast-5" : {
             "hostname" : "gameliftstreams.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "gameliftstreams.ap-southeast-7.api.aws"
           },
@@ -11898,12 +11967,45 @@
       },
       "globalaccelerator" : {
         "endpoints" : {
+          "af-south-1" : { },
+          "ap-east-1" : { },
+          "ap-east-2" : { },
+          "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
+          "ap-northeast-3" : { },
+          "ap-south-1" : { },
+          "ap-south-2" : { },
+          "ap-southeast-1" : { },
+          "ap-southeast-2" : { },
+          "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
+          "ca-central-1" : { },
+          "ca-west-1" : { },
+          "eu-central-1" : { },
+          "eu-central-2" : { },
+          "eu-north-1" : { },
+          "eu-south-1" : { },
+          "eu-south-2" : { },
+          "eu-west-1" : { },
+          "eu-west-2" : { },
+          "eu-west-3" : { },
           "fips-us-west-2" : {
             "credentialScope" : {
               "region" : "us-west-2"
             },
             "hostname" : "globalaccelerator-fips.us-west-2.amazonaws.com"
-          }
+          },
+          "il-central-1" : { },
+          "me-central-1" : { },
+          "me-south-1" : { },
+          "mx-central-1" : { },
+          "sa-east-1" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-1" : { },
+          "us-west-2" : { }
         }
       },
       "glue" : {
@@ -11920,6 +12022,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "glue.ap-northeast-1.api.aws",
@@ -11980,6 +12083,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "glue.ap-southeast-7.api.aws",
@@ -12228,6 +12332,7 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "greengrass-fips.ca-central-1.amazonaws.com",
@@ -12235,6 +12340,7 @@
             } ]
           },
           "eu-central-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "fips-ca-central-1" : {
@@ -12396,6 +12502,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -12406,6 +12513,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : {
@@ -12529,6 +12637,8 @@
         "endpoints" : {
           "ap-south-1" : { },
           "ap-southeast-2" : { },
+          "ca-central-1" : { },
+          "eu-west-1" : { },
           "eu-west-2" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -12600,6 +12710,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -12610,6 +12721,8 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
           "eu-central-1" : { },
@@ -12623,6 +12736,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -12779,14 +12893,20 @@
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
           "ap-south-1" : { },
+          "ap-south-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
           "eu-north-1" : { },
           "eu-south-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
@@ -12818,7 +12938,10 @@
             "deprecated" : true,
             "hostname" : "inspector2-fips.us-west-2.amazonaws.com"
           },
+          "il-central-1" : { },
+          "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
@@ -12870,6 +12993,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "internetmonitor.ap-northeast-1.api.aws",
             "variants" : [ {
@@ -12936,6 +13060,7 @@
           "ap-southeast-5" : {
             "hostname" : "internetmonitor.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "internetmonitor.ap-southeast-7.api.aws"
           },
@@ -13100,6 +13225,7 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "iot-fips.ca-central-1.amazonaws.com",
@@ -13108,6 +13234,7 @@
           },
           "eu-central-1" : { },
           "eu-north-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
@@ -13158,18 +13285,6 @@
               "tags" : [ "fips" ]
             } ]
           }
-        }
-      },
-      "iotanalytics" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-south-1" : { },
-          "ap-southeast-2" : { },
-          "eu-central-1" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { },
-          "us-east-2" : { },
-          "us-west-2" : { }
         }
       },
       "iotevents" : {
@@ -13781,6 +13896,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -13791,6 +13907,8 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "kafka-fips.ca-central-1.amazonaws.com",
@@ -13856,6 +13974,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
@@ -13885,17 +14004,35 @@
       },
       "kafkaconnect" : {
         "endpoints" : {
+          "af-south-1" : { },
+          "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
+          "ap-northeast-3" : { },
           "ap-south-1" : { },
+          "ap-south-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : { },
+          "eu-central-2" : { },
           "eu-north-1" : { },
+          "eu-south-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
+          "il-central-1" : { },
+          "me-central-1" : { },
+          "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -13981,6 +14118,7 @@
           "ap-east-1" : {
             "hostname" : "kendra-ranking.ap-east-1.api.aws"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "kendra-ranking.ap-northeast-1.api.aws"
           },
@@ -14011,6 +14149,7 @@
           "ap-southeast-5" : {
             "hostname" : "kendra-ranking.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "kendra-ranking.ap-southeast-7.api.aws"
           },
@@ -14087,6 +14226,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -14097,6 +14237,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -14171,6 +14312,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -14181,6 +14323,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -14284,11 +14427,14 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
+          "me-south-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -14330,6 +14476,7 @@
             "deprecated" : true,
             "hostname" : "kms-fips.ap-east-1.amazonaws.com"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "kms-fips.ap-northeast-1.amazonaws.com",
@@ -14460,6 +14607,7 @@
             "deprecated" : true,
             "hostname" : "kms-fips.ap-southeast-5.amazonaws.com"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "kms-fips.ap-southeast-7.amazonaws.com",
@@ -14736,6 +14884,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "lakeformation.ap-northeast-1.api.aws",
@@ -14796,6 +14945,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "lakeformation.ap-southeast-7.api.aws",
@@ -14984,6 +15134,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "lambda.ap-northeast-1.api.aws",
@@ -15044,6 +15195,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "lambda.ap-southeast-7.api.aws",
@@ -15210,6 +15362,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -15220,6 +15373,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -15294,6 +15448,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -15304,6 +15459,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -15378,6 +15534,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -15465,6 +15622,7 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-3" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-north-1" : { },
@@ -15490,6 +15648,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "logs.ap-northeast-1.api.aws",
@@ -15545,6 +15704,7 @@
             } ]
           },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -15722,30 +15882,6 @@
           "ap-northeast-2" : { },
           "eu-west-1" : { },
           "us-east-1" : { }
-        }
-      },
-      "lookoutmetrics" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-southeast-1" : { },
-          "ap-southeast-2" : { },
-          "eu-central-1" : { },
-          "eu-north-1" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { },
-          "us-east-2" : { },
-          "us-west-2" : { }
-        }
-      },
-      "lookoutvision" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-northeast-2" : { },
-          "eu-central-1" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { },
-          "us-east-2" : { },
-          "us-west-2" : { }
         }
       },
       "m2" : {
@@ -16072,6 +16208,7 @@
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-north-1" : { },
@@ -16136,6 +16273,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "mediaconvert-fips.ca-central-1.amazonaws.com",
@@ -16285,6 +16423,7 @@
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-north-1" : { },
@@ -16390,6 +16529,7 @@
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "mediapackagev2-fips.ca-central-1.amazonaws.com",
@@ -16757,6 +16897,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -16767,6 +16908,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -16885,6 +17027,8 @@
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
@@ -17046,6 +17190,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -17056,6 +17201,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -17130,6 +17276,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -17140,6 +17287,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -17335,6 +17483,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -17345,6 +17494,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -17472,6 +17622,7 @@
           "ap-east-1" : {
             "hostname" : "notifications.ap-east-1.api.aws"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "notifications.ap-northeast-1.api.aws"
           },
@@ -17502,6 +17653,7 @@
           "ap-southeast-5" : {
             "hostname" : "notifications.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "notifications.ap-southeast-7.api.aws"
           },
@@ -17576,10 +17728,16 @@
         "isRegionalized" : false,
         "partitionEndpoint" : "aws-global"
       },
+      "nova-act" : {
+        "endpoints" : {
+          "us-east-1" : { }
+        }
+      },
       "oam" : {
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -17590,6 +17748,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -17626,6 +17785,7 @@
             },
             "hostname" : "oidc.ap-east-1.amazonaws.com"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "credentialScope" : {
               "region" : "ap-northeast-1"
@@ -17686,6 +17846,8 @@
             },
             "hostname" : "oidc.ap-southeast-5.amazonaws.com"
           },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "credentialScope" : {
               "region" : "ca-central-1"
@@ -17764,6 +17926,7 @@
             },
             "hostname" : "oidc.me-south-1.amazonaws.com"
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "credentialScope" : {
               "region" : "sa-east-1"
@@ -17798,6 +17961,7 @@
       },
       "omics" : {
         "endpoints" : {
+          "ap-northeast-2" : { },
           "ap-southeast-1" : {
             "credentialScope" : {
               "region" : "ap-southeast-1"
@@ -17862,22 +18026,6 @@
               "tags" : [ "fips" ]
             } ]
           }
-        }
-      },
-      "opsworks" : {
-        "endpoints" : {
-          "ap-southeast-1" : { },
-          "eu-central-1" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { },
-          "us-west-2" : { }
-        }
-      },
-      "opsworks-cm" : {
-        "endpoints" : {
-          "ap-southeast-2" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { }
         }
       },
       "organizations" : {
@@ -17985,6 +18133,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
@@ -18050,6 +18199,11 @@
           }
         }
       },
+      "partnercentral-channel" : {
+        "endpoints" : {
+          "us-east-1" : { }
+        }
+      },
       "personalize" : {
         "endpoints" : {
           "ap-northeast-1" : { },
@@ -18081,6 +18235,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "protocols" : [ "https" ],
             "variants" : [ {
@@ -18151,6 +18306,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "protocols" : [ "https" ],
             "variants" : [ {
@@ -18560,6 +18716,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-central-2" : { },
           "eu-north-1" : {
             "variants" : [ {
               "hostname" : "polly.eu-north-1.api.aws",
@@ -18701,6 +18858,7 @@
             },
             "hostname" : "portal.sso.ap-east-1.amazonaws.com"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "credentialScope" : {
               "region" : "ap-northeast-1"
@@ -18761,6 +18919,8 @@
             },
             "hostname" : "portal.sso.ap-southeast-5.amazonaws.com"
           },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "credentialScope" : {
               "region" : "ca-central-1"
@@ -18839,6 +18999,7 @@
             },
             "hostname" : "portal.sso.me-south-1.amazonaws.com"
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "credentialScope" : {
               "region" : "sa-east-1"
@@ -18869,13 +19030,6 @@
             },
             "hostname" : "portal.sso.us-west-2.amazonaws.com"
           }
-        }
-      },
-      "private-networks" : {
-        "endpoints" : {
-          "us-east-1" : { },
-          "us-east-2" : { },
-          "us-west-2" : { }
         }
       },
       "profile" : {
@@ -18959,6 +19113,7 @@
           "ap-east-1" : {
             "hostname" : "qbusiness.ap-east-1.api.aws"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "qbusiness.ap-northeast-1.api.aws"
           },
@@ -18989,6 +19144,7 @@
           "ap-southeast-5" : {
             "hostname" : "qbusiness.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "qbusiness.ap-southeast-7.api.aws"
           },
@@ -19051,69 +19207,6 @@
           }
         }
       },
-      "qldb" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-northeast-2" : { },
-          "ap-southeast-1" : { },
-          "ap-southeast-2" : { },
-          "ca-central-1" : {
-            "variants" : [ {
-              "hostname" : "qldb-fips.ca-central-1.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "eu-central-1" : { },
-          "eu-west-1" : { },
-          "eu-west-2" : { },
-          "fips-ca-central-1" : {
-            "credentialScope" : {
-              "region" : "ca-central-1"
-            },
-            "deprecated" : true,
-            "hostname" : "qldb-fips.ca-central-1.amazonaws.com"
-          },
-          "fips-us-east-1" : {
-            "credentialScope" : {
-              "region" : "us-east-1"
-            },
-            "deprecated" : true,
-            "hostname" : "qldb-fips.us-east-1.amazonaws.com"
-          },
-          "fips-us-east-2" : {
-            "credentialScope" : {
-              "region" : "us-east-2"
-            },
-            "deprecated" : true,
-            "hostname" : "qldb-fips.us-east-2.amazonaws.com"
-          },
-          "fips-us-west-2" : {
-            "credentialScope" : {
-              "region" : "us-west-2"
-            },
-            "deprecated" : true,
-            "hostname" : "qldb-fips.us-west-2.amazonaws.com"
-          },
-          "us-east-1" : {
-            "variants" : [ {
-              "hostname" : "qldb-fips.us-east-1.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "us-east-2" : {
-            "variants" : [ {
-              "hostname" : "qldb-fips.us-east-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "us-west-2" : {
-            "variants" : [ {
-              "hostname" : "qldb-fips.us-west-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          }
-        }
-      },
       "query.timestream" : {
         "endpoints" : {
           "ap-northeast-1" : { },
@@ -19135,6 +19228,7 @@
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
@@ -19144,6 +19238,8 @@
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
+          "il-central-1" : { },
+          "me-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -19162,6 +19258,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -19212,6 +19309,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -19406,6 +19504,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "rbin.ap-northeast-1.api.aws",
@@ -19466,6 +19565,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -19660,6 +19760,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -19670,6 +19771,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -19937,6 +20039,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -19947,6 +20050,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -20043,14 +20147,19 @@
       },
       "redshift-serverless" : {
         "endpoints" : {
+          "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
+          "ap-northeast-3" : { },
           "ap-south-1" : { },
           "ap-south-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -20061,6 +20170,7 @@
           "eu-central-1" : { },
           "eu-central-2" : { },
           "eu-north-1" : { },
+          "eu-south-1" : { },
           "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
@@ -20296,6 +20406,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
               "hostname" : "rekognition-fips.us-east-1.amazonaws.com",
@@ -20502,6 +20613,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -20512,6 +20624,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -20628,6 +20741,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -20638,6 +20752,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -20708,21 +20823,11 @@
           }
         }
       },
-      "robomaker" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-southeast-1" : { },
-          "eu-central-1" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { },
-          "us-east-2" : { },
-          "us-west-2" : { }
-        }
-      },
       "rolesanywhere" : {
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -20733,6 +20838,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -20855,6 +20961,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "route53profiles.ap-northeast-1.api.aws",
@@ -20909,6 +21016,9 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "route53profiles-fips.ca-central-1.api.aws",
@@ -20993,6 +21103,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "variants" : [ {
               "hostname" : "route53profiles.sa-east-1.api.aws",
@@ -21054,6 +21165,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "route53resolver.ap-northeast-1.api.aws",
@@ -21114,6 +21226,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "route53resolver.ap-southeast-7.api.aws",
@@ -21327,7 +21440,10 @@
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
           "eu-north-1" : { },
@@ -21339,6 +21455,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -21416,6 +21533,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -21426,6 +21544,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -21523,6 +21642,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "s3.ap-northeast-1.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ],
@@ -21589,6 +21709,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "s3.dualstack.ap-southeast-7.amazonaws.com",
@@ -22410,6 +22531,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -22419,7 +22541,11 @@
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
           "eu-north-1" : { },
@@ -22428,8 +22554,10 @@
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
+          "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -22496,6 +22624,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -22546,6 +22675,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -22704,6 +22834,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "securityhub.ap-northeast-1.api.aws",
@@ -22764,6 +22895,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "securityhub.ap-southeast-7.api.aws",
@@ -23310,6 +23442,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "servicediscovery.ap-northeast-1.api.aws",
@@ -23370,6 +23503,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "servicediscovery.ap-southeast-7.api.aws",
@@ -23577,6 +23711,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -23587,6 +23722,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -23607,57 +23743,6 @@
           "us-east-2" : { },
           "us-west-1" : { },
           "us-west-2" : { }
-        }
-      },
-      "session.qldb" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-northeast-2" : { },
-          "ap-southeast-1" : { },
-          "ap-southeast-2" : { },
-          "ca-central-1" : { },
-          "eu-central-1" : { },
-          "eu-west-1" : { },
-          "eu-west-2" : { },
-          "fips-us-east-1" : {
-            "credentialScope" : {
-              "region" : "us-east-1"
-            },
-            "deprecated" : true,
-            "hostname" : "session.qldb-fips.us-east-1.amazonaws.com"
-          },
-          "fips-us-east-2" : {
-            "credentialScope" : {
-              "region" : "us-east-2"
-            },
-            "deprecated" : true,
-            "hostname" : "session.qldb-fips.us-east-2.amazonaws.com"
-          },
-          "fips-us-west-2" : {
-            "credentialScope" : {
-              "region" : "us-west-2"
-            },
-            "deprecated" : true,
-            "hostname" : "session.qldb-fips.us-west-2.amazonaws.com"
-          },
-          "us-east-1" : {
-            "variants" : [ {
-              "hostname" : "session.qldb-fips.us-east-1.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "us-east-2" : {
-            "variants" : [ {
-              "hostname" : "session.qldb-fips.us-east-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "us-west-2" : {
-            "variants" : [ {
-              "hostname" : "session.qldb-fips.us-west-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          }
         }
       },
       "shield" : {
@@ -23915,23 +24000,6 @@
           "us-west-2" : { }
         }
       },
-      "sms" : {
-        "endpoints" : {
-          "fips-us-west-2" : {
-            "credentialScope" : {
-              "region" : "us-west-2"
-            },
-            "deprecated" : true,
-            "hostname" : "sms-fips.us-west-2.amazonaws.com"
-          },
-          "us-west-2" : {
-            "variants" : [ {
-              "hostname" : "sms-fips.us-west-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          }
-        }
-      },
       "sms-voice" : {
         "endpoints" : {
           "af-south-1" : {
@@ -23940,6 +24008,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "sms-voice.ap-northeast-1.api.aws",
@@ -23994,6 +24063,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "sms-voice-fips.ca-central-1.amazonaws.com",
@@ -24641,6 +24711,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "sns.ap-northeast-1.api.aws",
@@ -24701,6 +24772,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "sns.ap-southeast-7.api.aws",
@@ -24891,6 +24963,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "sqs.ap-northeast-1.api.aws",
@@ -24951,6 +25024,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "sqs.ap-southeast-7.api.aws",
@@ -25138,6 +25212,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -25148,6 +25223,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -25796,6 +25872,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -25806,6 +25883,8 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
           "eu-central-1" : { },
@@ -25819,6 +25898,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -25830,6 +25910,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -25840,6 +25921,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -25938,6 +26020,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -25948,6 +26031,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -26052,6 +26136,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -26062,6 +26147,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -26095,6 +26181,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -26105,6 +26192,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "aws-global" : {
             "credentialScope" : {
@@ -26204,6 +26292,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -26214,6 +26303,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -26322,6 +26412,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "synthetics.ap-northeast-1.api.aws",
@@ -26382,6 +26473,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "synthetics.ap-southeast-7.api.aws",
@@ -26586,6 +26678,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -26596,6 +26689,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -26877,6 +26971,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-central-2" : { },
           "eu-north-1" : {
             "variants" : [ {
               "hostname" : "transcribe.eu-north-1.api.aws",
@@ -27036,6 +27131,8 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "transcribestreaming-fips.ca-central-1.amazonaws.com",
@@ -27054,6 +27151,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-central-2" : { },
           "eu-west-1" : {
             "variants" : [ {
               "hostname" : "transcribestreaming.eu-west-1.api.aws",
@@ -27094,6 +27192,7 @@
             "deprecated" : true,
             "hostname" : "transcribestreaming-fips.us-west-2.amazonaws.com"
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "variants" : [ {
               "hostname" : "transcribestreaming.sa-east-1.api.aws",
@@ -27142,6 +27241,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -27152,6 +27252,8 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "transfer-fips.ca-central-1.amazonaws.com",
@@ -27402,6 +27504,9 @@
       },
       "trustedadvisor" : {
         "endpoints" : {
+          "ap-northeast-2" : { },
+          "ap-southeast-2" : { },
+          "eu-west-1" : { },
           "fips-us-east-1" : {
             "credentialScope" : {
               "region" : "us-east-1"
@@ -27419,13 +27524,17 @@
               "region" : "us-west-2"
             },
             "hostname" : "trustedadvisor-fips.us-west-2.api.aws"
-          }
+          },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-2" : { }
         }
       },
       "verifiedpermissions" : {
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -27435,6 +27544,9 @@
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "verifiedpermissions-fips.ca-central-1.amazonaws.com",
@@ -27500,6 +27612,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
@@ -28199,6 +28312,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "credentialScope" : {
               "region" : "ap-northeast-1"
@@ -28299,6 +28413,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "credentialScope" : {
               "region" : "ap-southeast-7"
@@ -28919,6 +29034,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -28929,6 +29045,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -29893,11 +30010,6 @@
           "cn-northwest-1" : { }
         }
       },
-      "iotanalytics" : {
-        "endpoints" : {
-          "cn-north-1" : { }
-        }
-      },
       "iotevents" : {
         "endpoints" : {
           "cn-north-1" : { }
@@ -30433,6 +30545,12 @@
         },
         "isRegionalized" : true
       },
+      "scheduler" : {
+        "endpoints" : {
+          "cn-north-1" : { },
+          "cn-northwest-1" : { }
+        }
+      },
       "schemas" : {
         "endpoints" : {
           "cn-north-1" : { },
@@ -30519,11 +30637,6 @@
             },
             "hostname" : "verification.signer.cn-northwest-1.amazonaws.com.cn"
           }
-        }
-      },
-      "sms" : {
-        "endpoints" : {
-          "cn-north-1" : { }
         }
       },
       "snowball" : {
@@ -30730,6 +30843,12 @@
         }
       },
       "transfer" : {
+        "endpoints" : {
+          "cn-north-1" : { },
+          "cn-northwest-1" : { }
+        }
+      },
+      "verifiedpermissions" : {
         "endpoints" : {
           "cn-north-1" : { },
           "cn-northwest-1" : { }
@@ -31397,6 +31516,12 @@
             "deprecated" : true,
             "hostname" : "appstream2-fips.us-gov-west-1.amazonaws.com"
           }
+        }
+      },
+      "aps" : {
+        "endpoints" : {
+          "us-gov-east-1" : { },
+          "us-gov-west-1" : { }
         }
       },
       "arc-zonal-shift" : {
@@ -33237,6 +33362,12 @@
           }
         }
       },
+      "grafana" : {
+        "endpoints" : {
+          "us-gov-east-1" : { },
+          "us-gov-west-1" : { }
+        }
+      },
       "greengrass" : {
         "defaults" : {
           "protocols" : [ "https" ]
@@ -33715,6 +33846,12 @@
             "deprecated" : true,
             "hostname" : "kafka.us-gov-west-1.amazonaws.com"
           }
+        }
+      },
+      "kafkaconnect" : {
+        "endpoints" : {
+          "us-gov-east-1" : { },
+          "us-gov-west-1" : { }
         }
       },
       "kendra" : {
@@ -34916,11 +35053,6 @@
           }
         }
       },
-      "robomaker" : {
-        "endpoints" : {
-          "us-gov-west-1" : { }
-        }
-      },
       "rolesanywhere" : {
         "endpoints" : {
           "fips-us-gov-east-1" : {
@@ -35030,6 +35162,12 @@
             "deprecated" : true,
             "hostname" : "route53resolver.us-gov-west-1.amazonaws.com"
           }
+        }
+      },
+      "rum" : {
+        "endpoints" : {
+          "us-gov-east-1" : { },
+          "us-gov-west-1" : { }
         }
       },
       "runtime-v2-lex" : {
@@ -35232,6 +35370,12 @@
               "tags" : [ "fips" ]
             } ]
           }
+        }
+      },
+      "scheduler" : {
+        "endpoints" : {
+          "us-gov-east-1" : { },
+          "us-gov-west-1" : { }
         }
       },
       "schemas" : {
@@ -35592,23 +35736,6 @@
           "us-gov-west-1" : {
             "variants" : [ {
               "hostname" : "simspaceweaver.us-gov-west-1.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          }
-        }
-      },
-      "sms" : {
-        "endpoints" : {
-          "fips-us-gov-west-1" : {
-            "credentialScope" : {
-              "region" : "us-gov-west-1"
-            },
-            "deprecated" : true,
-            "hostname" : "sms-fips.us-gov-west-1.amazonaws.com"
-          },
-          "us-gov-west-1" : {
-            "variants" : [ {
-              "hostname" : "sms-fips.us-gov-west-1.amazonaws.com",
               "tags" : [ "fips" ]
             } ]
           }
@@ -36459,6 +36586,12 @@
       }
     },
     "services" : {
+      "acm" : {
+        "endpoints" : {
+          "us-iso-east-1" : { },
+          "us-iso-west-1" : { }
+        }
+      },
       "agreement-marketplace" : {
         "endpoints" : {
           "fips-us-iso-east-1" : {
@@ -36553,9 +36686,16 @@
           "us-iso-west-1" : { }
         }
       },
+      "backup" : {
+        "endpoints" : {
+          "us-iso-east-1" : { },
+          "us-iso-west-1" : { }
+        }
+      },
       "batch" : {
         "endpoints" : {
-          "us-iso-east-1" : { }
+          "us-iso-east-1" : { },
+          "us-iso-west-1" : { }
         }
       },
       "bedrock" : {
@@ -36998,7 +37138,8 @@
               "hostname" : "fsx-fips.us-iso-east-1.c2s.ic.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-iso-west-1" : { }
         }
       },
       "glacier" : {
@@ -37074,6 +37215,11 @@
           "us-iso-east-1" : { }
         }
       },
+      "kinesisvideo" : {
+        "endpoints" : {
+          "us-iso-east-1" : { }
+        }
+      },
       "kms" : {
         "endpoints" : {
           "ProdFips" : {
@@ -37109,6 +37255,11 @@
             "deprecated" : true,
             "hostname" : "kms-fips.us-iso-west-1.c2s.ic.gov"
           }
+        }
+      },
+      "lakeformation" : {
+        "endpoints" : {
+          "us-iso-east-1" : { }
         }
       },
       "lambda" : {
@@ -37160,6 +37311,11 @@
         "endpoints" : {
           "us-iso-east-1" : { },
           "us-iso-west-1" : { }
+        }
+      },
+      "network-firewall" : {
+        "endpoints" : {
+          "us-iso-east-1" : { }
         }
       },
       "oam" : {
@@ -37469,6 +37625,12 @@
           "us-iso-west-1" : { }
         }
       },
+      "servicequotas" : {
+        "endpoints" : {
+          "us-iso-east-1" : { },
+          "us-iso-west-1" : { }
+        }
+      },
       "snowball" : {
         "endpoints" : {
           "us-iso-east-1" : { },
@@ -37676,6 +37838,11 @@
           }
         }
       },
+      "wafv2" : {
+        "endpoints" : {
+          "us-iso-east-1" : { }
+        }
+      },
       "workspaces" : {
         "endpoints" : {
           "fips-us-iso-east-1" : {
@@ -37731,9 +37898,17 @@
     "regions" : {
       "us-isob-east-1" : {
         "description" : "US ISOB East (Ohio)"
+      },
+      "us-isob-west-1" : {
+        "description" : "US ISOB West"
       }
     },
     "services" : {
+      "agreement-marketplace" : {
+        "endpoints" : {
+          "us-isob-east-1" : { }
+        }
+      },
       "api.ecr" : {
         "endpoints" : {
           "us-isob-east-1" : {
@@ -37741,7 +37916,8 @@
               "region" : "us-isob-east-1"
             },
             "hostname" : "api.ecr.us-isob-east-1.sc2s.sgov.gov"
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "api.pricing" : {
@@ -37766,12 +37942,14 @@
       },
       "appconfig" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "appconfigdata" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "application-autoscaling" : {
@@ -37779,10 +37957,22 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "appstream2" : {
+        "endpoints" : {
           "us-isob-east-1" : { }
         }
       },
       "arc-zonal-shift" : {
+        "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "athena" : {
         "endpoints" : {
           "us-isob-east-1" : { }
         }
@@ -37792,10 +37982,22 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "backup" : {
+        "endpoints" : {
           "us-isob-east-1" : { }
         }
       },
       "batch" : {
+        "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "bedrock" : {
         "endpoints" : {
           "us-isob-east-1" : { }
         }
@@ -37832,12 +38034,14 @@
       },
       "cloudcontrolapi" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "cloudformation" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "cloudtrail" : {
@@ -37854,7 +38058,8 @@
               "hostname" : "cloudtrail-fips.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "codebuild" : {
@@ -37864,7 +38069,8 @@
       },
       "codedeploy" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "config" : {
@@ -37881,7 +38087,8 @@
               "hostname" : "config-fips.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "datasync" : {
@@ -37891,12 +38098,14 @@
       },
       "directconnect" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "dlm" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "dms" : {
@@ -37936,7 +38145,8 @@
             },
             "deprecated" : true,
             "hostname" : "dms.us-isob-east-1.sc2s.sgov.gov"
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "ds" : {
@@ -37961,12 +38171,14 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "ebs" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "ec2" : {
@@ -37974,12 +38186,14 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "ecs" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "eks" : {
@@ -37987,12 +38201,14 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "elasticache" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "elasticfilesystem" : {
@@ -38016,7 +38232,8 @@
         "endpoints" : {
           "us-isob-east-1" : {
             "protocols" : [ "https" ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "elasticmapreduce" : {
@@ -38033,17 +38250,20 @@
               "hostname" : "elasticmapreduce.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "es" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "events" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "firehose" : {
@@ -38102,7 +38322,8 @@
       },
       "kinesis" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "kinesisanalytics" : {
@@ -38131,12 +38352,19 @@
             },
             "deprecated" : true,
             "hostname" : "kms-fips.us-isob-east-1.sc2s.sgov.gov"
-          }
+          },
+          "us-isob-west-1" : { }
+        }
+      },
+      "lakeformation" : {
+        "endpoints" : {
+          "us-isob-east-1" : { }
         }
       },
       "lambda" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "license-manager" : {
@@ -38146,7 +38374,8 @@
       },
       "logs" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "medialive" : {
@@ -38188,12 +38417,19 @@
       },
       "monitoring" : {
         "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "network-firewall" : {
+        "endpoints" : {
           "us-isob-east-1" : { }
         }
       },
       "oam" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "organizations" : {
@@ -38215,12 +38451,14 @@
       },
       "pi" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "ram" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "rbin" : {
@@ -38237,7 +38475,8 @@
               "hostname" : "rbin-fips.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "rds" : {
@@ -38261,7 +38500,8 @@
             },
             "deprecated" : true,
             "hostname" : "rds.us-isob-east-1.sc2s.sgov.gov"
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "redshift" : {
@@ -38271,12 +38511,14 @@
               "region" : "us-isob-east-1"
             },
             "hostname" : "redshift.us-isob-east-1.sc2s.sgov.gov"
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "resource-groups" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "route53" : {
@@ -38322,7 +38564,8 @@
               "hostname" : "s3-fips.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "s3-control" : {
@@ -38372,7 +38615,8 @@
       },
       "scheduler" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "secretsmanager" : {
@@ -38384,12 +38628,26 @@
           },
           "us-isob-east-1-fips" : {
             "deprecated" : true
-          }
+          },
+          "us-isob-west-1" : { }
+        }
+      },
+      "securityhub" : {
+        "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "servicediscovery" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "servicequotas" : {
+        "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "snowball" : {
@@ -38402,7 +38660,8 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "sqs" : {
@@ -38423,12 +38682,14 @@
               "hostname" : "sqs.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "ssm" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "states" : {
@@ -38445,7 +38706,8 @@
               "hostname" : "states-fips.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "storagegateway" : {
@@ -38480,12 +38742,14 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "sts" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "support" : {
@@ -38513,15 +38777,23 @@
               "hostname" : "swf-fips.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "synthetics" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "tagging" : {
+        "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "wafv2" : {
         "endpoints" : {
           "us-isob-east-1" : { }
         }
@@ -38545,7 +38817,8 @@
       },
       "xray" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       }
     }
@@ -38609,6 +38882,11 @@
             "service" : "pricing"
           }
         },
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
+      "apigateway" : {
         "endpoints" : {
           "eu-isoe-west-1" : { }
         }
@@ -38683,6 +38961,11 @@
         }
       },
       "cloudtrail" : {
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
+      "cloudtrail-data" : {
         "endpoints" : {
           "eu-isoe-west-1" : { }
         }
@@ -38875,7 +39158,17 @@
           }
         }
       },
+      "license-manager" : {
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
       "logs" : {
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
+      "metrics.sagemaker" : {
         "endpoints" : {
           "eu-isoe-west-1" : { }
         }
@@ -38956,6 +39249,11 @@
         "isRegionalized" : false,
         "partitionEndpoint" : "aws-iso-e-global"
       },
+      "route53profiles" : {
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
       "route53resolver" : {
         "endpoints" : {
           "eu-isoe-west-1" : { }
@@ -38983,6 +39281,11 @@
         "partitionEndpoint" : "aws-iso-e-global"
       },
       "scheduler" : {
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
+      "schemas" : {
         "endpoints" : {
           "eu-isoe-west-1" : { }
         }
@@ -39068,6 +39371,11 @@
           "eu-isoe-west-1" : { }
         }
       },
+      "trustedadvisor" : {
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
       "xray" : {
         "endpoints" : {
           "eu-isoe-west-1" : { }
@@ -39126,6 +39434,11 @@
         },
         "endpoints" : {
           "us-isof-east-1" : { },
+          "us-isof-south-1" : { }
+        }
+      },
+      "agreement-marketplace" : {
+        "endpoints" : {
           "us-isof-south-1" : { }
         }
       },
@@ -39215,6 +39528,12 @@
           "us-isof-south-1" : { }
         }
       },
+      "bedrock" : {
+        "endpoints" : {
+          "us-isof-east-1" : { },
+          "us-isof-south-1" : { }
+        }
+      },
       "budgets" : {
         "endpoints" : {
           "aws-iso-f-global" : {
@@ -39263,6 +39582,12 @@
           "us-isof-south-1" : { }
         }
       },
+      "cloudtrail-data" : {
+        "endpoints" : {
+          "us-isof-east-1" : { },
+          "us-isof-south-1" : { }
+        }
+      },
       "codebuild" : {
         "endpoints" : {
           "us-isof-east-1" : { },
@@ -39292,6 +39617,7 @@
       },
       "compute-optimizer" : {
         "endpoints" : {
+          "us-isof-east-1" : { },
           "us-isof-south-1" : {
             "credentialScope" : {
               "region" : "us-isof-south-1"
@@ -39523,6 +39849,11 @@
         "isRegionalized" : false,
         "partitionEndpoint" : "aws-iso-f-global"
       },
+      "identitystore" : {
+        "endpoints" : {
+          "us-isof-east-1" : { }
+        }
+      },
       "kinesis" : {
         "endpoints" : {
           "us-isof-east-1" : { },
@@ -39694,6 +40025,12 @@
           "us-isof-south-1" : { }
         }
       },
+      "rolesanywhere" : {
+        "endpoints" : {
+          "us-isof-east-1" : { },
+          "us-isof-south-1" : { }
+        }
+      },
       "route53" : {
         "endpoints" : {
           "aws-iso-f-global" : {
@@ -39713,6 +40050,12 @@
         }
       },
       "route53resolver" : {
+        "endpoints" : {
+          "us-isof-east-1" : { },
+          "us-isof-south-1" : { }
+        }
+      },
+      "runtime.sagemaker" : {
         "endpoints" : {
           "us-isof-east-1" : { },
           "us-isof-south-1" : { }
@@ -39894,6 +40237,11 @@
           "us-isof-south-1" : { }
         }
       },
+      "trustedadvisor" : {
+        "endpoints" : {
+          "us-isof-south-1" : { }
+        }
+      },
       "xray" : {
         "endpoints" : {
           "us-isof-east-1" : { },
@@ -39910,6 +40258,14 @@
         "dnsSuffix" : "amazonaws.eu",
         "hostname" : "{service}-fips.{region}.{dnsSuffix}",
         "tags" : [ "fips" ]
+      }, {
+        "dnsSuffix" : "api.amazonwebservices.eu",
+        "hostname" : "{service}-fips.{region}.{dnsSuffix}",
+        "tags" : [ "dualstack", "fips" ]
+      }, {
+        "dnsSuffix" : "api.amazonwebservices.eu",
+        "hostname" : "{service}.{region}.{dnsSuffix}",
+        "tags" : [ "dualstack" ]
       } ]
     },
     "dnsSuffix" : "amazonaws.eu",
@@ -39918,10 +40274,533 @@
     "regionRegex" : "^eusc\\-(de)\\-\\w+\\-\\d+$",
     "regions" : {
       "eusc-de-east-1" : {
-        "description" : "EU (Germany)"
+        "description" : "AWS European Sovereign Cloud (Germany)"
       }
     },
-    "services" : { }
+    "services" : {
+      "access-analyzer" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "acm" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "acm-pca" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "agreement-marketplace" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "api.ecr" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "api.pricing" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "api.sagemaker" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "appconfig" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "appconfigdata" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "application-autoscaling" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "arc-zonal-shift" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "athena" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "autoscaling" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "backup" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "batch" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "bedrock" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "cloudcontrolapi" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "cloudformation" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "cloudtrail" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "codedeploy" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "cognito-identity" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "cognito-idp" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "compute-optimizer" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "config" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "controltower" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "cost-optimization-hub" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "datasync" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "datazone" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "directconnect" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "dlm" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "dms" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "ds" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "dynamodb" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "ebs" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "ec2" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "ecs" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "eks" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "eks-auth" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "elasticache" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "elasticfilesystem" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "elasticloadbalancing" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "elasticmapreduce" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "email" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "entitlement.marketplace" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "es" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "events" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "firehose" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "fsx" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "gameliftstreams" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "glue" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "guardduty" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "health" : {
+        "endpoints" : {
+          "eusc-de-east-1" : {
+            "deprecated" : true
+          }
+        }
+      },
+      "identitystore" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "internetmonitor" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "kafka" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "kendra-ranking" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "kinesis" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "kinesisanalytics" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "kms" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "lakeformation" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "lambda" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "license-manager" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "logs" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "metering.marketplace" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "metrics.sagemaker" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "monitoring" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "network-firewall" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "notifications" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "oam" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "pi" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "qbusiness" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "ram" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "rbin" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "rds" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "redshift" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "resource-groups" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "rolesanywhere" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "route53profiles" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "route53resolver" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "rum" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "runtime.sagemaker" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "s3" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "s3-control" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "scheduler" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "secretsmanager" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "securityhub" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "servicediscovery" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "servicequotas" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "signer" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "sms-voice" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "sns" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "sqs" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "ssm" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "states" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "storagegateway" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "streams.dynamodb" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "sts" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "swf" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "synthetics" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "tagging" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "transfer" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "trustedadvisor" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "wafv2" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "xray" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      }
+    }
   } ],
   "version" : 3
 }


### PR DESCRIPTION
- Removed deprecated AWS service IDs from endpoint_service_ids_gen.go.
- Added new regions "ap-east-2" (Taipei) and "ap-southeast-6" (New Zealand) in multi_region.go and endpoints.json.
- Updated rate limits for AWS Lambda API in plugin.go.

# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
Add example SQL query results here (please include the input queries as well)
```
</details>
