### PR TITLE
Extend `aws_ec2_ami` table with new fields

### DIFF
--- a/aws-test/tests/aws_ec2_ami/test-get-expected.json
+++ b/aws-test/tests/aws_ec2_ami/test-get-expected.json
@@ -5,6 +5,8 @@
       {
         "DeviceName":"/dev/sda1",
         "Ebs": {
+          "AvailabilityZone": null,
+          "AvailabilityZoneId": null,
           "DeleteOnTermination":true,
           "Encrypted":true,
           "Iops":null,
@@ -12,6 +14,7 @@
           "OutpostArn": null,
           "SnapshotId":"{{ output.snapshot_id.value }}",
           "Throughput": null,
+          "VolumeInitializationRate": null,
           "VolumeSize":8,
           "VolumeType":"standard"
         },
@@ -19,18 +22,24 @@
         "VirtualName":null
       }
     ],
+    "deregistration_protection": "disabled",
     "description": "This is a test image.",
     "ena_support": false,
+    "free_tier_eligible": true,
     "hypervisor": "xen",
+    "image_allowed": null,
     "image_id": "{{ output.resource_id.value }}",
     "image_location": "{{ output.account_id.value }}/{{resourceName}}",
     "image_type": "machine",
+    "last_launched_time": null,
     "name": "{{resourceName}}",
     "owner_id": "{{ output.account_id.value }}",
     "platform_details": "Linux/UNIX",
     "public": false,
     "root_device_name": "/dev/sda1",
     "root_device_type": "ebs",
