### PR TITLE
feat: add aws_synthetics_canary_run table

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -744,6 +744,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_ssoadmin_permission_set":                                  tableAwsSsoAdminPermissionSet(ctx),
 			"aws_sts_caller_identity":                                      tableAwsSTSCallerIdentity(ctx),
 			"aws_synthetics_canary":                                        tableAwsSyntheticsCanary(ctx),
+			"aws_synthetics_canary_run":                                    tableAwsSyntheticsCanaryRun(ctx),
 			"aws_tagging_resource":                                         tableAwsTaggingResource(ctx),
 			"aws_timestreamwrite_database":                                 tableAwsTimestreamwriteDatabase(ctx),
 			"aws_timestreamwrite_table":                                    tableAwsTimestreamwriteTable(ctx),

--- a/aws/table_aws_synthetics_canary_run.go
+++ b/aws/table_aws_synthetics_canary_run.go
@@ -1,0 +1,167 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/synthetics"
+	"github.com/aws/aws-sdk-go-v2/service/synthetics/types"
+
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/query_cache"
+)
+
+func tableAwsSyntheticsCanaryRun(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_synthetics_canary_run",
+		Description: "AWS CloudWatch Synthetics Canary Run",
+		List: &plugin.ListConfig{
+			KeyColumns: plugin.KeyColumnSlice{
+				{
+					Name:    "name",
+					Require: plugin.Required,
+				},
+				{
+					Name:       "dry_run_id",
+					Require:    plugin.Optional,
+					CacheMatch: query_cache.CacheMatchExact,
+				},
+				{
+					Name:       "run_type",
+					Require:    plugin.Optional,
+					CacheMatch: query_cache.CacheMatchExact,
+				},
+			},
+			Hydrate: listSyntheticsCanaryRuns,
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ResourceNotFoundException"}),
+			},
+			Tags: map[string]string{"service": "synthetics", "action": "GetCanaryRuns"},
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(AWS_SYNTHETICS_SERVICE_ID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "artifact_s3_location",
+				Description: "The S3 location where artifacts are stored for the canary run.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ArtifactS3Location"),
+			},
+			{
+				Name:        "browser_type",
+				Description: "The browser type for the canary run.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "dry_run_config",
+				Description: "The dry run configuration for the canary run.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "id",
+				Description: "The unique ID for the canary run.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "name",
+				Description: "The name of the canary.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "retry_attempt",
+				Description: "The number of retries for the canary run.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "scheduled_run_id",
+				Description: "The ID of the scheduled canary run.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "status",
+				Description: "The status of the canary run.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "timeline",
+				Description: "The timeline information for the canary run.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "dry_run_id",
+				Description: "The ID of the canary dry run.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("dry_run_id"),
+			},
+			{
+				Name:        "run_type",
+				Description: "The type of the canary dry run.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("run_type"),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Id"),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listSyntheticsCanaryRuns(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	// Get client
+	svc, err := SyntheticsClient(ctx, d, d.EqualsQualString(matrixKeyRegion))
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_synthetics_canary_run.listSyntheticsCanaryRuns", "client_error", err)
+		return nil, err
+	}
+
+	// Compile inputs
+	input := &synthetics.GetCanaryRunsInput{}
+	input.Name = aws.String(d.EqualsQualString("name"))
+
+	if d.EqualsQuals["dry_run_id"] != nil {
+		if d.EqualsQualString("dry_run_id") != "" {
+			input.DryRunId = aws.String(d.EqualsQualString("dry_run_id"))
+		}
+	}
+
+	if d.EqualsQuals["run_type"] != nil {
+		if d.EqualsQualString("run_type") != "" {
+			input.RunType = types.RunType(d.EqualsQualString("run_type"))
+		}
+	}
+
+	// Create paginator
+	paginator := synthetics.NewGetCanaryRunsPaginator(svc, input, func(o *synthetics.GetCanaryRunsPaginatorOptions) {
+		o.StopOnDuplicateToken = true
+	})
+
+	for paginator.HasMorePages() {
+		// Apply rate limiting
+		d.WaitForListRateLimit(ctx)
+
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_synthetics_canary_run.listSyntheticsCanaryRuns", "api_error", err)
+			return nil, err
+		}
+
+		for _, runDetail := range output.CanaryRuns {
+			d.StreamListItem(ctx, runDetail)
+
+			// Context may be cancelled due to manual cancellation or if the limit has been reached
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}

