### PR TITLE
Add support for custom AWS service endpoints

### DIFF
--- a/aws/endpoint_service_ids_gen.go
+++ b/aws/endpoint_service_ids_gen.go
@@ -30,8 +30,6 @@ const AWS_API_ECR_SERVICE_ID = "api.ecr"
 
 const AWS_API_ECR_PUBLIC_SERVICE_ID = "api.ecr-public"
 
-const AWS_API_FLEETHUB_IOT_SERVICE_ID = "api.fleethub.iot"
-
 const AWS_API_IOTDEVICEADVISOR_SERVICE_ID = "api.iotdeviceadvisor"
 
 const AWS_API_IOTWIRELESS_SERVICE_ID = "api.iotwireless"
@@ -56,6 +54,8 @@ const AWS_APPFLOW_SERVICE_ID = "appflow"
 
 const AWS_APPLICATION_AUTOSCALING_SERVICE_ID = "application-autoscaling"
 
+const AWS_APPLICATION_SIGNALS_SERVICE_ID = "application-signals"
+
 const AWS_APPLICATIONINSIGHTS_SERVICE_ID = "applicationinsights"
 
 const AWS_APPMESH_SERVICE_ID = "appmesh"
@@ -65,8 +65,6 @@ const AWS_APPRUNNER_SERVICE_ID = "apprunner"
 const AWS_APPSTREAM2_SERVICE_ID = "appstream2"
 
 const AWS_APPSYNC_SERVICE_ID = "appsync"
-
-const AWS_APPTEST_SERVICE_ID = "apptest"
 
 const AWS_APS_SERVICE_ID = "aps"
 
@@ -135,6 +133,8 @@ const AWS_CODECATALYST_SERVICE_ID = "codecatalyst"
 const AWS_CODECOMMIT_SERVICE_ID = "codecommit"
 
 const AWS_CODEDEPLOY_SERVICE_ID = "codedeploy"
+
+const AWS_CODEGURU_PROFILER_SERVICE_ID = "codeguru-profiler"
 
 const AWS_CODEGURU_REVIEWER_SERVICE_ID = "codeguru-reviewer"
 
@@ -232,8 +232,6 @@ const AWS_ELASTICLOADBALANCING_SERVICE_ID = "elasticloadbalancing"
 
 const AWS_ELASTICMAPREDUCE_SERVICE_ID = "elasticmapreduce"
 
-const AWS_ELASTICTRANSCODER_SERVICE_ID = "elastictranscoder"
-
 const AWS_EMAIL_SERVICE_ID = "email"
 
 const AWS_EMR_CONTAINERS_SERVICE_ID = "emr-containers"
@@ -245,8 +243,6 @@ const AWS_ENTITLEMENT_MARKETPLACE_SERVICE_ID = "entitlement.marketplace"
 const AWS_ES_SERVICE_ID = "es"
 
 const AWS_EVENTS_SERVICE_ID = "events"
-
-const AWS_EVIDENTLY_SERVICE_ID = "evidently"
 
 const AWS_FINSPACE_SERVICE_ID = "finspace"
 
@@ -306,8 +302,6 @@ const AWS_INTERNETMONITOR_SERVICE_ID = "internetmonitor"
 
 const AWS_IOT_SERVICE_ID = "iot"
 
-const AWS_IOTANALYTICS_SERVICE_ID = "iotanalytics"
-
 const AWS_IOTEVENTS_SERVICE_ID = "iotevents"
 
 const AWS_IOTEVENTSDATA_SERVICE_ID = "ioteventsdata"
@@ -361,10 +355,6 @@ const AWS_LIGHTSAIL_SERVICE_ID = "lightsail"
 const AWS_LOGS_SERVICE_ID = "logs"
 
 const AWS_LOOKOUTEQUIPMENT_SERVICE_ID = "lookoutequipment"
-
-const AWS_LOOKOUTMETRICS_SERVICE_ID = "lookoutmetrics"
-
-const AWS_LOOKOUTVISION_SERVICE_ID = "lookoutvision"
 
 const AWS_M2_SERVICE_ID = "m2"
 
@@ -434,15 +424,13 @@ const AWS_NOTIFICATIONS_SERVICE_ID = "notifications"
 
 const AWS_NOTIFICATIONS_CONTACTS_SERVICE_ID = "notifications-contacts"
 
+const AWS_NOVA_ACT_SERVICE_ID = "nova-act"
+
 const AWS_OAM_SERVICE_ID = "oam"
 
 const AWS_OIDC_SERVICE_ID = "oidc"
 
 const AWS_OMICS_SERVICE_ID = "omics"
-
-const AWS_OPSWORKS_SERVICE_ID = "opsworks"
-
-const AWS_OPSWORKS_CM_SERVICE_ID = "opsworks-cm"
 
 const AWS_ORGANIZATIONS_SERVICE_ID = "organizations"
 
@@ -451,6 +439,8 @@ const AWS_OSIS_SERVICE_ID = "osis"
 const AWS_OUTPOSTS_SERVICE_ID = "outposts"
 
 const AWS_PARTICIPANT_CONNECT_SERVICE_ID = "participant.connect"
+
+const AWS_PARTNERCENTRAL_CHANNEL_SERVICE_ID = "partnercentral-channel"
 
 const AWS_PERSONALIZE_SERVICE_ID = "personalize"
 
@@ -464,15 +454,11 @@ const AWS_POLLY_SERVICE_ID = "polly"
 
 const AWS_PORTAL_SSO_SERVICE_ID = "portal.sso"
 
-const AWS_PRIVATE_NETWORKS_SERVICE_ID = "private-networks"
-
 const AWS_PROFILE_SERVICE_ID = "profile"
 
 const AWS_PROTON_SERVICE_ID = "proton"
 
 const AWS_QBUSINESS_SERVICE_ID = "qbusiness"
-
-const AWS_QLDB_SERVICE_ID = "qldb"
 
 const AWS_QUERY_TIMESTREAM_SERVICE_ID = "query.timestream"
 
@@ -497,8 +483,6 @@ const AWS_RESILIENCEHUB_SERVICE_ID = "resiliencehub"
 const AWS_RESOURCE_EXPLORER_2_SERVICE_ID = "resource-explorer-2"
 
 const AWS_RESOURCE_GROUPS_SERVICE_ID = "resource-groups"
-
-const AWS_ROBOMAKER_SERVICE_ID = "robomaker"
 
 const AWS_ROLESANYWHERE_SERVICE_ID = "rolesanywhere"
 
@@ -552,15 +536,11 @@ const AWS_SERVICEDISCOVERY_SERVICE_ID = "servicediscovery"
 
 const AWS_SERVICEQUOTAS_SERVICE_ID = "servicequotas"
 
-const AWS_SESSION_QLDB_SERVICE_ID = "session.qldb"
-
 const AWS_SHIELD_SERVICE_ID = "shield"
 
 const AWS_SIGNER_SERVICE_ID = "signer"
 
 const AWS_SIMSPACEWEAVER_SERVICE_ID = "simspaceweaver"
-
-const AWS_SMS_SERVICE_ID = "sms"
 
 const AWS_SMS_VOICE_SERVICE_ID = "sms-voice"
 

