### PR TITLE
feat: Add `presigned_url` column and `start_after` pagination to `aws_s3_object`

### DIFF
--- a/aws/table_aws_s3_object.go
+++ b/aws/table_aws_s3_object.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"io"
 	"strings"
-	"time"
 	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -27,7 +26,7 @@ func tableAwsS3Object(_ context.Context) *plugin.Table {
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "bucket_name", Require: plugin.Required, CacheMatch: query_cache.CacheMatchExact},
 				{Name: "prefix", Require: plugin.Optional, CacheMatch: query_cache.CacheMatchExact},
-				{Name: "start_after", Require: plugin.Optional},
+				{Name: "start_after", Require: plugin.Optional, CacheMatch: query_cache.CacheMatchExact},
 
 				// If you encrypt an object by using server-side encryption with customer-provided
 				// encryption keys (SSE-C) when you store the object in Amazon S3, then when you
@@ -35,9 +34,6 @@ func tableAwsS3Object(_ context.Context) *plugin.Table {
 				{Name: "sse_customer_algorithm", Require: plugin.Optional},
 				{Name: "sse_customer_key", Require: plugin.Optional, CacheMatch: query_cache.CacheMatchExact},
 				{Name: "sse_customer_key_md5", Require: plugin.Optional},
-
-				// Presigned URL expiration in seconds (default: 900)
-				{Name: "presigned_url_expires_in", Require: plugin.Optional},
 			},
 		},
 
@@ -71,10 +67,6 @@ func tableAwsS3Object(_ context.Context) *plugin.Table {
 				Depends: []plugin.HydrateFunc{getBucketRegionForObjects},
 				Tags:    map[string]string{"service": "s3", "action": "GetObjectTagging"},
 			},