+    "source_image_id": null,
+    "source_image_region": null,
     "sriov_net_support": "simple",
     "tags_src": [
       {

--- a/aws-test/tests/aws_ec2_ami/test-get-query.sql
+++ b/aws-test/tests/aws_ec2_ami/test-get-query.sql
@@ -1,3 +1,3 @@
-select name, image_id, image_type, image_location, architecture, description, ena_support, hypervisor, owner_id, platform_details, public, root_device_name, root_device_type, sriov_net_support, usage_operation, virtualization_type, block_device_mappings, tags_src
+select name, image_id, image_type, image_location, architecture, description, ena_support, hypervisor, owner_id, platform_details, public, root_device_name, root_device_type, sriov_net_support, usage_operation, virtualization_type, block_device_mappings, tags_src, deregistration_protection, free_tier_eligible, image_allowed, source_image_id, source_image_region, last_launched_time
 from aws.aws_ec2_ami
 where image_id = '{{ output.resource_id.value }}'

--- a/aws/table_aws_ec2_ami.go
+++ b/aws/table_aws_ec2_ami.go
@@ -105,6 +105,37 @@ func tableAwsEc2Ami(_ context.Context) *plugin.Table {
 				Transform:   transform.FromField("DeprecationTime").Transform(transform.NullIfZeroValue),
 			},
 			{
+				Name:        "last_launched_time",
+				Description: "The date and time, in ISO 8601 date-time format, when the AMI was last used to launch an EC2 instance. When the AMI is used to launch an instance, there is a 24-hour delay before that usage is reported.",
+				Type:        proto.ColumnType_TIMESTAMP,
+				Transform:   transform.FromField("LastLaunchedTime").Transform(transform.NullIfZeroValue),
+			},
+			{
+				Name:        "deregistration_protection",
+				Description: "Indicates whether deregistration protection is enabled for the AMI.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "free_tier_eligible",
+				Description: "Indicates whether the image is eligible for Amazon Web Services Free Tier.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "image_allowed",
+				Description: "If true, the AMI satisfies the criteria for Allowed AMIs and can be discovered and used in the account.",
+				Type:        proto.ColumnType_BOOL,
+			},
+			{
+				Name:        "source_image_id",
+				Description: "The ID of the source AMI from which the AMI was created. Only appears if the AMI was created using CreateImage, CopyImage, or CreateRestoreImageTask.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
+				Name:        "source_image_region",
+				Description: "The Region of the source AMI. Only appears if the AMI was created using CreateImage, CopyImage, or CreateRestoreImageTask.",
+				Type:        proto.ColumnType_STRING,
+			},
+			{
 				Name:        "architecture",
 				Description: "The architecture of the image.",
 				Type:        proto.ColumnType_STRING,

--- a/docs/tables/aws_ec2_ami.md
+++ b/docs/tables/aws_ec2_ami.md
@@ -98,6 +98,35 @@ where
   state = 'failed';
 ```
 
+### List AMIs not launched in the last 90 days
+Identify AMIs that haven't been used recently, helping you find candidates for deregistration to reduce storage costs and simplify your AMI inventory.
+
+```sql+postgres
+select
+  name,
+  image_id,
+  creation_date,
+  last_launched_time
+from
+  aws_ec2_ami
+where
+  last_launched_time < now() - interval '90 days'
+  or last_launched_time is null;
+```
+
+```sql+sqlite
+select
+  name,
+  image_id,
+  creation_date,
+  last_launched_time
+from
+  aws_ec2_ami
+where
+  last_launched_time < datetime('now', '-90 days')
+  or last_launched_time is null;
+```
+
 ### Get volume info for each AMI
 Explore the characteristics of each Amazon Machine Image (AMI), such as volume size and type, encryption status, and deletion policy. This information is vital for managing storage resources efficiently and ensuring data security within your AWS EC2 environment.
 


### PR DESCRIPTION
AWS has added a couple of fields to [DescribeImageOutput](https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/service/ec2#DescribeImageAttributeOutput), among them the time when an image was launch last, as well as AMI ancestor information. Add those fields to steampipe. 

# Integration test logs
<details>
  <summary>Logs</summary>

```
❯ node tint.js aws_ec2_ami
No env file present for the current environment:  staging 
 Falling back to .env config
No env file present for the current environment:  staging
customEnv TURBOT_TEST_EXPECTED_TIMEOUT undefined

SETUP: tests/aws_ec2_ami []

PRETEST: tests/aws_ec2_ami

TEST: tests/aws_ec2_ami
Running terraform
data.aws_partition.current: Reading...
data.aws_region.primary: Reading...
data.aws_caller_identity.current: Reading...
data.aws_partition.current: Read complete after 0s [id=aws]
data.aws_region.primary: Read complete after 0s [id=us-east-1]
data.aws_region.alternate: Reading...
data.aws_region.alternate: Read complete after 0s [id=us-east-2]
data.aws_caller_identity.current: Read complete after 0s [id=653879934003]

Terraform used the selected providers to generate the following execution
plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # aws_ami.named_test_resource will be created
  + resource "aws_ami" "named_test_resource" {
      + architecture         = "x86_64"
      + arn                  = (known after apply)
      + description          = "This is a test image."
      + hypervisor           = (known after apply)
      + id                   = (known after apply)
      + image_location       = (known after apply)
      + image_owner_alias    = (known after apply)
      + image_type           = (known after apply)
      + last_launched_time   = (known after apply)
      + manage_ebs_snapshots = (known after apply)
      + name                 = "turbottest40226"
      + owner_id             = (known after apply)
      + platform             = (known after apply)
      + platform_details     = (known after apply)
      + public               = (known after apply)
      + region               = "us-east-1"
      + root_device_name     = "/dev/sda1"
      + root_snapshot_id     = (known after apply)
      + sriov_net_support    = "simple"
      + tags                 = {
          + "Name" = "turbottest40226"
        }
      + tags_all             = {
          + "Name" = "turbottest40226"
        }
      + usage_operation      = (known after apply)
      + virtualization_type  = "hvm"

      + ebs_block_device {
          + delete_on_termination = true
          + device_name           = "/dev/sda1"
          + snapshot_id           = (known after apply)
          + throughput            = (known after apply)
          + volume_size           = 8
          + volume_type           = "standard"
            # (1 unchanged attribute hidden)
        }

      + ephemeral_block_device (known after apply)
    }

  # aws_ami_launch_permission.allow_access will be created
  + resource "aws_ami_launch_permission" "allow_access" {
      + account_id = "388460667113"
      + id         = (known after apply)
      + image_id   = (known after apply)
      + region     = "us-east-1"
    }

  # aws_ami_launch_permission.deny_access will be created
  + resource "aws_ami_launch_permission" "deny_access" {
      + account_id = "013122550996"
      + id         = (known after apply)
      + image_id   = (known after apply)
      + region     = "us-east-1"
    }

  # aws_ebs_snapshot.my_snapshot will be created
  + resource "aws_ebs_snapshot" "my_snapshot" {
      + arn                    = (known after apply)
      + data_encryption_key_id = (known after apply)
      + encrypted              = (known after apply)
      + id                     = (known after apply)
      + kms_key_id             = (known after apply)
      + owner_alias            = (known after apply)
      + owner_id               = (known after apply)
      + region                 = "us-east-1"
      + storage_tier           = (known after apply)
      + tags                   = {
          + "Name" = "turbot-snapshot-test"
        }
      + tags_all               = {
          + "Name" = "turbot-snapshot-test"
        }
      + volume_id              = (known after apply)
      + volume_size            = (known after apply)
    }

  # aws_ebs_volume.my_volume will be created
  + resource "aws_ebs_volume" "my_volume" {
      + arn               = (known after apply)
      + availability_zone = "us-east-1a"
      + create_time       = (known after apply)
      + encrypted         = true
      + final_snapshot    = false
      + id                = (known after apply)
      + iops              = (known after apply)
      + kms_key_id        = (known after apply)
      + region            = "us-east-1"
      + size              = 8
      + snapshot_id       = (known after apply)
      + tags              = {
          + "Name" = "turbot-volume-test"
        }
      + tags_all          = {
          + "Name" = "turbot-volume-test"
        }
      + throughput        = (known after apply)
      + type              = (known after apply)
    }

  # aws_kms_key.ebs_cmk will be created
  + resource "aws_kms_key" "ebs_cmk" {
      + arn                                = (known after apply)
      + bypass_policy_lockout_safety_check = false
      + customer_master_key_spec           = "SYMMETRIC_DEFAULT"
      + deletion_window_in_days            = 7
      + description                        = "CMK for EBS volume encryption"
      + enable_key_rotation                = false
      + id                                 = (known after apply)
      + is_enabled                         = true
      + key_id                             = (known after apply)
      + key_usage                          = "ENCRYPT_DECRYPT"
      + multi_region                       = (known after apply)
      + policy                             = (known after apply)
      + region                             = "us-east-1"
      + rotation_period_in_days            = (known after apply)
      + tags_all                           = (known after apply)
    }

  # aws_kms_key_policy.ebs_cmk_policy will be created
  + resource "aws_kms_key_policy" "ebs_cmk_policy" {
      + bypass_policy_lockout_safety_check = false
      + id                                 = (known after apply)
      + key_id                             = (known after apply)
      + policy                             = jsonencode(
            {
              + Id        = "key-default-1"
              + Statement = [
                  + {
                      + Action    = "kms:*"
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:sts::653879934003:assumed-role/AWSReservedSSO_personal-admin_42fe988492eff64b/steffen.gebert@emnify.com"
                        }
                      + Resource  = "*"
                      + Sid       = "AllowRootAccount"
                    },
                  + {
                      + Action    = [
                          + "kms:Decrypt",
                          + "kms:ReEncryptFrom",
                          + "kms:ReEncryptTo",
                          + "kms:CreateGrant",
                          + "kms:DescribeKey",
                        ]
                      + Effect    = "Allow"
                      + Principal = {
                          + AWS = "arn:aws:iam::388460667113:root"
                        }
                      + Resource  = "*"
                      + Sid       = "AllowTrustedAccountUse"
                    },
                ]
              + Version   = "2012-10-17"
            }
        )
      + region                             = "us-east-1"
    }

Plan: 7 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + account_id    = "653879934003"
  + aws_partition = "aws"
  + region_name   = "us-east-1"
  + resource_aka  = (known after apply)
  + resource_id   = (known after apply)
  + resource_name = "turbottest40226"
  + snapshot_id   = (known after apply)
aws_kms_key.ebs_cmk: Creating...
aws_kms_key.ebs_cmk: Creation complete after 2s [id=66b03462-d39e-4457-8c41-e8d2880e06f2]
aws_kms_key_policy.ebs_cmk_policy: Creating...
aws_ebs_volume.my_volume: Creating...
aws_kms_key_policy.ebs_cmk_policy: Creation complete after 6s [id=66b03462-d39e-4457-8c41-e8d2880e06f2]
aws_ebs_volume.my_volume: Still creating... [00m10s elapsed]
aws_ebs_volume.my_volume: Creation complete after 12s [id=vol-068e815970c3b50e9]
aws_ebs_snapshot.my_snapshot: Creating...
aws_ebs_snapshot.my_snapshot: Still creating... [00m10s elapsed]
aws_ebs_snapshot.my_snapshot: Still creating... [00m20s elapsed]
aws_ebs_snapshot.my_snapshot: Still creating... [00m30s elapsed]
aws_ebs_snapshot.my_snapshot: Still creating... [00m40s elapsed]
aws_ebs_snapshot.my_snapshot: Creation complete after 41s [id=snap-0700db265c3b94dc5]
aws_ami.named_test_resource: Creating...
aws_ami.named_test_resource: Creation complete after 6s [id=ami-02860a2db04ad85cc]
aws_ami_launch_permission.allow_access: Creating...
aws_ami_launch_permission.deny_access: Creating...
aws_ami_launch_permission.allow_access: Creation complete after 2s [id=ami-02860a2db04ad85cc-388460667113]
aws_ami_launch_permission.deny_access: Creation complete after 2s [id=ami-02860a2db04ad85cc-013122550996]

Warning: Deprecated value used

  on variables.tf line 142, in output "resource_aka":
 142:   value      = "arn:${data.aws_partition.current.partition}:ec2:${data.aws_region.primary.name}:${data.aws_caller_identity.current.account_id}:image/${aws_ami.named_test_resource.id}"

  The deprecation originates from data.aws_region.primary.name

name is deprecated. Use region instead.

(and 4 more similar warnings elsewhere)

Apply complete! Resources: 7 added, 0 changed, 0 destroyed.

Outputs:

account_id = "653879934003"
aws_partition = "aws"
region_name = "us-east-1"
resource_aka = "arn:aws:ec2:us-east-1:653879934003:image/ami-02860a2db04ad85cc"
resource_id = "ami-02860a2db04ad85cc"
resource_name = "turbottest40226"
snapshot_id = "snap-0700db265c3b94dc5"

Running SQL query: query.sql
[
  {
    "image_id": "ami-02860a2db04ad85cc",
    "name": "turbottest40226"
  }
]
✔ PASSED

Running SQL query: test-get-query.sql
[
  {
    "architecture": "x86_64",
    "block_device_mappings": [
      {
        "DeviceName": "/dev/sda1",
        "Ebs": {
          "AvailabilityZone": null,
          "AvailabilityZoneId": null,
          "DeleteOnTermination": true,
          "Encrypted": true,
          "Iops": null,
          "KmsKeyId": null,
          "OutpostArn": null,
          "SnapshotId": "snap-0700db265c3b94dc5",
          "Throughput": null,
          "VolumeInitializationRate": null,
          "VolumeSize": 8,
          "VolumeType": "standard"
        },
        "NoDevice": null,
        "VirtualName": null
      }
    ],
    "deregistration_protection": "disabled",
    "description": "This is a test image.",
    "ena_support": false,
    "free_tier_eligible": true,
    "hypervisor": "xen",
    "image_allowed": null,
    "image_id": "ami-02860a2db04ad85cc",
    "image_location": "653879934003/turbottest40226",
    "image_type": "machine",
    "last_launched_time": null,
    "name": "turbottest40226",
    "owner_id": "653879934003",
    "platform_details": "Linux/UNIX",
    "public": false,
    "root_device_name": "/dev/sda1",
    "root_device_type": "ebs",
    "source_image_id": null,
    "source_image_region": null,
    "sriov_net_support": "simple",
    "tags_src": [
      {
        "Key": "Name",
        "Value": "turbottest40226"
      }
    ],
    "usage_operation": "RunInstances",
    "virtualization_type": "hvm"
  }
]
✔ PASSED

Running SQL query: test-hydrate-query.sql
[
  {
    "akas": [
      "arn:aws:ec2:us-east-1:653879934003:image/ami-02860a2db04ad85cc"
    ],
    "image_id": "ami-02860a2db04ad85cc",
    "tags": {
      "Name": "turbottest40226"
    },
    "title": "turbottest40226"
  }
]
✔ PASSED

Running SQL query: test-list-query.sql
[
  {
    "image_id": "ami-02860a2db04ad85cc",
    "name": "turbottest40226"
  }
]
✔ PASSED

POSTTEST: tests/aws_ec2_ami

TEARDOWN: tests/aws_ec2_ami

SUMMARY:

1/1 passed.
```
</details>

# Example query results
<details>
  <summary>Results</summary>

```
select
  name,
  image_id,
  creation_date,
  last_launched_time
from
  aws_ec2_ami
where
  last_launched_time < now() - interval '90 days'
  or last_launched_time is null;

+---------------------------------------------------------------------------------------+-----------------------+----------------------+----------------------+
| name                                                                                  | image_id              | creation_date        | last_launched_time   |
+---------------------------------------------------------------------------------------+-----------------------+----------------------+----------------------+
| acme/images/acme-myapp-v0.42.4-dp-v2-amd64-server-ubuntu-24.04-2025-07-22T09-17-47Z   | ami-0xxxxxx9cccc67765 | 2025-07-22T09:31:22Z | 2025-07-22T09:58:54Z |
| acme/images/acme-base-amd64-server-ubuntu-24.04-20260330-093345                       | ami-0xxxxxxd488b48494 | 2026-03-30T09:56:02Z | <null>               |
| acme/images/acme-base-amd64-server-ubuntu-24.04-20260303-094648                       | ami-0xxxxxx917ac8e1f2 | 2026-03-03T10:09:29Z | <null>               |
| acme/images/acme-base-amd64-server-ubuntu-20.04-20260303-095410                       | ami-0xxxxxx2de5ebd9b0 | 2026-03-03T10:17:37Z | <null>               |
| acme/images/acme-myapp-v0.46.1-dp-v2-amd64-server-ubuntu-24.04-2026-03-23T15-00-09Z   | ami-0xxxxxx8ef64cd1ea | 2026-03-23T15:08:09Z | <null>               |
| acme/images/acme-base-amd64-server-ubuntu-20.04-20260321-043419                       | ami-0xxxxxx7dee54dfac | 2026-03-21T04:56:58Z | <null>               |
| acme/images/acme-base-arm64-server-ubuntu-24.04-20260309-203617                       | ami-0xxxxxxe81564bc67 | 2026-03-09T20:51:55Z | <null>               |
| acme/images/acme-base-amd64-server-ubuntu-22.04-20260205-190306                       | ami-0xxxxxxe001239ca8 | 2026-02-05T19:25:26Z | <null>               |
| acme/images/acme-egn-1.73.0-20250414-122902                                           | ami-0xxxxxx3be2255d52 | 2025-04-14T12:42:21Z | 2025-05-07T07:27:17Z |
| acme/images/acme-base-arm64-server-ubuntu-24.04-20260202-203751                       | ami-0xxxxxx9401a6ae97 | 2026-02-02T20:56:42Z | <null>               |
+---------------------------------------------------------------------------------------+-----------------------+----------------------+----------------------+


```
</details>