--- a/aws/table_aws_synthetics_canary_run.go
+++ b/aws/table_aws_synthetics_canary_run.go
@@ -1,0 +1,163 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/synthetics"
+	"github.com/aws/aws-sdk-go-v2/service/synthetics/types"
+
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
+	"github.com/turbot/steampipe-plugin-sdk/v6/query_cache"
+)
+
+func tableAwsSyntheticsCanaryRun(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_synthetics_canary_run",
+		Description: "AWS CloudWatch Synthetics Canary Run",
+		List: &plugin.ListConfig{
+			KeyColumns: plugin.KeyColumnSlice{
+				{
+					Name:    "name",
+					Require: plugin.Required,
+				},
+				{
+					Name:       "dry_run_id",
+					Require:    plugin.Optional,
+					CacheMatch: query_cache.CacheMatchExact,
+				},
+				{
+					Name:       "run_type",
+					Require:    plugin.Optional,
+					CacheMatch: query_cache.CacheMatchExact,
+				},
+			},
+			Hydrate: listSyntheticsCanaryRuns,
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ResourceNotFoundException"}),
+			},
+			Tags: map[string]string{"service": "synthetics", "action": "GetCanaryRuns"},
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(AWS_SYNTHETICS_SERVICE_ID),
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "artifact_s3_location",
+				Description: "The S3 location where artifacts are stored for the canary run.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("ArtifactS3Location"),
+			},
+			{
+				Name:        "browser_type",
+				Description: "The browser type for the canary run.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "dry_run_config",
+				Description: "The dry run configuration for the canary run.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "id",
+				Description: "The unique ID for the canary run.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "name",
+				Description: "The name of the canary.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "retry_attempt",
+				Description: "The number of retries for the canary run.",
+				Type:        proto.ColumnType_INT,
+			},
+			{
+				Name:        "scheduled_run_id",
+				Description: "The ID of the scheduled canary run.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "status",
+				Description: "The status of the canary run.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "timeline",
+				Description: "The timeline information for the canary run.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "dry_run_id",
+				Description: "The ID of the canary dry run.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("DryRunConfig.DryRunId"),
+			},
+			{
+				Name:        "run_type",
+				Description: "The type of the canary run.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("run_type"),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Id"),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listSyntheticsCanaryRuns(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	// Get client
+	svc, err := SyntheticsClient(ctx, d, d.EqualsQualString(matrixKeyRegion))
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_synthetics_canary_run.listSyntheticsCanaryRuns", "client_error", err)
+		return nil, err
+	}
+
+	// Compile inputs
+	input := &synthetics.GetCanaryRunsInput{}
+	input.Name = aws.String(d.EqualsQualString("name"))
+
+	if d.EqualsQualString("dry_run_id") != "" {
+		input.DryRunId = aws.String(d.EqualsQualString("dry_run_id"))
+	}
+
+	if d.EqualsQualString("run_type") != "" {
+		input.RunType = types.RunType(d.EqualsQualString("run_type"))
+	}
+
+	// Create paginator
+	paginator := synthetics.NewGetCanaryRunsPaginator(svc, input, func(o *synthetics.GetCanaryRunsPaginatorOptions) {
+		o.StopOnDuplicateToken = true
+	})
+
+	for paginator.HasMorePages() {
+		// Apply rate limiting
+		d.WaitForListRateLimit(ctx)
+
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_synthetics_canary_run.listSyntheticsCanaryRuns", "api_error", err)
+			return nil, err
+		}
+
+		for _, runDetail := range output.CanaryRuns {
+			d.StreamListItem(ctx, runDetail)
+
+			// Context may be cancelled due to manual cancellation or if the limit has been reached
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}

