### PR TITLE
feat: add aws_application_signals_service_level_objective table

### DIFF
--- a/aws/plugin.go
+++ b/aws/plugin.go
@@ -246,6 +246,7 @@ func Plugin(ctx context.Context) *plugin.Plugin {
 			"aws_appautoscaling_policy":                                    tableAwsAppAutoScalingPolicy(ctx),
 			"aws_appautoscaling_target":                                    tableAwsAppAutoScalingTarget(ctx),
 			"aws_appconfig_application":                                    tableAwsAppConfigApplication(ctx),
+			"aws_application_signals_service_level_objective":              tableAwsApplicationSignalsServiceLevelObjective(ctx),
 			"aws_appstream_fleet":                                          tableAwsAppStreamFleet(ctx),
 			"aws_appstream_image":                                          tableAwsAppStreamImage(ctx),
 			"aws_appsync_api":                                              tableAwsAppsyncApi(ctx),

--- a/aws/service.go
+++ b/aws/service.go
@@ -26,6 +26,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/apigatewayv2"
 	"github.com/aws/aws-sdk-go-v2/service/appconfig"
 	"github.com/aws/aws-sdk-go-v2/service/applicationautoscaling"
+	"github.com/aws/aws-sdk-go-v2/service/applicationsignals"
 	"github.com/aws/aws-sdk-go-v2/service/apprunner"
 	"github.com/aws/aws-sdk-go-v2/service/appstream"
 	"github.com/aws/aws-sdk-go-v2/service/appsync"
@@ -266,6 +267,14 @@ func ApplicationAutoScalingClient(ctx context.Context, d *plugin.QueryData) (*ap
 		return nil, err
 	}
 	return applicationautoscaling.NewFromConfig(*cfg), nil
+}
+
+func ApplicationSignalsClient(ctx context.Context, d *plugin.QueryData) (*applicationsignals.Client, error) {
+	cfg, err := getClientForQueryRegion(ctx, d)
+	if err != nil {
+		return nil, err
+	}
+	return applicationsignals.NewFromConfig(*cfg), nil
 }
 
 func AppRunnerClient(ctx context.Context, d *plugin.QueryData) (*apprunner.Client, error) {

--- a/aws/table_aws_application_signals_service_level_objective.go
+++ b/aws/table_aws_application_signals_service_level_objective.go
@@ -1,0 +1,512 @@
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/applicationsignals"
+	"github.com/aws/aws-sdk-go-v2/service/applicationsignals/types"
+
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
+)
+
+func tableAwsApplicationSignalsServiceLevelObjective(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_application_signals_service_level_objective",
+		Description: "AWS CloudWatch Application Signals Service Level Objective (SLO)",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getApplicationSignalsSlo,
+			Tags:       map[string]string{"service": "application-signals", "action": "GetServiceLevelObjective"},
+		},
+		List: &plugin.ListConfig{
+			KeyColumns: plugin.KeyColumnSlice{
+				{
+					Name:    "include_linked_accounts",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "operation_name",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "slo_owner_aws_account_id",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "metric_source_type",
+					Require: plugin.Optional,
+				},
+
+				// Fields derived from DependencyConfig
+				// Ref: https://docs.aws.amazon.com/applicationsignals/latest/APIReference/API_DependencyConfig.html
+				{Name: "dependency_type", Require: plugin.Optional, Operators: []string{"="}},
+				{Name: "dependency_resource_type", Require: plugin.Optional, Operators: []string{"="}},
+				{Name: "dependency_name", Require: plugin.Optional, Operators: []string{"="}},
+				{Name: "dependency_identifier", Require: plugin.Optional, Operators: []string{"="}},
+				{Name: "dependency_environment", Require: plugin.Optional, Operators: []string{"="}},
+				{Name: "dependency_operation_name", Require: plugin.Optional, Operators: []string{"="}},
+
+				// Fields derived from KeyAttributes
+				// Ref: https://docs.aws.amazon.com/applicationsignals/latest/APIReference/API_ListServiceLevelObjectives.html#applicationsignals-ListServiceLevelObjectives-request-KeyAttributes
+				{Name: "slo_type", Require: plugin.Optional, Operators: []string{"="}},
+				{Name: "slo_resource_type", Require: plugin.Optional, Operators: []string{"="}},
+				{Name: "slo_name", Require: plugin.Optional, Operators: []string{"="}},
+				{Name: "slo_identifier", Require: plugin.Optional, Operators: []string{"="}},
+				{Name: "slo_environment", Require: plugin.Optional, Operators: []string{"="}},
+
+				// Fields derived from MetricSource
+				// Ref: https://docs.aws.amazon.com/applicationsignals/latest/APIReference/API_MetricSource.html
+				{Name: "metric_source_key_attributes", Require: plugin.Optional, Operators: []string{"="}},
+				{Name: "metric_source_attributes", Require: plugin.Optional, Operators: []string{"="}},
+			},
+			Hydrate: listApplicationSignalsSlo,
+			Tags:    map[string]string{"service": "application-signals", "action": "ListServiceLevelObjectives"},
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(AWS_APPLICATION_SIGNALS_SERVICE_ID),
+		HydrateConfig: []plugin.HydrateConfig{
+			{
+				Func: getApplicationSignalsSloTags,
+				Tags: map[string]string{"service": "application-signals", "action": "ListTagsForResource"},
+			},
+		},
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "arn",
+				Description: "The ARN of the SLO.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "burn_rate_configurations",
+				Description: "Array of configurations used to calculate the burn rate metrics of the SLO.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getApplicationSignalsSlo,
+			},
+			{
+				Name:        "created_time",
+				Description: "The creation timestamp of the SLO.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "description",
+				Description: "The description of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getApplicationSignalsSlo,
+			},
+			{
+				Name:        "evaluation_type",
+				Description: "Whether the SLO is a period-based SLO or a request-based SLO.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "goal",
+				Description: "Structure of attributes that define the goal of the SLO.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getApplicationSignalsSlo,
+			},
+			{
+				Name:        "id",
+				Description: "The ARN of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Arn"),
+			},
+			{
+				Name:        "last_updated_time",
+				Description: "The last update timestamp of the SLO.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Hydrate:     getApplicationSignalsSlo,
+			},
+			{
+				Name:        "metric_source_type",
+				Description: "The metric source type of the SLO.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "name",
+				Description: "The name of the SLO.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "operation_name",
+				Description: "If the SLO is specific to a single operation, this provides name of that operation.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "request_based_sli",
+				Description: "If this is a request-based SLO, this contains information about the performance metric.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getApplicationSignalsSlo,
+			},
+			{
+				Name:        "sli",
+				Description: "If this is a period-based SLO, this contains information about the performance metric.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getApplicationSignalsSlo,
+			},
+			{
+				Name:        "tags",
+				Description: "The tags assigned to the group.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getApplicationSignalsSloTags,
+				Transform:   transform.FromValue(),
+			},
+
+			// Attributes related to DependencyConfig
+			{
+				Name:        "dependency_config",
+				Description: "The dependency config of the SLO.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "dependency_type",
+				Description: "Corresponds to DependencyConfig.DependencyKeyAttributes.Type of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DependencyConfig.DependencyKeyAttributes.Type"),
+			},
+			{
+				Name:        "dependency_resource_type",
+				Description: "Corresponds to DependencyConfig.DependencyKeyAttributes.ResourceType of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DependencyConfig.DependencyKeyAttributes.ResourceType"),
+			},
+			{
+				Name:        "dependency_name",
+				Description: "Corresponds to DependencyConfig.DependencyKeyAttributes.Name of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DependencyConfig.DependencyKeyAttributes.Name"),
+			},
+			{
+				Name:        "dependency_identifier",
+				Description: "Corresponds to DependencyConfig.DependencyKeyAttributes.Identifier of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DependencyConfig.DependencyKeyAttributes.Identifier"),
+			},
+			{
+				Name:        "dependency_environment",
+				Description: "Corresponds to DependencyConfig.DependencyKeyAttributes.Environment of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DependencyConfig.DependencyKeyAttributes.Environment"),
+			},
+			{
+				Name:        "dependency_operation_name",
+				Description: "Corresponds to DependencyConfig.DependencyOperationName of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("DependencyConfig.DependencyOperationName"),
+			},
+
+			// Attributes related to KeyAttributes
+			{
+				Name:        "key_attributes",
+				Description: "A string-to-string map of key attributes of the SLO.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "slo_type",
+				Description: "Corresponds to KeyAttributes.Type of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("KeyAttributes.Type"),
+			},
+			{
+				Name:        "slo_resource_type",
+				Description: "Corresponds to KeyAttributes.ResourceType of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("KeyAttributes.ResourceType"),
+			},
+			{
+				Name:        "slo_name",
+				Description: "Corresponds to KeyAttributes.Name of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("KeyAttributes.Name"),
+			},
+			{
+				Name:        "slo_identifier",
+				Description: "Corresponds to KeyAttributes.Identifier of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("KeyAttributes.Identifier"),
+			},
+			{
+				Name:        "slo_environment",
+				Description: "Corresponds to KeyAttributes.Environment of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("KeyAttributes.Environment"),
+			},
+
+			// Attributes related to MetricSource
+			{
+				Name:        "metric_source",
+				Description: "The metric source of the SLO on resources other than Application Signals services.",
+				Type:        proto.ColumnType_JSON,
+			},
+			{
+				Name:        "metric_source_key_attributes",
+				Description: "Corresponds to MetricSource.MetricSourceKeyAttributes of the SLO.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("MetricSource.MetricSourceKeyAttributes"),
+			},
+			{
+				Name:        "metric_source_attributes",
+				Description: "Corresponds to MetricSource.MetricSourceAttributes of the SLO.",
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("MetricSource.MetricSourceAttributes"),
+			},
+
+			// Attributes derived from qualifiers
+			{
+				Name:        "include_linked_accounts",
+				Description: "Flag indicating whether the result set includes linked accounts.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromQual("include_linked_accounts"),
+			},
+			{
+				Name:        "slo_owner_aws_account_id",
+				Description: "AWS account ID that owns the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("slo_owner_aws_account_id"),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Arn"),
+			},
+			{
+				Name:        "akas",
+				Description: resourceInterfaceDescription("akas"),
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Arn").Transform(transform.EnsureStringArray),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listApplicationSignalsSlo(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	// Get client
+	svc, err := ApplicationSignalsClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_slo.listApplicationSignalsSlo", "client_error", err)
+		return nil, err
+	}
+
+	// Compile inputs
+	input := &applicationsignals.ListServiceLevelObjectivesInput{}
+
+	if d.EqualsQuals["include_linked_accounts"] != nil {
+		input.IncludeLinkedAccounts = d.EqualsQuals["include_linked_accounts"].GetBoolValue()
+	}
+
+	if d.EqualsQuals["operation_name"] != nil {
+		if d.EqualsQualString("operation_name") != "" {
+			input.OperationName = aws.String(d.EqualsQualString("operation_name"))
+		}
+	}
+
+	if d.EqualsQuals["slo_owner_aws_account_id"] != nil {
+		if d.EqualsQualString("slo_owner_aws_account_id") != "" {
+			input.SloOwnerAwsAccountId = aws.String(d.EqualsQualString("slo_owner_aws_account_id"))
+		}
+	}
+
+	dependencyConfig := buildDependencyConfigParam(d.Quals)
+	if dependencyConfig != nil {
+		input.DependencyConfig = dependencyConfig
+	}
+
+	keyAttributes := buildKeyAttributesParam(d.Quals)
+	if keyAttributes != nil {
+		input.KeyAttributes = *keyAttributes
+	}
+
+	paginator := applicationsignals.NewListServiceLevelObjectivesPaginator(
+		svc,
+		input,
+		func(o *applicationsignals.ListServiceLevelObjectivesPaginatorOptions) {
+			o.StopOnDuplicateToken = true
+		},
+	)
+
+	for paginator.HasMorePages() {
+		// Apply rate limiting
+		d.WaitForListRateLimit(ctx)
+
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_application_signals_slo.listApplicationSignalsSlo", "api_error", err)
+			return nil, err
+		}
+
+		for _, sloSummary := range output.SloSummaries {
+			d.StreamListItem(ctx, sloSummary)
+
+			// Context may be cancelled due to manual cancellation or if the limit has been reached
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getApplicationSignalsSlo(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var sloId string
+	// The SLO ID may be supplied as a parameter for a Get hydration call
+	// or as may have already been hydrated from the List hydration call.
+	if d.EqualsQualString("id") != "" {
+		sloId = d.EqualsQualString("id")
+	} else {
+		sloId = *h.Item.(types.ServiceLevelObjectiveSummary).Arn
+	}
+
+	if sloId == "" {
+		return nil, nil
+	}
+
+	// Get client
+	svc, err := ApplicationSignalsClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_slo.getApplicationSignalsSlo", "client_error", err)
+		return nil, err
+	}
+
+	output, err := svc.GetServiceLevelObjective(ctx, &applicationsignals.GetServiceLevelObjectiveInput{
+		Id: aws.String(sloId),
+	})
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_slo.getApplicationSignalsSlo", "api_error", err)
+		return nil, err
+	}
+
+	return output.Slo, nil
+}
+
+func getApplicationSignalsSloTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	arn, err := getSloArn(ctx, d, h)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_slo.getApplicationSignalsSloTags", "parse_error", err)
+		return nil, err
+	}
+
+	// Get client
+	svc, err := ApplicationSignalsClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_slo.getApplicationSignalsSloTags", "client_error", err)
+		return nil, err
+	}
+
+	output, err := svc.ListTagsForResource(ctx, &applicationsignals.ListTagsForResourceInput{
+		ResourceArn: arn,
+	})
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_slo.getApplicationSignalsSloTags", "api_error", err)
+		return nil, err
+	}
+
+	tags := make(map[string]string)
+	for _, tag := range output.Tags {
+		tags[*tag.Key] = *tag.Value
+	}
+
+	return tags, nil
+}
+
+// // UTILITY FUNCTIONS
+func buildDependencyConfigParam(quals plugin.KeyColumnQualMap) *types.DependencyConfig {
+	dependencyConfig := &types.DependencyConfig{}
+	updated := false
+
+	// Build DependencyConfig.DependencyKeyAttributes parameter
+	dependencyKeyAttributeColumnNames := map[string]string{
+		"dependency_type":          "Type",
+		"dependency_resource_type": "ResourceType",
+		"dependency_name":          "Name",
+		"dependency_identifier":    "Identifier",
+		"dependency_environment":   "Environment",
+	}
+	for qualName, paramName := range dependencyKeyAttributeColumnNames {
+		if quals[qualName] == nil {
+			continue
+		}
+		for _, q := range quals[qualName].Quals {
+			value := q.Value.GetStringValue()
+			if value == "" || q.Operator != "=" {
+				continue
+			}
+
+			dependencyConfig.DependencyKeyAttributes[paramName] = value
+			updated = true
+		}
+	}
+
+	// Build DependencyConfig.DependencyOperationName
+	if quals["dependency_operation_name"] != nil {
+		for _, q := range quals["dependency_operation_name"].Quals {
+			value := q.Value.GetStringValue()
+			if value == "" || q.Operator != "=" {
+				continue
+			}
+
+			dependencyConfig.DependencyOperationName = aws.String(value)
+			updated = true
+		}
+	}
+
+	// Return the filters only if it was updated by any of the qualifiers.
+	if updated {
+		return dependencyConfig
+	} else {
+		return nil
+	}
+}
+
+func buildKeyAttributesParam(quals plugin.KeyColumnQualMap) *map[string]string {
+	keyAttributes := make(map[string]string)
+
+	// Build KeyAttributes parameter
+	keyAttributeColumnNames := map[string]string{
+		"slo_type":          "Type",
+		"slo_resource_type": "ResourceType",
+		"slo_name":          "Name",
+		"slo_identifier":    "Identifier",
+		"slo_environment":   "Environment",
+	}
+	for qualName, paramName := range keyAttributeColumnNames {
+		if quals[qualName] == nil {
+			continue
+		}
+		for _, q := range quals[qualName].Quals {
+			value := q.Value.GetStringValue()
+			if value == "" || q.Operator != "=" {
+				continue
+			}
+
+			keyAttributes[paramName] = value
+		}
+	}
+
+	// Return only if any key attributes are provided.
+	if len(keyAttributes) > 0 {
+		return &keyAttributes
+	} else {
+		return nil
+	}
+}
+
+func getSloArn(_ context.Context, _ *plugin.QueryData, h *plugin.HydrateData) (*string, error) {
+	if h.Item != nil {
+		switch item := h.Item.(type) {
+		case *types.ServiceLevelObjective:
+			return item.Arn, nil
+		case types.ServiceLevelObjectiveSummary:
+			return item.Arn, nil
+		}
+	}
+	return nil, nil
+}