--- a/aws/table_aws_cloudtrail_trail.go
+++ b/aws/table_aws_cloudtrail_trail.go
@@ -302,7 +302,7 @@ func getCloudtrailTrail(ctx context.Context, d *plugin.QueryData, _ *plugin.Hydr
 	// Create session
 	svc, err := CloudTrailClient(ctx, d)
 	if err != nil {
-		plugin.Logger(ctx).Error("aws_cloudtrail_trail.getCloudtrailTrailStatus", "client_error", err)
+		plugin.Logger(ctx).Error("aws_cloudtrail_trail.getCloudtrailTrail", "client_error", err)
 		return nil, err
 	}
 

--- a/aws/table_aws_secretsmanager_secret.go
+++ b/aws/table_aws_secretsmanager_secret.go
@@ -38,7 +38,7 @@ func tableAwsSecretsManagerSecret(_ context.Context) *plugin.Table {
 		HydrateConfig: []plugin.HydrateConfig{
 			{
 				Func: describeSecretsManagerSecret,
-				Tags: map[string]string{"service": "sagemaker", "action": "DescribeSecret"},
+				Tags: map[string]string{"service": "secretsmanager", "action": "DescribeSecret"},
 			},
 		},
 		GetMatrixItemFunc: SupportedRegionMatrix(AWS_SECRETSMANAGER_SERVICE_ID),

--- a/internal/aws_endpoint_generator/endpoints.json
+++ b/internal/aws_endpoint_generator/endpoints.json
@@ -29,6 +29,9 @@
       "ap-east-1" : {
         "description" : "Asia Pacific (Hong Kong)"
       },
+      "ap-east-2" : {
+        "description" : "Asia Pacific (Taipei)"
+      },
       "ap-northeast-1" : {
         "description" : "Asia Pacific (Tokyo)"
       },
@@ -58,6 +61,9 @@
       },
       "ap-southeast-5" : {
         "description" : "Asia Pacific (Malaysia)"
+      },
+      "ap-southeast-6" : {
+        "description" : "Asia Pacific (New Zealand)"
       },
       "ap-southeast-7" : {
         "description" : "Asia Pacific (Thailand)"
@@ -135,6 +141,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "access-analyzer.ap-northeast-1.api.aws",
@@ -195,6 +202,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "access-analyzer.ap-southeast-7.api.aws",
@@ -411,6 +419,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -421,6 +430,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -522,6 +532,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -532,6 +543,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -649,6 +661,8 @@
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
           "eu-central-1" : { },
@@ -744,7 +758,9 @@
           "ap-east-1" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
+          "ap-northeast-3" : { },
           "ap-south-1" : { },
+          "ap-south-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ca-central-1" : { },
@@ -989,6 +1005,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "credentialScope" : {
               "region" : "ap-northeast-1"
@@ -1089,6 +1106,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "credentialScope" : {
               "region" : "ap-southeast-7"
@@ -1431,71 +1449,6 @@
           }
         }
       },
-      "api.fleethub.iot" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-northeast-2" : { },
-          "ap-south-1" : { },
-          "ap-southeast-1" : { },
-          "ap-southeast-2" : { },
-          "ca-central-1" : {
-            "variants" : [ {
-              "hostname" : "api.fleethub.iot-fips.ca-central-1.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "eu-central-1" : { },
-          "eu-north-1" : { },
-          "eu-west-1" : { },
-          "eu-west-2" : { },
-          "fips-ca-central-1" : {
-            "credentialScope" : {
-              "region" : "ca-central-1"
-            },
-            "deprecated" : true,
-            "hostname" : "api.fleethub.iot-fips.ca-central-1.amazonaws.com"
-          },
-          "fips-us-east-1" : {
-            "credentialScope" : {
-              "region" : "us-east-1"
-            },
-            "deprecated" : true,
-            "hostname" : "api.fleethub.iot-fips.us-east-1.amazonaws.com"
-          },
-          "fips-us-east-2" : {
-            "credentialScope" : {
-              "region" : "us-east-2"
-            },
-            "deprecated" : true,
-            "hostname" : "api.fleethub.iot-fips.us-east-2.amazonaws.com"
-          },
-          "fips-us-west-2" : {
-            "credentialScope" : {
-              "region" : "us-west-2"
-            },
-            "deprecated" : true,
-            "hostname" : "api.fleethub.iot-fips.us-west-2.amazonaws.com"
-          },
-          "us-east-1" : {
-            "variants" : [ {
-              "hostname" : "api.fleethub.iot-fips.us-east-1.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "us-east-2" : {
-            "variants" : [ {
-              "hostname" : "api.fleethub.iot-fips.us-east-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "us-west-2" : {
-            "variants" : [ {
-              "hostname" : "api.fleethub.iot-fips.us-west-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          }
-        }
-      },
       "api.iotdeviceadvisor" : {
         "endpoints" : {
           "ap-northeast-1" : {
@@ -1581,10 +1534,12 @@
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-north-1" : { },
           "eu-west-1" : { },
+          "eu-west-2" : { },
           "eu-west-3" : { },
           "me-central-1" : { },
           "sa-east-1" : { },
@@ -1615,6 +1570,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -1625,6 +1581,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -1772,6 +1729,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "api.iot-tunneling-fips.ca-central-1.api.aws",
@@ -1796,6 +1754,8 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-south-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : {
             "variants" : [ {
               "hostname" : "api.iot-tunneling.eu-west-1.api.aws",
@@ -1849,6 +1809,7 @@
             "deprecated" : true,
             "hostname" : "api.tunneling.iot-fips.us-west-2.amazonaws.com"
           },
+          "il-central-1" : { },
           "me-central-1" : {
             "variants" : [ {
               "hostname" : "api.iot-tunneling.me-central-1.api.aws",
@@ -1921,6 +1882,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -1931,6 +1893,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -2043,6 +2006,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -2053,6 +2017,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -2079,6 +2044,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -2089,6 +2055,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -2186,6 +2153,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -2196,6 +2164,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -2757,8 +2726,11 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
+          "eu-south-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
@@ -2769,6 +2741,7 @@
             "deprecated" : true,
             "hostname" : "appstream2-fips.us-west-2.amazonaws.com"
           },
+          "il-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
@@ -2867,12 +2840,15 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "appsync.ca-central-1.api.aws",
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ca-west-1" : { },
           "eu-central-1" : {
             "variants" : [ {
               "hostname" : "appsync.eu-central-1.api.aws",
@@ -2971,26 +2947,14 @@
           }
         }
       },
-      "apptest" : {
-        "endpoints" : {
-          "ap-southeast-2" : { },
-          "eu-central-1" : { },
-          "fips-us-east-1" : {
-            "deprecated" : true
-          },
-          "sa-east-1" : { },
-          "us-east-1" : {
-            "variants" : [ {
-              "tags" : [ "fips" ]
-            } ]
-          }
-        }
-      },
       "aps" : {
         "defaults" : {
           "protocols" : [ "https" ]
         },
         "endpoints" : {
+          "af-south-1" : { },
+          "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -3001,11 +2965,13 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-northeast-3" : { },
           "ap-south-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-south-2" : { },
           "ap-southeast-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -3016,17 +2982,25 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-central-2" : { },
           "eu-north-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-south-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -3042,6 +3016,10 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "il-central-1" : { },
+          "me-central-1" : { },
+          "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -3071,6 +3049,7 @@
           "us-east-2-fips" : {
             "deprecated" : true
           },
+          "us-west-1" : { },
           "us-west-2" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -3089,6 +3068,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -3099,6 +3079,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -3135,6 +3116,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "athena.ap-northeast-1.api.aws",
@@ -3195,6 +3177,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -3456,6 +3439,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -3466,6 +3450,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -3593,6 +3578,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -3603,6 +3589,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -3660,6 +3647,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -3670,6 +3658,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -3742,6 +3731,8 @@
       },
       "bedrock" : {
         "endpoints" : {
+          "af-south-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -3749,6 +3740,11 @@
           "ap-south-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "bedrock-ap-northeast-1" : {
             "credentialScope" : {
               "region" : "ap-northeast-1"
@@ -4038,6 +4034,7 @@
             "hostname" : "bedrock.us-west-2.amazonaws.com"
           },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
           "eu-north-1" : { },
@@ -4046,9 +4043,14 @@
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
+          "il-central-1" : { },
+          "me-central-1" : { },
+          "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
+          "us-west-1" : { },
           "us-west-2" : { }
         }
       },
@@ -4112,6 +4114,7 @@
       },
       "cases" : {
         "endpoints" : {
+          "af-south-1" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-southeast-1" : { },
@@ -4166,6 +4169,7 @@
             "deprecated" : true,
             "hostname" : "cassandra-fips.us-west-2.amazonaws.com"
           },
+          "me-central-1" : { },
           "me-south-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
@@ -4519,6 +4523,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "cloudcontrolapi.ap-northeast-1.api.aws",
@@ -4579,6 +4584,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "cloudcontrolapi.ap-southeast-7.api.aws",
@@ -4796,6 +4802,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -4806,6 +4813,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -4961,12 +4969,16 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "cloudhsmv2.ca-central-1.api.aws",
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ca-west-1" : { },
           "eu-central-1" : {
             "variants" : [ {
               "hostname" : "cloudhsmv2.eu-central-1.api.aws",
@@ -4991,6 +5003,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-south-2" : { },
           "eu-west-1" : {
             "variants" : [ {
               "hostname" : "cloudhsmv2.eu-west-1.api.aws",
@@ -5027,6 +5040,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "variants" : [ {
               "hostname" : "cloudhsmv2.sa-east-1.api.aws",
@@ -5077,6 +5091,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -5087,6 +5102,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -5390,6 +5406,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -5400,6 +5417,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -5468,6 +5486,20 @@
             "deprecated" : true,
             "hostname" : "codedeploy-fips.us-west-2.amazonaws.com"
           }
+        }
+      },
+      "codeguru-profiler" : {
+        "endpoints" : {
+          "ap-northeast-1" : { },
+          "ap-southeast-1" : { },
+          "ap-southeast-2" : { },
+          "eu-central-1" : { },
+          "eu-north-1" : { },
+          "eu-west-1" : { },
+          "eu-west-2" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-2" : { }
         }
       },
       "codeguru-reviewer" : {
@@ -5634,6 +5666,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "cognito-identity.ap-northeast-1.amazonaws.com",
@@ -5694,6 +5727,8 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "cognito-identity.ca-central-1.amazonaws.com",
@@ -5800,6 +5835,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "variants" : [ {
               "hostname" : "cognito-identity.sa-east-1.amazonaws.com",
@@ -5870,6 +5906,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "cognito-idp.ap-northeast-1.amazonaws.com",
@@ -5930,6 +5967,8 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "cognito-idp.ca-central-1.amazonaws.com",
@@ -6036,6 +6075,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "variants" : [ {
               "hostname" : "cognito-idp.sa-east-1.amazonaws.com",
@@ -6473,6 +6513,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -6483,6 +6524,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -6606,6 +6648,9 @@
       "connect-campaigns" : {
         "endpoints" : {
           "af-south-1" : { },
+          "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
+          "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
@@ -6656,6 +6701,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -6666,6 +6712,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -6789,6 +6836,7 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "data.iot-fips.ca-central-1.amazonaws.com",
@@ -6797,6 +6845,8 @@
           },
           "eu-central-1" : { },
           "eu-north-1" : { },
+          "eu-south-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
@@ -6835,6 +6885,7 @@
             "deprecated" : true,
             "hostname" : "data.iot-fips.us-west-2.amazonaws.com"
           },
+          "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
           "sa-east-1" : { },
@@ -6960,6 +7011,7 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "data.jobs.iot-fips.ca-central-1.amazonaws.com",
@@ -6968,6 +7020,7 @@
           },
           "eu-central-1" : { },
           "eu-north-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
@@ -7006,6 +7059,7 @@
             "deprecated" : true,
             "hostname" : "data.jobs.iot-fips.us-west-2.amazonaws.com"
           },
+          "me-central-1" : { },
           "me-south-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
@@ -7156,6 +7210,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "datasync.ap-northeast-1.api.aws",
@@ -7216,6 +7271,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "datasync.ap-southeast-7.api.aws",
@@ -7426,6 +7482,9 @@
           } ]
         },
         "endpoints" : {
+          "af-south-1" : { },
+          "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "datazone.ap-northeast-1.api.aws"
           },
@@ -7456,6 +7515,7 @@
           "ap-southeast-5" : {
             "hostname" : "datazone.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "datazone.ap-southeast-7.api.aws"
           },
@@ -7472,12 +7532,14 @@
           "eu-central-1" : {
             "hostname" : "datazone.eu-central-1.api.aws"
           },
+          "eu-central-2" : { },
           "eu-north-1" : {
             "hostname" : "datazone.eu-north-1.api.aws"
           },
           "eu-south-1" : {
             "hostname" : "datazone.eu-south-1.api.aws"
           },
+          "eu-south-2" : { },
           "eu-west-1" : {
             "hostname" : "datazone.eu-west-1.api.aws"
           },
@@ -7639,6 +7701,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -7649,6 +7712,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -7768,6 +7832,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "dlm.ap-northeast-1.api.aws",
@@ -7828,6 +7893,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "dlm.ap-southeast-7.api.aws",
@@ -7972,6 +8038,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -7982,6 +8049,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -8352,6 +8420,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -8362,6 +8431,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -8467,6 +8537,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -8477,6 +8548,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -8588,6 +8660,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "ec2.ap-northeast-1.api.aws",
@@ -8623,6 +8696,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -8776,6 +8850,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -8786,6 +8861,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -8877,6 +8953,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -8887,6 +8964,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -8973,6 +9051,7 @@
           "ap-east-1" : {
             "hostname" : "eks-auth.ap-east-1.api.aws"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "eks-auth.ap-northeast-1.api.aws"
           },
@@ -9003,6 +9082,7 @@
           "ap-southeast-5" : {
             "hostname" : "eks-auth.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "eks-auth.ap-southeast-7.api.aws"
           },
@@ -9069,6 +9149,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -9079,6 +9160,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -9194,6 +9276,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-south-2" : { },
           "ap-southeast-1" : {
             "variants" : [ {
               "hostname" : "elasticbeanstalk.ap-southeast-1.api.aws",
@@ -9212,18 +9295,24 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "elasticbeanstalk.ca-central-1.api.aws",
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ca-west-1" : { },
           "eu-central-1" : {
             "variants" : [ {
               "hostname" : "elasticbeanstalk.eu-central-1.api.aws",
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-central-2" : { },
           "eu-north-1" : {
             "variants" : [ {
               "hostname" : "elasticbeanstalk.eu-north-1.api.aws",
@@ -9236,6 +9325,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-south-2" : { },
           "eu-west-1" : {
             "variants" : [ {
               "hostname" : "elasticbeanstalk.eu-west-1.api.aws",
@@ -9288,6 +9378,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "me-central-1" : { },
           "me-south-1" : {
             "variants" : [ {
               "hostname" : "elasticbeanstalk.me-south-1.api.aws",
@@ -9364,6 +9455,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "elasticfilesystem-fips.ap-northeast-1.amazonaws.com",
@@ -9424,6 +9516,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "elasticfilesystem-fips.ap-southeast-7.amazonaws.com",
@@ -9777,6 +9870,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -9787,6 +9881,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -9865,6 +9960,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -9875,6 +9971,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -9975,18 +10072,6 @@
           }
         }
       },
-      "elastictranscoder" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-south-1" : { },
-          "ap-southeast-1" : { },
-          "ap-southeast-2" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { },
-          "us-west-1" : { },
-          "us-west-2" : { }
-        }
-      },
       "email" : {
         "endpoints" : {
           "af-south-1" : { },
@@ -9994,16 +10079,20 @@
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
           "ap-south-1" : { },
+          "ap-south-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "email-fips.ca-central-1.amazonaws.com",
               "tags" : [ "fips" ]
             } ]
           },
+          "ca-west-1" : { },
           "eu-central-1" : { },
+          "eu-central-2" : { },
           "eu-north-1" : { },
           "eu-south-1" : { },
           "eu-west-1" : { },
@@ -10045,6 +10134,7 @@
             "hostname" : "email-fips.us-west-2.amazonaws.com"
           },
           "il-central-1" : { },
+          "me-central-1" : { },
           "me-south-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
@@ -10175,6 +10265,8 @@
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "emr-serverless-fips.ca-central-1.amazonaws.com",
@@ -10183,6 +10275,7 @@
           },
           "ca-west-1" : { },
           "eu-central-1" : { },
+          "eu-central-2" : { },
           "eu-north-1" : { },
           "eu-south-1" : { },
           "eu-south-2" : { },
@@ -10224,6 +10317,7 @@
             "deprecated" : true,
             "hostname" : "emr-serverless-fips.us-west-2.amazonaws.com"
           },
+          "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
           "sa-east-1" : { },
@@ -10282,6 +10376,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "aos.ap-northeast-1.api.aws",
@@ -10342,6 +10437,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "aos.ap-southeast-7.api.aws",
@@ -10525,6 +10621,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "events.ap-northeast-1.api.aws",
@@ -10585,6 +10682,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "events.ap-southeast-7.api.aws",
@@ -10759,37 +10857,6 @@
           }
         }
       },
-      "evidently" : {
-        "endpoints" : {
-          "ap-northeast-1" : {
-            "hostname" : "evidently.ap-northeast-1.amazonaws.com"
-          },
-          "ap-southeast-1" : {
-            "hostname" : "evidently.ap-southeast-1.amazonaws.com"
-          },
-          "ap-southeast-2" : {
-            "hostname" : "evidently.ap-southeast-2.amazonaws.com"
-          },
-          "eu-central-1" : {
-            "hostname" : "evidently.eu-central-1.amazonaws.com"
-          },
-          "eu-north-1" : {
-            "hostname" : "evidently.eu-north-1.amazonaws.com"
-          },
-          "eu-west-1" : {
-            "hostname" : "evidently.eu-west-1.amazonaws.com"
-          },
-          "us-east-1" : {
-            "hostname" : "evidently.us-east-1.amazonaws.com"
-          },
-          "us-east-2" : {
-            "hostname" : "evidently.us-east-2.amazonaws.com"
-          },
-          "us-west-2" : {
-            "hostname" : "evidently.us-west-2.amazonaws.com"
-          }
-        }
-      },
       "finspace" : {
         "endpoints" : {
           "ap-northeast-1" : { },
@@ -10827,6 +10894,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "firehose.ap-northeast-1.api.aws",
@@ -10882,6 +10950,7 @@
             } ]
           },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "firehose.ap-southeast-7.api.aws",
@@ -11073,6 +11142,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "fms-fips.ap-northeast-1.amazonaws.com",
@@ -11108,6 +11178,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -11449,6 +11520,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -11459,6 +11531,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -11665,6 +11738,8 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-north-1" : { },
@@ -11696,6 +11771,7 @@
           "ap-east-1" : {
             "hostname" : "gameliftstreams.ap-east-1.api.aws"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "gameliftstreams.ap-northeast-1.api.aws"
           },
@@ -11726,6 +11802,7 @@
           "ap-southeast-5" : {
             "hostname" : "gameliftstreams.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "gameliftstreams.ap-southeast-7.api.aws"
           },
@@ -11898,12 +11975,46 @@
       },
       "globalaccelerator" : {
         "endpoints" : {
+          "af-south-1" : { },
+          "ap-east-1" : { },
+          "ap-east-2" : { },
+          "ap-northeast-1" : { },
+          "ap-northeast-2" : { },
+          "ap-northeast-3" : { },
+          "ap-south-1" : { },
+          "ap-south-2" : { },
+          "ap-southeast-1" : { },
+          "ap-southeast-2" : { },
+          "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
+          "ca-central-1" : { },
+          "ca-west-1" : { },
+          "eu-central-1" : { },
+          "eu-central-2" : { },
+          "eu-north-1" : { },
+          "eu-south-1" : { },
+          "eu-south-2" : { },
+          "eu-west-1" : { },
+          "eu-west-2" : { },
+          "eu-west-3" : { },
           "fips-us-west-2" : {
             "credentialScope" : {
               "region" : "us-west-2"
             },
             "hostname" : "globalaccelerator-fips.us-west-2.amazonaws.com"
-          }
+          },
+          "il-central-1" : { },
+          "me-central-1" : { },
+          "me-south-1" : { },
+          "mx-central-1" : { },
+          "sa-east-1" : { },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-1" : { },
+          "us-west-2" : { }
         }
       },
       "glue" : {
@@ -11920,6 +12031,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "glue.ap-northeast-1.api.aws",
@@ -11980,6 +12092,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "glue.ap-southeast-7.api.aws",
@@ -12228,6 +12341,7 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "greengrass-fips.ca-central-1.amazonaws.com",
@@ -12235,6 +12349,7 @@
             } ]
           },
           "eu-central-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "fips-ca-central-1" : {
@@ -12396,6 +12511,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -12406,6 +12522,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : {
@@ -12529,6 +12646,8 @@
         "endpoints" : {
           "ap-south-1" : { },
           "ap-southeast-2" : { },
+          "ca-central-1" : { },
+          "eu-west-1" : { },
           "eu-west-2" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -12600,6 +12719,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -12610,6 +12730,8 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
           "eu-central-1" : { },
@@ -12623,6 +12745,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -12779,14 +12902,20 @@
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
           "ap-south-1" : { },
+          "ap-south-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
           "eu-north-1" : { },
           "eu-south-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
@@ -12818,7 +12947,10 @@
             "deprecated" : true,
             "hostname" : "inspector2-fips.us-west-2.amazonaws.com"
           },
+          "il-central-1" : { },
+          "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
@@ -12870,6 +13002,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "internetmonitor.ap-northeast-1.api.aws",
             "variants" : [ {
@@ -12936,6 +13069,7 @@
           "ap-southeast-5" : {
             "hostname" : "internetmonitor.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "internetmonitor.ap-southeast-7.api.aws"
           },
@@ -13100,6 +13234,7 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "iot-fips.ca-central-1.amazonaws.com",
@@ -13108,6 +13243,8 @@
           },
           "eu-central-1" : { },
           "eu-north-1" : { },
+          "eu-south-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
@@ -13131,6 +13268,7 @@
             "deprecated" : true,
             "hostname" : "iot-fips.us-west-2.amazonaws.com"
           },
+          "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
           "sa-east-1" : { },
@@ -13158,18 +13296,6 @@
               "tags" : [ "fips" ]
             } ]
           }
-        }
-      },
-      "iotanalytics" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-south-1" : { },
-          "ap-southeast-2" : { },
-          "eu-central-1" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { },
-          "us-east-2" : { },
-          "us-west-2" : { }
         }
       },
       "iotevents" : {
@@ -13781,6 +13907,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -13791,6 +13918,8 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "kafka-fips.ca-central-1.amazonaws.com",
@@ -13856,6 +13985,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
@@ -13885,17 +14015,35 @@
       },
       "kafkaconnect" : {
         "endpoints" : {
+          "af-south-1" : { },
+          "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
+          "ap-northeast-3" : { },
           "ap-south-1" : { },
+          "ap-south-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : { },
+          "eu-central-2" : { },
           "eu-north-1" : { },
+          "eu-south-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
+          "il-central-1" : { },
+          "me-central-1" : { },
+          "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -13981,6 +14129,7 @@
           "ap-east-1" : {
             "hostname" : "kendra-ranking.ap-east-1.api.aws"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "kendra-ranking.ap-northeast-1.api.aws"
           },
@@ -14011,6 +14160,7 @@
           "ap-southeast-5" : {
             "hostname" : "kendra-ranking.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "kendra-ranking.ap-southeast-7.api.aws"
           },
@@ -14087,6 +14237,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -14097,6 +14248,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -14171,6 +14323,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -14181,6 +14334,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -14284,11 +14438,14 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
+          "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
+          "me-south-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -14330,6 +14487,7 @@
             "deprecated" : true,
             "hostname" : "kms-fips.ap-east-1.amazonaws.com"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "kms-fips.ap-northeast-1.amazonaws.com",
@@ -14460,6 +14618,7 @@
             "deprecated" : true,
             "hostname" : "kms-fips.ap-southeast-5.amazonaws.com"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "kms-fips.ap-southeast-7.amazonaws.com",
@@ -14736,6 +14895,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "lakeformation.ap-northeast-1.api.aws",
@@ -14796,6 +14956,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "lakeformation.ap-southeast-7.api.aws",
@@ -14984,6 +15145,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "lambda.ap-northeast-1.api.aws",
@@ -15044,6 +15206,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "lambda.ap-southeast-7.api.aws",
@@ -15210,6 +15373,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -15220,6 +15384,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -15294,6 +15459,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -15304,6 +15470,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -15378,6 +15545,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -15465,6 +15633,8 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-3" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-north-1" : { },
@@ -15490,6 +15660,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "logs.ap-northeast-1.api.aws",
@@ -15545,6 +15716,7 @@
             } ]
           },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -15722,30 +15894,6 @@
           "ap-northeast-2" : { },
           "eu-west-1" : { },
           "us-east-1" : { }
-        }
-      },
-      "lookoutmetrics" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-southeast-1" : { },
-          "ap-southeast-2" : { },
-          "eu-central-1" : { },
-          "eu-north-1" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { },
-          "us-east-2" : { },
-          "us-west-2" : { }
-        }
-      },
-      "lookoutvision" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-northeast-2" : { },
-          "eu-central-1" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { },
-          "us-east-2" : { },
-          "us-west-2" : { }
         }
       },
       "m2" : {
@@ -16072,6 +16220,7 @@
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-north-1" : { },
@@ -16136,6 +16285,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "mediaconvert-fips.ca-central-1.amazonaws.com",
@@ -16285,6 +16435,7 @@
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-north-1" : { },
@@ -16390,6 +16541,7 @@
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "mediapackagev2-fips.ca-central-1.amazonaws.com",
@@ -16757,6 +16909,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -16767,6 +16920,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -16876,6 +17030,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -16885,7 +17040,11 @@
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
           "eu-north-1" : { },
@@ -16925,6 +17084,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
@@ -17046,6 +17206,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -17056,6 +17217,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -17130,6 +17292,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -17140,6 +17303,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -17335,6 +17499,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -17345,6 +17510,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -17472,6 +17638,7 @@
           "ap-east-1" : {
             "hostname" : "notifications.ap-east-1.api.aws"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "notifications.ap-northeast-1.api.aws"
           },
@@ -17502,6 +17669,7 @@
           "ap-southeast-5" : {
             "hostname" : "notifications.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "notifications.ap-southeast-7.api.aws"
           },
@@ -17576,10 +17744,16 @@
         "isRegionalized" : false,
         "partitionEndpoint" : "aws-global"
       },
+      "nova-act" : {
+        "endpoints" : {
+          "us-east-1" : { }
+        }
+      },
       "oam" : {
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -17590,6 +17764,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -17626,6 +17801,7 @@
             },
             "hostname" : "oidc.ap-east-1.amazonaws.com"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "credentialScope" : {
               "region" : "ap-northeast-1"
@@ -17686,6 +17862,8 @@
             },
             "hostname" : "oidc.ap-southeast-5.amazonaws.com"
           },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "credentialScope" : {
               "region" : "ca-central-1"
@@ -17764,6 +17942,7 @@
             },
             "hostname" : "oidc.me-south-1.amazonaws.com"
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "credentialScope" : {
               "region" : "sa-east-1"
@@ -17798,6 +17977,7 @@
       },
       "omics" : {
         "endpoints" : {
+          "ap-northeast-2" : { },
           "ap-southeast-1" : {
             "credentialScope" : {
               "region" : "ap-southeast-1"
@@ -17862,22 +18042,6 @@
               "tags" : [ "fips" ]
             } ]
           }
-        }
-      },
-      "opsworks" : {
-        "endpoints" : {
-          "ap-southeast-1" : { },
-          "eu-central-1" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { },
-          "us-west-2" : { }
-        }
-      },
-      "opsworks-cm" : {
-        "endpoints" : {
-          "ap-southeast-2" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { }
         }
       },
       "organizations" : {
@@ -17985,6 +18149,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
@@ -18050,6 +18215,11 @@
           }
         }
       },
+      "partnercentral-channel" : {
+        "endpoints" : {
+          "us-east-1" : { }
+        }
+      },
       "personalize" : {
         "endpoints" : {
           "ap-northeast-1" : { },
@@ -18081,6 +18251,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "protocols" : [ "https" ],
             "variants" : [ {
@@ -18151,6 +18322,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "protocols" : [ "https" ],
             "variants" : [ {
@@ -18560,6 +18732,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-central-2" : { },
           "eu-north-1" : {
             "variants" : [ {
               "hostname" : "polly.eu-north-1.api.aws",
@@ -18701,6 +18874,7 @@
             },
             "hostname" : "portal.sso.ap-east-1.amazonaws.com"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "credentialScope" : {
               "region" : "ap-northeast-1"
@@ -18761,6 +18935,8 @@
             },
             "hostname" : "portal.sso.ap-southeast-5.amazonaws.com"
           },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "credentialScope" : {
               "region" : "ca-central-1"
@@ -18839,6 +19015,7 @@
             },
             "hostname" : "portal.sso.me-south-1.amazonaws.com"
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "credentialScope" : {
               "region" : "sa-east-1"
@@ -18869,13 +19046,6 @@
             },
             "hostname" : "portal.sso.us-west-2.amazonaws.com"
           }
-        }
-      },
-      "private-networks" : {
-        "endpoints" : {
-          "us-east-1" : { },
-          "us-east-2" : { },
-          "us-west-2" : { }
         }
       },
       "profile" : {
@@ -18959,6 +19129,7 @@
           "ap-east-1" : {
             "hostname" : "qbusiness.ap-east-1.api.aws"
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "qbusiness.ap-northeast-1.api.aws"
           },
@@ -18989,6 +19160,7 @@
           "ap-southeast-5" : {
             "hostname" : "qbusiness.ap-southeast-5.api.aws"
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "hostname" : "qbusiness.ap-southeast-7.api.aws"
           },
@@ -19051,69 +19223,6 @@
           }
         }
       },
-      "qldb" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-northeast-2" : { },
-          "ap-southeast-1" : { },
-          "ap-southeast-2" : { },
-          "ca-central-1" : {
-            "variants" : [ {
-              "hostname" : "qldb-fips.ca-central-1.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "eu-central-1" : { },
-          "eu-west-1" : { },
-          "eu-west-2" : { },
-          "fips-ca-central-1" : {
-            "credentialScope" : {
-              "region" : "ca-central-1"
-            },
-            "deprecated" : true,
-            "hostname" : "qldb-fips.ca-central-1.amazonaws.com"
-          },
-          "fips-us-east-1" : {
-            "credentialScope" : {
-              "region" : "us-east-1"
-            },
-            "deprecated" : true,
-            "hostname" : "qldb-fips.us-east-1.amazonaws.com"
-          },
-          "fips-us-east-2" : {
-            "credentialScope" : {
-              "region" : "us-east-2"
-            },
-            "deprecated" : true,
-            "hostname" : "qldb-fips.us-east-2.amazonaws.com"
-          },
-          "fips-us-west-2" : {
-            "credentialScope" : {
-              "region" : "us-west-2"
-            },
-            "deprecated" : true,
-            "hostname" : "qldb-fips.us-west-2.amazonaws.com"
-          },
-          "us-east-1" : {
-            "variants" : [ {
-              "hostname" : "qldb-fips.us-east-1.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "us-east-2" : {
-            "variants" : [ {
-              "hostname" : "qldb-fips.us-east-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "us-west-2" : {
-            "variants" : [ {
-              "hostname" : "qldb-fips.us-west-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          }
-        }
-      },
       "query.timestream" : {
         "endpoints" : {
           "ap-northeast-1" : { },
@@ -19135,6 +19244,7 @@
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
@@ -19144,6 +19254,8 @@
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
+          "il-central-1" : { },
+          "me-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -19162,6 +19274,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -19212,6 +19325,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -19406,6 +19520,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "rbin.ap-northeast-1.api.aws",
@@ -19466,6 +19581,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -19660,6 +19776,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -19670,6 +19787,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -19937,6 +20055,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -19947,6 +20066,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -20043,14 +20163,20 @@
       },
       "redshift-serverless" : {
         "endpoints" : {
+          "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
+          "ap-northeast-3" : { },
           "ap-south-1" : { },
           "ap-south-2" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
+          "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -20058,9 +20184,11 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ca-west-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
           "eu-north-1" : { },
+          "eu-south-1" : { },
           "eu-south-2" : { },
           "eu-west-1" : { },
           "eu-west-2" : { },
@@ -20296,6 +20424,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
               "hostname" : "rekognition-fips.us-east-1.amazonaws.com",
@@ -20502,6 +20631,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -20512,6 +20642,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -20628,6 +20759,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -20638,6 +20770,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -20708,21 +20841,11 @@
           }
         }
       },
-      "robomaker" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-southeast-1" : { },
-          "eu-central-1" : { },
-          "eu-west-1" : { },
-          "us-east-1" : { },
-          "us-east-2" : { },
-          "us-west-2" : { }
-        }
-      },
       "rolesanywhere" : {
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -20733,6 +20856,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -20855,6 +20979,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "route53profiles.ap-northeast-1.api.aws",
@@ -20909,6 +21034,9 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "route53profiles-fips.ca-central-1.api.aws",
@@ -20993,6 +21121,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "variants" : [ {
               "hostname" : "route53profiles.sa-east-1.api.aws",
@@ -21054,6 +21183,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "route53resolver.ap-northeast-1.api.aws",
@@ -21114,6 +21244,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "route53resolver.ap-southeast-7.api.aws",
@@ -21327,7 +21458,10 @@
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
           "eu-north-1" : { },
@@ -21339,6 +21473,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -21416,6 +21551,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -21426,6 +21562,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -21523,6 +21660,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "hostname" : "s3.ap-northeast-1.amazonaws.com",
             "signatureVersions" : [ "s3", "s3v4" ],
@@ -21589,6 +21727,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "s3.dualstack.ap-southeast-7.amazonaws.com",
@@ -22410,6 +22549,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -22419,7 +22559,11 @@
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
+          "ca-west-1" : { },
           "eu-central-1" : { },
           "eu-central-2" : { },
           "eu-north-1" : { },
@@ -22428,8 +22572,10 @@
           "eu-west-1" : { },
           "eu-west-2" : { },
           "eu-west-3" : { },
+          "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -22496,6 +22642,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -22546,6 +22693,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "tags" : [ "dualstack" ]
@@ -22704,6 +22852,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "securityhub.ap-northeast-1.api.aws",
@@ -22764,6 +22913,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "securityhub.ap-southeast-7.api.aws",
@@ -23310,6 +23460,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "servicediscovery.ap-northeast-1.api.aws",
@@ -23370,6 +23521,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "servicediscovery.ap-southeast-7.api.aws",
@@ -23577,6 +23729,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -23587,6 +23740,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -23607,57 +23761,6 @@
           "us-east-2" : { },
           "us-west-1" : { },
           "us-west-2" : { }
-        }
-      },
-      "session.qldb" : {
-        "endpoints" : {
-          "ap-northeast-1" : { },
-          "ap-northeast-2" : { },
-          "ap-southeast-1" : { },
-          "ap-southeast-2" : { },
-          "ca-central-1" : { },
-          "eu-central-1" : { },
-          "eu-west-1" : { },
-          "eu-west-2" : { },
-          "fips-us-east-1" : {
-            "credentialScope" : {
-              "region" : "us-east-1"
-            },
-            "deprecated" : true,
-            "hostname" : "session.qldb-fips.us-east-1.amazonaws.com"
-          },
-          "fips-us-east-2" : {
-            "credentialScope" : {
-              "region" : "us-east-2"
-            },
-            "deprecated" : true,
-            "hostname" : "session.qldb-fips.us-east-2.amazonaws.com"
-          },
-          "fips-us-west-2" : {
-            "credentialScope" : {
-              "region" : "us-west-2"
-            },
-            "deprecated" : true,
-            "hostname" : "session.qldb-fips.us-west-2.amazonaws.com"
-          },
-          "us-east-1" : {
-            "variants" : [ {
-              "hostname" : "session.qldb-fips.us-east-1.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "us-east-2" : {
-            "variants" : [ {
-              "hostname" : "session.qldb-fips.us-east-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          },
-          "us-west-2" : {
-            "variants" : [ {
-              "hostname" : "session.qldb-fips.us-west-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          }
         }
       },
       "shield" : {
@@ -23915,23 +24018,6 @@
           "us-west-2" : { }
         }
       },
-      "sms" : {
-        "endpoints" : {
-          "fips-us-west-2" : {
-            "credentialScope" : {
-              "region" : "us-west-2"
-            },
-            "deprecated" : true,
-            "hostname" : "sms-fips.us-west-2.amazonaws.com"
-          },
-          "us-west-2" : {
-            "variants" : [ {
-              "hostname" : "sms-fips.us-west-2.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          }
-        }
-      },
       "sms-voice" : {
         "endpoints" : {
           "af-south-1" : {
@@ -23940,6 +24026,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "sms-voice.ap-northeast-1.api.aws",
@@ -23994,6 +24081,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "sms-voice-fips.ca-central-1.amazonaws.com",
@@ -24641,6 +24729,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "sns.ap-northeast-1.api.aws",
@@ -24701,6 +24790,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "sns.ap-southeast-7.api.aws",
@@ -24891,6 +24981,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "sqs.ap-northeast-1.api.aws",
@@ -24951,6 +25042,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "sqs.ap-southeast-7.api.aws",
@@ -25138,6 +25230,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -25148,6 +25241,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -25796,6 +25890,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -25806,6 +25901,8 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
           "eu-central-1" : { },
@@ -25819,6 +25916,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -25830,6 +25928,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -25840,6 +25939,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -25938,6 +26038,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -25948,6 +26049,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -26052,6 +26154,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -26062,6 +26165,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -26095,6 +26199,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -26105,6 +26210,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "aws-global" : {
             "credentialScope" : {
@@ -26204,6 +26310,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -26214,6 +26321,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
@@ -26322,6 +26430,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "variants" : [ {
               "hostname" : "synthetics.ap-northeast-1.api.aws",
@@ -26382,6 +26491,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "variants" : [ {
               "hostname" : "synthetics.ap-southeast-7.api.aws",
@@ -26586,6 +26696,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -26596,6 +26707,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -26877,6 +26989,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-central-2" : { },
           "eu-north-1" : {
             "variants" : [ {
               "hostname" : "transcribe.eu-north-1.api.aws",
@@ -27036,6 +27149,8 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "ap-southeast-5" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "transcribestreaming-fips.ca-central-1.amazonaws.com",
@@ -27054,6 +27169,7 @@
               "tags" : [ "dualstack" ]
             } ]
           },
+          "eu-central-2" : { },
           "eu-west-1" : {
             "variants" : [ {
               "hostname" : "transcribestreaming.eu-west-1.api.aws",
@@ -27094,6 +27210,7 @@
             "deprecated" : true,
             "hostname" : "transcribestreaming-fips.us-west-2.amazonaws.com"
           },
+          "mx-central-1" : { },
           "sa-east-1" : {
             "variants" : [ {
               "hostname" : "transcribestreaming.sa-east-1.api.aws",
@@ -27142,6 +27259,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -27152,6 +27270,8 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "transfer-fips.ca-central-1.amazonaws.com",
@@ -27402,6 +27522,9 @@
       },
       "trustedadvisor" : {
         "endpoints" : {
+          "ap-northeast-2" : { },
+          "ap-southeast-2" : { },
+          "eu-west-1" : { },
           "fips-us-east-1" : {
             "credentialScope" : {
               "region" : "us-east-1"
@@ -27419,13 +27542,17 @@
               "region" : "us-west-2"
             },
             "hostname" : "trustedadvisor-fips.us-west-2.api.aws"
-          }
+          },
+          "us-east-1" : { },
+          "us-east-2" : { },
+          "us-west-2" : { }
         }
       },
       "verifiedpermissions" : {
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -27435,6 +27562,9 @@
           "ap-southeast-2" : { },
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
+          "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
+          "ap-southeast-7" : { },
           "ca-central-1" : {
             "variants" : [ {
               "hostname" : "verifiedpermissions-fips.ca-central-1.amazonaws.com",
@@ -27500,6 +27630,7 @@
           "il-central-1" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : {
             "variants" : [ {
@@ -27650,6 +27781,7 @@
           "eu-west-3" : { },
           "me-central-1" : { },
           "me-south-1" : { },
+          "mx-central-1" : { },
           "sa-east-1" : { },
           "us-east-1" : { },
           "us-east-2" : { },
@@ -28199,6 +28331,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ap-east-2" : { },
           "ap-northeast-1" : {
             "credentialScope" : {
               "region" : "ap-northeast-1"
@@ -28299,6 +28432,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : {
             "credentialScope" : {
               "region" : "ap-southeast-7"
@@ -28842,6 +28976,7 @@
           "ap-south-1" : { },
           "ap-southeast-1" : { },
           "ap-southeast-2" : { },
+          "ap-southeast-5" : { },
           "ca-central-1" : { },
           "eu-central-1" : { },
           "eu-west-1" : { },
@@ -28869,6 +29004,7 @@
               "tags" : [ "fips" ]
             } ]
           },
+          "us-east-2" : { },
           "us-west-2" : {
             "variants" : [ {
               "hostname" : "workspaces-fips.us-west-2.amazonaws.com",
@@ -28919,6 +29055,7 @@
         "endpoints" : {
           "af-south-1" : { },
           "ap-east-1" : { },
+          "ap-east-2" : { },
           "ap-northeast-1" : { },
           "ap-northeast-2" : { },
           "ap-northeast-3" : { },
@@ -28929,6 +29066,7 @@
           "ap-southeast-3" : { },
           "ap-southeast-4" : { },
           "ap-southeast-5" : { },
+          "ap-southeast-6" : { },
           "ap-southeast-7" : { },
           "ca-central-1" : { },
           "ca-west-1" : { },
@@ -28995,6 +29133,232 @@
             "variants" : [ {
               "hostname" : "xray-fips.us-west-2.amazonaws.com",
               "tags" : [ "fips" ]
+            } ]
+          }
+        }
+      },
+      "application-signals" : {
+        "endpoints" : {
+          "af-south-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.af-south-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-east-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-east-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-east-2" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-east-2.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-northeast-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-northeast-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-northeast-2" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-northeast-2.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-northeast-3" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-northeast-3.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-south-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-south-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-south-2" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-south-2.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-southeast-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-southeast-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-southeast-2" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-southeast-2.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-southeast-3" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-southeast-3.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-southeast-4" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-southeast-4.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-southeast-5" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-southeast-5.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-southeast-6" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-southeast-6.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ap-southeast-7" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ap-southeast-7.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ca-central-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ca-central-1.api.aws",
+              "tags" : [ "custom" ]
+            }, {
+              "hostname" : "application-signals-fips.ca-central-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "ca-west-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.ca-west-1.api.aws",
+              "tags" : [ "custom" ]
+            }, {
+              "hostname" : "application-signals-fips.ca-west-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "eu-central-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.eu-central-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "eu-central-2" : {
+            "variants" : [ {
+              "hostname" : "application-signals.eu-central-2.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "eu-north-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.eu-north-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "eu-south-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.eu-south-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "eu-south-2" : {
+            "variants" : [ {
+              "hostname" : "application-signals.eu-south-2.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "eu-west-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.eu-west-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "eu-west-2" : {
+            "variants" : [ {
+              "hostname" : "application-signals.eu-west-2.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "eu-west-3" : {
+            "variants" : [ {
+              "hostname" : "application-signals.eu-west-3.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "il-central-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.il-central-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "me-central-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.me-central-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "me-south-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.me-south-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "mx-central-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.mx-central-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "sa-east-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.sa-east-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "us-east-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.us-east-1.api.aws",
+              "tags" : [ "custom" ]
+            }, {
+              "hostname" : "application-signals-fips.us-east-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "us-east-2" : {
+            "variants" : [ {
+              "hostname" : "application-signals.us-east-2.api.aws",
+              "tags" : [ "custom" ]
+            }, {
+              "hostname" : "application-signals-fips.us-east-2.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "us-west-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.us-west-1.api.aws",
+              "tags" : [ "custom" ]
+            }, {
+              "hostname" : "application-signals-fips.us-west-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "us-west-2" : {
+            "variants" : [ {
+              "hostname" : "application-signals.us-west-2.api.aws",
+              "tags" : [ "custom" ]
+            }, {
+              "hostname" : "application-signals-fips.us-west-2.api.aws",
+              "tags" : [ "custom" ]
             } ]
           }
         }
@@ -29893,11 +30257,6 @@
           "cn-northwest-1" : { }
         }
       },
-      "iotanalytics" : {
-        "endpoints" : {
-          "cn-north-1" : { }
-        }
-      },
       "iotevents" : {
         "endpoints" : {
           "cn-north-1" : { }
@@ -30433,6 +30792,12 @@
         },
         "isRegionalized" : true
       },
+      "scheduler" : {
+        "endpoints" : {
+          "cn-north-1" : { },
+          "cn-northwest-1" : { }
+        }
+      },
       "schemas" : {
         "endpoints" : {
           "cn-north-1" : { },
@@ -30519,11 +30884,6 @@
             },
             "hostname" : "verification.signer.cn-northwest-1.amazonaws.com.cn"
           }
-        }
-      },
-      "sms" : {
-        "endpoints" : {
-          "cn-north-1" : { }
         }
       },
       "snowball" : {
@@ -30730,6 +31090,12 @@
         }
       },
       "transfer" : {
+        "endpoints" : {
+          "cn-north-1" : { },
+          "cn-northwest-1" : { }
+        }
+      },
+      "verifiedpermissions" : {
         "endpoints" : {
           "cn-north-1" : { },
           "cn-northwest-1" : { }
@@ -31397,6 +31763,12 @@
             "deprecated" : true,
             "hostname" : "appstream2-fips.us-gov-west-1.amazonaws.com"
           }
+        }
+      },
+      "aps" : {
+        "endpoints" : {
+          "us-gov-east-1" : { },
+          "us-gov-west-1" : { }
         }
       },
       "arc-zonal-shift" : {
@@ -33237,6 +33609,12 @@
           }
         }
       },
+      "grafana" : {
+        "endpoints" : {
+          "us-gov-east-1" : { },
+          "us-gov-west-1" : { }
+        }
+      },
       "greengrass" : {
         "defaults" : {
           "protocols" : [ "https" ]
@@ -33715,6 +34093,12 @@
             "deprecated" : true,
             "hostname" : "kafka.us-gov-west-1.amazonaws.com"
           }
+        }
+      },
+      "kafkaconnect" : {
+        "endpoints" : {
+          "us-gov-east-1" : { },
+          "us-gov-west-1" : { }
         }
       },
       "kendra" : {
@@ -34880,6 +35264,12 @@
           }
         }
       },
+      "resource-explorer-2" : {
+        "endpoints" : {
+          "us-gov-east-1" : { },
+          "us-gov-west-1" : { }
+        }
+      },
       "resource-groups" : {
         "defaults" : {
           "variants" : [ {
@@ -34914,11 +35304,6 @@
               "tags" : [ "fips" ]
             } ]
           }
-        }
-      },
-      "robomaker" : {
-        "endpoints" : {
-          "us-gov-west-1" : { }
         }
       },
       "rolesanywhere" : {
@@ -35030,6 +35415,12 @@
             "deprecated" : true,
             "hostname" : "route53resolver.us-gov-west-1.amazonaws.com"
           }
+        }
+      },
+      "rum" : {
+        "endpoints" : {
+          "us-gov-east-1" : { },
+          "us-gov-west-1" : { }
         }
       },
       "runtime-v2-lex" : {
@@ -35232,6 +35623,12 @@
               "tags" : [ "fips" ]
             } ]
           }
+        }
+      },
+      "scheduler" : {
+        "endpoints" : {
+          "us-gov-east-1" : { },
+          "us-gov-west-1" : { }
         }
       },
       "schemas" : {
@@ -35592,23 +35989,6 @@
           "us-gov-west-1" : {
             "variants" : [ {
               "hostname" : "simspaceweaver.us-gov-west-1.amazonaws.com",
-              "tags" : [ "fips" ]
-            } ]
-          }
-        }
-      },
-      "sms" : {
-        "endpoints" : {
-          "fips-us-gov-west-1" : {
-            "credentialScope" : {
-              "region" : "us-gov-west-1"
-            },
-            "deprecated" : true,
-            "hostname" : "sms-fips.us-gov-west-1.amazonaws.com"
-          },
-          "us-gov-west-1" : {
-            "variants" : [ {
-              "hostname" : "sms-fips.us-gov-west-1.amazonaws.com",
               "tags" : [ "fips" ]
             } ]
           }
@@ -36433,6 +36813,28 @@
             } ]
           }
         }
+      },
+      "application-signals" : {
+        "endpoints" : {
+          "us-gov-east-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.us-gov-east-1.api.aws",
+              "tags" : [ "custom" ]
+            }, {
+              "hostname" : "application-signals-fips.us-gov-east-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          },
+          "us-gov-west-1" : {
+            "variants" : [ {
+              "hostname" : "application-signals.us-gov-west-1.api.aws",
+              "tags" : [ "custom" ]
+            }, {
+              "hostname" : "application-signals-fips.us-gov-west-1.api.aws",
+              "tags" : [ "custom" ]
+            } ]
+          }
+        }
       }
     }
   }, {
@@ -36459,6 +36861,12 @@
       }
     },
     "services" : {
+      "acm" : {
+        "endpoints" : {
+          "us-iso-east-1" : { },
+          "us-iso-west-1" : { }
+        }
+      },
       "agreement-marketplace" : {
         "endpoints" : {
           "fips-us-iso-east-1" : {
@@ -36553,9 +36961,16 @@
           "us-iso-west-1" : { }
         }
       },
+      "backup" : {
+        "endpoints" : {
+          "us-iso-east-1" : { },
+          "us-iso-west-1" : { }
+        }
+      },
       "batch" : {
         "endpoints" : {
-          "us-iso-east-1" : { }
+          "us-iso-east-1" : { },
+          "us-iso-west-1" : { }
         }
       },
       "bedrock" : {
@@ -36998,7 +37413,8 @@
               "hostname" : "fsx-fips.us-iso-east-1.c2s.ic.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-iso-west-1" : { }
         }
       },
       "glacier" : {
@@ -37074,6 +37490,11 @@
           "us-iso-east-1" : { }
         }
       },
+      "kinesisvideo" : {
+        "endpoints" : {
+          "us-iso-east-1" : { }
+        }
+      },
       "kms" : {
         "endpoints" : {
           "ProdFips" : {
@@ -37109,6 +37530,11 @@
             "deprecated" : true,
             "hostname" : "kms-fips.us-iso-west-1.c2s.ic.gov"
           }
+        }
+      },
+      "lakeformation" : {
+        "endpoints" : {
+          "us-iso-east-1" : { }
         }
       },
       "lambda" : {
@@ -37160,6 +37586,16 @@
         "endpoints" : {
           "us-iso-east-1" : { },
           "us-iso-west-1" : { }
+        }
+      },
+      "mq" : {
+        "endpoints" : {
+          "us-iso-east-1" : { }
+        }
+      },
+      "network-firewall" : {
+        "endpoints" : {
+          "us-iso-east-1" : { }
         }
       },
       "oam" : {
@@ -37469,6 +37905,12 @@
           "us-iso-west-1" : { }
         }
       },
+      "servicequotas" : {
+        "endpoints" : {
+          "us-iso-east-1" : { },
+          "us-iso-west-1" : { }
+        }
+      },
       "snowball" : {
         "endpoints" : {
           "us-iso-east-1" : { },
@@ -37676,6 +38118,11 @@
           }
         }
       },
+      "wafv2" : {
+        "endpoints" : {
+          "us-iso-east-1" : { }
+        }
+      },
       "workspaces" : {
         "endpoints" : {
           "fips-us-iso-east-1" : {
@@ -37731,9 +38178,23 @@
     "regions" : {
       "us-isob-east-1" : {
         "description" : "US ISOB East (Ohio)"
+      },
+      "us-isob-west-1" : {
+        "description" : "US ISOB West"
       }
     },
     "services" : {
+      "acm" : {
+        "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "agreement-marketplace" : {
+        "endpoints" : {
+          "us-isob-east-1" : { }
+        }
+      },
       "api.ecr" : {
         "endpoints" : {
           "us-isob-east-1" : {
@@ -37741,7 +38202,8 @@
               "region" : "us-isob-east-1"
             },
             "hostname" : "api.ecr.us-isob-east-1.sc2s.sgov.gov"
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "api.pricing" : {
@@ -37766,12 +38228,14 @@
       },
       "appconfig" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "appconfigdata" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "application-autoscaling" : {
@@ -37779,10 +38243,22 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "appstream2" : {
+        "endpoints" : {
           "us-isob-east-1" : { }
         }
       },
       "arc-zonal-shift" : {
+        "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "athena" : {
         "endpoints" : {
           "us-isob-east-1" : { }
         }
@@ -37792,10 +38268,22 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "backup" : {
+        "endpoints" : {
           "us-isob-east-1" : { }
         }
       },
       "batch" : {
+        "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "bedrock" : {
         "endpoints" : {
           "us-isob-east-1" : { }
         }
@@ -37832,12 +38320,14 @@
       },
       "cloudcontrolapi" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "cloudformation" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "cloudtrail" : {
@@ -37854,7 +38344,8 @@
               "hostname" : "cloudtrail-fips.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "codebuild" : {
@@ -37864,7 +38355,8 @@
       },
       "codedeploy" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "config" : {
@@ -37881,7 +38373,8 @@
               "hostname" : "config-fips.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "datasync" : {
@@ -37891,12 +38384,14 @@
       },
       "directconnect" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "dlm" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "dms" : {
@@ -37936,7 +38431,8 @@
             },
             "deprecated" : true,
             "hostname" : "dms.us-isob-east-1.sc2s.sgov.gov"
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "ds" : {
@@ -37961,12 +38457,14 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "ebs" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "ec2" : {
@@ -37974,12 +38472,14 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "ecs" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "eks" : {
@@ -37987,12 +38487,14 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "elasticache" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "elasticfilesystem" : {
@@ -38016,7 +38518,8 @@
         "endpoints" : {
           "us-isob-east-1" : {
             "protocols" : [ "https" ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "elasticmapreduce" : {
@@ -38033,22 +38536,26 @@
               "hostname" : "elasticmapreduce.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "es" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "events" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "firehose" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "fsx" : {
@@ -38102,7 +38609,8 @@
       },
       "kinesis" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "kinesisanalytics" : {
@@ -38131,12 +38639,19 @@
             },
             "deprecated" : true,
             "hostname" : "kms-fips.us-isob-east-1.sc2s.sgov.gov"
-          }
+          },
+          "us-isob-west-1" : { }
+        }
+      },
+      "lakeformation" : {
+        "endpoints" : {
+          "us-isob-east-1" : { }
         }
       },
       "lambda" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "license-manager" : {
@@ -38146,7 +38661,8 @@
       },
       "logs" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "medialive" : {
@@ -38188,12 +38704,19 @@
       },
       "monitoring" : {
         "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "network-firewall" : {
+        "endpoints" : {
           "us-isob-east-1" : { }
         }
       },
       "oam" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "organizations" : {
@@ -38215,12 +38738,14 @@
       },
       "pi" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "ram" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "rbin" : {
@@ -38237,7 +38762,8 @@
               "hostname" : "rbin-fips.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "rds" : {
@@ -38261,7 +38787,8 @@
             },
             "deprecated" : true,
             "hostname" : "rds.us-isob-east-1.sc2s.sgov.gov"
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "redshift" : {
@@ -38271,12 +38798,14 @@
               "region" : "us-isob-east-1"
             },
             "hostname" : "redshift.us-isob-east-1.sc2s.sgov.gov"
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "resource-groups" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "route53" : {
@@ -38293,7 +38822,8 @@
       },
       "route53resolver" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "runtime.sagemaker" : {
@@ -38322,7 +38852,8 @@
               "hostname" : "s3-fips.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "s3-control" : {
@@ -38372,7 +38903,8 @@
       },
       "scheduler" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "secretsmanager" : {
@@ -38384,12 +38916,26 @@
           },
           "us-isob-east-1-fips" : {
             "deprecated" : true
-          }
+          },
+          "us-isob-west-1" : { }
+        }
+      },
+      "securityhub" : {
+        "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "servicediscovery" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "servicequotas" : {
+        "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "snowball" : {
@@ -38402,7 +38948,8 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "sqs" : {
@@ -38423,12 +38970,14 @@
               "hostname" : "sqs.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "ssm" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "states" : {
@@ -38445,7 +38994,8 @@
               "hostname" : "states-fips.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "storagegateway" : {
@@ -38480,12 +39030,14 @@
           "protocols" : [ "http", "https" ]
         },
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "sts" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "support" : {
@@ -38513,15 +39065,23 @@
               "hostname" : "swf-fips.us-isob-east-1.sc2s.sgov.gov",
               "tags" : [ "fips" ]
             } ]
-          }
+          },
+          "us-isob-west-1" : { }
         }
       },
       "synthetics" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       },
       "tagging" : {
+        "endpoints" : {
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
+        }
+      },
+      "wafv2" : {
         "endpoints" : {
           "us-isob-east-1" : { }
         }
@@ -38545,7 +39105,8 @@
       },
       "xray" : {
         "endpoints" : {
-          "us-isob-east-1" : { }
+          "us-isob-east-1" : { },
+          "us-isob-west-1" : { }
         }
       }
     }
@@ -38609,6 +39170,11 @@
             "service" : "pricing"
           }
         },
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
+      "apigateway" : {
         "endpoints" : {
           "eu-isoe-west-1" : { }
         }
@@ -38683,6 +39249,11 @@
         }
       },
       "cloudtrail" : {
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
+      "cloudtrail-data" : {
         "endpoints" : {
           "eu-isoe-west-1" : { }
         }
@@ -38875,7 +39446,17 @@
           }
         }
       },
+      "license-manager" : {
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
       "logs" : {
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
+      "metrics.sagemaker" : {
         "endpoints" : {
           "eu-isoe-west-1" : { }
         }
@@ -38956,6 +39537,11 @@
         "isRegionalized" : false,
         "partitionEndpoint" : "aws-iso-e-global"
       },
+      "route53profiles" : {
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
       "route53resolver" : {
         "endpoints" : {
           "eu-isoe-west-1" : { }
@@ -38983,6 +39569,11 @@
         "partitionEndpoint" : "aws-iso-e-global"
       },
       "scheduler" : {
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
+      "schemas" : {
         "endpoints" : {
           "eu-isoe-west-1" : { }
         }
@@ -39068,6 +39659,11 @@
           "eu-isoe-west-1" : { }
         }
       },
+      "trustedadvisor" : {
+        "endpoints" : {
+          "eu-isoe-west-1" : { }
+        }
+      },
       "xray" : {
         "endpoints" : {
           "eu-isoe-west-1" : { }
@@ -39126,6 +39722,11 @@
         },
         "endpoints" : {
           "us-isof-east-1" : { },
+          "us-isof-south-1" : { }
+        }
+      },
+      "agreement-marketplace" : {
+        "endpoints" : {
           "us-isof-south-1" : { }
         }
       },
@@ -39215,6 +39816,12 @@
           "us-isof-south-1" : { }
         }
       },
+      "bedrock" : {
+        "endpoints" : {
+          "us-isof-east-1" : { },
+          "us-isof-south-1" : { }
+        }
+      },
       "budgets" : {
         "endpoints" : {
           "aws-iso-f-global" : {
@@ -39263,6 +39870,12 @@
           "us-isof-south-1" : { }
         }
       },
+      "cloudtrail-data" : {
+        "endpoints" : {
+          "us-isof-east-1" : { },
+          "us-isof-south-1" : { }
+        }
+      },
       "codebuild" : {
         "endpoints" : {
           "us-isof-east-1" : { },
@@ -39292,6 +39905,7 @@
       },
       "compute-optimizer" : {
         "endpoints" : {
+          "us-isof-east-1" : { },
           "us-isof-south-1" : {
             "credentialScope" : {
               "region" : "us-isof-south-1"
@@ -39523,6 +40137,11 @@
         "isRegionalized" : false,
         "partitionEndpoint" : "aws-iso-f-global"
       },
+      "identitystore" : {
+        "endpoints" : {
+          "us-isof-east-1" : { }
+        }
+      },
       "kinesis" : {
         "endpoints" : {
           "us-isof-east-1" : { },
@@ -39694,6 +40313,12 @@
           "us-isof-south-1" : { }
         }
       },
+      "rolesanywhere" : {
+        "endpoints" : {
+          "us-isof-east-1" : { },
+          "us-isof-south-1" : { }
+        }
+      },
       "route53" : {
         "endpoints" : {
           "aws-iso-f-global" : {
@@ -39713,6 +40338,12 @@
         }
       },
       "route53resolver" : {
+        "endpoints" : {
+          "us-isof-east-1" : { },
+          "us-isof-south-1" : { }
+        }
+      },
+      "runtime.sagemaker" : {
         "endpoints" : {
           "us-isof-east-1" : { },
           "us-isof-south-1" : { }
@@ -39894,6 +40525,11 @@
           "us-isof-south-1" : { }
         }
       },
+      "trustedadvisor" : {
+        "endpoints" : {
+          "us-isof-south-1" : { }
+        }
+      },
       "xray" : {
         "endpoints" : {
           "us-isof-east-1" : { },
@@ -39910,6 +40546,14 @@
         "dnsSuffix" : "amazonaws.eu",
         "hostname" : "{service}-fips.{region}.{dnsSuffix}",
         "tags" : [ "fips" ]
+      }, {
+        "dnsSuffix" : "api.amazonwebservices.eu",
+        "hostname" : "{service}-fips.{region}.{dnsSuffix}",
+        "tags" : [ "dualstack", "fips" ]
+      }, {
+        "dnsSuffix" : "api.amazonwebservices.eu",
+        "hostname" : "{service}.{region}.{dnsSuffix}",
+        "tags" : [ "dualstack" ]
       } ]
     },
     "dnsSuffix" : "amazonaws.eu",
@@ -39918,10 +40562,553 @@
     "regionRegex" : "^eusc\\-(de)\\-\\w+\\-\\d+$",
     "regions" : {
       "eusc-de-east-1" : {
-        "description" : "EU (Germany)"
+        "description" : "AWS European Sovereign Cloud (Germany)"
       }
     },
-    "services" : { }
+    "services" : {
+      "access-analyzer" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "acm" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "acm-pca" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "agreement-marketplace" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "api.ecr" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "api.pricing" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "api.sagemaker" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "appconfig" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "appconfigdata" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "application-autoscaling" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "arc-zonal-shift" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "athena" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "autoscaling" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "backup" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "batch" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "bedrock" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "cloudcontrolapi" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "cloudformation" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "cloudtrail" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "codedeploy" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "cognito-identity" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "cognito-idp" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "compute-optimizer" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "config" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "controltower" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "cost-optimization-hub" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "datasync" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "datazone" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "directconnect" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "dlm" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "dms" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "drs" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "ds" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "dynamodb" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "ebs" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "ec2" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "ecs" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "eks" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "eks-auth" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "elasticache" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "elasticfilesystem" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "elasticloadbalancing" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "elasticmapreduce" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "email" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "entitlement.marketplace" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "es" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "events" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "firehose" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "fsx" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "gameliftstreams" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "glue" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "guardduty" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "health" : {
+        "endpoints" : {
+          "eusc-de-east-1" : {
+            "deprecated" : true
+          }
+        }
+      },
+      "identitystore" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "internetmonitor" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "kafka" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "kendra-ranking" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "kinesis" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "kinesisanalytics" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "kms" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "lakeformation" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "lambda" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "license-manager" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "logs" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "metering.marketplace" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "metrics.sagemaker" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "monitoring" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "network-firewall" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "notifications" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "oam" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "oidc" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "pi" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "portal.sso" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "qbusiness" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "ram" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "rbin" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "rds" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "redshift" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "resource-groups" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "rolesanywhere" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "route53profiles" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "route53resolver" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "rum" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "runtime.sagemaker" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "s3" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "s3-control" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "scheduler" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "secretsmanager" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "securityhub" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "servicediscovery" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "servicequotas" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "signer" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "sms-voice" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "sns" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "sqs" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "ssm" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "sso" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "states" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "storagegateway" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "streams.dynamodb" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "sts" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "swf" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "synthetics" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "tagging" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "transfer" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "trustedadvisor" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "wafv2" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      },
+      "xray" : {
+        "endpoints" : {
+          "eusc-de-east-1" : { }
+        }
+      }
+    }
   } ],
   "version" : 3
 }

--- a/scripts/generate_aws_supported_endpoints/custom_endpoints.json
+++ b/scripts/generate_aws_supported_endpoints/custom_endpoints.json
@@ -1,0 +1,124 @@
+{
+  "application-signals": {
+    "aws": {
+      "af-south-1": [
+        "application-signals.af-south-1.api.aws"
+      ],
+      "ap-east-1": [
+        "application-signals.ap-east-1.api.aws"
+      ],
+      "ap-east-2": [
+        "application-signals.ap-east-2.api.aws"
+      ],
+      "ap-northeast-1": [
+        "application-signals.ap-northeast-1.api.aws"
+      ],
+      "ap-northeast-2": [
+        "application-signals.ap-northeast-2.api.aws"
+      ],
+      "ap-northeast-3": [
+        "application-signals.ap-northeast-3.api.aws"
+      ],
+      "ap-south-1": [
+        "application-signals.ap-south-1.api.aws"
+      ],
+      "ap-south-2": [
+        "application-signals.ap-south-2.api.aws"
+      ],
+      "ap-southeast-1": [
+        "application-signals.ap-southeast-1.api.aws"
+      ],
+      "ap-southeast-2": [
+        "application-signals.ap-southeast-2.api.aws"
+      ],
+      "ap-southeast-3": [
+        "application-signals.ap-southeast-3.api.aws"
+      ],
+      "ap-southeast-4": [
+        "application-signals.ap-southeast-4.api.aws"
+      ],
+      "ap-southeast-5": [
+        "application-signals.ap-southeast-5.api.aws"
+      ],
+      "ap-southeast-6": [
+        "application-signals.ap-southeast-6.api.aws"
+      ],
+      "ap-southeast-7": [
+        "application-signals.ap-southeast-7.api.aws"
+      ],
+      "ca-central-1": [
+        "application-signals.ca-central-1.api.aws",
+        "application-signals-fips.ca-central-1.api.aws"
+      ],
+      "ca-west-1": [
+        "application-signals.ca-west-1.api.aws",
+        "application-signals-fips.ca-west-1.api.aws"
+      ],
+      "eu-central-1": [
+        "application-signals.eu-central-1.api.aws"
+      ],
+      "eu-central-2": [
+        "application-signals.eu-central-2.api.aws"
+      ],
+      "eu-north-1": [
+        "application-signals.eu-north-1.api.aws"
+      ],
+      "eu-south-1": [
+        "application-signals.eu-south-1.api.aws"
+      ],
+      "eu-south-2": [
+        "application-signals.eu-south-2.api.aws"
+      ],
+      "eu-west-1": [
+        "application-signals.eu-west-1.api.aws"
+      ],
+      "eu-west-2": [
+        "application-signals.eu-west-2.api.aws"
+      ],
+      "eu-west-3": [
+        "application-signals.eu-west-3.api.aws"
+      ],
+      "il-central-1": [
+        "application-signals.il-central-1.api.aws"
+      ],
+      "me-central-1": [
+        "application-signals.me-central-1.api.aws"
+      ],
+      "me-south-1": [
+        "application-signals.me-south-1.api.aws"
+      ],
+      "mx-central-1": [
+        "application-signals.mx-central-1.api.aws"
+      ],
+      "sa-east-1": [
+        "application-signals.sa-east-1.api.aws"
+      ],
+      "us-east-1": [
+        "application-signals.us-east-1.api.aws",
+        "application-signals-fips.us-east-1.api.aws"
+      ],
+      "us-east-2": [
+        "application-signals.us-east-2.api.aws",
+        "application-signals-fips.us-east-2.api.aws"
+      ],
+      "us-west-1": [
+        "application-signals.us-west-1.api.aws",
+        "application-signals-fips.us-west-1.api.aws"
+      ],
+      "us-west-2": [
+        "application-signals.us-west-2.api.aws",
+        "application-signals-fips.us-west-2.api.aws"
+      ]
+    },
+    "aws-us-gov": {
+      "us-gov-east-1": [
+        "application-signals.us-gov-east-1.api.aws",
+        "application-signals-fips.us-gov-east-1.api.aws"
+      ],
+      "us-gov-west-1": [
+        "application-signals.us-gov-west-1.api.aws",
+        "application-signals-fips.us-gov-west-1.api.aws"
+      ]
+    }
+  }
+}

--- a/scripts/generate_aws_supported_endpoints/encoders.py
+++ b/scripts/generate_aws_supported_endpoints/encoders.py
@@ -1,0 +1,240 @@
+from json.encoder import (INFINITY, JSONEncoder,
+                          encode_basestring_ascii, encode_basestring)
+
+
+class CompactishJsonEncoder(JSONEncoder):
+    """Compact-ish encoding in order to match the AWS Go SDK style of JSON encoding."""
+    def iterencode(self, o, _one_shot=False):
+        """Most of the original method has been left as is.
+
+        We remove entirely the branch that opts to use `c_make_encoder` in order to
+        instantiate our own encoder.
+        """
+        if self.check_circular:
+            markers = {}
+        else:
+            markers = None
+        if self.ensure_ascii:
+            _encoder = encode_basestring_ascii
+        else:
+            _encoder = encode_basestring
+
+        def floatstr(o, allow_nan=self.allow_nan,
+                     _repr=float.__repr__, _inf=INFINITY, _neginf=-INFINITY):
+            # Check for specials.  Note that this type of test is processor
+            # and/or platform-specific, so do tests which don't depend on the
+            # internals.
+
+            if o != o:
+                text = 'NaN'
+            elif o == _inf:
+                text = 'Infinity'
+            elif o == _neginf:
+                text = '-Infinity'
+            else:
+                return _repr(o)
+
+            if not allow_nan:
+                raise ValueError(
+                    "Out of range float values are not JSON compliant: " +
+                    repr(o))
+
+            return text
+
+        if self.indent is None or isinstance(self.indent, str):
+            indent = self.indent
+        else:
+            indent = ' ' * self.indent
+
+        _iterencode = _make_iterencode(
+            markers, self.default, _encoder, indent, floatstr,
+            self.key_separator, self.item_separator, self.sort_keys,
+            self.skipkeys, _one_shot)
+        return _iterencode(o, 0)
+
+
+def _make_iterencode(markers, _default, _encoder, _indent, _floatstr,
+        _key_separator, _item_separator, _sort_keys, _skipkeys, _one_shot,
+        ## HACK: hand-optimized bytecode; turn globals into locals
+        ValueError=ValueError,
+        dict=dict,
+        float=float,
+        id=id,
+        int=int,
+        isinstance=isinstance,
+        list=list,
+        str=str,
+        tuple=tuple,
+        _intstr=int.__repr__,
+    ):
+    """Adapted from the built-in `json.encoder` module.
+
+    The lines that have been changed are suffixed with the comment "# line changed".
+    """
+
+    def _iterencode_list(lst, _current_indent_level):
+        if not lst:
+            yield '[ ]'  # line changed
+            return
+        if markers is not None:
+            markerid = id(lst)
+            if markerid in markers:
+                raise ValueError("Circular reference detected")
+            markers[markerid] = lst
+        buf = '['
+        if _indent is not None:
+            newline_indent = '\n' + _indent * _current_indent_level
+            separator = _item_separator + ' '  # line changed
+            buf += ' '  # line changed
+        else:
+            newline_indent = None
+            separator = _item_separator
+        first = True
+        for value in lst:
+            if first:
+                first = False
+            else:
+                buf = separator
+            if isinstance(value, str):
+                yield buf + _encoder(value)
+            elif value is None:
+                yield buf + 'null'
+            elif value is True:
+                yield buf + 'true'
+            elif value is False:
+                yield buf + 'false'
+            elif isinstance(value, int):
+                # Subclasses of int/float may override __repr__, but we still
+                # want to encode them as integers/floats in JSON. One example
+                # within the standard library is IntEnum.
+                yield buf + _intstr(value)
+            elif isinstance(value, float):
+                # see comment above for int
+                yield buf + _floatstr(value)
+            else:
+                yield buf
+                if isinstance(value, (list, tuple)):
+                    chunks = _iterencode_list(value, _current_indent_level)
+                elif isinstance(value, dict):
+                    chunks = _iterencode_dict(value, _current_indent_level)
+                else:
+                    chunks = _iterencode(value, _current_indent_level)
+                yield from chunks
+        if newline_indent is not None:
+            _current_indent_level -= 1
+            yield ' '
+        yield ']'
+        if markers is not None:
+            del markers[markerid]
+
+    def _iterencode_dict(dct, _current_indent_level):
+        if not dct:
+            yield '{ }'  # line changed
+            return
+        if markers is not None:
+            markerid = id(dct)
+            if markerid in markers:
+                raise ValueError("Circular reference detected")
+            markers[markerid] = dct
+        yield '{'
+        if _indent is not None:
+            _current_indent_level += 1
+            newline_indent = '\n' + _indent * _current_indent_level
+            item_separator = _item_separator + newline_indent
+        else:
+            newline_indent = None
+            item_separator = _item_separator
+        first = True
+        if _sort_keys:
+            items = sorted(dct.items())
+        else:
+            items = dct.items()
+        for key, value in items:
+            if isinstance(key, str):
+                pass
+            # JavaScript is weakly typed for these, so it makes sense to
+            # also allow them.  Many encoders seem to do something like this.
+            elif isinstance(key, float):
+                # see comment for int/float in _make_iterencode
+                key = _floatstr(key)
+            elif key is True:
+                key = 'true'
+            elif key is False:
+                key = 'false'
+            elif key is None:
+                key = 'null'
+            elif isinstance(key, int):
+                # see comment for int/float in _make_iterencode
+                key = _intstr(key)
+            elif _skipkeys:
+                continue
+            else:
+                raise TypeError(f'keys must be str, int, float, bool or None, '
+                                f'not {key.__class__.__name__}')
+            if first:
+                first = False
+                if newline_indent is not None:
+                    yield newline_indent
+            else:
+                yield item_separator
+            yield _encoder(key)
+            yield _key_separator
+            if isinstance(value, str):
+                yield _encoder(value)
+            elif value is None:
+                yield 'null'
+            elif value is True:
+                yield 'true'
+            elif value is False:
+                yield 'false'
+            elif isinstance(value, int):
+                # see comment for int/float in _make_iterencode
+                yield _intstr(value)
+            elif isinstance(value, float):
+                # see comment for int/float in _make_iterencode
+                yield _floatstr(value)
+            else:
+                if isinstance(value, (list, tuple)):
+                    chunks = _iterencode_list(value, _current_indent_level)
+                elif isinstance(value, dict):
+                    chunks = _iterencode_dict(value, _current_indent_level)
+                else:
+                    chunks = _iterencode(value, _current_indent_level)
+                yield from chunks
+        if not first and newline_indent is not None:
+            _current_indent_level -= 1
+            yield '\n' + _indent * _current_indent_level
+        yield '}'
+        if markers is not None:
+            del markers[markerid]
+
+    def _iterencode(o, _current_indent_level):
+        if isinstance(o, str):
+            yield _encoder(o)
+        elif o is None:
+            yield 'null'
+        elif o is True:
+            yield 'true'
+        elif o is False:
+            yield 'false'
+        elif isinstance(o, int):
+            # see comment for int/float in _make_iterencode
+            yield _intstr(o)
+        elif isinstance(o, float):
+            # see comment for int/float in _make_iterencode
+            yield _floatstr(o)
+        elif isinstance(o, (list, tuple)):
+            yield from _iterencode_list(o, _current_indent_level)
+        elif isinstance(o, dict):
+            yield from _iterencode_dict(o, _current_indent_level)
+        else:
+            if markers is not None:
+                markerid = id(o)
+                if markerid in markers:
+                    raise ValueError("Circular reference detected")
+                markers[markerid] = o
+            o = _default(o)
+            yield from _iterencode(o, _current_indent_level)
+            if markers is not None:
+                del markers[markerid]
+    return _iterencode

--- a/scripts/generate_aws_supported_endpoints/main.py
+++ b/scripts/generate_aws_supported_endpoints/main.py
@@ -5,6 +5,7 @@ import json
 import requests
 import subprocess
 from jinja2 import Template
+from encoders import CompactishJsonEncoder
 
 # URL for fetching AWS endpoints JSON data
 ENDPOINTS_JSON_URL = "https://raw.githubusercontent.com/aws/aws-sdk-go-v2/master/codegen/smithy-aws-go-codegen/src/main/resources/software/amazon/smithy/aws/go/codegen/endpoints.json"
@@ -12,6 +13,9 @@ ENDPOINTS_JSON_URL = "https://raw.githubusercontent.com/aws/aws-sdk-go-v2/master
 # Define output directories
 OUTPUT_DIR = "internal/aws_endpoint_generator"
 ENDPOINTS_FILE_PATH = os.path.join(OUTPUT_DIR, "endpoints.json")
+CUSTOM_ENDPOINTS_FILE_PATH = os.path.relpath(
+    os.path.join(os.path.dirname(__file__), "custom_endpoints.json"),
+    os.getcwd())
 GENERATED_GO_FILE = "aws/endpoint_service_ids_gen.go"
 
 # Ensure output directories exist
@@ -24,7 +28,7 @@ def download_file(url, output_path):
     try:
         response = requests.get(url, stream=True)
         response.raise_for_status()
-        
+
         with open(output_path, "wb") as file:
             for chunk in response.iter_content(chunk_size=8192):
                 file.write(chunk)
@@ -32,6 +36,69 @@ def download_file(url, output_path):
         print(f"File downloaded successfully: {output_path}")
     except requests.exceptions.RequestException as e:
         print(f"Error downloading file: {e}")
+        exit(1)
+
+
+def merge_custom_endpoints(endpoint_file_path, custom_endpoint_file_path):
+    """Merge the downloaded AWS endpoints file with our custom set of endpoints.
+
+    AWS Go SDK v2 has officially stated that the endpoint metadata file (which this package uses to
+    resolve service region information) is intended as a purely internal construct and is not used
+    as the default approach to endpoint resolution. This means that for some newer services, endpoint
+    metadata may not be present.
+
+    As such, this package now maintains its own set of endpoint metadata which is merged into the set
+    pulled from AWS Go SDK v2.
+
+    See also:
+        - https://github.com/aws/aws-sdk-go-v2/issues/2740
+        - https://github.com/aws/aws-sdk-go-v2/discussions/1026
+    """
+    try:
+        with open(endpoint_file_path, "r", encoding="utf-8") as file:
+            aws_endpoints = json.load(file)
+
+        with open(custom_endpoint_file_path, "r", encoding="utf-8") as file:
+            custom_endpoints = json.load(file)
+    except Exception as e:
+        print(f"Error parsing JSON: {e}")
+        exit(1)
+
+    for service, partition_endpoints in custom_endpoints.items():
+        for partition in aws_endpoints["partitions"]:
+            partition_name = partition["partition"]
+            if partition_name not in partition_endpoints:
+                continue
+
+            aws_service_metadata = partition["services"].get(service, {"endpoints": {}})
+
+            for region, region_endpoints in partition_endpoints[partition_name].items():
+                # Validate the region against the partition.
+                if region not in partition["regions"]:
+                    print(f"Invalid region `{region}` for partition `{partition}`")
+                    exit(1)
+
+                if region not in aws_service_metadata["endpoints"]:
+                    aws_service_metadata["endpoints"][region] = {"variants": []}
+
+                aws_service_metadata["endpoints"][region]["variants"].extend([
+                    {
+                        "hostname": region_endpoint,
+                        "tags": ["custom"]
+                    }
+                    for region_endpoint in region_endpoints
+                ])
+
+            partition["services"][service] = aws_service_metadata
+
+    try:
+        with open(endpoint_file_path, "w", encoding="utf-8") as file:
+            # Use the customised encoder to minimise diffs.
+            json.dump(aws_endpoints, file, cls=CompactishJsonEncoder, indent=2, separators=(',', ' : '))
+
+        print(f"Merged custom endpoints from {custom_endpoint_file_path} into {endpoint_file_path}")
+    except Exception as e:
+        print(f"Error writing merged file: {e}")
         exit(1)
 
 
@@ -63,7 +130,6 @@ const AWS_{{ service | replace(".", "_") | replace("-", "_") | upper }}_SERVICE_
 {% endfor %}
 """
 
-
     template = Template(template_str)
     rendered_content = template.render(service_keys=service_keys)
 
@@ -93,13 +159,16 @@ def main():
     # Step 1: Download the JSON file
     download_file(ENDPOINTS_JSON_URL, ENDPOINTS_FILE_PATH)
 
-    # Step 2: Extract unique service keys
+    # Step 2: Merge the downloaded JSON file with the custom set of endpoints that are maintained internally.
+    merge_custom_endpoints(ENDPOINTS_FILE_PATH, CUSTOM_ENDPOINTS_FILE_PATH)
+
+    # Step 3: Extract unique service keys
     service_keys = extract_unique_service_keys(ENDPOINTS_FILE_PATH)
 
-    # Step 3: Generate the Go file
+    # Step 4: Generate the Go file
     generate_go_file(service_keys, GENERATED_GO_FILE)
 
-    # Step 4: Format the generated Go file
+    # Step 5: Format the generated Go file
     format_go_file(GENERATED_GO_FILE)
 
 


### PR DESCRIPTION
# Summary
Add support for a set of internally maintained custom AWS service endpoints, intended to fill the gap for any services that are not present in the endpoint metadata synced from aws-sdk-go-v2.

Closes https://github.com/turbot/steampipe-plugin-aws/issues/2741.

# Changes

- feat: update sync script to merge custom endpoints
- feat: add custom endpoint metadata file
- fix: correct logging outputs in `aws_cloudtrail_trail` and `aws_secretsmanager_secret` tables

# Execution logs
<details>
  <summary>Logs</summary>

```
Working Directory: <omitted>/steampipe-plugin-aws
File downloaded successfully: internal/aws_endpoint_generator/endpoints.json
Merged custom endpoints from scripts/generate_aws_supported_endpoints/custom_endpoints.json into internal/aws_endpoint_generator/endpoints.json
Go file generated: aws/endpoint_service_ids_gen.go
Formatted aws/endpoint_service_ids_gen.go using gofmt.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
N/A
```
</details>