--- a/docs/tables/aws_synthetics_canary_run.md
+++ b/docs/tables/aws_synthetics_canary_run.md
@@ -1,0 +1,102 @@
+---
+title: "Steampipe Table: aws_synthetics_canary_run - Query AWS CloudWatch Synthetics Canary Runs using SQL"
+description: "Allows users to query AWS CloudWatch Synthetics Canary Runs for information about their run configuration and status."
+folder: "Synthetics"
+---
+
+# Table: aws_synthetics_canary_run - Query AWS CloudWatch Synthetics Canary Runs using SQL
+
+The AWS CloudWatch Synthetics Canary Run is a synthetic monitoring service that allows you to execute canary runs that
+simulates user actions to monitor your endpoints and APIs.
+
+## Table Usage Guide
+
+The `aws_synthetics_canary_run` table in Steampipe provides you with information about Synthetics Canary Runs within AWS
+CloudWatch. This table allows you, as a DevOps engineer, to query canary run details, including execution timestamps,
+browser types, and status information. You can utilize this table to gather insights on the health of your endpoints
+and APIs that have been setup to be monitored by canaries. The schema outlines the various attributes of the Synthetics
+Canary Run for you, including the canary name, timeline, and status.
+
+**Important Notes**
+- You must specify a `name` in a where or join clause in order to use this table.
+- `dry_run_id` must be specified together with `run_type = 'DRY_RUN'` or an exception will be raised. See
+  https://docs.aws.amazon.com/AmazonSynthetics/latest/APIReference/API_GetCanaryRuns.html for more information.
+
+## Examples
+
+### List Runs of a Canary
+Query run information for a specific canary.
+
+```sql+postgres
+select
+  name,
+  id,
+  status
+from
+  aws_synthetics_canary_run
+where
+  name = 'TargetCanary'
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  status
+from
+  aws_synthetics_canary_run
+where
+  name = 'TargetCanary'
+```
+
+### List Failed Canary Runs
+Query run information for failed canary runs. This could be helpful to identify potential health issues in your systems.
+
+```sql+postgres
+select
+  id,
+  status
+from
+  aws_synthetics_canary_run
+where
+  name = 'TargetCanary'
+  and status ->> 'State' = 'FAILED'
+```
+
+```sql+sqlite
+select
+  id,
+  status
+from
+  aws_synthetics_canary_run
+where
+  name = 'TargetCanary'
+  and status ->> 'State' = 'FAILED'
+```
+
+### List Canary Dry Runs
+Query information for canary dry runs. All rows returned are dry runs when `run_type = 'DRY_RUN''.
+
+```sql+postgres
+select
+  name,
+  id,
+  status
+from
+  aws_synthetics_canary_run
+where
+  name = 'TargetCanary'
+  and run_type = 'DRY_RUN'
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  status
+from
+  aws_synthetics_canary_run
+where
+  name = 'TargetCanary'
+  and run_type = 'DRY_RUN'
+```

--- a/docs/tables/aws_synthetics_canary_run.md
+++ b/docs/tables/aws_synthetics_canary_run.md
@@ -1,0 +1,104 @@
+---
+title: "Steampipe Table: aws_synthetics_canary_run - Query AWS CloudWatch Synthetics Canary Runs using SQL"
+description: "Allows users to query AWS CloudWatch Synthetics Canary Runs for information about their run configuration and status."
+folder: "Synthetics"
+---
+
+# Table: aws_synthetics_canary_run - Query AWS CloudWatch Synthetics Canary Runs using SQL
+
+The AWS CloudWatch Synthetics Canary Run is a synthetic monitoring service that allows you to execute canary runs that
+simulates user actions to monitor your endpoints and APIs.
+
+## Table Usage Guide
+
+The `aws_synthetics_canary_run` table in Steampipe provides you with information about Synthetics Canary Runs within AWS
+CloudWatch. This table allows you, as a DevOps engineer, to query canary run details, including execution timestamps,
+browser types, and status information. You can utilize this table to gather insights on the health of your endpoints
+and APIs that have been setup to be monitored by canaries. The schema outlines the various attributes of the Synthetics
+Canary Run for you, including the canary name, timeline, and status.
+
+**Important Notes**
+- You must specify a `name` in a where or join clause in order to use this table.
+- `dry_run_id` must be specified together with `run_type = 'DRY_RUN'` or an exception will be raised. See
+  https://docs.aws.amazon.com/AmazonSynthetics/latest/APIReference/API_GetCanaryRuns.html for more information.
+
+## Examples
+
+### List canary runs
+Query run information for a specific canary.
+
+```sql+postgres
+select
+  name,
+  id,
+  status
+from
+  aws_synthetics_canary_run
+where
+  name = 'TargetCanary'
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  status
+from
+  aws_synthetics_canary_run
+where
+  name = 'TargetCanary'
+```
+
+### List failed canary runs
+Query run information for failed canary runs. This could be helpful to identify potential health issues in your systems.
+
+```sql+postgres
+select
+  id,
+  status
+from
+  aws_synthetics_canary_run
+where
+  name = 'TargetCanary'
+  and status ->> 'State' = 'FAILED'
+```
+
+```sql+sqlite
+select
+  id,
+  status
+from
+  aws_synthetics_canary_run
+where
+  name = 'TargetCanary'
+  and json_extract(status, '$.State') = 'FAILED'
+```
+
+### List canary dry runs
+Query information for canary dry runs. All rows returned are dry runs when `run_type = 'DRY_RUN'`.
+
+```sql+postgres
+select
+  name,
+  id,
+  status
+from
+  aws_synthetics_canary_run
+where
+  name = 'TargetCanary'
+  and run_type = 'DRY_RUN'
+  and dry_run_id = 'some_dry_run'
+```
+
+```sql+sqlite
+select
+  name,
+  id,
+  status
+from
+  aws_synthetics_canary_run
+where
+  name = 'TargetCanary'
+  and run_type = 'DRY_RUN'
+  and dry_run_id = 'some_dry_run'
+```


### PR DESCRIPTION
# Integration test logs
Not applicable due to lack of Terraform support for Synthetics canary runs.

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_synthetics_canary_run where name = 'canary-01'
+--------------------------------------------------------------------------+--------------+----------------+--------------------------------------+-----------+---------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------+------------+----------+-----------+-----------+--------------+--------------------+----------------------------------------------------------------------+----------------------------------------------------------------------+
| artifact_s3_location                                                     | browser_type | dry_run_config | id                                   | name      | retry_attempt | scheduled_run_id | status                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | timeline                                                                                                             | dry_run_id | run_type | partition | region    | account_id   | sp_connection_name | sp_ctx                                                               | _ctx                                                                 |
+--------------------------------------------------------------------------+--------------+----------------+--------------------------------------+-----------+---------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------+------------+----------+-----------+-----------+--------------+--------------------+----------------------------------------------------------------------+----------------------------------------------------------------------+
| cw-syn-results/canary/canary-01-bee-445d0a5b46ba/2026/06/04/02/40-45-810 |              | <null>         | abe5416b-a9db-4fbc-8bdc-3b5b71ce7b5c | canary-01 | <null>        | <null>           | {"State":"FAILED","StateReason":"Error: Step 3 - base_ssl_certificate_check_example failed during execution\n at APIStepOrchestrator.executeSteps (/opt/lib/orchestration/APIStepOrchestrator.js:69:19)\n at process.processTicksAndRejections (node:internal/process/task_queues:103:5)\n at async CheckExecutor.handler (/opt/nodejs/node_modules/@amzn/synthetics-blueprints-common-nodejs/dist/lib/monitoring/CheckExecutor.js:60:13)\n at async Module.handler (/opt/blueprint.js:24:9)\n at async Runtime.handler (file:///opt/index.mjs:38:13). Additional error: Step 3: base_ssl_certificate_check_example failed with 1 of 6 assertions failed: Certificate issuer O 'SSL Corporation' does not contains 'DigiCert'\n at /opt/lib/orchestration/APIStepOrchestrator.js:145:27\n at async SyntheticsCore.executeStepAndRecordRequests (/opt/nodejs/node_modules/@aws/synthetics-core/dist/lib/synthetics-core.js:687:33)\n at async SyntheticsCore.executeStep (/opt/nodejs/node_modules/@aws/synthetics-core/dist/lib/synthetics-core.js:670:16)\n at  | {"Completed":"2026-06-04T02:40:57.638Z","MetricTimestampForRunAndRetries":null,"Started":"2026-06-04T02:40:53.934Z"} | <null>     | <null>   | aws       | us-east-1 | <omitted>    | steampipe          | {"connection_name":"steampipe","steampipe":{"sdk_version":"5.14.0"}} | {"connection_name":"steampipe","steampipe":{"sdk_version":"5.14.0"}} |
|                                                                          |              |                |                                      |           |               |                  | async APIStepOrchestrator.executeNonHttpStep (/opt/lib/orchestration/APIStepOrchestrator.js:130:13)\n at async APIStepOrchestrator.executeSteps (/opt/lib/orchestration/APIStepOrchestrator.js:45:23)\n at async CheckExecutor.handler (/opt/nodejs/node_modules/@amzn/synthetics-blueprints-common-nodejs/dist/lib/monitoring/CheckExecutor.js:60:13)\n at async Module.handler (/opt/blueprint.js:24:9)\n at async Runtime.handler (file:///opt/index.mjs:38:13)","StateReasonCode":"CANARY_FAILURE","TestResult":"FAILED"}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |                                                                                                                      |            |          |           |           |              |                    |                                                                      |                                                                      |
+--------------------------------------------------------------------------+--------------+----------------+--------------------------------------+-----------+---------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------+------------+----------+-----------+-----------+--------------+--------------------+----------------------------------------------------------------------+----------------------------------------------------------------------+

select * from aws_synthetics_canary_run where name = 'canary-01' and run_type = 'DRY_RUN'
+---------------------------------------------------------------------------------+--------------+-----------------------------------------------------+--------------------------------------+-----------+---------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------+------------+----------+-----------+-----------+--------------+--------------------+----------------------------------------------------------------------+----------------------------------------------------------------------+
| artifact_s3_location                                                            | browser_type | dry_run_config                                      | id                                   | name      | retry_attempt | scheduled_run_id | status                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           | timeline                                                                                                             | dry_run_id | run_type | partition | region    | account_id   | sp_connection_name | sp_ctx                                                               | _ctx                                                                 |
+---------------------------------------------------------------------------------+--------------+-----------------------------------------------------+--------------------------------------+-----------+---------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------+------------+----------+-----------+-----------+--------------+--------------------+----------------------------------------------------------------------+----------------------------------------------------------------------+
| cw-syn-results/canary/canary-01-bee-445d0a5b46ba/2026/06/04/02/41-38-348-dryrun |              | {"DryRunId":"ed55fd40-ddf6-4283-a695-4e539909625b"} | 10ef03f0-012b-431d-83d6-44db05d11aed | canary-01 | <null>        | <null>           | {"State":"FAILED","StateReason":"Error: Step 3 - base_ssl_certificate_check_example failed during execution\n at APIStepOrchestrator.executeSteps (/opt/lib/orchestration/APIStepOrchestrator.js:69:19)\n at process.processTicksAndRejections (node:internal/process/task_queues:103:5)\n at async CheckExecutor.handler (/opt/nodejs/node_modules/@amzn/synthetics-blueprints-common-nodejs/dist/lib/monitoring/CheckExecutor.js:60:13)\n at async Module.handler (/opt/blueprint.js:24:9)\n at async Runtime.handler (file:///opt/index.mjs:38:13). Additional error: Step 3: base_ssl_certificate_check_example failed with 1 of 6 assertions failed: Certificate issuer O 'SSL Corporation' does not contains 'DigiCert'\n at /opt/lib/orchestration/APIStepOrchestrator.js:145:27\n at async SyntheticsCore.executeStepAndRecordRequests (/opt/nodejs/node_modules/@aws/synthetics-core/dist/lib/synthetics-core.js:687:33)\n at async SyntheticsCore.executeStep (/opt/nodejs/node_modules/@aws/synthetics-core/dist/lib/synthetics-core.js:670:16)\n at  | {"Completed":"2026-06-04T02:41:48.323Z","MetricTimestampForRunAndRetries":null,"Started":"2026-06-04T02:41:44.894Z"} | <null>     | DRY_RUN  | aws       | us-east-1 | <omitted>    | steampipe          | {"connection_name":"steampipe","steampipe":{"sdk_version":"5.14.0"}} | {"connection_name":"steampipe","steampipe":{"sdk_version":"5.14.0"}} |
|                                                                                 |              |                                                     |                                      |           |               |                  | async APIStepOrchestrator.executeNonHttpStep (/opt/lib/orchestration/APIStepOrchestrator.js:130:13)\n at async APIStepOrchestrator.executeSteps (/opt/lib/orchestration/APIStepOrchestrator.js:45:23)\n at async CheckExecutor.handler (/opt/nodejs/node_modules/@amzn/synthetics-blueprints-common-nodejs/dist/lib/monitoring/CheckExecutor.js:60:13)\n at async Module.handler (/opt/blueprint.js:24:9)\n at async Runtime.handler (file:///opt/index.mjs:38:13)","StateReasonCode":"CANARY_FAILURE","TestResult":"FAILED"}                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |                                                                                                                      |            |          |           |           |              |                    |                                                                      |                                                                      |
+---------------------------------------------------------------------------------+--------------+-----------------------------------------------------+--------------------------------------+-----------+---------------+------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------+------------+----------+-----------+-----------+--------------+--------------------+----------------------------------------------------------------------+----------------------------------------------------------------------+
```
</details>

Closes https://github.com/turbot/steampipe-plugin-aws/issues/2767.