### PR TITLE
feat: add aws_eks_pod_identity_association table

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -451,6 +451,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_eks_fargate_profile":                                      tableAwsEksFargateProfile(ctx),
 			"aws_eks_identity_provider_config":                             tableAwsEksIdentityProviderConfig(ctx),
 			"aws_eks_node_group":                                           tableAwsEksNodeGroup(ctx),
+			"aws_eks_pod_identity_association":                             tableAwsEksPodIdentityAssociation(ctx),
 			"aws_elastic_beanstalk_application_version":                    tableAwsElasticBeanstalkApplicationVersion(ctx),
 			"aws_elastic_beanstalk_application":                            tableAwsElasticBeanstalkApplication(ctx),
 			"aws_elastic_beanstalk_environment":                            tableAwsElasticBeanstalkEnvironment(ctx),

--- a/aws/table_aws_eks_pod_identity_association.go
+++ b/aws/table_aws_eks_pod_identity_association.go
@@ -1,0 +1,250 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/eks"
+	"github.com/aws/aws-sdk-go-v2/service/eks/types"
+
+	"github.com/turbot/steampipe-plugin-sdk/v5/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v5/plugin/transform"
+)
+
+//// TABLE DEFINITION
+
+func tableAwsEksPodIdentityAssociation(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_eks_pod_identity_association",
+		Description: "AWS EKS Pod Identity Association",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.AllColumns([]string{"cluster_name", "association_id"}),
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ResourceNotFoundException", "InvalidParameterException", "InvalidParameter"}),
+			},
+			Hydrate: getEksPodIdentityAssociation,
+			Tags:    map[string]string{"service": "eks", "action": "DescribePodIdentityAssociation"},
+		},
+		List: &plugin.ListConfig{
+			ParentHydrate: listEKSClusters,
+			Hydrate:       listEKSPodIdentityAssociations,
+			Tags:          map[string]string{"service": "eks", "action": "ListPodIdentityAssociations"},
+			KeyColumns: []*plugin.KeyColumn{
+				{Name: "cluster_name", Require: plugin.Optional},
+				{Name: "namespace", Require: plugin.Optional},
+				{Name: "service_account", Require: plugin.Optional},
+			},
+		},
+		HydrateConfig: []plugin.HydrateConfig{
+			{
+				Func: getEksPodIdentityAssociation,
+				Tags: map[string]string{"service": "eks", "action": "DescribePodIdentityAssociation"},
+			},
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(AWS_EKS_SERVICE_ID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "cluster_name",
+				Description: "The name of the cluster that the association is in.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "association_id",
+				Description: "The ID of the association.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "association_arn",
+				Description: "The Amazon Resource Name (ARN) of the association.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "namespace",
+				Description: "The name of the Kubernetes namespace inside the cluster that the association is in.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "service_account",
+				Description: "The name of the Kubernetes service account that the association uses.",
+				Type:        proto.ColumnType_STRING,
+			},
+			// Fields that require DescribePodIdentityAssociation
+			{
+				Name:        "role_arn",
+				Description: "The Amazon Resource Name (ARN) of the IAM role associated with the service account.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getEksPodIdentityAssociation,
+			},
+			{
+				Name:        "created_at",
+				Description: "The timestamp that the association was created at.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Hydrate:     getEksPodIdentityAssociation,
+			},
+			{
+				Name:        "modified_at",
+				Description: "The most recent timestamp that the association was modified at.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Hydrate:     getEksPodIdentityAssociation,
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("AssociationId"),
+			},
+			{
+				Name:        "tags",
+				Description: "The metadata that you apply to the association to assist with categorization and organization.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getEksPodIdentityAssociation,
+			},
+			{
+				Name:        "akas",
+				Description: resourceInterfaceDescription("akas"),
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("AssociationArn").Transform(transform.EnsureStringArray),
+			},
+		}),
+	}
+}
+
+// PodIdentityAssociationInfo holds the list-level summary fields
+type PodIdentityAssociationInfo struct {
+	ClusterName    *string
+	AssociationId  *string
+	AssociationArn *string
+	Namespace      *string
+	ServiceAccount *string
+}
+
+//// LIST FUNCTION
+
+func listEKSPodIdentityAssociations(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	clusterName := *h.Item.(types.Cluster).Name
+
+	// Apply optional cluster_name filter — skip this cluster if it doesn't match
+	filterClusterName := d.EqualsQuals["cluster_name"].GetStringValue()
+	if filterClusterName != "" && filterClusterName != clusterName {
+		return nil, nil
+	}
+
+	svc, err := EKSClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_eks_pod_identity_association.listEKSPodIdentityAssociations", "get_client_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region check
+		return nil, nil
+	}
+
+	input := &eks.ListPodIdentityAssociationsInput{
+		ClusterName: &clusterName,
+		MaxResults:  aws.Int32(100),
+	}
+
+	// Apply optional namespace filter
+	if ns := d.EqualsQuals["namespace"].GetStringValue(); ns != "" {
+		input.Namespace = aws.String(ns)
+	}
+
+	// Apply optional service_account filter
+	if sa := d.EqualsQuals["service_account"].GetStringValue(); sa != "" {
+		input.ServiceAccount = aws.String(sa)
+	}
+
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < *input.MaxResults {
+			if limit < 1 {
+				input.MaxResults = aws.Int32(1)
+			} else {
+				input.MaxResults = aws.Int32(limit)
+			}
+		}
+	}
+
+	paginator := eks.NewListPodIdentityAssociationsPaginator(svc, input, func(o *eks.ListPodIdentityAssociationsPaginatorOptions) {
+		o.Limit = *input.MaxResults
+		o.StopOnDuplicateToken = true
+	})
+
+	for paginator.HasMorePages() {
+		// apply rate limiting
+		d.WaitForListRateLimit(ctx)
+
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_eks_pod_identity_association.listEKSPodIdentityAssociations", "api_error", err)
+			return nil, err
+		}
+
+		for _, item := range output.Associations {
+			d.StreamListItem(ctx, &PodIdentityAssociationInfo{
+				ClusterName:    item.ClusterName,
+				AssociationId:  item.AssociationId,
+				AssociationArn: item.AssociationArn,
+				Namespace:      item.Namespace,
+				ServiceAccount: item.ServiceAccount,
+			})
+
+			// Context can be cancelled due to manual cancellation or the limit has been hit
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getEksPodIdentityAssociation(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var clusterName, associationId string
+
+	if h.Item != nil {
+		info := h.Item.(*PodIdentityAssociationInfo)
+		clusterName = aws.ToString(info.ClusterName)
+		associationId = aws.ToString(info.AssociationId)
+	} else {
+		clusterName = d.EqualsQuals["cluster_name"].GetStringValue()
+		associationId = d.EqualsQuals["association_id"].GetStringValue()
+	}
+
+	// check for empty parameters
+	if clusterName == "" || associationId == "" {
+		return nil, nil
+	}
+
+	svc, err := EKSClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_eks_pod_identity_association.getEksPodIdentityAssociation", "get_client_error", err)
+		return nil, err
+	}
+	if svc == nil {
+		// Unsupported region check
+		return nil, nil
+	}
+
+	input := &eks.DescribePodIdentityAssociationInput{
+		ClusterName:   aws.String(clusterName),
+		AssociationId: aws.String(associationId),
+	}
+
+	output, err := svc.DescribePodIdentityAssociation(ctx, input)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_eks_pod_identity_association.getEksPodIdentityAssociation", "api_error", err)
+		return nil, err
+	}
+
+	if output.Association == nil {
+		return nil, nil
+	}
+
+	return output.Association, nil
+}

