### PR TITLE
Fix deprecated CloudTrail DescribeQuery input

### DIFF
--- a/aws/table_aws_cloudtrail_query.go
+++ b/aws/table_aws_cloudtrail_query.go
@@ -259,8 +259,7 @@ func getCloudTrailQuery(ctx context.Context, d *plugin.QueryData, h *plugin.Hydr
 	}
 
 	params := &cloudtrail.DescribeQueryInput{
-		EventDataStore: aws.String(eventDataSourceArn),
-		QueryId:        aws.String(queryId),
+		QueryId: aws.String(queryId),
 	}
 
 	// execute list call


### PR DESCRIPTION
## Summary

- Remove the deprecated EventDataStore field from DescribeQueryInput
- Keep QueryId as the only required DescribeQuery parameter

## Testing

- go test ./...
- golangci-lint v2.13.2 run ./... (0 issues)
- Fork CI golangci-lint workflow passed