-			{
-				Func: getS3ObjectPresignedURL,
-				Tags: map[string]string{"service": "s3", "action": "PresignGetObject"},
-			},
 		},
 		Columns: awsAccountColumns([]*plugin.Column{
 			{
@@ -97,7 +89,7 @@ func tableAwsS3Object(_ context.Context) *plugin.Table {
 			},
 			{
 				Name:        "start_after",
-				Description: "When set, listing starts after this key in lexicographic order. Use the last key from a previous LIMIT query to paginate. Only works with default key ordering (no ORDER BY).",
+				Description: "Amazon S3 starts listing after this specified key. StartAfter can be any key in the bucket.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromQual("start_after"),
 			},
@@ -346,19 +338,6 @@ func tableAwsS3Object(_ context.Context) *plugin.Table {
 				Hydrate:     headS3Object,
 			},
 			{
-				Name:        "presigned_url",
-				Description: "A presigned URL for the object that can be used to download it without authentication. Use presigned_url_expires_in to control expiration (default 900 seconds).",
-				Type:        proto.ColumnType_STRING,
-				Transform:   transform.FromValue(),
-				Hydrate:     getS3ObjectPresignedURL,
-			},
-			{
-				Name:        "presigned_url_expires_in",
-				Description: "The duration in seconds for which the presigned URL is valid. Default is 900 seconds (15 minutes).",
-				Type:        proto.ColumnType_INT,
-				Transform:   transform.FromQual("presigned_url_expires_in"),
-			},
-			{
 				Name:        "acl",
 				Description: "ACLs define which AWS accounts or groups are granted access along with the type of access.",
 				Type:        proto.ColumnType_JSON,
@@ -457,8 +436,6 @@ func listS3Objects(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 		return nil, err
 	}
 
-	equalQuals := d.EqualsQuals
-
 	// default supported max value is 1000 by ListObjectsV2
 	maxItems := int32(1000)
 
@@ -477,6 +454,7 @@ func listS3Objects(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 		FetchOwner: aws.Bool(true),
 	}
 
+	equalQuals := d.EqualsQuals
 	if equalQuals["prefix"] != nil {
 		if equalQuals["prefix"].GetStringValue() != "" {
 			input.Prefix = aws.String(equalQuals["prefix"].GetStringValue())
@@ -792,47 +770,6 @@ func isOutpostObject(storageClass string) bool {
 	// S3 on Outposts provides a new storage class, OUTPOSTS
 	// as in https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html
 	return strings.EqualFold(storageClass, "OUTPOSTS")
-}
-
-func getS3ObjectPresignedURL(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
-	bucketName := d.EqualsQuals["bucket_name"].GetStringValue()
-
-	bucketRegion, err := doGetBucketRegion(ctx, d, h, bucketName)
-	if err != nil {
-		return nil, err
-	}
-	if bucketRegion == "" {
-		return nil, nil
-	}
-
-	svc, err := S3Client(ctx, d, bucketRegion)
-	if err != nil {
-		plugin.Logger(ctx).Error("aws_s3_object.getS3ObjectPresignedURL", "client_error", err)
-		return nil, err
-	}
-
-	object := h.Item.(types.Object)
-
-	// Default expiration: 900 seconds (15 minutes)
-	expires := time.Duration(900) * time.Second
-	if d.EqualsQuals["presigned_url_expires_in"] != nil {
-		expiresIn := d.EqualsQuals["presigned_url_expires_in"].GetInt64Value()
-		if expiresIn > 0 {
-			expires = time.Duration(expiresIn) * time.Second
-		}
-	}
-
-	presignClient := s3.NewPresignClient(svc)
-	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
-		Bucket: aws.String(bucketName),
-		Key:    object.Key,
-	}, s3.WithPresignExpires(expires))
-	if err != nil {
-		plugin.Logger(ctx).Error("aws_s3_object.getS3ObjectPresignedURL", "api_error", err)
-		return nil, err
-	}
-
-	return presignedReq.URL, nil
 }
 
 //// TRANSFORM FUNCTIONS

--- a/aws/table_aws_s3_object.go
+++ b/aws/table_aws_s3_object.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"io"
 	"strings"
+	"time"
 	"unicode/utf8"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -26,6 +27,7 @@ func tableAwsS3Object(_ context.Context) *plugin.Table {
 			KeyColumns: []*plugin.KeyColumn{
 				{Name: "bucket_name", Require: plugin.Required, CacheMatch: query_cache.CacheMatchExact},
 				{Name: "prefix", Require: plugin.Optional, CacheMatch: query_cache.CacheMatchExact},
+				{Name: "start_after", Require: plugin.Optional},
 
 				// If you encrypt an object by using server-side encryption with customer-provided
 				// encryption keys (SSE-C) when you store the object in Amazon S3, then when you
@@ -33,6 +35,9 @@ func tableAwsS3Object(_ context.Context) *plugin.Table {
 				{Name: "sse_customer_algorithm", Require: plugin.Optional},
 				{Name: "sse_customer_key", Require: plugin.Optional, CacheMatch: query_cache.CacheMatchExact},
 				{Name: "sse_customer_key_md5", Require: plugin.Optional},
+
+				// Presigned URL expiration in seconds (default: 900)
+				{Name: "presigned_url_expires_in", Require: plugin.Optional},
 			},
 		},
 
@@ -66,6 +71,10 @@ func tableAwsS3Object(_ context.Context) *plugin.Table {
 				Depends: []plugin.HydrateFunc{getBucketRegionForObjects},
 				Tags:    map[string]string{"service": "s3", "action": "GetObjectTagging"},
 			},
+			{
+				Func: getS3ObjectPresignedURL,
+				Tags: map[string]string{"service": "s3", "action": "PresignGetObject"},
+			},
 		},
 		Columns: awsAccountColumns([]*plugin.Column{
 			{
@@ -85,6 +94,12 @@ func tableAwsS3Object(_ context.Context) *plugin.Table {
 				Description: "The name of the container bucket of this object.",
 				Type:        proto.ColumnType_STRING,
 				Transform:   transform.FromQual("bucket_name"),
+			},
+			{
+				Name:        "start_after",
+				Description: "When set, listing starts after this key in lexicographic order. Use the last key from a previous LIMIT query to paginate. Only works with default key ordering (no ORDER BY).",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromQual("start_after"),
 			},
 			{
 				Name:        "last_modified",
@@ -331,6 +346,19 @@ func tableAwsS3Object(_ context.Context) *plugin.Table {
 				Hydrate:     headS3Object,
 			},
 			{
+				Name:        "presigned_url",
+				Description: "A presigned URL for the object that can be used to download it without authentication. Use presigned_url_expires_in to control expiration (default 900 seconds).",
+				Type:        proto.ColumnType_STRING,
+				Transform:   transform.FromValue(),
+				Hydrate:     getS3ObjectPresignedURL,
+			},
+			{
+				Name:        "presigned_url_expires_in",
+				Description: "The duration in seconds for which the presigned URL is valid. Default is 900 seconds (15 minutes).",
+				Type:        proto.ColumnType_INT,
+				Transform:   transform.FromQual("presigned_url_expires_in"),
+			},
+			{
 				Name:        "acl",
 				Description: "ACLs define which AWS accounts or groups are granted access along with the type of access.",
 				Type:        proto.ColumnType_JSON,
@@ -429,6 +457,8 @@ func listS3Objects(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 		return nil, err
 	}
 
+	equalQuals := d.EqualsQuals
+
 	// default supported max value is 1000 by ListObjectsV2
 	maxItems := int32(1000)
 
@@ -447,10 +477,15 @@ func listS3Objects(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 		FetchOwner: aws.Bool(true),
 	}
 
-	equalQuals := d.EqualsQuals
 	if equalQuals["prefix"] != nil {
 		if equalQuals["prefix"].GetStringValue() != "" {
 			input.Prefix = aws.String(equalQuals["prefix"].GetStringValue())
+		}
+	}
+
+	if equalQuals["start_after"] != nil {
+		if equalQuals["start_after"].GetStringValue() != "" {
+			input.StartAfter = aws.String(equalQuals["start_after"].GetStringValue())
 		}
 	}
 
@@ -473,13 +508,14 @@ func listS3Objects(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateDa
 				return nil, nil
 			}
 		}
+
 		input.ContinuationToken = objects.NextContinuationToken
 		if objects.NextContinuationToken == nil {
 			break
 		}
 	}
 
-	return nil, err
+	return nil, nil
 }
 
 func getS3Object(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
@@ -756,6 +792,47 @@ func isOutpostObject(storageClass string) bool {
 	// S3 on Outposts provides a new storage class, OUTPOSTS
 	// as in https://docs.aws.amazon.com/AmazonS3/latest/userguide/S3onOutposts.html
 	return strings.EqualFold(storageClass, "OUTPOSTS")
+}
+
+func getS3ObjectPresignedURL(ctx context.Context, d *plugin.QueryData, h *plugin.HydrateData) (interface{}, error) {
+	bucketName := d.EqualsQuals["bucket_name"].GetStringValue()
+
+	bucketRegion, err := doGetBucketRegion(ctx, d, h, bucketName)
+	if err != nil {
+		return nil, err
+	}
+	if bucketRegion == "" {
+		return nil, nil
+	}
+
+	svc, err := S3Client(ctx, d, bucketRegion)
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_s3_object.getS3ObjectPresignedURL", "client_error", err)
+		return nil, err
+	}
+
+	object := h.Item.(types.Object)
+
+	// Default expiration: 900 seconds (15 minutes)
+	expires := time.Duration(900) * time.Second
+	if d.EqualsQuals["presigned_url_expires_in"] != nil {
+		expiresIn := d.EqualsQuals["presigned_url_expires_in"].GetInt64Value()
+		if expiresIn > 0 {
+			expires = time.Duration(expiresIn) * time.Second
+		}
+	}
+
+	presignClient := s3.NewPresignClient(svc)
+	presignedReq, err := presignClient.PresignGetObject(ctx, &s3.GetObjectInput{
+		Bucket: aws.String(bucketName),
+		Key:    object.Key,
+	}, s3.WithPresignExpires(expires))
+	if err != nil {
+		plugin.Logger(ctx).Error("aws_s3_object.getS3ObjectPresignedURL", "api_error", err)
+		return nil, err
+	}
+
+	return presignedReq.URL, nil
 }
 
 //// TRANSFORM FUNCTIONS

--- a/docs/tables/aws_s3_object.md
+++ b/docs/tables/aws_s3_object.md
@@ -15,6 +15,7 @@ The `aws_s3_object` table in Steampipe provides you with information about objec
 **Important Notes**
 - You must specify a `bucket_name` in a where or join clause in order to use this table.
 - It's recommended that you specify the `prefix` column when querying buckets with a large number of objects to reduce the query time.
+- The `start_after` column can be used to continue listing objects after a known key. S3 applies `StartAfter` while listing keys in lexicographic order, so it is intended for continuing a listing from a known key, not for paginating arbitrary SQL result orderings.
 - The `body` column returns the raw bytes of the object data as a string. If the bytes entirely consist of valid UTF8 runes, e.g., `.txt files`, an UTF8 data will be set as column value and you will be able to query the object body ([refer example below](#get-data-details-of-a-particular-object-in-a-bucket)). However, for the invalid UTF8 runes, e.g., `.png files`, the bas64 encoding of the bytes will be set as column value and you will not be able to query the object body for those objects.
 - Using this table adds to the cost of your monthly bill from AWS. Optimizations have been put in place to minimize the impact as much as possible. You should refer to AWS S3 Pricing to understand the cost implications.
 - If you encrypt an object by using server-side encryption with customer-provided encryption keys (SSE-C) when you store the object in Amazon S3, then when you GET the object, you must use the following query parameter:
@@ -86,6 +87,41 @@ from
 where
   bucket_name = 'steampipe-test'
   and prefix = 'test/logs/2021/03/01/12';
+```
+
+### Continue listing objects after a known key
+Continue listing objects in a bucket after a known key. This can be useful when you have saved the last key from a previous listing and want to resume from the next object in S3's lexicographic key order.
+
+```sql+postgres
+select
+  key,
+  arn,
+  bucket_name,
+  last_modified,
+  storage_class,
+  version_id
+from
+  aws_s3_object
+where
+  bucket_name = 'steampipe-test'
+  and start_after = 'test/logs/2021/03/01/12/abc.txt'
+limit 100;
+```
+
+```sql+sqlite
+select
+  key,
+  arn,
+  bucket_name,
+  last_modified,
+  storage_class,
+  version_id
+from
+  aws_s3_object
+where
+  bucket_name = 'steampipe-test'
+  and start_after = 'test/logs/2021/03/01/12/abc.txt'
+limit 100;
 ```
 
 ### Get object with a `key` in a bucket


### PR DESCRIPTION
## Summary

Adds two enhancements to the `aws_s3_object` table:

- **`presigned_url` column** — generates a temporary pre-authenticated download URL for each object. Expiration is controlled via `presigned_url_expires_in` (default 900s / 15 minutes).
- **`start_after` column** — enables cursor-based pagination over large buckets. Maps directly to the S3 `ListObjectsV2` `StartAfter` parameter. Combined with `LIMIT`, allows efficient page-by-page traversal without loading the entire bucket.

## Usage examples

```sql
-- Generate presigned URLs (valid 1 hour)
select key, presigned_url
from aws_s3_object
where bucket_name = 'my-bucket'
  and prefix = 'reports/'
  and presigned_url_expires_in = 3600;

-- Paginate through a large bucket
select key from aws_s3_object
where bucket_name = 'huge-bucket' limit 1000;

-- Next page: use last key from previous result
select key from aws_s3_object
where bucket_name = 'huge-bucket'
  and start_after = 'last-key-from-previous-page'
limit 1000;
```

## Test plan

- [ ] `go build ./...` — compiles cleanly
- [ ] Query with `presigned_url` column returns valid, working URLs
- [ ] Query with `presigned_url_expires_in = 3600` generates URLs with correct expiry
- [ ] Query with `start_after` returns objects lexicographically after the specified key
- [ ] Query without new columns behaves identically to before (no regression)
- [ ] Presigned URL errors (e.g., insufficient permissions) return clean error, not panic