--- a/docs/tables/aws_eks_pod_identity_association.md
+++ b/docs/tables/aws_eks_pod_identity_association.md
@@ -1,0 +1,255 @@
+---
+title: "Steampipe Table: aws_eks_pod_identity_association - Query AWS EKS Pod Identity Associations using SQL"
+description: "Allows users to query AWS EKS Pod Identity Associations to retrieve information about IAM role bindings for Kubernetes service accounts in Amazon EKS clusters."
+folder: "EKS"
+---
+
+# Table: aws_eks_pod_identity_association - Query AWS EKS Pod Identity Associations using SQL
+
+AWS EKS Pod Identity Associations link Kubernetes service accounts to IAM roles, allowing pods running under those service accounts to assume the associated IAM role and access AWS services. Pod Identity is a simplified alternative to IAM Roles for Service Accounts (IRSA) that does not require annotating the service account or configuring an OIDC provider. Each association is scoped to a specific cluster, namespace, and service account combination.
+
+## Table Usage Guide
+
+The `aws_eks_pod_identity_association` table in Steampipe provides you with information about pod identity associations in your Amazon EKS clusters. This table allows you, as a DevOps engineer or security administrator, to query association-specific details including the IAM role ARN, Kubernetes namespace and service account, and associated metadata. You can use this table to audit which service accounts have IAM role access, review pod identity configurations across clusters, and identify associations by cluster, namespace, or service account. The schema outlines the various attributes of each association, including the association ARN, role ARN, creation time, and tags.
+
+## Examples
+
+### Basic info
+Explore all pod identity associations across your EKS clusters to understand service account to IAM role mappings.
+
+```sql+postgres
+select
+  cluster_name,
+  association_id,
+  namespace,
+  service_account,
+  role_arn,
+  created_at
+from
+  aws_eks_pod_identity_association;
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  association_id,
+  namespace,
+  service_account,
+  role_arn,
+  created_at
+from
+  aws_eks_pod_identity_association;
+```
+
+### Filter associations by cluster name
+List all pod identity associations for a specific EKS cluster.
+
+```sql+postgres
+select
+  cluster_name,
+  association_id,
+  namespace,
+  service_account,
+  role_arn
+from
+  aws_eks_pod_identity_association
+where
+  cluster_name = 'my-eks-cluster';
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  association_id,
+  namespace,
+  service_account,
+  role_arn
+from
+  aws_eks_pod_identity_association
+where
+  cluster_name = 'my-eks-cluster';
+```
+
+### Filter associations by namespace
+Identify all service accounts in a specific Kubernetes namespace that have IAM role bindings.
+
+```sql+postgres
+select
+  cluster_name,
+  association_id,
+  namespace,
+  service_account,
+  role_arn
+from
+  aws_eks_pod_identity_association
+where
+  namespace = 'kube-system';
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  association_id,
+  namespace,
+  service_account,
+  role_arn
+from
+  aws_eks_pod_identity_association
+where
+  namespace = 'kube-system';
+```
+
+### List associations for a specific service account
+Find all IAM role associations for a particular Kubernetes service account across all clusters.
+
+```sql+postgres
+select
+  cluster_name,
+  namespace,
+  service_account,
+  association_id,
+  role_arn,
+  created_at
+from
+  aws_eks_pod_identity_association
+where
+  service_account = 'my-service-account';
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  namespace,
+  service_account,
+  association_id,
+  role_arn,
+  created_at
+from
+  aws_eks_pod_identity_association
+where
+  service_account = 'my-service-account';
+```
+
+### Get a specific association by cluster and association ID
+Retrieve details of a particular pod identity association using its cluster name and association ID.
+
+```sql+postgres
+select
+  cluster_name,
+  association_id,
+  association_arn,
+  namespace,
+  service_account,
+  role_arn,
+  created_at,
+  modified_at
+from
+  aws_eks_pod_identity_association
+where
+  cluster_name = 'my-eks-cluster'
+  and association_id = 'a-9njjin9gfghecgocd';
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  association_id,
+  association_arn,
+  namespace,
+  service_account,
+  role_arn,
+  created_at,
+  modified_at
+from
+  aws_eks_pod_identity_association
+where
+  cluster_name = 'my-eks-cluster'
+  and association_id = 'a-9njjin9gfghecgocd';
+```
+
+### List associations that have tags
+Find pod identity associations that have been tagged for resource management or cost allocation.
+
+```sql+postgres
+select
+  cluster_name,
+  association_id,
+  namespace,
+  service_account,
+  role_arn,
+  tags
+from
+  aws_eks_pod_identity_association
+where
+  tags != '{}';
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  association_id,
+  namespace,
+  service_account,
+  role_arn,
+  tags
+from
+  aws_eks_pod_identity_association
+where
+  tags != '{}';
+```
+
+### Count pod identity associations per cluster
+Determine the number of pod identity associations configured in each EKS cluster.
+
+```sql+postgres
+select
+  cluster_name,
+  count(*) as association_count
+from
+  aws_eks_pod_identity_association
+group by
+  cluster_name
+order by
+  association_count desc;
+```
+
+```sql+sqlite
+select
+  cluster_name,
+  count(*) as association_count
+from
+  aws_eks_pod_identity_association
+group by
+  cluster_name
+order by
+  association_count desc;
+```
+
+### Join with IAM roles to review associated role details
+Combine pod identity association data with IAM role information to review permissions granted to service accounts.
+
+```sql+postgres
+select
+  pia.cluster_name,
+  pia.namespace,
+  pia.service_account,
+  pia.role_arn,
+  r.create_date as role_created_at,
+  r.max_session_duration
+from
+  aws_eks_pod_identity_association pia
+  left join aws_iam_role r on pia.role_arn = r.arn;
+```
+
+```sql+sqlite
+select
+  pia.cluster_name,
+  pia.namespace,
+  pia.service_account,
+  pia.role_arn,
+  r.create_date as role_created_at,
+  r.max_session_duration
+from
+  aws_eks_pod_identity_association pia
+  left join aws_iam_role r on pia.role_arn = r.arn;
+```