--- a/aws/table_aws_application_signals_service_level_objective.go
+++ b/aws/table_aws_application_signals_service_level_objective.go
@@ -1,0 +1,676 @@
+package aws
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/applicationsignals"
+	"github.com/aws/aws-sdk-go-v2/service/applicationsignals/types"
+
+	"github.com/turbot/steampipe-plugin-sdk/v6/grpc/proto"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin"
+	"github.com/turbot/steampipe-plugin-sdk/v6/plugin/transform"
+)
+
+func tableAwsApplicationSignalsServiceLevelObjective(_ context.Context) *plugin.Table {
+	return &plugin.Table{
+		Name:        "aws_application_signals_service_level_objective",
+		Description: "AWS CloudWatch Application Signals Service Level Objective (SLO)",
+		Get: &plugin.GetConfig{
+			KeyColumns: plugin.SingleColumn("id"),
+			Hydrate:    getApplicationSignalsSlo,
+			IgnoreConfig: &plugin.IgnoreConfig{
+				ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ResourceNotFoundException", "ValidationException"}),
+			},
+			Tags: map[string]string{"service": "application-signals", "action": "GetServiceLevelObjective"},
+		},
+		List: &plugin.ListConfig{
+			KeyColumns: plugin.KeyColumnSlice{
+				{
+					Name:    "include_linked_accounts",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "operation_name",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "slo_owner_aws_account_id",
+					Require: plugin.Optional,
+				},
+				{
+					Name:    "metric_source_type",
+					Require: plugin.Optional,
+				},
+
+				// Fields derived from DependencyConfig
+				// Ref: https://docs.aws.amazon.com/applicationsignals/latest/APIReference/API_DependencyConfig.html
+				{Name: "dependency_type", Require: plugin.Optional},
+				{Name: "dependency_resource_type", Require: plugin.Optional},
+				{Name: "dependency_name", Require: plugin.Optional},
+				{Name: "dependency_identifier", Require: plugin.Optional},
+				{Name: "dependency_environment", Require: plugin.Optional},
+				{Name: "dependency_operation_name", Require: plugin.Optional},
+
+				// Fields derived from KeyAttributes
+				// Ref: https://docs.aws.amazon.com/applicationsignals/latest/APIReference/API_ListServiceLevelObjectives.html#applicationsignals-ListServiceLevelObjectives-request-KeyAttributes
+				{Name: "slo_type", Require: plugin.Optional},
+				{Name: "slo_resource_type", Require: plugin.Optional},
+				{Name: "slo_name", Require: plugin.Optional},
+				{Name: "slo_identifier", Require: plugin.Optional},
+				{Name: "slo_environment", Require: plugin.Optional},
+
+				// Fields derived from MetricSource
+				// Ref: https://docs.aws.amazon.com/applicationsignals/latest/APIReference/API_MetricSource.html
+				{Name: "metric_source_key_attributes", Require: plugin.Optional},
+				{Name: "metric_source_attributes", Require: plugin.Optional},
+			},
+			Hydrate: listApplicationSignalsSlo,
+			Tags:    map[string]string{"service": "application-signals", "action": "ListServiceLevelObjectives"},
+		},
+		GetMatrixItemFunc: SupportedRegionMatrix(AWS_APPLICATION_SIGNALS_SERVICE_ID),
+		HydrateConfig: []plugin.HydrateConfig{
+			{
+				Func: getApplicationSignalsSlo,
+				IgnoreConfig: &plugin.IgnoreConfig{
+					ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ResourceNotFoundException", "ValidationException"}),
+				},
+				Tags: map[string]string{"service": "application-signals", "action": "GetServiceLevelObjective"},
+			},
+			{
+				Func: getApplicationSignalsSloTags,
+				IgnoreConfig: &plugin.IgnoreConfig{
+					ShouldIgnoreErrorFunc: shouldIgnoreErrors([]string{"ResourceNotFoundException"}),
+				},
+				Tags: map[string]string{"service": "application-signals", "action": "ListTagsForResource"},
+			},
+		},
+		Columns: awsRegionalColumns([]*plugin.Column{
+			{
+				Name:        "arn",
+				Description: "The ARN of the SLO.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "burn_rate_configurations",
+				Description: "Array of configurations used to calculate the burn rate metrics of the SLO.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getApplicationSignalsSlo,
+			},
+			{
+				Name:        "created_time",
+				Description: "The creation timestamp of the SLO.",
+				Type:        proto.ColumnType_TIMESTAMP,
+			},
+			{
+				Name:        "description",
+				Description: "The description of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Hydrate:     getApplicationSignalsSlo,
+			},
+			{
+				Name:        "evaluation_type",
+				Description: "Whether the SLO is a period-based SLO or a request-based SLO.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "goal",
+				Description: "Structure of attributes that define the goal of the SLO.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getApplicationSignalsSlo,
+			},
+			{
+				Name:        "id",
+				Description: "The ARN of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Arn"),
+			},
+			{
+				Name:        "last_updated_time",
+				Description: "The last update timestamp of the SLO.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Hydrate:     getApplicationSignalsSlo,
+			},
+			{
+				Name:        "metric_source_type",
+				Description: "The metric source type of the SLO.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "name",
+				Description: "The name of the SLO.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "operation_name",
+				Description: "If the SLO is specific to a single operation, this provides name of that operation.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField(
+					"OperationName",
+					"Sli.SliMetric.OperationName",
+					"RequestBasedSli.RequestBasedSliMetric.OperationName",
+				),
+			},
+			{
+				Name:        "request_based_sli",
+				Description: "If this is a request-based SLO, this contains information about the performance metric.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getApplicationSignalsSlo,
+			},
+			{
+				Name:        "sli",
+				Description: "If this is a period-based SLO, this contains information about the performance metric.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getApplicationSignalsSlo,
+			},
+
+			// Attributes related to DependencyConfig
+			{
+				Name:        "dependency_config",
+				Description: "The dependency config of the SLO.",
+				Type:        proto.ColumnType_JSON,
+				Transform: transform.FromField(
+					"DependencyConfig",
+					"Sli.SliMetric.DependencyConfig",
+					"RequestBasedSli.RequestBasedSliMetric.DependencyConfig",
+				),
+			},
+			{
+				Name:        "dependency_type",
+				Description: "Corresponds to DependencyConfig.DependencyKeyAttributes.Type of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField(
+					"DependencyConfig.DependencyKeyAttributes.Type",
+					"Sli.SliMetric.DependencyConfig.DependencyKeyAttributes.Type",
+					"RequestBasedSli.RequestBasedSliMetric.DependencyConfig.DependencyKeyAttributes.Type",
+				),
+			},
+			{
+				Name:        "dependency_resource_type",
+				Description: "Corresponds to DependencyConfig.DependencyKeyAttributes.ResourceType of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField(
+					"DependencyConfig.DependencyKeyAttributes.ResourceType",
+					"Sli.SliMetric.DependencyConfig.DependencyKeyAttributes.ResourceType",
+					"RequestBasedSli.RequestBasedSliMetric.DependencyConfig.DependencyKeyAttributes.ResourceType",
+				),
+			},
+			{
+				Name:        "dependency_name",
+				Description: "Corresponds to DependencyConfig.DependencyKeyAttributes.Name of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField(
+					"DependencyConfig.DependencyKeyAttributes.Name",
+					"Sli.SliMetric.DependencyConfig.DependencyKeyAttributes.Name",
+					"RequestBasedSli.RequestBasedSliMetric.DependencyConfig.DependencyKeyAttributes.Name",
+				),
+			},
+			{
+				Name:        "dependency_identifier",
+				Description: "Corresponds to DependencyConfig.DependencyKeyAttributes.Identifier of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField(
+					"DependencyConfig.DependencyKeyAttributes.Identifier",
+					"Sli.SliMetric.DependencyConfig.DependencyKeyAttributes.Identifier",
+					"RequestBasedSli.RequestBasedSliMetric.DependencyConfig.DependencyKeyAttributes.Identifier",
+				),
+			},
+			{
+				Name:        "dependency_environment",
+				Description: "Corresponds to DependencyConfig.DependencyKeyAttributes.Environment of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField(
+					"DependencyConfig.DependencyKeyAttributes.Environment",
+					"Sli.SliMetric.DependencyConfig.DependencyKeyAttributes.Environment",
+					"RequestBasedSli.RequestBasedSliMetric.DependencyConfig.DependencyKeyAttributes.Environment",
+				),
+			},
+			{
+				Name:        "dependency_operation_name",
+				Description: "Corresponds to DependencyConfig.DependencyOperationName of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField(
+					"DependencyConfig.DependencyOperationName",
+					"Sli.SliMetric.DependencyConfig.DependencyOperationName",
+					"RequestBasedSli.RequestBasedSliMetric.DependencyConfig.DependencyOperationName",
+				),
+			},
+
+			// Attributes related to KeyAttributes
+			{
+				Name:        "key_attributes",
+				Description: "A string-to-string map of key attributes of the SLO.",
+				Type:        proto.ColumnType_JSON,
+				Transform: transform.FromField(
+					"KeyAttributes",
+					"Sli.SliMetric.KeyAttributes",
+					"RequestBasedSli.RequestBasedSliMetric.KeyAttributes",
+				),
+			},
+			{
+				Name:        "slo_type",
+				Description: "Corresponds to KeyAttributes.Type of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField(
+					"KeyAttributes.Type",
+					"Sli.SliMetric.KeyAttributes.Type",
+					"RequestBasedSli.RequestBasedSliMetric.KeyAttributes.Type",
+				),
+			},
+			{
+				Name:        "slo_resource_type",
+				Description: "Corresponds to KeyAttributes.ResourceType of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField(
+					"KeyAttributes.ResourceType",
+					"Sli.SliMetric.KeyAttributes.ResourceType",
+					"RequestBasedSli.RequestBasedSliMetric.KeyAttributes.ResourceType",
+				),
+			},
+			{
+				Name:        "slo_name",
+				Description: "Corresponds to KeyAttributes.Name of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField(
+					"KeyAttributes.Name",
+					"Sli.SliMetric.KeyAttributes.Name",
+					"RequestBasedSli.RequestBasedSliMetric.KeyAttributes.Name",
+				),
+			},
+			{
+				Name:        "slo_identifier",
+				Description: "Corresponds to KeyAttributes.Identifier of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField(
+					"KeyAttributes.Identifier",
+					"Sli.SliMetric.KeyAttributes.Identifier",
+					"RequestBasedSli.RequestBasedSliMetric.KeyAttributes.Identifier",
+				),
+			},
+			{
+				Name:        "slo_environment",
+				Description: "Corresponds to KeyAttributes.Environment of the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform: transform.FromField(
+					"KeyAttributes.Environment",
+					"Sli.SliMetric.KeyAttributes.Environment",
+					"RequestBasedSli.RequestBasedSliMetric.KeyAttributes.Environment",
+				),
+			},
+			{
+				Name:        "tags_src",
+				Description: "A list of tags assigned to the group.",
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getApplicationSignalsSloTags,
+				Transform:   transform.FromValue(),
+			},
+
+			// Attributes related to MetricSource
+			{
+				Name:        "metric_source",
+				Description: "The metric source of the SLO on resources other than Application Signals services.",
+				Type:        proto.ColumnType_JSON,
+				Transform: transform.FromField(
+					"MetricSource",
+					"Sli.SliMetric.MetricSource",
+					"RequestBasedSli.RequestBasedSliMetric.MetricSource",
+				),
+			},
+			{
+				Name:        "metric_source_key_attributes",
+				Description: "Corresponds to MetricSource.MetricSourceKeyAttributes of the SLO.",
+				Type:        proto.ColumnType_JSON,
+				Transform: transform.FromField(
+					"MetricSource.MetricSourceKeyAttributes",
+					"Sli.SliMetric.MetricSource.MetricSourceKeyAttributes",
+					"RequestBasedSli.RequestBasedSliMetric.MetricSource.MetricSourceKeyAttributes",
+				),
+			},
+			{
+				Name:        "metric_source_attributes",
+				Description: "Corresponds to MetricSource.MetricSourceAttributes of the SLO.",
+				Type:        proto.ColumnType_JSON,
+				Transform: transform.FromField(
+					"MetricSource.MetricSourceAttributes",
+					"Sli.SliMetric.MetricSource.MetricSourceAttributes",
+					"RequestBasedSli.RequestBasedSliMetric.MetricSource.MetricSourceAttributes",
+				),
+			},
+
+			// Attributes derived from qualifiers
+			{
+				Name:        "include_linked_accounts",
+				Description: "Flag indicating whether the result set includes linked accounts.",
+				Type:        proto.ColumnType_BOOL,
+				Transform:   transform.FromQual("include_linked_accounts"),
+			},
+			{
+				Name:        "slo_owner_aws_account_id",
+				Description: "AWS account ID that owns the SLO.",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("slo_owner_aws_account_id"),
+			},
+
+			// Steampipe standard columns
+			{
+				Name:        "title",
+				Description: resourceInterfaceDescription("title"),
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromField("Name"),
+			},
+			{
+				Name:        "akas",
+				Description: resourceInterfaceDescription("akas"),
+				Type:        proto.ColumnType_JSON,
+				Transform:   transform.FromField("Arn").Transform(transform.EnsureStringArray),
+			},
+			{
+				Name:        "tags",
+				Description: resourceInterfaceDescription("tags"),
+				Type:        proto.ColumnType_JSON,
+				Hydrate:     getApplicationSignalsSloTags,
+				Transform:   transform.From(getApplicationSignalsSloTurbotTags),
+			},
+		}),
+	}
+}
+
+//// LIST FUNCTION
+
+func listApplicationSignalsSlo(ctx context.Context, d *plugin.QueryData, _ *plugin.HydrateData) (interface{}, error) {
+	// Get client
+	svc, err := ApplicationSignalsClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_service_level_objective.listApplicationSignalsSlo", "client_error", err)
+		return nil, err
+	}
+
+	// Compile inputs
+	input := &applicationsignals.ListServiceLevelObjectivesInput{}
+
+	maxLimit := int32(50)
+	if d.QueryContext.Limit != nil {
+		limit := int32(*d.QueryContext.Limit)
+		if limit < maxLimit {
+			if limit < 1 {
+				maxLimit = 1
+			} else {
+				maxLimit = limit
+			}
+		}
+	}
+	input.MaxResults = aws.Int32(maxLimit)
+
+	if d.EqualsQuals["include_linked_accounts"] != nil {
+		input.IncludeLinkedAccounts = d.EqualsQuals["include_linked_accounts"].GetBoolValue()
+	}
+
+	if d.EqualsQualString("operation_name") != "" {
+		input.OperationName = aws.String(d.EqualsQualString("operation_name"))
+	}
+
+	if d.EqualsQualString("slo_owner_aws_account_id") != "" {
+		input.SloOwnerAwsAccountId = aws.String(d.EqualsQualString("slo_owner_aws_account_id"))
+	}
+
+	if d.EqualsQualString("metric_source_type") != "" {
+		input.MetricSourceTypes = []types.MetricSourceType{types.MetricSourceType(d.EqualsQualString("metric_source_type"))}
+	}
+
+	dependencyConfig := buildDependencyConfigParam(d.Quals)
+	if dependencyConfig != nil {
+		input.DependencyConfig = dependencyConfig
+	}
+
+	keyAttributes := buildKeyAttributesParam(d.Quals)
+	if keyAttributes != nil {
+		input.KeyAttributes = *keyAttributes
+	}
+
+	metricSourceAttributesParam, err := buildParamsFromJson(d.Quals, "metric_source_attributes")
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_service_level_objective.listApplicationSignalsSlo", "parse_error", err)
+		return nil, err
+	}
+
+	metricSourceKeyAttributesParam, err := buildParamsFromJson(d.Quals, "metric_source_key_attributes")
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_service_level_objective.listApplicationSignalsSlo", "parse_error", err)
+		return nil, err
+	}
+
+	if len(metricSourceKeyAttributesParam) > 0 || len(metricSourceAttributesParam) > 0 {
+		input.MetricSource = &types.MetricSource{}
+		if len(metricSourceKeyAttributesParam) > 0 {
+			input.MetricSource.MetricSourceKeyAttributes = metricSourceKeyAttributesParam
+		}
+		if len(metricSourceAttributesParam) > 0 {
+			input.MetricSource.MetricSourceAttributes = metricSourceAttributesParam
+		}
+	}
+
+	paginator := applicationsignals.NewListServiceLevelObjectivesPaginator(
+		svc,
+		input,
+		func(o *applicationsignals.ListServiceLevelObjectivesPaginatorOptions) {
+			o.StopOnDuplicateToken = true
+		},
+	)
+
+	for paginator.HasMorePages() {
+		// Apply rate limiting
+		d.WaitForListRateLimit(ctx)
+
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			plugin.Logger(ctx).Error("aws_application_signals_service_level_objective.listApplicationSignalsSlo", "api_error", err)
+			return nil, err
+		}
+
+		for _, sloSummary := range output.SloSummaries {
+			d.StreamListItem(ctx, sloSummary)
+
+			// Context may be cancelled due to manual cancellation or if the limit has been reached
+			if d.RowsRemaining(ctx) == 0 {
+				return nil, nil
+			}
+		}
+	}
+
+	return nil, nil
+}
+
+//// HYDRATE FUNCTIONS
+
+func getApplicationSignalsSlo(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	var sloId string
+	// The SLO ID may be supplied as a parameter for a Get hydration call
+	// or may have already been hydrated from the List hydration call.
+	if d.EqualsQualString("id") != "" {
+		sloId = d.EqualsQualString("id")
+	} else {
+		sloId = *h.Item.(types.ServiceLevelObjectiveSummary).Arn
+	}
+
+	if sloId == "" {
+		return nil, nil
+	}
+
+	// Get client
+	svc, err := ApplicationSignalsClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_service_level_objective.getApplicationSignalsSlo", "client_error", err)
+		return nil, err
+	}
+
+	output, err := svc.GetServiceLevelObjective(ctx, &applicationsignals.GetServiceLevelObjectiveInput{
+		Id: aws.String(sloId),
+	})
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_service_level_objective.getApplicationSignalsSlo", "api_error", err)
+		return nil, err
+	}
+
+	return output.Slo, nil
+}
+
+func getApplicationSignalsSloTags(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	arn, err := getSloArn(ctx, d, h)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_service_level_objective.getApplicationSignalsSloTags", "parse_error", err)
+		return nil, err
+	}
+
+	// Get client
+	svc, err := ApplicationSignalsClient(ctx, d)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_service_level_objective.getApplicationSignalsSloTags", "client_error", err)
+		return nil, err
+	}
+
+	output, err := svc.ListTagsForResource(ctx, &applicationsignals.ListTagsForResourceInput{
+		ResourceArn: arn,
+	})
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_application_signals_service_level_objective.getApplicationSignalsSloTags", "api_error", err)
+		return nil, err
+	}
+
+	if len(output.Tags) > 0 {
+		return output.Tags, nil
+	}
+
+	return nil, nil
+}
+
+func getApplicationSignalsSloTurbotTags(_ context.Context, d *transform.TransformData) (interface{}, error) {
+	tags := d.HydrateItem.([]types.Tag)
+
+	if tags != nil {
+		turbotTags := map[string]string{}
+		for _, tag := range tags {
+			turbotTags[*tag.Key] = *tag.Value
+		}
+		return turbotTags, nil
+	}
+
+	return nil, nil
+}
+
+//// UTILITY FUNCTIONS
+
+func buildDependencyConfigParam(quals plugin.KeyColumnQualMap) *types.DependencyConfig {
+	dependencyConfig := &types.DependencyConfig{
+		DependencyKeyAttributes: make(map[string]string),
+	}
+	updated := false
+
+	// Build DependencyConfig.DependencyKeyAttributes parameter
+	dependencyKeyAttributeColumnNames := map[string]string{
+		"dependency_type":          "Type",
+		"dependency_resource_type": "ResourceType",
+		"dependency_name":          "Name",
+		"dependency_identifier":    "Identifier",
+		"dependency_environment":   "Environment",
+	}
+	for qualName, paramName := range dependencyKeyAttributeColumnNames {
+		if quals[qualName] == nil {
+			continue
+		}
+		for _, q := range quals[qualName].Quals {
+			value := q.Value.GetStringValue()
+			if value == "" || q.Operator != "=" {
+				continue
+			}
+
+			dependencyConfig.DependencyKeyAttributes[paramName] = value
+			updated = true
+		}
+	}
+
+	// Build DependencyConfig.DependencyOperationName
+	if quals["dependency_operation_name"] != nil {
+		for _, q := range quals["dependency_operation_name"].Quals {
+			value := q.Value.GetStringValue()
+			if value == "" || q.Operator != "=" {
+				continue
+			}
+
+			dependencyConfig.DependencyOperationName = aws.String(value)
+			updated = true
+		}
+	}
+
+	// Return the filters only if it was updated by any of the qualifiers.
+	if updated {
+		return dependencyConfig
+	} else {
+		return nil
+	}
+}
+
+func buildKeyAttributesParam(quals plugin.KeyColumnQualMap) *map[string]string {
+	keyAttributes := make(map[string]string)
+
+	// Build KeyAttributes parameter
+	keyAttributeColumnNames := map[string]string{
+		"slo_type":          "Type",
+		"slo_resource_type": "ResourceType",
+		"slo_name":          "Name",
+		"slo_identifier":    "Identifier",
+		"slo_environment":   "Environment",
+	}
+	for qualName, paramName := range keyAttributeColumnNames {
+		if quals[qualName] == nil {
+			continue
+		}
+		for _, q := range quals[qualName].Quals {
+			value := q.Value.GetStringValue()
+			if value == "" || q.Operator != "=" {
+				continue
+			}
+
+			keyAttributes[paramName] = value
+		}
+	}
+
+	// Return only if any key attributes are provided.
+	if len(keyAttributes) > 0 {
+		return &keyAttributes
+	} else {
+		return nil
+	}
+}
+
+func buildParamsFromJson(quals plugin.KeyColumnQualMap, qualName string) (map[string]string, error) {
+	var parsed map[string]string
+
+	if quals[qualName] != nil {
+		for _, q := range quals[qualName].Quals {
+			value := q.Value.GetJsonbValue()
+			if value == "" || q.Operator != "=" {
+				continue
+			}
+
+			err := json.Unmarshal([]byte(value), &parsed)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return parsed, nil
+}
+
+func getSloArn(_ context.Context, _ *plugin.QueryData, h *plugin.HydrateData) (*string, error) {
+	if h.Item != nil {
+		switch item := h.Item.(type) {
+		case *types.ServiceLevelObjective:
+			return item.Arn, nil
+		case types.ServiceLevelObjectiveSummary:
+			return item.Arn, nil
+		}
+	}
+	return nil, nil
+}

--- a/docs/tables/aws_application_signals_service_level_objective.md
+++ b/docs/tables/aws_application_signals_service_level_objective.md
@@ -1,0 +1,44 @@
+---
+title: "Steampipe Table: aws_application_signals_service_level_objective - Query AWS CloudWatch Application Signals Service Level Objectives using SQL"
+description: "Allows users to query AWS CloudWatch Application Signals for information about their service level objectives."
+folder: "Application Signals"
+---
+
+# Table: aws_application_signals_service_level_objective - Query AWS CloudWatch Application Signals Service Level Objectives using SQL
+
+The AWS CloudWatch Application Signals is a service that allows you to monitor and improve application performance.
+
+## Table Usage Guide
+
+The `aws_application_signals_service_level_objective` table in Steampipe provides you with information about CloudWatch
+Application Signals service level objectives. This table allows you, as a DevOps engineer, to configure service level
+objectives based on a variety of metrics and monitor your applications' performance. You can utilize this table to
+manage and monitor service level objectives of your applications. The schema outlines the various attributes of the
+service level objectives for you, including their metric sources and alarm thresholds.
+
+## Examples
+
+### Fetch Service Level Objectives Based on CloudWatch Metrics
+Fetch service level objectives configured based on CloudWatch metrics.
+
+```sql+postgres
+select
+  name,
+  burn_rate_configurations,
+  goal
+from
+  aws_application_signals_slo
+where
+  metric_source_type = 'CloudWatchMetric'
+```
+
+```sql+sqlite
+select
+  name,
+  burn_rate_configurations,
+  goal
+from
+  aws_application_signals_slo
+where
+  metric_source_type = 'CloudWatchMetric'
+```

--- a/docs/tables/aws_application_signals_service_level_objective.md
+++ b/docs/tables/aws_application_signals_service_level_objective.md
@@ -1,0 +1,73 @@
+---
+title: "Steampipe Table: aws_application_signals_service_level_objective - Query AWS CloudWatch Application Signals Service Level Objectives using SQL"
+description: "Allows users to query AWS CloudWatch Application Signals for information about their service level objectives."
+folder: "Application Signals"
+---
+
+# Table: aws_application_signals_service_level_objective - Query AWS CloudWatch Application Signals Service Level Objectives using SQL
+
+The AWS CloudWatch Application Signals is a service that allows you to monitor and improve application performance.
+
+## Table Usage Guide
+
+The `aws_application_signals_service_level_objective` table in Steampipe provides you with information about CloudWatch
+Application Signals service level objectives. This table allows you, as a DevOps engineer, to configure service level
+objectives based on a variety of metrics and monitor your applications' performance. You can utilize this table to
+manage and monitor service level objectives of your applications. The schema outlines the various attributes of the
+service level objectives for you, including their metric sources and alarm thresholds.
+
+## Examples
+
+### Basic info
+Explore the basic details of your service level objectives, including their evaluation type, creation time, and description. This helps you get an overview of the SLOs configured in your environment and understand how each one is set up.
+
+```sql+postgres
+select
+  name,
+  arn,
+  evaluation_type,
+  metric_source_type,
+  created_time,
+  last_updated_time,
+  description
+from
+  aws_application_signals_service_level_objective;
+```
+
+```sql+sqlite
+select
+  name,
+  arn,
+  evaluation_type,
+  metric_source_type,
+  created_time,
+  last_updated_time,
+  description
+from
+  aws_application_signals_service_level_objective;
+```
+
+### List service level objectives based on CloudWatch metrics
+List service level objectives configured based on CloudWatch metrics.
+
+```sql+postgres
+select
+  name,
+  burn_rate_configurations,
+  goal
+from
+  aws_application_signals_service_level_objective
+where
+  metric_source_type = 'CloudWatchMetric';
+```
+
+```sql+sqlite
+select
+  name,
+  burn_rate_configurations,
+  goal
+from
+  aws_application_signals_service_level_objective
+where
+  metric_source_type = 'CloudWatchMetric';
+```

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/turbot/steampipe-plugin-aws
 go 1.26.0
 
 require (
-	github.com/aws/aws-sdk-go-v2 v1.41.6
+	github.com/aws/aws-sdk-go-v2 v1.41.11
 	github.com/aws/aws-sdk-go-v2/config v1.32.12
 	github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.21
 	github.com/aws/aws-sdk-go-v2/service/accessanalyzer v1.29.1
@@ -145,7 +145,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/wafv2 v1.48.2
 	github.com/aws/aws-sdk-go-v2/service/wellarchitected v1.29.4
 	github.com/aws/aws-sdk-go-v2/service/workspaces v1.38.4
-	github.com/aws/smithy-go v1.25.0
+	github.com/aws/smithy-go v1.27.0
 	github.com/gocarina/gocsv v0.0.0-20201208093247-67c824bc04d4
 	github.com/goccy/go-yaml v1.11.3
 	github.com/golang/protobuf v1.5.4
@@ -168,6 +168,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.55.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/aws/aws-sdk-go-v2/credentials v1.19.12 // indirect
+	github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.4 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
 	github.com/cncf/xds/go v0.0.0-20251210132809-ee656c7534f5 // indirect
 	github.com/envoyproxy/go-control-plane/envoy v1.36.0 // indirect
@@ -197,8 +198,8 @@ require (
 	github.com/apparentlymart/go-textseg/v15 v15.0.0 // indirect
 	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 // indirect
 	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.18.20 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.27 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.27 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 // indirect
 	github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.13.7 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,6 +78,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/aws/aws-sdk-go-v2 v1.41.6 h1:1AX0AthnBQzMx1vbmir3Y4WsnJgiydmnJjiLu+LvXOg=
 github.com/aws/aws-sdk-go-v2 v1.41.6/go.mod h1:dy0UzBIfwSeot4grGvY1AqFWN5zgziMmWGzysDnHFcQ=
+github.com/aws/aws-sdk-go-v2 v1.41.11 h1:9PRf7jyTMEUM6fuNRAJa2mO/skJfrF50rENJwf2LXqw=
+github.com/aws/aws-sdk-go-v2 v1.41.11/go.mod h1:iiUX27gOXRuYaoeUVXhUpPwjJHzISfPAjjcuhUbLSVs=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8 h1:eBMB84YGghSocM7PsjmmPffTa+1FBUeNvGvFou6V/4o=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.8/go.mod h1:lyw7GFp3qENLh7kwzf7iMzAxDn+NzjXEAGjKS2UOKqI=
 github.com/aws/aws-sdk-go-v2/config v1.32.12 h1:O3csC7HUGn2895eNrLytOJQdoL2xyJy0iYXhoZ1OmP0=
@@ -90,8 +92,12 @@ github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.21 h1:1v8Ii0MRVGYB/sdhkbxr
 github.com/aws/aws-sdk-go-v2/feature/s3/manager v1.16.21/go.mod h1:cxdd1rc8yxCjKz28hi30XN1jDXr2DxZvD44vLxTz/bg=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22 h1:GmLa5Kw1ESqtFpXsx5MmC84QWa/ZrLZvlJGa2y+4kcQ=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.22/go.mod h1:6sW9iWm9DK9YRpRGga/qzrzNLgKpT2cIxb7Vo2eNOp0=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.27 h1:8sPbKi1/KRHwl5oR3qN9mUXestCeHuaRutxylnr/eVY=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.4.27/go.mod h1:QV9IVIopJ1dpQUno0f9VYDUwOEjj8u0iEJ4JiZVre3Y=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22 h1:dY4kWZiSaXIzxnKlj17nHnBcXXBfac6UlsAx2qL6XrU=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.22/go.mod h1:KIpEUx0JuRZLO7U6cbV204cWAEco2iC3l061IxlwLtI=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.27 h1:9d8AoASQY9UwrOSmiJ7uSM0MGUPFhnenwSvpaFfat2c=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.7.27/go.mod h1:x0rldpsnUQaQIs4Rh+Vwm9Z/0vI6BxadGtsgJfZFb8s=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6 h1:qYQ4pzQ2Oz6WpQ8T3HvGHnZydA72MnLuFK9tJwmrbHw=
 github.com/aws/aws-sdk-go-v2/internal/ini v1.8.6/go.mod h1:O3h0IK87yXci+kg6flUKzJnWeziQUKciKrLjcatSNcY=
 github.com/aws/aws-sdk-go-v2/internal/v4a v1.4.22 h1:rWyie/PxDRIdhNf4DzRk0lvjVOqFJuNnO8WwaIRVxzQ=
@@ -114,6 +120,8 @@ github.com/aws/aws-sdk-go-v2/service/appconfig v1.29.2 h1:Nm1Pqug23c/Ib+/FgwYpFZ
 github.com/aws/aws-sdk-go-v2/service/appconfig v1.29.2/go.mod h1:Z4uxjsQCQYIZQYOf5js8AN9B5ZCFfwRkEHuiihgjHWs=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.27.4 h1:QGG9y+wEdP5KpTbcvpi8ETAoMq0zB6UJdqJ3JmVu/Wc=
 github.com/aws/aws-sdk-go-v2/service/applicationautoscaling v1.27.4/go.mod h1:g7O+8ghAn49ysZShSpeOxIRiI0/BgPoqHwZFNKnykco=
+github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.4 h1:ihlizMnsipF93eJ0T8KbCtdZELyqJ3vldLnGHbxyhrw=
+github.com/aws/aws-sdk-go-v2/service/applicationsignals v1.22.4/go.mod h1:+CBWFMpICQmClrhgTQFQU8P8veUu/yfTEALg8I8W70Y=
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.28.8 h1:vTSRA431Gi6tQcUDfCTF1PwnLvw7M+7SoMWb0FRvKAY=
 github.com/aws/aws-sdk-go-v2/service/apprunner v1.28.8/go.mod h1:0ClIRoMxROYgDXb/kSvAsZSO41p4j9p4xkquAFzNEjM=
 github.com/aws/aws-sdk-go-v2/service/appstream v1.34.4 h1:chEtg7jpLbd+wzNEZR5Y7if5S3+zCL4HO892dk4JRHI=
@@ -394,6 +402,8 @@ github.com/aws/aws-sdk-go-v2/service/workspaces v1.38.4 h1:SvHYikdxmnyptMebU3zFf
 github.com/aws/aws-sdk-go-v2/service/workspaces v1.38.4/go.mod h1:1XK49PATLHBd7mpKqO91GqRuV7bEsmyQ8Lslvn3fFj4=
 github.com/aws/smithy-go v1.25.0 h1:Sz/XJ64rwuiKtB6j98nDIPyYrV1nVNJ4YU74gttcl5U=
 github.com/aws/smithy-go v1.25.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
+github.com/aws/smithy-go v1.27.0 h1:ZoFioDKJxkSIW2otF9T0aPtNlUwhdVCcuZh/rzH9Hus=
+github.com/aws/smithy-go v1.27.0/go.mod h1:YE2RhdIuDbA5E5bTdciG9KrW3+TiEONeUWCqxX9i1Fc=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
# Integration test logs
Not applicable due to lack of Terraform support for Application Signals service level objectives.

# Example query results
<details>
  <summary>Results</summary>

```
> select * from aws_application_signals_service_level_objective
+----------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------+----------------------+-------------+-----------------+----------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------+----------------------+--------------------+-------------------------------------------------+--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+-------------------+-------------------------------------------------------------------------------------------------------------+-----------------+--------------------------+-----------------+-----------------------+------------------------+---------------------------+---------------------------------------------------------------------+----------+-------------------+----------+----------------+-----------------+---------------+------------------------------+--------------------------+-------------------------+--------------------------+-----------+----------------+------------+--------------------+----------------------------------------------------------------+----------------------------------------------------------------+
| arn                                                                                                      | burn_rate_configurations                                                                    | created_time         | description | evaluation_type | goal                                                                                                     | id                                                                                                       | last_updated_time    | metric_source_type | name                                            | operation_name           | request_based_sli                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                | sli    | tags              | dependency_config                                                                                           | dependency_type | dependency_resource_type | dependency_name | dependency_identifier | dependency_environment | dependency_operation_name | key_attributes                                                      | slo_type | slo_resource_type | slo_name | slo_identifier | slo_environment | metric_source | metric_source_key_attributes | metric_source_attributes | include_linked_accounts | slo_owner_aws_account_id | partition | region         | account_id | sp_connection_name | sp_ctx                                                         | _ctx                                                           |
+----------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------+----------------------+-------------+-----------------+----------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------+----------------------+--------------------+-------------------------------------------------+--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+-------------------+-------------------------------------------------------------------------------------------------------------+-----------------+--------------------------+-----------------+-----------------------+------------------------+---------------------------+---------------------------------------------------------------------+----------+-------------------+----------+----------------+-----------------+---------------+------------------------------+--------------------------+-------------------------+--------------------------+-----------+----------------+------------+--------------------+----------------------------------------------------------------+----------------------------------------------------------------+
| arn:aws:application-signals:ap-southeast-1:<omitted>:slo/is-this-metric-source                           | <null>                                                                                      | 2026-05-07T06:20:11Z | <null>      | RequestBased    | {"AttainmentGoal":99.9,"Interval":{"Value":{"Duration":1,"DurationUnit":"DAY"}},"WarningThreshold":50}   | arn:aws:application-signals:ap-southeast-1:<omitted>:slo/is-this-metric-source                           | 2026-05-07T06:20:11Z | CloudWatchMetric   | is-this-metric-source                           | <null>                   | {"ComparisonOperator":"","MetricThreshold":null,"RequestBasedSliMetric":{"CompositeSliConfig":null,"DependencyConfig":null,"KeyAttributes":null,"MetricSource":null,"MetricType":"","MonitoredRequestCountMetric":{"Value":[{"AccountId":null,"Expression":null,"Id":"cwMetricNumerator","Label":null,"MetricStat":{"Metric":{"Dimensions":null,"MetricName":"Errors","Namespace":"AWS/Lambda"},"Period":300,"Stat":"Average","Unit":""},"Period":null,"ReturnData":true}]},"OperationName":null,"TotalRequestCountMetric":[{"AccountId":null,"Expression":null,"Id":"cwMetricDenominator","Label":null,"MetricStat":{"Metric":{"Dimensions":null,"MetricName":"Invocations","Namespace":"AWS/Lambda"},"Period":300,"Stat":"Average","Unit":""},"Period":null,"ReturnData":true}]}}                                                                                                                                                                                                                                                                              | <null> | {}                | <null>                                                                                                      | <null>          | <null>                   | <null>          | <null>                | <null>                 | <null>                    | <null>                                                              | <null>   | <null>            | <null>   | <null>         | <null>          | <null>        | <null>                       | <null>                   | <null>                  | <null>                   | aws       | ap-southeast-1 | <omitted>  | aws                | {"connection_name":"aws","steampipe":{"sdk_version":"5.14.0"}} | {"connection_name":"aws","steampipe":{"sdk_version":"5.14.0"}} |
| arn:aws:application-signals:ap-southeast-1:<omitted>:slo/slo-test--all-operations--AVAILABILITY-97f9c797 | [{"LookBackWindowMinutes":60},{"LookBackWindowMinutes":360},{"LookBackWindowMinutes":4320}] | 2026-05-05T02:54:51Z | <null>      | RequestBased    | {"AttainmentGoal":99,"Interval":{"Value":{"Duration":28,"DurationUnit":"DAY"}},"WarningThreshold":50}    | arn:aws:application-signals:ap-southeast-1:<omitted>:slo/slo-test--all-operations--AVAILABILITY-97f9c797 | 2026-05-10T15:40:36Z | ServiceDependency  | slo-test--all-operations--AVAILABILITY-97f9c797 | <null>                   | {"ComparisonOperator":"","MetricThreshold":null,"RequestBasedSliMetric":{"CompositeSliConfig":null,"DependencyConfig":{"DependencyKeyAttributes":{"Name":"example.com","Type":"RemoteService"},"DependencyOperationName":"GET /"},"KeyAttributes":{"Environment":"lambda:default","Name":"slo-test","Type":"Service"},"MetricSource":null,"MetricType":"AVAILABILITY","MonitoredRequestCountMetric":{"Value":[{"AccountId":null,"Expression":"volume_53c54ce9510d4628bfafdb2d2c6bce86 - fault_53c54ce9510d4628bfafdb2d2c6bce86","Id":"availability_53c54ce9510d4628bfafdb2d2c6bce86","Label":null,"MetricStat":null,"Period":60,"ReturnData":true},{"AccountId":null,"Expression":null,"Id":"volume_53c54ce9510d4628bfafdb2d2c6bce86","Label":null,"MetricStat":{"Metric":{"Dimensions":[{"Name":"Service","Value":"slo-test"},{"Name":"RemoteService","Value":"example.com"},{"Name":"Environment","Value":"lambda:default"},{"Name":"RemoteOperation","Value":"GET /"}],"MetricName":"Latency","Namespace":"ApplicationSignals"},"Period":60,"Stat":"SampleCou | <null> | {"hello":"world"} | {"DependencyKeyAttributes":{"Name":"example.com","Type":"RemoteService"},"DependencyOperationName":"GET /"} | RemoteService   | <null>                   | example.com     | <null>                | <null>                 | GET /                     | {"Environment":"lambda:default","Name":"slo-test","Type":"Service"} | Service  | <null>            | slo-test | <null>         | lambda:default  | <null>        | <null>                       | <null>                   | <null>                  | <null>                   | aws       | ap-southeast-1 | <omitted>  | aws                | {"connection_name":"aws","steampipe":{"sdk_version":"5.14.0"}} | {"connection_name":"aws","steampipe":{"sdk_version":"5.14.0"}} |
|                                                                                                          |                                                                                             |                      |             |                 |                                                                                                          |                                                                                                          |                      |                    |                                                 |                          | nt","Unit":""},"Period":null,"ReturnData":false},{"AccountId":null,"Expression":null,"Id":"fault_53c54ce9510d4628bfafdb2d2c6bce86","Label":null,"MetricStat":{"Metric":{"Dimensions":[{"Name":"Service","Value":"slo-test"},{"Name":"RemoteService","Value":"example.com"},{"Name":"Environment","Value":"lambda:default"},{"Name":"RemoteOperation","Value":"GET /"}],"MetricName":"Fault","Namespace":"ApplicationSignals"},"Period":60,"Stat":"Sum","Unit":""},"Period":null,"ReturnData":false}]},"OperationName":null,"TotalRequestCountMetric":[{"AccountId":null,"Expression":null,"Id":"totalCount_53c54ce9510d4628bfafdb2d2c6bce86","Label":null,"MetricStat":{"Metric":{"Dimensions":[{"Name":"Service","Value":"slo-test"},{"Name":"RemoteService","Value":"example.com"},{"Name":"Environment","Value":"lambda:default"},{"Name":"RemoteOperation","Value":"GET /"}],"MetricName":"Latency","Namespace":"ApplicationSignals"},"Period":60,"Stat":"SampleCount","Unit":""},"Period":null,"ReturnData":true}]}}                                        |        |                   |                                                                                                             |                 |                          |                 |                       |                        |                           |                                                                     |          |                   |          |                |                 |               |                              |                          |                         |                          |           |                |            |                    |                                                                |                                                                |
| arn:aws:application-signals:ap-southeast-1:<omitted>:slo/slo-test-FunctionHandler-AVAILABILITY-9cd96247  | [{"LookBackWindowMinutes":60},{"LookBackWindowMinutes":360},{"LookBackWindowMinutes":4320}] | 2026-05-05T02:37:18Z | <null>      | RequestBased    | {"AttainmentGoal":99.99,"Interval":{"Value":{"Duration":28,"DurationUnit":"DAY"}},"WarningThreshold":50} | arn:aws:application-signals:ap-southeast-1:<omitted>:slo/slo-test-FunctionHandler-AVAILABILITY-9cd96247  | 2026-05-05T02:37:18Z | ServiceOperation   | slo-test-FunctionHandler-AVAILABILITY-9cd96247  | slo-test/FunctionHandler | {"ComparisonOperator":"","MetricThreshold":null,"RequestBasedSliMetric":{"CompositeSliConfig":null,"DependencyConfig":null,"KeyAttributes":{"Environment":"lambda:default","Name":"slo-test","Type":"Service"},"MetricSource":null,"MetricType":"AVAILABILITY","MonitoredRequestCountMetric":{"Value":[{"AccountId":null,"Expression":"volume_4192d9bf3ffb408fae6d96879520bb38 - fault_4192d9bf3ffb408fae6d96879520bb38","Id":"availability_4192d9bf3ffb408fae6d96879520bb38","Label":null,"MetricStat":null,"Period":60,"ReturnData":true},{"AccountId":null,"Expression":null,"Id":"volume_4192d9bf3ffb408fae6d96879520bb38","Label":null,"MetricStat":{"Metric":{"Dimensions":[{"Name":"Service","Value":"slo-test"},{"Name":"Environment","Value":"lambda:default"},{"Name":"Operation","Value":"slo-test/FunctionHandler"}],"MetricName":"Latency","Namespace":"ApplicationSignals"},"Period":60,"Stat":"SampleCount","Unit":""},"Period":null,"ReturnData":false},{"AccountId":null,"Expression":null,"Id":"fault_4192d9bf3ffb408fae6d96879520bb38","Label | <null> | {}                | <null>                                                                                                      | <null>          | <null>                   | <null>          | <null>                | <null>                 | <null>                    | {"Environment":"lambda:default","Name":"slo-test","Type":"Service"} | Service  | <null>            | slo-test | <null>         | lambda:default  | <null>        | <null>                       | <null>                   | <null>                  | <null>                   | aws       | ap-southeast-1 | <omitted>  | aws                | {"connection_name":"aws","steampipe":{"sdk_version":"5.14.0"}} | {"connection_name":"aws","steampipe":{"sdk_version":"5.14.0"}} |
|                                                                                                          |                                                                                             |                      |             |                 |                                                                                                          |                                                                                                          |                      |                    |                                                 |                          | ":null,"MetricStat":{"Metric":{"Dimensions":[{"Name":"Service","Value":"slo-test"},{"Name":"Environment","Value":"lambda:default"},{"Name":"Operation","Value":"slo-test/FunctionHandler"}],"MetricName":"Fault","Namespace":"ApplicationSignals"},"Period":60,"Stat":"Sum","Unit":""},"Period":null,"ReturnData":false}]},"OperationName":"slo-test/FunctionHandler","TotalRequestCountMetric":[{"AccountId":null,"Expression":null,"Id":"totalCount_4192d9bf3ffb408fae6d96879520bb38","Label":null,"MetricStat":{"Metric":{"Dimensions":[{"Name":"Service","Value":"slo-test"},{"Name":"Environment","Value":"lambda:default"},{"Name":"Operation","Value":"slo-test/FunctionHandler"}],"MetricName":"Latency","Namespace":"ApplicationSignals"},"Period":60,"Stat":"SampleCount","Unit":""},"Period":null,"ReturnData":true}]}}                                                                                                                                                                                                                               |        |                   |                                                                                                             |                 |                          |                 |                       |                        |                           |                                                                     |          |                   |          |                |                 |               |                              |                          |                         |                          |           |                |            |                    |                                                                |                                                                |
+----------------------------------------------------------------------------------------------------------+---------------------------------------------------------------------------------------------+----------------------+-------------+-----------------+----------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------+----------------------+--------------------+-------------------------------------------------+--------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+--------+-------------------+-------------------------------------------------------------------------------------------------------------+-----------------+--------------------------+-----------------+-----------------------+------------------------+---------------------------+---------------------------------------------------------------------+----------+-------------------+----------+----------------+-----------------+---------------+------------------------------+--------------------------+-------------------------+--------------------------+-----------+----------------+------------+--------------------+----------------------------------------------------------------+----------------------------------------------------------------+
```
</details>