### PR DESCRIPTION
# Integration test logs
<details>
  <summary>Logs</summary>

```
Add passing integration test logs here
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
+--------------------+-----------------------+----------------------------------------------------------------------------------------------------+-----------------+-------------------------+----------------------------------------------------------------------------+---------------------------+---------------------------+-----------------------+------+--------------------------------------------------------------------------------------------------------+-----------+------------+--------------+--------------------+-----------------------------------------------------------------------+-----------------------------------------------------------------------+
| cluster_name       | association_id        | association_arn                                                                                    | namespace       | service_account         | role_arn                                                                   | created_at                | modified_at               | title                 | tags | akas                                                                                                   | partition | region     | account_id   | sp_connection_name | sp_ctx                                                                | _ctx                                                                  |
+--------------------+-----------------------+----------------------------------------------------------------------------------------------------+-----------------+-------------------------+----------------------------------------------------------------------------+---------------------------+---------------------------+-----------------------+------+--------------------------------------------------------------------------------------------------------+-----------+------------+--------------+--------------------+-----------------------------------------------------------------------+-----------------------------------------------------------------------+
| sample-eks-cluster | a-example000000000001 | arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000001 | namespace-a     | app-controller          | arn:aws:iam::111122223333:role/app-controller-role                         | 2025-12-19T08:28:07+00:00 | 2025-12-19T08:28:07+00:00 | a-example000000000001 | {}   | ["arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000001"] | aws       | us-east-1  | 111122223333 | sample_aws         | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} |
| sample-eks-cluster | a-example000000000002 | arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000002 | namespace-b     | csi-controller-sa       | arn:aws:iam::111122223333:role/csi-controller-role                         | 2024-08-30T15:02:06+00:00 | 2024-08-30T15:02:06+00:00 | a-example000000000002 | {}   | ["arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000002"] | aws       | us-east-1  | 111122223333 | sample_aws         | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} |
| sample-eks-cluster | a-example000000000003 | arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000003 | namespace-c     | default                 | arn:aws:iam::111122223333:role/workload-default-role                       | 2024-10-15T14:56:25+00:00 | 2024-10-15T14:56:25+00:00 | a-example000000000003 | {}   | ["arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000003"] | aws       | us-east-1  | 111122223333 | sample_aws         | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} |
| sample-eks-cluster | a-example000000000004 | arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000004 | namespace-b     | csi-node-sa             | arn:aws:iam::111122223333:role/csi-node-role                               | 2024-08-30T18:12:49+00:00 | 2024-08-30T18:12:49+00:00 | a-example000000000004 | {}   | ["arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000004"] | aws       | us-east-1  | 111122223333 | sample_aws         | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} |
| sample-eks-cluster | a-example000000000005 | arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000005 | namespace-d     | graph-service           | arn:aws:iam::111122223333:role/graph-service-role                          | 2026-03-19T11:21:23+00:00 | 2026-03-19T11:21:23+00:00 | a-example000000000005 | {}   | ["arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000005"] | aws       | us-east-1  | 111122223333 | sample_aws         | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} |
| sample-eks-cluster | a-example000000000006 | arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000006 | namespace-c     | runner-sa               | arn:aws:iam::111122223333:role/workload-runner-role                        | 2025-02-12T11:33:35+00:00 | 2025-02-12T11:33:35+00:00 | a-example000000000006 | {}   | ["arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000006"] | aws       | us-east-1  | 111122223333 | sample_aws         | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} |
| sample-eks-cluster | a-example000000000007 | arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000007 | kube-system     | storage-csi-controller  | arn:aws:iam::111122223333:role/storage-csi-controller-role                 | 2025-02-03T23:40:39+00:00 | 2025-02-03T23:40:39+00:00 | a-example000000000007 | {}   | ["arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000007"] | aws       | us-east-1  | 111122223333 | sample_aws         | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} |
| sample-eks-cluster | a-example000000000008 | arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000008 | namespace-e     | default                 | arn:aws:iam::111122223333:role/backend-api-role                            | 2024-05-21T15:27:32+00:00 | 2024-05-21T15:27:32+00:00 | a-example000000000008 | {}   | ["arn:aws:eks:us-east-1:111122223333:podidentityassociation/sample-eks-cluster/a-example000000000008"] | aws       | us-east-1  | 111122223333 | sample_aws         | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} | {"connection_name":"sample_aws","steampipe":{"sdk_version":"5.13.1"}} |
+--------------------+-----------------------+----------------------------------------------------------------------------------------------------+-----------------+-------------------------+----------------------------------------------------------------------------+---------------------------+---------------------------+-----------------------+------+--------------------------------------------------------------------------------------------------------+-----------+------------+--------------+--------------------+-----------------------------------------------------------------------+-----------------------------------------------------------------------+
```
</details>
